### PR TITLE
Add FP8 Convolution Kernels

### DIFF
--- a/bench/conv/__init__.py
+++ b/bench/conv/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/bench/conv/conv_bench.py
+++ b/bench/conv/conv_bench.py
@@ -1,0 +1,507 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+import os
+import sys
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+import click
+
+import matplotlib.pyplot as plt
+
+import pandas as pd
+import seaborn as sns
+import torch
+from tabulate import tabulate
+
+try:
+    from accelerators.utils.torch_profiler import profiler_or_nullcontext
+except ImportError:
+    from contextlib import nullcontext
+
+    class profiler_or_nullcontext(nullcontext):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+
+from mslk.bench.conv.conv_ops import ConvOpBase, get_conv_ops
+
+
+shape_registry = {}
+
+
+def register_shapes(name):
+    def decorator(op):
+        shape_registry[name] = op
+        return op
+
+    return decorator
+
+
+@register_shapes("default")
+def default_shapes() -> (
+    list[tuple[int, int, int, int, int, int, int, int, int, int, int, int]]
+):
+    """
+    Default convolution shapes for benchmarking.
+
+    Returns tuples of (N, D, H, W, C, K, T, R, S, pad, stride, dilation)
+    where:
+        N = batch size
+        D, H, W = input spatial dimensions (depth, height, width)
+        C = input channels
+        K = output channels (filters)
+        T, R, S = kernel spatial dimensions
+        pad, stride, dilation = convolution parameters (applied uniformly to D, H, W)
+    """
+    shapes = []
+    # Common batch sizes
+    for N in [1, 4, 8, 16]:
+        # Common configurations
+        shapes += [
+            # Small spatial dimensions, various channel sizes
+            (N, 8, 8, 8, 64, 64, 3, 3, 3, 1, 1, 1),
+            (N, 8, 8, 8, 64, 128, 3, 3, 3, 1, 1, 1),
+            (N, 8, 8, 8, 128, 128, 3, 3, 3, 1, 1, 1),
+            # Medium spatial dimensions
+            (N, 16, 16, 16, 64, 64, 3, 3, 3, 1, 1, 1),
+            (N, 16, 16, 16, 64, 128, 3, 3, 3, 1, 1, 1),
+            # Larger spatial dimensions
+            (N, 32, 32, 32, 32, 64, 3, 3, 3, 1, 1, 1),
+            (N, 32, 32, 32, 64, 64, 3, 3, 3, 1, 1, 1),
+            # 1x1x1 convolutions (common in ResNets)
+            (N, 16, 16, 16, 64, 128, 1, 1, 1, 0, 1, 1),
+            (N, 16, 16, 16, 128, 256, 1, 1, 1, 0, 1, 1),
+        ]
+    return shapes
+
+
+@dataclass
+class Metrics:
+    op_name: str
+
+    sim: float = 0.0
+    ms: float = 0.0
+    tflops: float = 0.0
+    gbps: float = 0.0
+
+    def __str__(self) -> str:
+        return (
+            "%s sim: %.3f.\n%s ms: %.3f. \n" "%s TFLOPS: %.3f. \n%s GB/s: %.3f."
+        ) % (
+            self.op_name,
+            self.sim,
+            self.op_name,
+            self.ms,
+            self.op_name,
+            self.tflops,
+            self.op_name,
+            self.gbps,
+        )
+
+
+def benchmark(
+    conv_ops: list[ConvOpBase],
+    n: int,
+    d: int,
+    h: int,
+    w: int,
+    c: int,
+    k: int,
+    t: int,
+    r: int,
+    s: int,
+    pad: int,
+    stride: int,
+    dilation: int,
+    bench_quantize: bool = False,
+    use_cuda_graph: bool = True,
+    trace: bool = False,
+    num_iters: int = 1,
+    torch_compile: bool = False,
+) -> dict[str, Any]:
+    # Create input tensors in NCDHW format
+    activation = torch.randn(n, c, d, h, w, device="cuda", dtype=torch.bfloat16)
+    # Create filter tensors in KCTRS format
+    filter = torch.randn(k, c, t, r, s, device="cuda", dtype=torch.bfloat16)
+
+    # Convolution parameters (uniform for all dimensions)
+    padding = [pad, pad, pad]
+    stride_vec = [stride, stride, stride]
+    dilation_vec = [dilation, dilation, dilation]
+
+    # Compute baseline output for correctness checking using PyTorch
+    # Convert to NCDHW for PyTorch
+    out_ref = torch.nn.functional.conv3d(
+        activation,
+        filter,
+        bias=None,
+        stride=stride_vec,
+        padding=padding,
+        dilation=dilation_vec,
+    )
+
+    # Keep track of results.
+    results: dict[str, Any] = {
+        "N": n,
+        "C": c,
+        "D": d,
+        "H": h,
+        "W": w,
+        "K": k,
+        "T": t,
+        "R": r,
+        "S": s,
+        "pad": pad,
+        "stride": stride,
+        "dilation": dilation,
+    }
+
+    # Benchmark each operator.
+    for conv_op in conv_ops:
+        metrics = Metrics(op_name=conv_op.name)
+        if hasattr(conv_op, "torch_compile"):
+            conv_op.torch_compile = torch_compile
+        # Preprocess data if needed.
+        preprocessed_args = conv_op.preprocess(
+            activation, filter, padding, stride_vec, dilation_vec
+        )
+        # Get the quantized tensors for this operator.
+        quantized_vals = conv_op.quantize(*preprocessed_args)
+        # Compute the output given quantized values.
+        output = conv_op.compute(*quantized_vals)
+        # Compare the quantize op output to reference as a sanity check.
+        metrics.sim = torch.mean(torch.pow(output - out_ref, 2)).item()
+
+        for _ in range(num_iters):
+            # Now perform benchmark.
+            if bench_quantize:
+                # Benchmark both quantize and compute.
+                with profiler_or_nullcontext(enabled=trace, with_stack=True):
+                    ms_runtime = conv_op.benchmark(
+                        *preprocessed_args,
+                        bench_quantize=True,
+                        use_cuda_graph=use_cuda_graph,
+                    )
+            else:
+                with profiler_or_nullcontext(enabled=trace, with_stack=True):
+                    ms_runtime = conv_op.benchmark(
+                        *quantized_vals,
+                        bench_quantize=False,
+                        use_cuda_graph=use_cuda_graph,
+                    )
+
+            # Compute performance metrics
+            # FLOPs for convolution: 2 * N * Z * P * Q * K * T * R * S * C
+            # where Z, P, Q are output spatial dimensions
+            z = 1 + (d + 2 * pad - ((t - 1) * dilation + 1)) // stride
+            p = 1 + (h + 2 * pad - ((r - 1) * dilation + 1)) // stride
+            q = 1 + (w + 2 * pad - ((s - 1) * dilation + 1)) // stride
+
+            flops = 2 * n * z * p * q * k * t * r * s * c
+            metrics.tflops += flops / (ms_runtime / 1e3) / 1e12
+
+            # Compute memory bandwidth
+            # Input: N * D * H * W * C, Filter: K * T * R * S * C, Output: N * Z * P * Q * K
+            input_size = n * d * h * w * c * quantized_vals[0].element_size()
+            filter_size = k * t * r * s * c * quantized_vals[1].element_size()
+            output_size = n * z * p * q * k * output.element_size()
+
+            metrics.gbps += (
+                (input_size + filter_size + output_size) / (ms_runtime / 1e3) / 1e9
+            )
+            metrics.ms += ms_runtime
+
+        # Print out results for this op.
+        metrics.ms /= num_iters
+        metrics.tflops /= num_iters
+        metrics.gbps /= num_iters
+        print(f"Average metrics over {num_iters} iterations:")
+        print(metrics)
+
+        # Save results for this operator.
+        results[f"{conv_op.name}_sim"] = metrics.sim
+        results[f"{conv_op.name}_ms"] = metrics.ms
+        results[f"{conv_op.name}_tflops"] = metrics.tflops
+        results[f"{conv_op.name}_gb/s"] = metrics.gbps
+
+    return results
+
+
+def plot_benchmark(results: list[dict[str, Any]], output_dir: str) -> None:
+    """Create a barplot visualizing the TFLOPS of each kernel."""
+    # Reprocess into new dataframe with proper graph format.
+    data = []
+    # Extract measurements for each shape.
+    for impl in results:
+        shape_str = f"N{impl['N']}_D{impl['D']}_H{impl['H']}_W{impl['W']}_C{impl['C']}_K{impl['K']}"
+        # Iterate over keys to find tflops entries.
+        for key in impl:
+            if "tflops" in key:
+                op_name = key.split("_tflops")[0]
+                op_tflops = impl[key]
+                data.append(
+                    {"Shape": shape_str, "kernel": op_name, "TFLOPS": op_tflops}
+                )
+
+    # Create a barplot using seaborn.
+    df = pd.DataFrame(data)
+    plot = plt.figure()
+    plt.xticks(rotation=30)
+    plt.yscale("log")
+    ax = sns.barplot(x="Shape", y="TFLOPS", hue="kernel", data=df)
+    ax.tick_params(axis="x", labelsize=3)
+    img_fn = os.path.join(output_dir, "conv_ops_benchmark.png")
+    plot.savefig(img_fn, dpi=300)
+    print(f"Plot saved to {img_fn}")
+
+
+def collect_kernels_to_profile(kernels: Optional[list[str]]) -> list[ConvOpBase]:
+    # Get existing convolution operators.
+    conv_ops = [op for op in get_conv_ops() if op.supported]
+    if kernels is None:
+        return conv_ops
+    return [op for op in conv_ops if op.name in kernels]
+
+
+def print_kernels(kernels: Optional[list[str]]) -> list[ConvOpBase]:
+    data = sorted(
+        [
+            (op.name, "Yes" if op.cuda else "No", "Yes" if op.hip else "No")
+            for op in get_conv_ops()
+        ]
+    )
+    print(tabulate(data, headers=["Name", "CUDA", "ROCm"], tablefmt="orgtbl"))
+
+
+@click.command()
+@click.option(
+    "--output-dir",
+    default="/tmp",
+    help="Directory to save plots and csvs to",
+)
+@click.option(
+    "--num-iters",
+    default=1,
+    type=int,
+    help="Number of iterations to repeat each benchmark.",
+)
+@click.option(
+    "--export-csv",
+    is_flag=True,
+    help="Export results to a CSV file.",
+)
+@click.option(
+    "--plot",
+    is_flag=True,
+    help="Create a plot of the benchmark measurements.",
+)
+@click.option(
+    "--bench-quantize",
+    is_flag=True,
+    help="If set, include quantization cost in benchmark.",
+)
+@click.option(
+    "--kernels",
+    default=None,
+    help="Comma separated list of kernels to benchmark. Defaults to all kernels.",
+)
+@click.option(
+    "--N",
+    default=None,
+    help="Comma separated list of batch sizes to benchmark.",
+)
+@click.option(
+    "--D",
+    default=None,
+    help="Comma separated list of depth values to benchmark.",
+)
+@click.option(
+    "--H",
+    default=None,
+    help="Comma separated list of height values to benchmark.",
+)
+@click.option(
+    "--W",
+    default=None,
+    help="Comma separated list of width values to benchmark.",
+)
+@click.option(
+    "--C",
+    default=None,
+    help="Comma separated list of input channel values to benchmark.",
+)
+@click.option(
+    "--K",
+    default=None,
+    help="Comma separated list of output channel (filter) values to benchmark.",
+)
+@click.option(
+    "--T",
+    default=None,
+    help="Comma separated list of kernel depth values to benchmark.",
+)
+@click.option(
+    "--R",
+    default=None,
+    help="Comma separated list of kernel height values to benchmark.",
+)
+@click.option(
+    "--S",
+    default=None,
+    help="Comma separated list of kernel width values to benchmark.",
+)
+@click.option(
+    "--pad",
+    default=None,
+    help="Comma separated list of padding values to benchmark.",
+)
+@click.option(
+    "--stride",
+    default=None,
+    help="Comma separated list of stride values to benchmark.",
+)
+@click.option(
+    "--dilation",
+    default=None,
+    help="Comma separated list of dilation values to benchmark.",
+)
+@click.option(
+    "--no-cuda-graph",
+    is_flag=True,
+    help="If set, do not use cuda graph for benchmarking.",
+)
+@click.option(
+    "--shapes",
+    default=None,
+    help=f"Specific model shapes to use, options: {", ".join(shape_registry.keys())}.",
+)
+@click.option(
+    "--trace",
+    is_flag=True,
+    help="If set, produce a performance trace of the benchmark.",
+)
+@click.option(
+    "--torch-compile",
+    is_flag=True,
+    help="If set, torch.compile will be used for aten backed ops.",
+)
+def invoke_main(
+    output_dir: str,
+    num_iters: int,
+    export_csv: bool,
+    plot: bool,
+    bench_quantize: bool,
+    kernels: Optional[str],
+    n: Optional[str],
+    d: Optional[str],
+    h: Optional[str],
+    w: Optional[str],
+    c: Optional[str],
+    k: Optional[str],
+    t: Optional[str],
+    r: Optional[str],
+    s: Optional[str],
+    pad: Optional[str],
+    stride: Optional[str],
+    dilation: Optional[str],
+    no_cuda_graph: bool,
+    shapes: Optional[str],
+    trace: bool,
+    torch_compile: bool,
+):
+    # If kernel filter is provided, parse it. Else, benchmark all kernels.
+    all_kernels = kernels.strip().split(",") if kernels else None
+    conv_ops = collect_kernels_to_profile(all_kernels)
+
+    if len(conv_ops) == 0:
+        print("No valid kernels to benchmark. Available kernels:")
+        print_kernels(all_kernels)
+        sys.exit(1)
+
+    if num_iters < 1:
+        print("Warning: Number of iterations must be at least 1.")
+        num_iters = 1
+
+    # Enumerate shapes to benchmark.
+    if shapes:
+        if shapes not in shape_registry:
+            print(
+                f"Shape {shapes} not found in shape registry. Valid shapes: {", ".join(shape_registry.keys())}."
+            )
+            sys.exit(1)
+        conv_shapes = shape_registry[shapes]()
+    else:
+        # Parse individual dimension parameters
+        N = [int(n_val) for n_val in n.strip().split(",")] if n else [1, 4, 8]
+        D = [int(d_val) for d_val in d.strip().split(",")] if d else [8, 16]
+        H = [int(h_val) for h_val in h.strip().split(",")] if h else [8, 16]
+        W = [int(w_val) for w_val in w.strip().split(",")] if w else [8, 16]
+        C = [int(c_val) for c_val in c.strip().split(",")] if c else [64, 128]
+        K = [int(k_val) for k_val in k.strip().split(",")] if k else [64, 128]
+        T = [int(t_val) for t_val in t.strip().split(",")] if t else [3]
+        R = [int(r_val) for r_val in r.strip().split(",")] if r else [3]
+        S = [int(s_val) for s_val in s.strip().split(",")] if s else [3]
+        Pad = [int(p_val) for p_val in pad.strip().split(",")] if pad else [1]
+        Stride = (
+            [int(st_val) for st_val in stride.strip().split(",")] if stride else [1]
+        )
+        Dilation = (
+            [int(di_val) for di_val in dilation.strip().split(",")] if dilation else [1]
+        )
+
+        # Create all combinations
+        conv_shapes = list(
+            itertools.product(N, D, H, W, C, K, T, R, S, Pad, Stride, Dilation)
+        )
+
+    # Iterate over shapes and benchmark.
+    benchmark_results = []
+    for n, d, h, w, c, k, t, r, s, pad, stride, dilation in conv_shapes:
+        print(
+            f"Benchmarking N={n}, D={d}, H={h}, W={w}, C={c}, K={k}, T={t}, R={r}, S={s}, pad={pad}, stride={stride}, dilation={dilation}."
+        )
+        conv_measurements = benchmark(
+            conv_ops,
+            n,
+            d,
+            h,
+            w,
+            c,
+            k,
+            t,
+            r,
+            s,
+            pad,
+            stride,
+            dilation,
+            bench_quantize,
+            not no_cuda_graph,
+            trace,
+            num_iters,
+            torch_compile,
+        )
+        benchmark_results.append(conv_measurements)
+
+    if export_csv or plot:
+        os.makedirs(output_dir, exist_ok=True)
+    if export_csv:
+        datetime_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+        csv_file = os.path.join(output_dir, f"conv_ops_benchmark_{datetime_str}.csv")
+        print(f"CSV saved to {csv_file}")
+        # Export results to a CSV file.
+        df = pd.DataFrame(benchmark_results)
+        df.to_csv(csv_file, index=False)
+    if plot:
+        plot_benchmark(benchmark_results, output_dir)
+
+
+if __name__ == "__main__":
+    invoke_main()  # pragma: no cover

