### PR TITLE
Add MXFP8 torch._scaled_mm benchmark

### DIFF
--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -513,6 +513,55 @@ class ScaledMMRowwise(GemmOpBase):
 
 
 @register_gemm_op
+class ScaledMMMXFP8(GemmOpBase):
+    def __init__(self):
+        self.torch_compile = False
+
+    def quantize(self, x, w):
+        x_scale, xq = to_mxfp8(x)
+        x_scale = _to_blocked(x_scale)
+        w_scale, wq = to_mxfp8(w)
+        w_scale = _to_blocked(w_scale)
+        return xq, wq.t(), x_scale, w_scale
+
+    def compute(self, xq, wq, x_scale, w_scale):
+        if self.torch_compile:
+            f = torch.compile(
+                torch._scaled_mm,
+                options={
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON,CK,CUTLASS,ATEN",
+                },
+            )
+        else:
+            f = torch._scaled_mm
+
+        return f(
+            xq,
+            wq,
+            bias=None,
+            out_dtype=torch.bfloat16,
+            scale_a=x_scale,
+            scale_b=w_scale,
+        )
+
+    def quantize_and_compute(self, x, w):
+        return self.compute(*self.quantize(x, w))
+
+    @property
+    def name(self) -> str:
+        return "scaled_mm_mxfp8"
+
+    @property
+    def hip(self) -> bool:
+        return True
+
+    @property
+    def cuda(self) -> bool:
+        return True
+
+
+@register_gemm_op
 class FP8TensorwiseGemm(GemmOpBase):
     """
     FP8 matmul with tensorwise scaling.


### PR DESCRIPTION
Summary: This small diff adds the torch mxfp8 gemm to our collection of gemm operators.

Differential Revision: D88199201


