### PR TITLE
Revert D88304133

### DIFF
--- a/include/mslk/utils/tuning_cache.cuh
+++ b/include/mslk/utils/tuning_cache.cuh
@@ -19,12 +19,6 @@
 
 #include <ostream>
 
-#if !defined(FBGEMM_FBCODE) && ROCM_VERSION >= 70000
-using GPUEvent = at::hip::HIPEvent;
-#else
-using GPUEvent = at::cuda::CUDAEvent;
-#endif
-
 namespace mslk {
 
 /**
@@ -285,8 +279,8 @@ class TuningCache final {
 
   constexpr static std::string_view MSLK_CACHE_DIR = ".mslk";
 
-  GPUEvent start_ = GPUEvent(cudaEventDefault);
-  GPUEvent stop_ = GPUEvent(cudaEventDefault);
+  at::cuda::CUDAEvent start_ = at::cuda::CUDAEvent(cudaEventDefault);
+  at::cuda::CUDAEvent stop_ = at::cuda::CUDAEvent(cudaEventDefault);
 
   // If MSLK_AUTOTUNE_USE_CUDA_GRAPH is set, use CUDA graph for benchmarking.
   // CUDA graphs use a separate memory pool to do allocation in PyTorch


### PR DESCRIPTION
Summary: - Revert D88304133, now that the ROCm hipify issue is gone

Reviewed By: cthi, atalman, huydhn

Differential Revision: D88795496