--- a/bench/conv/conv_ops.py
+++ b/bench/conv/conv_ops.py
@@ -1,0 +1,227 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Keep a registry of all convolution operators.
+import abc
+
+import mslk.conv  # noqa: F401
+
+import torch
+import triton  # @manual=//triton:triton
+from mslk.quantize.triton.fp8_quantize import quantize_fp8_tensor
+
+
+conv_op_registry = []
+
+
+class ConvOpBase(metaclass=abc.ABCMeta):
+    """Helper abstract class to define expected methods of conv ops."""
+
+    @abc.abstractmethod
+    def quantize(self, *args):
+        """Function which quantizes inputs."""
+        pass
+
+    @abc.abstractmethod
+    def compute(self, *args, **kwargs):
+        """Function which performs main compute operation."""
+        pass
+
+    @abc.abstractmethod
+    def quantize_and_compute(self, *args, **kwargs):
+        """Function which quantizes inputs and performs main compute operation."""
+        pass
+
+    def preprocess(self, *args):
+        """Preprocess inputs before benchmarking. These outputs will be passed to quantize."""
+        return args
+
+    def benchmark(
+        self,
+        *args,
+        bench_quantize: bool = False,
+        use_cuda_graph: bool = True,
+        **kwargs,
+    ) -> float:
+        """Benchmark runtime of this operator."""
+        if bench_quantize:
+            if use_cuda_graph:
+                with torch.cuda.stream(torch.cuda.Stream()):
+                    t = triton.testing.do_bench_cudagraph(
+                        lambda: self.quantize_and_compute(*args, **kwargs), rep=200
+                    )
+            else:
+                t = triton.testing.do_bench(
+                    lambda: self.quantize_and_compute(*args, **kwargs)
+                )
+        else:
+            if use_cuda_graph:
+                with torch.cuda.stream(torch.cuda.Stream()):
+                    t = triton.testing.do_bench_cudagraph(
+                        lambda: self.compute(*args, **kwargs), rep=200
+                    )
+            else:
+                t = triton.testing.do_bench(lambda: self.compute(*args, **kwargs))
+        return t
+
+    @abc.abstractproperty
+    def name(self) -> str:
+        """Name of the operator."""
+        pass
+
+    @abc.abstractproperty
+    def hip(self) -> bool:
+        """Whether this operator supports AMD or not."""
+        pass
+
+    @abc.abstractproperty
+    def cuda(self) -> bool:
+        """Whether this operator supports Nvidia or not."""
+        pass
+
+    @property
+    def supported(self) -> bool:
+        """Whether this op will run on the current device."""
+        if torch.version.hip is not None:
+            return self.hip
+        elif torch.version.cuda is not None:
+            return self.cuda
+        else:
+            return False
+
+
+def register_conv_op(op):
+    """Decorator function for assembling all conv ops."""
+    conv_op_registry.append(op())
+    return op
+
+
+def get_conv_ops() -> list[ConvOpBase]:
+    """Get all registered conv ops."""
+    return conv_op_registry
+
+
+@register_conv_op
+class TorchBaseline(ConvOpBase):
+    """
+    PyTorch baseline convolution.
+    """
+
+    def __init__(self):
+        self.torch_compile = False
+
+    def quantize(self, activation, filter, padding, stride, dilation):
+        return (
+            activation.to(torch.bfloat16),
+            filter.to(torch.bfloat16),
+            padding,
+            stride,
+            dilation,
+        )
+
+    def compute(self, activation, filter, padding, stride, dilation):
+        if self.torch_compile:
+            f = torch.compile(
+                torch.nn.functional.conv3d,
+                options={
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON,CK,CUTLASS,ATEN",
+                },
+            )
+        else:
+            f = torch.nn.functional.conv3d
+
+        return f(
+            activation,
+            filter,
+            bias=None,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+        )
+
+    def quantize_and_compute(self, activation, filter, padding, stride, dilation):
+        return self.compute(
+            *self.quantize(activation, filter, padding, stride, dilation)
+        )
+
+    @property
+    def name(self) -> str:
+        return "torch_baseline"
+
+    @property
+    def hip(self) -> bool:
+        return True
+
+    @property
+    def cuda(self) -> bool:
+        return True
+
+
+@register_conv_op
+class F8F8BF16Conv(ConvOpBase):
+    """
+    FP8 convolution with rowwise scaling.
+    """
+
+    def preprocess(self, activation, filter, padding, stride, dilation):
+        # Inputs and filters are provided in channels first layout.
+        # Cutlass kernels support this but require the underlying memory
+        # to be channels last. Torch enables this through the memory format
+        # transformation which we assume has been applied ahead of time.
+        activation = activation.to(memory_format=torch.channels_last_3d)
+        filter = filter.to(memory_format=torch.channels_last_3d)
+        return activation, filter, padding, stride, dilation
+
+    def _quantize_tensor(self, x):
+        """Quantize tensor to FP8 with rowwise scaling."""
+        xq, x_scale = quantize_fp8_tensor(x)
+        return xq, x_scale
+
+    def quantize(self, activation, filter, padding, stride, dilation):
+        # Quantize both input tensors
+        activation_q, activation_scale = self._quantize_tensor(activation)
+        filter_q, filter_scale = self._quantize_tensor(filter)
+
+        # Compute combined scale for output
+        # For conv, we need a single scale value
+        scale = torch.tensor(
+            [activation_scale * filter_scale],
+            device=activation.device,
+            dtype=torch.float32,
+        )
+
+        return activation_q, filter_q, scale, padding, stride, dilation
+
+    def compute(self, activation_q, filter_q, scale, padding, stride, dilation):
+        output = torch.ops.mslk.f8f8bf16_conv(
+            activation_q,
+            filter_q,
+            scale,
+            padding,
+            stride,
+            dilation,
+        )
+        return output
+
+    def quantize_and_compute(self, activation, filter, padding, stride, dilation):
+        activation_q, filter_q, scale, padding, stride, dilation = self.quantize(
+            activation, filter, padding, stride, dilation
+        )
+        return self.compute(activation_q, filter_q, scale, padding, stride, dilation)
+
+    @property
+    def name(self) -> str:
+        return "f8f8bf16_conv"
+
+    @property
+    def hip(self) -> bool:
+        # Currently only supported on CUDA
+        return False
+
+    @property
+    def cuda(self) -> bool:
+        return True

