### PR TITLE
Fix num_iters mem_bw

### DIFF
--- a/bench/quantize/quantize_bench.py
+++ b/bench/quantize/quantize_bench.py
@@ -175,9 +175,10 @@ def benchmark(
             input_bytes = input.numel() * input.element_size()
             output_bytes = sum(t.numel() * t.element_size() for t in quantized)
             total_size_bytes = input_bytes + output_bytes
-            metrics.gbps += (total_size_bytes / 1e9) / (ms_runtime / 1e3)
+            gbps = (total_size_bytes / 1e9) / (ms_runtime / 1e3)
+            metrics.gbps += gbps
             metrics.us += ms_runtime * 1000
-            metrics.memory_bw_util += (metrics.gbps / mem_bw_roofline_gbps) * 100
+            metrics.memory_bw_util += (gbps / mem_bw_roofline_gbps) * 100
 
         metrics.us /= num_iters
         metrics.gbps /= num_iters


### PR DESCRIPTION
Summary:
Thanks to coreyhu for finding this bug:

>  qq about how how memory bandwidth utilized is being computed.

> metrics.memory_bw_util += (metrics.gbps / mem_bw_roofline_gbps) * 100

> Shouldn't it be using that iteration's gbps instead of the global sum (metrics.gbps)?

Confirmed its not working properly for num_iters > 1:

```
Quantize Bench
-----------------------------------------------------------------------------------
OpName               Problem Shape   Sim        Us         GB/s       Mem BW Util %
-----------------------------------------------------------------------------------
TritonFP8Rowwise     (4096, 4096)    0.001      8.161      6169.08    241.30
TritonFP8Blockwise   (4096, 4096)    0.001      7.056      7133.97    278.74
TritonFP8Groupwise   (4096, 4096)    0.001      7.191      7071.99    276.51
TritonNVFP4          (4096, 4096)    0.009      10.577     4064.62    158.90
CudaFP8Rowwise       (4096, 4096)    0.001      56.308     894.15     34.96
```

Differential Revision: D88848609


