### PR TITLE
Add triton per tensor quantize (#42)

### DIFF
--- a/test/quantize/fp8_quantize_correctness_test.py
+++ b/test/quantize/fp8_quantize_correctness_test.py
@@ -13,7 +13,11 @@ from typing import Any, Callable, List
 import mslk.quantize  # noqa: F401
 import torch
 from hypothesis import given, settings, strategies as st
-from mslk.quantize.triton.fp8_quantize import quantize_fp8_block, quantize_fp8_row
+from mslk.quantize.triton.fp8_quantize import (
+    quantize_fp8_block,
+    quantize_fp8_row,
+    quantize_fp8_tensor,
+)
 
 
 def undo_tensorwise_quant(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
@@ -64,6 +68,7 @@ class FP8CorrectnessTest(unittest.TestCase):
             [
                 [quantize_fp8_row, undo_rowwise_quant],
                 [quantize_fp8_block, undo_blockwise_quant],
+                [quantize_fp8_tensor, undo_tensorwise_quant],
                 [torch.ops.mslk.quantize_fp8_per_row, undo_rowwise_quant],
                 [torch.ops.mslk.quantize_fp8_per_col, undo_colwise_quant],
                 [torch.ops.mslk.quantize_fp8_per_tensor, undo_tensorwise_quant],

--- a/test/quantize/fp8_quantize_export_test.py
+++ b/test/quantize/fp8_quantize_export_test.py
@@ -13,7 +13,11 @@ from typing import Any, Callable, List
 import mslk.quantize  # noqa: F401
 import torch
 from hypothesis import given, settings, strategies as st
-from mslk.quantize.triton.fp8_quantize import quantize_fp8_block, quantize_fp8_row
+from mslk.quantize.triton.fp8_quantize import (
+    quantize_fp8_block,
+    quantize_fp8_row,
+    quantize_fp8_tensor,
+)
 
 
 @unittest.skipIf(
@@ -50,6 +54,7 @@ class Fp8QuantizeExportTest(unittest.TestCase):
             [
                 quantize_fp8_row,
                 quantize_fp8_block,
+                quantize_fp8_tensor,
                 torch.ops.mslk.quantize_fp8_per_row,
                 torch.ops.mslk.quantize_fp8_per_col,
                 torch.ops.mslk.quantize_fp8_per_tensor,


### PR DESCRIPTION
Summary:

Adds an optimized triton per-tensor quantization function to mslk. This approach uses a fused scale-quant kernel with atomics and consistently outperforms the cuda equivalent (torch.ops.mslk.quantize_per_tensor).

Reviewed By: cthi

Differential Revision: D88897548