--- a/csrc/conv/conv_ops.cpp
+++ b/csrc/conv/conv_ops.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <mslk/conv/conv.h> // @manual
+#include <mslk/utils/torch/op_registration.h> // @manual
+#include <torch/library.h>
+
+namespace mslk::conv {
+
+TORCH_LIBRARY_FRAGMENT(mslk, m) {
+#ifndef USE_ROCM
+  m.def(
+      "f8f8bf16_conv(Tensor activation, Tensor filter, Tensor scale, int[] padding, int[] stride, int[] dilation) -> Tensor");
+#endif
+}
+
+TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
+#ifndef USE_ROCM
+  m.impl("f8f8bf16_conv", f8f8bf16_conv);
+#endif
+}
+
+at::Tensor f8f8bf16_conv_meta(
+    at::Tensor activation,
+    at::Tensor filter,
+    at::Tensor /* scale */,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation) {
+  TORCH_CHECK(activation.dim() == 5, "Activation must be 5D tensor");
+  TORCH_CHECK(filter.dim() == 5, "Filter must be 5D tensor");
+
+  // Check if input is channels first or channels last.
+  bool channels_last_act = activation.strides()[4] == 1;
+  bool channels_last_filt = filter.strides()[4] == 1;
+
+  at::SymInt n, d, h, w, k, t, r, s;
+
+  if (channels_last_act) {
+    n = activation.sym_size(0);
+    d = activation.sym_size(1);
+    h = activation.sym_size(2);
+    w = activation.sym_size(3);
+  } else {
+    n = activation.sym_size(0);
+    d = activation.sym_size(2);
+    h = activation.sym_size(3);
+    w = activation.sym_size(4);
+  }
+  if (channels_last_filt) {
+    k = filter.sym_size(0);
+    t = filter.sym_size(1);
+    r = filter.sym_size(2);
+    s = filter.sym_size(3);
+  } else {
+    k = filter.sym_size(0);
+    t = filter.sym_size(2);
+    r = filter.sym_size(3);
+    s = filter.sym_size(4);
+  }
+
+  TORCH_CHECK(
+      padding.size() == 3,
+      "Padding must have 3 elements corresponding to [d, h, w]");
+  TORCH_CHECK(
+      stride.size() == 3,
+      "Stride must have 3 elements corresponding to [d, h, w]");
+  TORCH_CHECK(
+      dilation.size() == 3,
+      "Dilation must have 3 elements corresponding to [d, h, w]");
+
+  int64_t pad_d = padding[0];
+  int64_t pad_h = padding[1];
+  int64_t pad_w = padding[2];
+  int64_t stride_d = stride[0];
+  int64_t stride_h = stride[1];
+  int64_t stride_w = stride[2];
+  int64_t dilation_d = dilation[0];
+  int64_t dilation_h = dilation[1];
+  int64_t dilation_w = dilation[2];
+
+  at::SymInt z = 1 + (d + 2 * pad_d - ((t - 1) * dilation_d + 1)) / stride_d;
+  at::SymInt p = 1 + (h + 2 * pad_h - ((r - 1) * dilation_h + 1)) / stride_h;
+  at::SymInt q = 1 + (w + 2 * pad_w - ((s - 1) * dilation_w + 1)) / stride_w;
+
+  at::Tensor Y;
+
+  if (channels_last_act) {
+    Y = at::empty_symint(
+        {n, z, p, q, k}, activation.options().dtype(at::kBFloat16));
+  } else {
+    Y = at::empty_symint(
+        {n, k, z, p, q},
+        activation.options()
+            .dtype(at::kBFloat16)
+            .memory_format(c10::MemoryFormat::ChannelsLast3d));
+  }
+  return Y;
+}
+
+TORCH_LIBRARY_IMPL(mslk, Meta, m) {
+#ifndef USE_ROCM
+  m.impl("f8f8bf16_conv", f8f8bf16_conv_meta);
+#endif
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv.cu
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cutlass/util/host_tensor.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/cutlass.h>
+#include <cutlass/conv/collective/collective_builder.hpp>
+#include <cutlass/conv/convnd_problem_shape.hpp>
+#include <cutlass/conv/convolution.h>
+#include <cutlass/conv/device/conv_universal_adapter.hpp>
+#include <cutlass/conv/dispatch_policy.hpp>
+#include <cutlass/conv/kernel/conv_universal.hpp>
+#include <cutlass/epilogue/collective/collective_builder.hpp>
+// clang-format on
+
+#include "f8f8bf16_conv/f8f8bf16_conv_manifest.cuh"
+
+namespace mslk::conv {
+
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+struct ProblemSize {
+  std::vector<int64_t> activation_shape; // [N, D, H, W, C]
+  std::vector<int64_t> filter_shape; // [K, T, R, S, C]
+  std::vector<int64_t> padding;
+  std::vector<int64_t> stride;
+  std::vector<int64_t> dilation;
+  bool operator==(const ProblemSize& ps) const {
+    return activation_shape == ps.activation_shape &&
+        filter_shape == ps.filter_shape;
+  }
+  void print() const {
+    // clang-format off
+    std::cout << "actv: " // [N, D, H, W, C]
+              << activation_shape[0] << ","
+              << activation_shape[1] << ","
+              << activation_shape[2] << ","
+              << activation_shape[3] << ","
+              << activation_shape[4] << ","
+              << "filter: " // [K, T, R, S, C]
+              << filter_shape[0] << ","
+              << filter_shape[1] << ","
+              << filter_shape[2] << ","
+              << filter_shape[3] << ","
+              << filter_shape[4] << ","
+              << std::endl;
+    // clang-format on
+  }
+};
+
+inline void hash_combine(std::size_t& seed, std::size_t value) {
+  seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+// Hash function for ProblemSize for use in unordered_map
+struct ProblemSizeHash {
+  std::size_t operator()(const ProblemSize& ps) const {
+    std::size_t seed = 0;
+    auto vec_hash = [](const std::vector<int64_t>& v) {
+      std::size_t h = 0;
+      for (auto x : v)
+        hash_combine(h, std::hash<int64_t>{}(x));
+      return h;
+    };
+    hash_combine(seed, vec_hash(ps.activation_shape));
+    hash_combine(seed, vec_hash(ps.filter_shape));
+    // hash_combine(seed, vec_hash(ps.padding));
+    // hash_combine(seed, vec_hash(ps.stride));
+    // hash_combine(seed, vec_hash(ps.dilation));
+    return seed;
+  }
+};
+
+// clang-format off
+std::unordered_map<ProblemSize, Kernel_f8f8bf16_conv, ProblemSizeHash> kernel_map = {
+{{{1,1,192,128,1024}, {512,1,1,1,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_128x256x128_2x1x1},
+{{{1,1,192,128,160}, {320,1,1,1,160}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_2x1x1},
+{{{1,1,384,256,512}, {256,1,1,1,512}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_512x256x128_4x1x1},
+{{{1,1,96,64,320}, {640,1,1,1,320}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_128x256x128_1x2x1},
+{{{1,3,194,130,1024}, {512,3,3,3,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_512x256x128_4x1x1},
+{{{1,3,194,130,160}, {320,3,3,3,160}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_512x256x128_4x1x1},
+{{{1,3,194,130,320}, {320,3,3,3,320}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x128x128_4x1x1},
+{{{1,3,194,130,512}, {512,3,3,3,512}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_512x256x128_4x1x1},
+{{{1,3,386,258,160}, {160,3,3,3,160}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_512x256x128_4x1x1},
+{{{1,3,386,258,256}, {256,3,3,3,256}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_2x1x1},
+{{{1,3,386,258,512}, {256,3,3,3,512}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_512x256x128_4x1x1},
+{{{1,3,48,32,1024}, {2048,3,1,1,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x128x128_4x1x1},
+{{{1,3,50,34,1024}, {1024,3,3,3,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_128x256x128_2x1x1},
+{{{1,3,50,34,48}, {1024,3,3,3,48}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_4x1x1},
+{{{1,3,50,34,640}, {640,3,3,3,640}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x128x128_4x1x1},
+{{{1,3,50,34,640}, {96,3,3,3,640}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_4x2x1},
+{{{1,3,98,66,1024}, {1024,3,3,3,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_4x1x1},
+{{{1,3,98,66,1024}, {1024,3,3,3,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_4x1x1},
+{{{1,3,98,66,320}, {640,3,3,3,320}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_2x1x1},
+{{{1,3,98,66,640}, {640,3,3,3,640}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_128x256x128_2x1x1},
+{{{1,4,192,128,1024}, {512,1,1,1,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_128x256x128_2x1x1},
+{{{1,4,384,256,512}, {256,1,1,1,512}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_512x256x128_4x1x1},
+{{{1,4,96,64,1024}, {2048,3,1,1,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_512x256x128_4x1x1},
+{{{1,4,98,66,1024}, {1024,3,3,3,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_512x256x128_4x1x1},
+{{{1,6,194,130,1024}, {512,3,3,3,1024}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_2x1x1},
+{{{1,6,194,130,512}, {512,3,3,3,512}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_2x1x1},
+{{{1,6,386,258,256}, {256,3,3,3,256}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_2x1x1},
+{{{1,6,386,258,512}, {256,3,3,3,512}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}}, f8f8bf16_conv_256x256x128_2x1x1},
+};
+// clang-format on
+
+Kernel_f8f8bf16_conv get_kernel_via_heuristic(
+    std::vector<int64_t> activation_shape,
+    std::vector<int64_t> filter_shape,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation) {
+  ProblemSize ps = {activation_shape, filter_shape, padding, stride, dilation};
+  auto it = kernel_map.find(ps);
+  if (it != kernel_map.end()) {
+    return it->second;
+  }
+  // Fallback kernel
+  return f8f8bf16_conv_256x256x128_2x1x1;
+}
+
+at::Tensor f8f8bf16_conv(
+    at::Tensor activation, // FP8 - 5D
+    at::Tensor filter, // FP8 - 5D
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+  // Process input shapes, this function supports both NDHWC and NCDHW layouts
+  // but for channels first, we need to make sure underlying memory is channels
+  // last.
+  TORCH_CHECK(activation.dim() == 5, "Activation must be 5D tensor.");
+  TORCH_CHECK(filter.dim() == 5, "Filter must be 5D tensor.");
+  // Check the layouts of inputs and extract shapes.
+  bool channels_last_act = activation.strides()[4] == 1;
+  bool channels_last_filt = filter.strides()[4] == 1;
+  int64_t n, d, h, w, c;
+  int64_t k, t, r, s, fc;
+  auto act_sizes = activation.sizes();
+  auto filt_sizes = filter.sizes();
+  if (channels_last_act) {
+    n = act_sizes[0];
+    d = act_sizes[1];
+    h = act_sizes[2];
+    w = act_sizes[3];
+    c = act_sizes[4];
+  } else {
+    // When input is NCDHW, we expect the underlying memory to be channels last.
+    // Make sure thats true.
+    TORCH_CHECK(
+        activation.is_contiguous(c10::MemoryFormat::ChannelsLast3d),
+        "NCDHW inputs must have channels last underlying memory.");
+    n = act_sizes[0];
+    c = act_sizes[1];
+    d = act_sizes[2];
+    h = act_sizes[3];
+    w = act_sizes[4];
+  }
+  if (channels_last_filt) {
+    k = filt_sizes[0];
+    t = filt_sizes[1];
+    r = filt_sizes[2];
+    s = filt_sizes[3];
+    fc = filt_sizes[4];
+  } else {
+    // When filter is KCTRS, we expect the underlying memory to be channels
+    // last. Make sure thats true.
+    TORCH_CHECK(
+        filter.is_contiguous(c10::MemoryFormat::ChannelsLast3d),
+        "KCTRS filters must have channels last underlying memory.");
+    k = filt_sizes[0];
+    fc = filt_sizes[1];
+    t = filt_sizes[2];
+    r = filt_sizes[3];
+    s = filt_sizes[4];
+  }
+
+  TORCH_CHECK(c == fc, "Activation and filter channels must match");
+
+  // Select kernel to run via heuristics or tuning.
+  // Lookup is based on channels last layout regardless of true shape.
+  auto kernel = [&]() {
+    return get_kernel_via_heuristic(
+        {n, d, h, w, c}, {k, t, r, s, fc}, padding, stride, dilation);
+  }();
+
+  return kernel(activation, filter, scale, padding, stride, dilation);
+}
+
+#else
+
+at::Tensor f8f8bf16_conv(
+    at::Tensor activation,
+    at::Tensor filter,
+    at::Tensor scale,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation) {
+  throw std::runtime_error(
+      "SM100 (Blackwell) architecture not supported. Requires CUTLASS 3.x with SM100 support.");
+}
+
+#endif
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_128x128x128_1x1x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_128x128x128_1x1x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_128x128x128_1x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      128,
+      128,
+      128,
+      1,
+      1,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized1SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_128x256x128_1x2x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_128x256x128_1x2x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_128x256x128_1x2x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      128,
+      128,
+      128,
+      1,
+      2,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized1SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_128x256x128_2x1x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_128x256x128_2x1x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_128x256x128_2x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      128,
+      256,
+      128,
+      2,
+      1,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized2SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_128x256x128_2x2x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_128x256x128_2x2x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_128x256x128_2x2x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      128,
+      128,
+      128,
+      2,
+      2,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized2SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x128x128_4x1x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x128x128_4x1x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_256x128x128_4x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      128,
+      128,
+      128,
+      4,
+      1,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized2SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x256x128_2x1x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x256x128_2x1x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_256x256x128_2x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      256,
+      256,
+      128,
+      2,
+      1,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized2SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x256x128_4x1x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x256x128_4x1x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_256x256x128_4x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      128,
+      256,
+      128,
+      4,
+      1,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized2SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x256x128_4x2x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x256x128_4x2x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_256x256x128_4x2x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      128,
+      128,
+      128,
+      4,
+      2,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized2SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x512x128_2x2x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_256x512x128_2x2x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_256x512x128_2x2x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      256,
+      256,
+      128,
+      2,
+      2,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized2SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_512x256x128_4x1x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_512x256x128_4x1x1.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_512x256x128_4x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<
+      256,
+      256,
+      128,
+      4,
+      1,
+      1,
+      cutlass::conv::KernelImplicitTmaWarpSpecialized2SmSm100>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_64x64x64_1x1x1.cu
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_64x64x64_1x1x1.cu
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_conv_common.cuh"
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_64x64x64_1x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+
+  return f8f8bf16_conv_impl<64, 64, 64, 1, 1, 1>(
+      activation, filter, scale, padding, stride, dilation);
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_common.cuh
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_common.cuh
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cutlass/util/host_tensor.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/cutlass.h>
+#include <cutlass/conv/collective/collective_builder.hpp>
+#include <cutlass/conv/convnd_problem_shape.hpp>
+#include <cutlass/conv/convolution.h>
+#include <cutlass/conv/device/conv_universal_adapter.hpp>
+#include <cutlass/conv/dispatch_policy.hpp>
+#include <cutlass/conv/kernel/conv_universal.hpp>
+#include <cutlass/epilogue/collective/collective_builder.hpp>
+// clang-format on
+
+namespace mslk::conv {
+
+// Cutlass FP8 convolution kernel for SM100 (Blackwell architecture)
+template <
+    int TB_M,
+    int TB_N,
+    int TB_K,
+    int TBS_M,
+    int TBS_N,
+    int TBS_K,
+    class KernelScheduleType = cutlass::conv::collective::KernelScheduleAuto>
+at::Tensor f8f8bf16_conv_impl(
+    at::Tensor
+        activation, // FP8 - NDHWC layout or NCDHW with channels last memory.
+    at::Tensor filter, // FP8 - KTRSC layout or KCTRS with channels last memory.
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation) { // [dilation_d, dilation_h, dilation_w]
+  c10::cuda::CUDAGuard deviceGuard(activation.device());
+
+  // Extract dimensions from activation.
+  TORCH_CHECK(activation.dim() == 5, "Activation must be 5D tensor.");
+  TORCH_CHECK(filter.dim() == 5, "Filter must be 5D tensor.");
+
+  // Check if inputs are channels last or channels first. If channels first,
+  // we need to do some extra checks to make sure underlying memory is channels
+  // last.
+  bool channels_last_act = activation.strides()[4] == 1;
+  bool channels_last_filt = filter.strides()[4] == 1;
+  int n, d, h, w, c;
+  int k, t, r, s, fc;
+  auto act_sizes = activation.sizes();
+  auto filt_sizes = filter.sizes();
+  if (channels_last_act) {
+    n = act_sizes[0];
+    d = act_sizes[1];
+    h = act_sizes[2];
+    w = act_sizes[3];
+    c = act_sizes[4];
+  } else {
+    // When input is NCDHW, we expect the underlying memory to be channels last.
+    // Make sure thats true.
+    TORCH_CHECK(
+        activation.is_contiguous(c10::MemoryFormat::ChannelsLast3d),
+        "NCDHW inputs must have channels last underlying memory.");
+    n = act_sizes[0];
+    c = act_sizes[1];
+    d = act_sizes[2];
+    h = act_sizes[3];
+    w = act_sizes[4];
+  }
+  if (channels_last_filt) {
+    k = filt_sizes[0];
+    t = filt_sizes[1];
+    r = filt_sizes[2];
+    s = filt_sizes[3];
+    fc = filt_sizes[4];
+  } else {
+    // When filter is KCTRS, we expect the underlying memory to be channels
+    // last. Make sure thats true.
+    TORCH_CHECK(
+        filter.is_contiguous(c10::MemoryFormat::ChannelsLast3d),
+        "KCTRS filters must have channels last underlying memory.");
+    k = filt_sizes[0];
+    fc = filt_sizes[1];
+    t = filt_sizes[2];
+    r = filt_sizes[3];
+    s = filt_sizes[4];
+  }
+
+  TORCH_CHECK(c == fc, "Activation and filter channels must match");
+
+  // Extract padding, stride, dilation
+  TORCH_CHECK(padding.size() == 3, "Padding must have 3 elements");
+  TORCH_CHECK(stride.size() == 3, "Stride must have 3 elements");
+  TORCH_CHECK(dilation.size() == 3, "Dilation must have 3 elements");
+
+  int pad_d = padding[0];
+  int pad_h = padding[1];
+  int pad_w = padding[2];
+
+  int stride_d = stride[0];
+  int stride_h = stride[1];
+  int stride_w = stride[2];
+
+  int dilation_d = dilation[0];
+  int dilation_h = dilation[1];
+  int dilation_w = dilation[2];
+
+  // Calculate output dimensions
+  int z = 1 + (d + 2 * pad_d - ((t - 1) * dilation_d + 1)) / stride_d;
+  int p = 1 + (h + 2 * pad_h - ((r - 1) * dilation_h + 1)) / stride_h;
+  int q = 1 + (w + 2 * pad_w - ((s - 1) * dilation_w + 1)) / stride_w;
+
+  TORCH_CHECK(activation.is_cuda());
+  TORCH_CHECK(filter.is_cuda());
+
+  at::Tensor output;
+
+  if (channels_last_act) {
+    output =
+        at::empty({n, z, p, q, k}, activation.options().dtype(at::kBFloat16));
+  } else {
+    output = at::empty(
+        {n, k, z, p, q},
+        activation.options()
+            .dtype(at::kBFloat16)
+            .memory_format(c10::MemoryFormat::ChannelsLast3d));
+  }
+
+  using ElementAct = cutlass::float_e4m3_t;
+  using LayoutA = cutlass::layout::TensorNDHWC;
+  constexpr int AlignmentAct = 128 / cutlass::sizeof_bits<ElementAct>::value;
+
+  using ElementFlt = cutlass::float_e4m3_t;
+  using LayoutB = cutlass::layout::TensorNDHWC;
+  constexpr int AlignmentFlt = 128 / cutlass::sizeof_bits<ElementFlt>::value;
+
+  using ElementOutput = cutlass::bfloat16_t;
+  using LayoutC = cutlass::layout::TensorNDHWC;
+  constexpr int AlignmentOutput =
+      128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+  using ElementAccumulator = float;
+  using ElementCompute = float;
+  using ArchTag = cutlass::arch::Sm100;
+  using OperatorClass = cutlass::arch::OpClassTensorOp;
+  constexpr cutlass::conv::Operator ConvOp = cutlass::conv::Operator::kFprop;
+
+  using TileShape = cute::
+      Shape<cute::Int<TB_M>, cute::Int<TB_N>, cute::Shape<cute::Int<TB_K>>>;
+  using ClusterShape =
+      cute::Shape<cute::Int<TBS_M>, cute::Int<TBS_N>, cute::Int<TBS_K>>;
+
+  // Define Scale EVT.
+  using Scale_ =
+      cutlass::epilogue::fusion::Sm90ScalarBroadcast<ElementAccumulator>;
+
+  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+  using EpilogueCompute = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementOutput,
+      ElementAccumulator,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EpilogueEVT =
+      cutlass::epilogue::fusion::Sm90EVT<EpilogueCompute, Scale_, Accum>;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          TileShape,
+          ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementCompute,
+          ElementOutput,
+          LayoutC,
+          AlignmentOutput,
+          ElementOutput,
+          LayoutC,
+          AlignmentOutput,
+          cutlass::epilogue::collective::EpilogueScheduleAuto,
+          EpilogueEVT>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::conv::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          ConvOp,
+          ElementAct,
+          LayoutA,
+          AlignmentAct,
+          ElementFlt,
+          LayoutB,
+          AlignmentFlt,
+          ElementAccumulator,
+          TileShape,
+          ClusterShape,
+          cutlass::conv::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          KernelScheduleType>::CollectiveOp;
+
+  using ProblemShape = cutlass::conv::ConvProblemShape<
+      ConvOp,
+      CollectiveMainloop::DispatchPolicy::NumSpatialDimensions>;
+  using ConvKernel = cutlass::conv::kernel::
+      ConvUniversal<ProblemShape, CollectiveMainloop, CollectiveEpilogue>;
+
+  using Conv = cutlass::conv::device::ConvUniversalAdapter<ConvKernel>;
+
+  using StrideC = typename Conv::ConvKernel::StrideC;
+  using StrideD = typename Conv::ConvKernel::StrideD;
+
+  ProblemShape problem_shape(
+      cutlass::conv::Mode::kCrossCorrelation,
+      {n, d, h, w, c},
+      {k, t, r, s, c},
+      {pad_d, pad_h, pad_w},
+      {pad_d, pad_h, pad_w},
+      {stride_d, stride_h, stride_w},
+      {dilation_d, dilation_h, dilation_w},
+      1 // group
+  );
+
+  StrideC stride_C;
+  StrideD stride_D;
+
+  cute::for_each(cute::make_seq<cute::rank<0>(StrideC{})>{}, [&](auto i) {
+    cute::get<0, i>(stride_C) =
+        problem_shape.stride_C[ProblemShape::RankT - 2 - i];
+  });
+  cute::for_each(cute::make_seq<cute::rank<0>(StrideD{})>{}, [&](auto i) {
+    cute::get<0, i>(stride_D) =
+        problem_shape.stride_C[ProblemShape::RankT - 2 - i];
+  });
+
+  typename Conv::Arguments arguments{
+      problem_shape,
+      {reinterpret_cast<ElementAct*>(activation.data_ptr()),
+       reinterpret_cast<ElementFlt*>(filter.data_ptr())},
+      {{},
+       reinterpret_cast<ElementOutput*>(output.data_ptr<at::BFloat16>()),
+       stride_C,
+       reinterpret_cast<ElementOutput*>(output.data_ptr<at::BFloat16>()),
+       stride_D}};
+
+  arguments.epilogue.thread = {
+      {{}, {reinterpret_cast<ElementAccumulator*>(scale.data_ptr())}},
+      {}, // Accumulator
+      {}, // Multiplies
+  };
+
+  Conv conv;
+
+  size_t workspace_size = Conv::get_workspace_size(arguments);
+  at::Tensor workspace =
+      at::empty(workspace_size, activation.options().dtype(at::kByte));
+
+  cutlass::Status status = conv.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement convolution");
+  }
+
+  status = conv.initialize(arguments, workspace.data_ptr());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize convolution");
+  }
+
+  status = conv(at::cuda::getCurrentCUDAStream());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot run convolution: ") +
+        cutlass::cutlassGetStatusString(status));
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return output;
+}
+
+} // namespace mslk::conv

--- a/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_manifest.cuh
+++ b/csrc/conv/cutlass/f8f8bf16_conv/f8f8bf16_conv_manifest.cuh
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv_64x64x64_1x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_128x128x128_1x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_128x256x128_1x2x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_256x128x128_4x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_128x256x128_2x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_128x256x128_2x2x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_256x256x128_2x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_256x256x128_4x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_256x256x128_4x2x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_256x512x128_2x2x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+at::Tensor f8f8bf16_conv_512x256x128_4x1x1(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation);
+
+using Kernel_f8f8bf16_conv = at::Tensor (*)(
+    at::Tensor activation, // FP8 - NDHWC layout
+    at::Tensor filter, // FP8 - KTRSC layout
+    at::Tensor scale,
+    std::vector<int64_t> padding, // [pad_d, pad_h, pad_w]
+    std::vector<int64_t> stride, // [stride_d, stride_h, stride_w]
+    std::vector<int64_t> dilation); // [dilation_d, dilation_h, dilation_w]
+
+} // namespace mslk::conv

--- a/include/mslk/conv/conv.h
+++ b/include/mslk/conv/conv.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <vector>
+
+#pragma once
+
+namespace mslk::conv {
+
+at::Tensor f8f8bf16_conv(
+    at::Tensor activation,
+    at::Tensor filter,
+    at::Tensor scale,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation);
+
+} // namespace mslk::conv

--- a/mslk/conv/__init__.py
+++ b/mslk/conv/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from mslk.utils.torch.library import load_library_buck
+
+load_library_buck("//mslk/csrc/conv:conv_ops")

--- a/test/conv/conv_test.py
+++ b/test/conv/conv_test.py
@@ -1,0 +1,262 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+# pyre-ignore-all-errors[56]
+
+import unittest
+
+import mslk.conv  # noqa: F401
+import torch
+from mslk.quantize.triton.fp8_quantize import quantize_fp8_tensor
+
+
+def evaluate_cuda_compute_capability(
+    major_min: int, major_max: int | None = None
+) -> bool:
+    major, _ = torch.cuda.get_device_capability()
+    return major >= major_min and (major_max is None or major <= major_max)
+
+
+def supports_f8f8bf16_conv() -> bool:
+    """Check if f8f8bf16_conv is supported on this device."""
+    if torch.cuda.is_available():
+        # Currently only supported on CUDA (not HIP) and requires SM100+
+        if torch.version.cuda:
+            return evaluate_cuda_compute_capability(10)
+    return False
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available(),
+    "Operators are only available on CUDA enabled machines",
+)
+@unittest.skipIf(
+    not supports_f8f8bf16_conv(),
+    "f8f8bf16_conv is not supported on this device.",
+)
+class F8F8BF16ConvTest(unittest.TestCase):
+    """Test f8f8bf16_conv operator for correctness, compile, and export."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.device = torch.accelerator.current_accelerator()
+
+    def _prepare_inputs(
+        self,
+        n: int,
+        c: int,
+        d: int,
+        h: int,
+        w: int,
+        k: int,
+        t: int,
+        r: int,
+        s: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Prepare FP8 quantized inputs for conv operation.
+
+        Args:
+            n: batch size
+            c: input channels
+            d, h, w: input spatial dimensions (depth, height, width)
+            k: output channels (filters)
+            t, r, s: kernel spatial dimensions
+
+        Returns:
+            activation_q: quantized activation tensor (FP8)
+            filter_q: quantized filter tensor (FP8)
+            scale: combined scale tensor
+            activation_bf16: original activation for reference
+            filter_bf16: original filter for reference
+        """
+        # Create input tensors in NCDHW format
+        activation = torch.randn(
+            n, c, d, h, w, device=self.device, dtype=torch.bfloat16
+        )
+        # Create filter tensors in KCTRS format
+        filter_tensor = torch.randn(
+            k, c, t, r, s, device=self.device, dtype=torch.bfloat16
+        )
+
+        # Convert to channels_last_3d memory format (required by CUTLASS kernels)
+        activation = activation.to(memory_format=torch.channels_last_3d)
+        filter_tensor = filter_tensor.to(memory_format=torch.channels_last_3d)
+
+        # Quantize to FP8 with rowwise scaling
+        activation_q, activation_scale = quantize_fp8_tensor(activation)
+        filter_q, filter_scale = quantize_fp8_tensor(filter_tensor)
+
+        # Compute combined scale for output
+        scale = torch.tensor(
+            [activation_scale * filter_scale],
+            device=self.device,
+            dtype=torch.float32,
+        )
+
+        return activation_q, filter_q, scale, activation, filter_tensor
+
+    def test_f8f8bf16_conv_correctness(self) -> None:
+        """Test that f8f8bf16_conv produces outputs close to reference."""
+        # Use a simple shape for correctness testing
+        n, c, d, h, w = 1, 64, 8, 8, 8
+        k, t, r, s = 64, 3, 3, 3
+        padding = [1, 1, 1]
+        stride = [1, 1, 1]
+        dilation = [1, 1, 1]
+
+        activation_q, filter_q, scale, _, _ = self._prepare_inputs(
+            n, c, d, h, w, k, t, r, s
+        )
+
+        # Compute reference output using PyTorch conv3d
+        out_ref = (
+            torch.nn.functional.conv3d(
+                activation_q.to(torch.bfloat16),
+                filter_q.to(torch.bfloat16),
+                bias=None,
+                stride=stride,
+                padding=padding,
+                dilation=dilation,
+            )
+            * scale
+        )
+
+        # Compute FP8 conv output
+        output = torch.ops.mslk.f8f8bf16_conv(
+            activation_q,
+            filter_q,
+            scale,
+            padding,
+            stride,
+            dilation,
+        )
+
+        # Check output shape matches reference
+        self.assertEqual(output.shape, out_ref.shape)
+
+        # Check output dtype
+        self.assertEqual(output.dtype, torch.bfloat16)
+
+        # Check outputs are reasonably close (FP8 has limited precision)
+        # Using mean squared error as a sanity check
+        torch.testing.assert_close(output, out_ref.to(torch.bfloat16))
+
+    def test_f8f8bf16_conv_various_shapes(self) -> None:
+        """Test f8f8bf16_conv with various input shapes."""
+        test_shapes = [
+            # (N, C, D, H, W, K, T, R, S, pad, stride, dilation)
+            (1, 64, 8, 8, 8, 64, 3, 3, 3, 1, 1, 1),
+            (4, 64, 8, 8, 8, 128, 3, 3, 3, 1, 1, 1),
+            (1, 128, 16, 16, 16, 128, 3, 3, 3, 1, 1, 1),
+            # 1x1x1 convolution
+            (1, 64, 16, 16, 16, 128, 1, 1, 1, 0, 1, 1),
+        ]
+
+        for n, c, d, h, w, k, t, r, s, pad, stride_val, dilation_val in test_shapes:
+            with self.subTest(N=n, C=c, D=d, H=h, W=w, K=k, T=t, R=r, S=s):
+                padding = [pad, pad, pad]
+                stride = [stride_val, stride_val, stride_val]
+                dilation = [dilation_val, dilation_val, dilation_val]
+
+                activation_q, filter_q, scale, _, _ = self._prepare_inputs(
+                    n, c, d, h, w, k, t, r, s
+                )
+
+                # Compute reference using dequantized inputs.
+
+                out_ref = (
+                    torch.nn.functional.conv3d(
+                        activation_q.to(torch.bfloat16),
+                        filter_q.to(torch.bfloat16),
+                        bias=None,
+                        stride=stride,
+                        padding=padding,
+                        dilation=dilation,
+                    )
+                    * scale
+                )
+
+                # Compute FP8 output
+                output = torch.ops.mslk.f8f8bf16_conv(
+                    activation_q,
+                    filter_q,
+                    scale,
+                    padding,
+                    stride,
+                    dilation,
+                )
+
+                self.assertEqual(output.shape, out_ref.shape)
+                torch.testing.assert_close(output, out_ref.to(torch.bfloat16))
+
+    def test_compile_f8f8bf16_conv(self) -> None:
+        """Test that f8f8bf16_conv can be compiled with torch.compile."""
+        n, c, d, h, w = 1, 64, 8, 8, 8
+        k, t, r, s = 64, 3, 3, 3
+        padding = [1, 1, 1]
+        stride = [1, 1, 1]
+        dilation = [1, 1, 1]
+
+        activation_q, filter_q, scale, _, _ = self._prepare_inputs(
+            n, c, d, h, w, k, t, r, s
+        )
+
+        # Test that the operator can be compiled
+        compiled_fn = torch.compile(torch.ops.mslk.f8f8bf16_conv)
+        output = compiled_fn(
+            activation_q,
+            filter_q,
+            scale,
+            padding,
+            stride,
+            dilation,
+        )
+
+        # Verify output is valid
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertFalse(output.isnan().any(), "Output contains NaN values")
+
+    def test_export_f8f8bf16_conv(self) -> None:
+        """Test that f8f8bf16_conv can be exported with torch.export."""
+
+        class TestModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(
+                self,
+                activation_q: torch.Tensor,
+                filter_q: torch.Tensor,
+                scale: torch.Tensor,
+            ) -> torch.Tensor:
+                padding = [1, 1, 1]
+                stride = [1, 1, 1]
+                dilation = [1, 1, 1]
+                return torch.ops.mslk.f8f8bf16_conv(
+                    activation_q,
+                    filter_q,
+                    scale,
+                    padding,
+                    stride,
+                    dilation,
+                )
+
+        n, c, d, h, w = 1, 64, 8, 8, 8
+        k, t, r, s = 64, 3, 3, 3
+
+        activation_q, filter_q, scale, _, _ = self._prepare_inputs(
+            n, c, d, h, w, k, t, r, s
+        )
+
+        model = TestModule().cuda()
+
+        # Test that the model can be exported
+        _ = torch.export.export(model, (activation_q, filter_q, scale), strict=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: This diff adds a full suite of support for convolution in MSLK including the underlying kernels (just fp8 for now), a benchmarking and op script, and testing.

Differential Revision: D88166093
