### PR TITLE
Copy fmha from xformers to mslk

### DIFF
--- a/mslk/attention/fmha/__init__.py
+++ b/mslk/attention/fmha/__init__.py
@@ -1,0 +1,967 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+from typing import Any, cast, List, Optional, Sequence, Tuple, Type, Union
+
+import torch
+
+from . import (
+    attn_bias,
+    ck,
+    ck_decoder,
+    ck_splitk,
+    cutlass,
+    cutlass_blackwell,
+    flash,
+    flash3,
+    flash_mtia,
+    triton_splitk,
+)
+
+from .attn_bias import (
+    AttentionBias,
+    BlockDiagonalMask,
+    LowerTriangularMask,
+    VARLEN_BIASES,
+)
+from .common import (
+    AttentionBwOpBase,
+    AttentionFwOpBase,
+    AttentionOp,
+    AttentionOpBase,
+    bmk2bmhk,
+    Context,
+    Gradients,
+    Inputs,
+)
+from .dispatch import (
+    _dispatch_bw,
+    _dispatch_fw,
+    _ensure_op_supports_or_raise,
+    _get_use_fa3,
+    _set_use_fa3,
+)
+
+MemoryEfficientAttentionCutlassOp = (cutlass.FwOp, cutlass.BwOp)
+MemoryEfficientAttentionCutlassBlackwellOp = (
+    cutlass_blackwell.FwOp,
+    cutlass_blackwell.BwOp,
+)
+MemoryEfficientAttentionCutlassFwdFlashBwOp = (cutlass.FwOp, flash.BwOp)
+MemoryEfficientAttentionFlashAttentionOp = (flash.FwOp, flash.BwOp)
+MemoryEfficientAttentionFlashMtiaAttentionOp = (flash_mtia.FwOp, flash_mtia.BwOp)
+MemoryEfficientAttentionCkOp = (ck.FwOp, ck.BwOp)
+MemoryEfficientAttentionCkDecoderOp = (ck_decoder.FwOp, ck.BwOp)
+MemoryEfficientAttentionSplitKCkOp = (ck_splitk.FwOp, ck.BwOp)
+
+
+def _deserialize_bias(attn_bias_ctx, attn_bias_tensor: Optional[torch.Tensor]) -> Any:
+    if attn_bias_tensor is None:
+        return attn_bias_ctx
+    return attn_bias_tensor
+
+
+# Note: `torch.compile` only allows custom autograd functions
+# to accept a subset of types. Therefore we serialize `op` objects
+# to `str` before entering the function, and unserialize them inside.
+# See also: https://github.com/pytorch/pytorch/issues/118395
+_OPS_LOOKUP = {
+    flash.FwOp.NAME: flash.FwOp,
+    flash.BwOp.NAME: flash.BwOp,
+    flash_mtia.FwOp.NAME: flash_mtia.FwOp,
+    flash_mtia.BwOp.NAME: flash_mtia.BwOp,
+}
+
+
+def _serialize_op(op):
+    if op is not None and op.NAME in _OPS_LOOKUP:
+        return op.NAME
+    return op
+
+
+def _unserialize_op(op):
+    if isinstance(op, str):
+        return _OPS_LOOKUP[op]
+    return op
+
+
+class _fMHA(torch.autograd.Function):
+    @staticmethod
+    # type: ignore
+    def forward(ctx, op_fw, op_bw, *args: Any) -> Any:
+        inp = Inputs(*args)
+
+        op_fw = _unserialize_op(op_fw)
+        op_bw = _unserialize_op(op_bw)
+
+        out, op_ctx = _memory_efficient_attention_forward_requires_grad(
+            inp=inp, op=op_fw
+        )
+
+        # Saving attn_bias is a bit complicated, as the
+        # torch part should go in `save_for_backward`
+        if isinstance(inp.attn_bias, torch.Tensor):
+            attn_bias_tensor = inp.attn_bias
+            attn_bias_ctx = None
+        else:
+            attn_bias_tensor = None
+            attn_bias_ctx = inp.attn_bias
+
+        ctx.save_for_backward(
+            inp.query,
+            inp.key,
+            inp.value,
+            op_ctx.out,
+            op_ctx.lse,
+        )
+        ctx.rng_state = op_ctx.rng_state
+        ctx.attn_bias_tensor = attn_bias_tensor
+        if op_ctx.op_bw is not None:
+            if op_bw is not None and op_bw is not op_ctx.op_bw:
+                raise ValueError(
+                    f"Specified op_bw={op_bw.NAME}, but forward op "
+                    f"can only run with op_bw={op_ctx.op_bw.NAME}. Please set op_bw=None."
+                )
+            op_bw = op_ctx.op_bw
+        if (
+            op_fw is not None
+            and op_bw is not None
+            and isinstance(inp.attn_bias, VARLEN_BIASES)
+            and inp.attn_bias.q_seqinfo.seqstart.shape[0] > 2
+            and op_bw.VARLEN_LSE_PACKED != op_fw.VARLEN_LSE_PACKED
+        ):
+            raise ValueError(
+                f"Specified op_bw={op_bw.NAME} is not compatible with the "
+                f"op_fw={op_fw.NAME}, because they use different format of logsumexp. "
+                f"NOTE: This is new with xFormers 0.0.28"
+            )
+        if op_bw is None and (
+            inp.query.requires_grad or inp.key.requires_grad or inp.value.requires_grad
+        ):
+            varlen_lse_packed = _detect_lse_packed_or_raise(op_ctx.lse, inp)
+            if varlen_lse_packed is not None and op_fw is not None:
+                assert (
+                    op_fw.VARLEN_LSE_PACKED == varlen_lse_packed
+                ), f"{op_fw.NAME}: wrong value for `VARLEN_LSE_PACKED` ?"
+            # NOTE: We need to check tensor strides to decide which operator we run in the BW pass.
+            # Unfortunately, PyTorch only allows to call this function during the FW pass, so
+            # we decide the operator to use now.
+            op_bw = _dispatch_bw(inp, varlen_lse_packed=varlen_lse_packed)
+        ctx.op_fw = op_fw
+        ctx.op_bw = op_bw
+        ctx.p = inp.p
+        # This allows to create gradients from a single storage,
+        # to avoid a "cat" in the BW pass.
+        # The heuristic is approximative, but:
+        # (1) It's not a big issue to create a shared storage
+        # (2) The heuristic needs to pass `torch.compile`
+        #  (this is also why we run it in the FW pass, the BW pass is stricter)
+        ctx.qkv_share_storage = (
+            inp.query.shape[0] == inp.key.shape[0]
+            and inp.query.shape[-1] == inp.value.shape[-1]
+            and inp.query.stride(-2)
+            == (inp.key.shape[-1] + inp.query.shape[-1] + inp.value.shape[-1])
+        )
+
+        ctx.scale = inp.scale
+        ctx.attn_bias_ctx = attn_bias_ctx
+        ctx.n_args = len(args)
+        return out, op_ctx.lse
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, grad, grad_lse):
+        # Re-create context
+        query, key, value, out, lse = ctx.saved_tensors
+        attn_bias_tensor = ctx.attn_bias_tensor
+        rng_state = ctx.rng_state
+        inp = Inputs(
+            query=query,
+            key=key,
+            value=value,
+            attn_bias=_deserialize_bias(ctx.attn_bias_ctx, attn_bias_tensor),
+            p=ctx.p,
+            scale=ctx.scale,
+        )
+        op_ctx = Context(
+            lse=lse,
+            out=out,
+            rng_state=rng_state,
+            qkv_share_storage=ctx.qkv_share_storage,
+        )
+        grads = _memory_efficient_attention_backward(
+            ctx=op_ctx,
+            inp=inp,
+            grad=grad,
+            op=ctx.op_bw,
+            _skip_op_checks=True,
+        )
+        return (None, None, grads.dq, grads.dk, grads.dv, grads.db) + (None,) * (
+            ctx.n_args - 2
+        )
+
+
+def memory_efficient_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]] = None,
+    p: float = 0.0,
+    scale: Optional[float] = None,
+    *,
+    op: Optional[AttentionOp] = None,
+    output_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    """Implements the memory-efficient attention mechanism following
+    `"Self-Attention Does Not Need O(n^2) Memory" <http://arxiv.org/abs/2112.05682>`_.
+
+    :Inputs shape:
+
+    - Input tensors must be in format ``[B, M, H, K]``, where B is the batch size, M \
+        the sequence length, H the number of heads, and K the embeding size per head
+
+    - If inputs have dimension 3, it is assumed that the dimensions are ``[B, M, K]`` and ``H=1``
+
+    - Inputs can also be of dimension 5 with GQA - see note below
+
+    - Inputs can be non-contiguous - we only require the last dimension's stride to be 1
+
+
+    :Equivalent pytorch code:
+
+    .. code-block:: python
+
+        scale = 1.0 / query.shape[-1] ** 0.5
+        query = query * scale
+        query = query.transpose(1, 2)
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+        attn = query @ key.transpose(-2, -1)
+        if attn_bias is not None:
+            attn = attn + attn_bias
+        attn = attn.softmax(-1)
+        attn = F.dropout(attn, p)
+        attn = attn @ value
+        return attn.transpose(1, 2).contiguous()
+
+    :Examples:
+
+    .. code-block:: python
+
+        import xformers.ops as xops
+
+        # Compute regular attention
+        y = xops.memory_efficient_attention(q, k, v)
+
+        # With a dropout of 0.2
+        y = xops.memory_efficient_attention(q, k, v, p=0.2)
+
+        # Causal attention
+        y = xops.memory_efficient_attention(
+            q, k, v,
+            attn_bias=xops.LowerTriangularMask()
+        )
+
+    :Supported hardware:
+
+        NVIDIA GPUs with compute capability above 6.0 (P100+), datatype ``f16``, ``bf16`` and ``f32``.
+
+    :EXPERIMENTAL: Using with Multi Query Attention (MQA) and Grouped Query Attention (GQA):
+
+        MQA/GQA is an experimental feature supported only for the forward pass.
+        If you have 16 heads in query, and 2 in key/value, you can provide 5-dim tensors
+        in the ``[B, M, G, H, K]`` format, where ``G`` is the number of head groups (here 2), and
+        ``H`` is the number of heads per group (8 in the example).
+
+        Please note that xFormers will not automatically broadcast the inputs, so you will need
+        to broadcast it manually before calling `memory_efficient_attention`.
+
+    :GQA/MQA example:
+
+    .. code-block:: python
+
+        import torch
+        import xformers.ops as xops
+
+        B, M, K = 3, 32, 128
+        kwargs = dict(device="cuda", dtype=torch.float16)
+        q = torch.randn([B, M, 8, K], **kwargs)
+        k = torch.randn([B, M, 2, K], **kwargs)
+        v = torch.randn([B, M, 2, K], **kwargs)
+        out_gqa = xops.memory_efficient_attention(
+            q.reshape([B, M, 2, 4, K]),
+            k.reshape([B, M, 2, 1, K]).expand([B, M, 2, 4, K]),
+            v.reshape([B, M, 2, 1, K]).expand([B, M, 2, 4, K]),
+        )
+
+    Raises:
+        NotImplementedError: if there is no operator available to compute the MHA
+        ValueError: if inputs are invalid
+
+    :parameter query: Tensor of shape ``[B, Mq, H, K]``
+    :parameter key: Tensor of shape ``[B, Mkv, H, K]``
+    :parameter value: Tensor of shape ``[B, Mkv, H, Kv]``
+    :parameter attn_bias: Bias to apply to the attention matrix - defaults to no masking. \
+        For common biases implemented efficiently in xFormers, see :attr:`xformers.ops.fmha.attn_bias.AttentionBias`. \
+        This can also be a :attr:`torch.Tensor` for an arbitrary mask (slower).
+    :parameter p: Dropout probability. Disabled if set to ``0.0``
+    :parameter scale: Scaling factor for ``Q @ K.transpose()``. If set to ``None``, the default \
+        scale (q.shape[-1]**-0.5) will be used.
+    :parameter op: The operators to use - see :attr:`xformers.ops.AttentionOpBase`. \
+        If set to ``None`` (recommended), xFormers \
+        will dispatch to the best available operator, depending on the inputs \
+        and options.
+    :return: multi-head attention Tensor with shape ``[B, Mq, H, Kv]``
+    """
+    return _memory_efficient_attention(
+        Inputs(
+            query=query,
+            key=key,
+            value=value,
+            p=p,
+            attn_bias=attn_bias,
+            scale=scale,
+            output_dtype=output_dtype,
+        ),
+        op=op,
+    )
+
+
+torch.library.define(
+    "mslk::memory_efficient_attention_forward",
+    "(Tensor q, Tensor k, Tensor v, Tensor? b = None, float? p = 0.0, float? scale = None) -> Tensor",
+)
+
+
+def _memory_efficient_attention_forward_torch_wrapper_meta(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]] = None,
+    p: float = 0.0,
+    scale: Optional[float] = None,
+):
+    return torch.empty_like(query)
+
+
+torch.library.impl(
+    "mslk::memory_efficient_attention_forward",
+    "Meta",
+    _memory_efficient_attention_forward_torch_wrapper_meta,
+)
+
+
+# torch.compile has issue when tracing through op dispatch and ensure_op_support
+# so provide a wrapper to register it as a custom torch library op.
+def _memory_efficient_attention_forward_torch_wrapper(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]] = None,
+    p: float = 0.0,
+    scale: Optional[float] = None,
+) -> torch.Tensor:
+    """
+    This provides a torch-compilable wrapper op to
+    memory_efficient_attention_forward in certain special cases.
+
+    Note that the following are not supported
+        - `op` input (?)
+        - certain attn_bias types (?)
+        - output_dtype
+        - K != Kv
+    """
+    return memory_efficient_attention_forward(
+        query,
+        key,
+        value,
+        attn_bias,
+        p,
+        scale,
+    )
+
+
+torch.library.impl(
+    "mslk::memory_efficient_attention_forward",
+    "CUDA",
+    _memory_efficient_attention_forward_torch_wrapper,
+)
+
+
+torch.library.define(
+    "mslk::memory_efficient_attention_forward_with_bias",
+    "(Tensor q, Tensor k, Tensor v, Tensor b, float? p = 0.0, float? scale = None) -> Tensor",
+)
+
+
+def _memory_efficient_attention_forward_torch_wrapper_with_bias_meta(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Union[torch.Tensor, AttentionBias],
+    p: float = 0.0,
+    scale: Optional[float] = None,
+):
+    return torch.empty_like(query)
+
+
+torch.library.impl(
+    "mslk::memory_efficient_attention_forward_with_bias",
+    "Meta",
+    _memory_efficient_attention_forward_torch_wrapper_with_bias_meta,
+)
+
+
+# torch.compile has issue when tracing through op dispatch and ensure_op_support
+# so provide a wrapper to register it as a custom torch library op.
+
+
+def _memory_efficient_attention_forward_torch_wrapper_with_bias(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Union[torch.Tensor, AttentionBias],
+    p: float = 0.0,
+    scale: Optional[float] = None,
+) -> torch.Tensor:
+    """
+    This provides a torch-compilable wrapper op to
+    memory_efficient_attention_forward in certain special cases.
+
+    Note that the following are not supported
+        - `op` input (?)
+        - certain attn_bias types (?)
+        - output_dtype
+        - K != Kv
+    """
+    return memory_efficient_attention_forward(
+        query,
+        key,
+        value,
+        attn_bias,
+        p,
+        scale,
+    )
+
+
+torch.library.impl(
+    "mslk::memory_efficient_attention_forward_with_bias",
+    "CUDA",
+    _memory_efficient_attention_forward_torch_wrapper_with_bias,
+)
+
+
+def memory_efficient_attention_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]] = None,
+    p: float = 0.0,
+    scale: Optional[float] = None,
+    *,
+    op: Optional[Type[AttentionFwOpBase]] = None,
+    output_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    """
+    Calculates the forward pass of :attr:`xformers.ops.memory_efficient_attention`.
+    """
+    return _memory_efficient_attention_forward(
+        Inputs(
+            query=query,
+            key=key,
+            value=value,
+            p=p,
+            attn_bias=attn_bias,
+            scale=scale,
+            output_dtype=output_dtype,
+        ),
+        op=op,
+    )
+
+
+def memory_efficient_attention_forward_requires_grad(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]] = None,
+    p: float = 0.0,
+    scale: Optional[float] = None,
+    *,
+    op: Optional[Type[AttentionFwOpBase]] = None,
+    output_dtype: Optional[torch.dtype] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Returns a tuple (output, lse), where `lse` can be used to compute the backward pass later.
+    See :attr:`xformers.ops.memory_efficient_attention` for an explanation of the arguments
+    See :attr:`xformers.ops.memory_efficient_attention_backward` for running the backward pass
+    """
+    if p != 0.0:
+        raise NotImplementedError(
+            "dropout is not supported on the non-autograd API."
+            " If you want to use dropout, please call `memory_efficient_attention` directly"
+        )
+    out, ctx = _memory_efficient_attention_forward_requires_grad(
+        Inputs(
+            query=query,
+            key=key,
+            value=value,
+            p=p,
+            attn_bias=attn_bias,
+            scale=scale,
+            output_dtype=output_dtype,
+        ),
+        op=op,
+    )
+    return out, ctx.lse
+
+
+def memory_efficient_attention_backward(
+    grad: torch.Tensor,
+    output: torch.Tensor,
+    lse: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]] = None,
+    p: float = 0.0,
+    scale: Optional[float] = None,
+    *,
+    op: Optional[Type[AttentionBwOpBase]] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Computes the gradient of the attention.
+    Returns a tuple (dq, dk, dv)
+    See :attr:`xformers.ops.memory_efficient_attention` for an explanation of the arguments.
+    `lse` is the tensor returned by
+    :attr:`xformers.ops.memory_efficient_attention_forward_requires_grad`
+    """
+    if p != 0.0:
+        raise NotImplementedError(
+            "dropout is not supported on the non-autograd API."
+            " If you want to use dropout, please call `memory_efficient_attention` directly"
+        )
+    gradients = _memory_efficient_attention_backward(
+        Context(out=output, lse=lse),
+        Inputs(
+            query=query, key=key, value=value, p=p, attn_bias=attn_bias, scale=scale
+        ),
+        grad,
+        op=op,
+    )
+    return (gradients.dq, gradients.dk, gradients.dv)
+
+
+def _memory_efficient_attention(
+    inp: Inputs, op: Optional[AttentionOp] = None
+) -> torch.Tensor:
+    # fast-path that doesn't require computing the logsumexp for backward computation
+    if all(x.requires_grad is False for x in [inp.query, inp.key, inp.value]):
+        return _memory_efficient_attention_forward(
+            inp, op=op[0] if op is not None else None
+        )
+
+    output_shape = inp.normalize_bmhk()
+
+    op_fw = _serialize_op(op[0] if op is not None else None)
+    op_bw = _serialize_op(op[1] if op is not None else None)
+    return _fMHA.apply(
+        op_fw, op_bw, inp.query, inp.key, inp.value, inp.attn_bias, inp.p, inp.scale
+    )[0].reshape(output_shape)
+
+
+def _memory_efficient_attention_forward(
+    inp: Inputs, op: Optional[Type[AttentionFwOpBase]]
+) -> torch.Tensor:
+    inp.validate_inputs()
+    output_shape = inp.normalize_bmhk()
+    if op is None:
+        op = _dispatch_fw(inp, False)
+    else:
+        _ensure_op_supports_or_raise(ValueError, "memory_efficient_attention", op, inp)
+
+    out, *_ = op.apply(inp, needs_gradient=False)
+    return out.reshape(output_shape)
+
+
+def _memory_efficient_attention_forward_requires_grad(
+    inp: Inputs, op: Optional[Type[AttentionFwOpBase]]
+) -> Tuple[torch.Tensor, Context]:
+    inp.validate_inputs()
+    output_shape = inp.normalize_bmhk()
+    if op is None:
+        op = _dispatch_fw(inp, True)
+    else:
+        _ensure_op_supports_or_raise(ValueError, "memory_efficient_attention", op, inp)
+    out, ctx = op.apply(inp, needs_gradient=True)
+    assert ctx is not None
+    return (out.reshape(output_shape), ctx)
+
+
+def _detect_lse_packed_or_raise(lse: torch.Tensor, inp: Inputs) -> Optional[bool]:
+    """
+    Detects the LSE format if we're in a varlen case.
+    Returns `None` if the format is not relevant (eg not varlen)
+    Raises an exception if the `lse` has the wrong shape
+    """
+    shape_mismatch_err = (
+        "Input tensors have incompatible shapes.\n"
+        f"  lse.shape    : {lse.shape}\n"
+        f"  query.shape  : {inp.query.shape}\n"
+        f"  attn_bias    : {type(inp.attn_bias)}"
+    )
+    # 1. Check ndim & head dimensions
+    # In any case, LSE should be [*, *GH]
+    if lse.ndim != (inp.query.ndim - 1) or lse.shape[1:-1] != inp.query.shape[2:-1]:
+        raise ValueError(shape_mismatch_err)
+    lse_bm = [lse.shape[0], lse.shape[-1]]
+    lse_packed_shape = [inp.query.shape[0], inp.query.shape[1]]
+    lse_packed = lse_bm[0] == lse_packed_shape[0] and lse_bm >= lse_packed_shape
+    # 2. Check correctness for varlen biases with query.shape = [1, M, *GH, K]
+    # Either [1, *GH, M] (packed)
+    # Or     [num_seq, *GH, Mq] .. with `Mq >= max_q` (padded)
+    if isinstance(inp.attn_bias, VARLEN_BIASES):
+        si = inp.attn_bias.q_seqinfo
+        lse_padded_shape = [si.seqstart.shape[0] - 1, si.max_seqlen]
+        lse_padded = lse_bm[0] == lse_padded_shape[0] and lse_bm >= lse_padded_shape
+        if lse_packed and lse_padded:
+            return None
+        elif lse_packed:
+            return True
+        elif lse_padded:
+            return False
+        raise ValueError(shape_mismatch_err)
+    # 3. For non-varlen, shape must be [B, *GH] with query.shape=[B, M, *GH, K]
+    if not lse_packed:
+        raise ValueError(shape_mismatch_err)
+    return None
+
+
+def _memory_efficient_attention_backward(
+    ctx: Context,
+    inp: Inputs,
+    grad: torch.Tensor,
+    op: Optional[Type[AttentionBwOpBase]],
+    *,
+    _skip_op_checks: bool = False,
+) -> Gradients:
+    """Warning: grad/ctx.out is potentially in BMK format"""
+    inp.validate_inputs()
+    if grad.ndim != inp.query.ndim or grad.ndim != ctx.out.ndim:
+        raise ValueError(
+            "All tensors should be either in BMK (ndim=3) or BMHK (ndim=4) format. \n"
+            f"grad.shape : {grad.shape} \n"
+            f"out.shape  : {ctx.out.shape} \n"
+            f"query.shape: {inp.query.shape}"
+        )
+    shape_dq, shape_dk, shape_dv = tuple(
+        x.shape for x in (inp.query, inp.key, inp.value)
+    )
+    inp.normalize_bmhk()
+    varlen_lse_packed = _detect_lse_packed_or_raise(ctx.lse, inp)
+    grad = bmk2bmhk(grad, 1)
+    ctx.out = bmk2bmhk(ctx.out, 1)
+
+    if op is None:
+        op = _dispatch_bw(inp, varlen_lse_packed=varlen_lse_packed)
+    elif not _skip_op_checks:
+        _ensure_op_supports_or_raise(
+            ValueError, "memory_efficient_attention_backward", op, inp
+        )
+        if varlen_lse_packed is not None and varlen_lse_packed != op.VARLEN_LSE_PACKED:
+            raise ValueError(
+                f"Wrong LSE format for {op.NAME} in variable seqlen case. "
+                f"Double-check that the BW operator {op.NAME} is compatible "
+                f"with the operator used in the FW pass."
+            )
+
+    grads = op.apply(ctx, inp, grad)
+    grads.dq = grads.dq.reshape(shape_dq)
+    grads.dk = grads.dk.reshape(shape_dk)
+    grads.dv = grads.dv.reshape(shape_dv)
+    return grads
+
+
+def memory_efficient_attention_partial(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]] = None,
+    p: float = 0.0,
+    scale: Optional[float] = None,
+    *,
+    op: Optional[Union[AttentionOp, Type[AttentionFwOpBase]]] = None,
+    output_dtype: Optional[torch.dtype] = None,
+    _allow_backward: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Returns a tuple (output, lse), where `output` is the attention in the style of
+    memory_efficient_attention, and  `lse` is extra data, a log-sum-exp.
+    The outputs of calls to this with the same query and separate keys and values
+    can be merged with merge_attentions to obtain the attention of the queries
+    against the disjoint union of the keys and values.
+
+    This function doesn't have a backward pass.
+
+    If _allow_backward is set to True, then a backward pass is allowed,
+    but it is restricted: only the gradient of the output, not the gradient of
+    the LSE, is used.
+    Note that this makes it very easy to accidentally get wrong gradients.
+    """
+    if p != 0.0:
+        raise NotImplementedError("dropout is not supported.")
+    fwop: Optional[Type[AttentionFwOpBase]] = op[0] if isinstance(op, tuple) else op
+    inp = Inputs(
+        query=query,
+        key=key,
+        value=value,
+        p=p,
+        attn_bias=attn_bias,
+        scale=scale,
+        output_dtype=output_dtype,
+        is_partial=True,
+    )
+    is_grad = (
+        _allow_backward
+        and torch.is_grad_enabled()
+        and any(x.requires_grad for x in [query, key, value])
+    )
+
+    if not is_grad:
+        out, ctx = _memory_efficient_attention_forward_requires_grad(
+            inp,
+            op=fwop,
+        )
+        return out, ctx.lse
+
+    if query.ndim == 5:
+        raise ValueError("gradients not supported for 5D tensors")
+    if isinstance(op, tuple):
+        op_fw = _serialize_op(op[0])
+        op_bw = _serialize_op(op[1])
+    elif op is None:
+        op_fw = op_bw = None
+    else:
+        op_fw = _serialize_op(op)
+        op_bw = None
+    return _fMHA.apply(
+        op_fw,
+        op_bw,
+        inp.query,
+        inp.key,
+        inp.value,
+        inp.attn_bias,
+        inp.p,
+        inp.scale,
+        inp.output_dtype,
+        inp.is_partial,
+    )
+
+
+def merge_attentions(  # noqa: C901
+    attn_split: Union[torch.Tensor, Sequence[torch.Tensor]],
+    lse_split: Union[torch.Tensor, Sequence[torch.Tensor]],
+    write_lse: bool = True,
+    output_dtype: Optional[torch.dtype] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """
+    Combine attention output computed on different parts of K/V for the same
+    query to get attention on the whole K/V. See https://arxiv.org/abs/2402.05099
+    The result is equal to
+        Out_full = (Out1 * exp(LSE1) + Out2 * exp(LSE2) + ...) / (exp(LSE1) + exp(LSE2) + ...)
+        LSE_full = log(exp(LSE1) + exp(LSE2) + ...)
+
+    Args:
+        attn_split: attention outputs for chunks,
+            either as a list of tensors of shapes [B, M, G, H, Kq] or [B, M, H, Kq]
+            or as a single tensor of shape [num_chunks, B, M, G, H, Kq]
+            or [num_chunks, B, M, H, Kq]
+        lse_split: LSE for chunks,
+            either as a list of tensors of shapes [B, G, H, M] or [B, H, M]
+            or as a single tensor of shape [num_chunks, B, G, H, M] or [num_chunks, B, H, M]
+        write_lse: whether to output LSE
+        output_dtype: dtype of attn_out
+
+    Returns:
+        attn_out: [B, M, G, H, Kq] or [B, M, H, Kq]
+        lse_out: [B, G, H, M] or [B, H, M] if write_lse
+                 or None otherwise
+    """
+
+    attn_is_concat = isinstance(attn_split, torch.Tensor)
+    lse_is_concat = isinstance(lse_split, torch.Tensor)
+
+    attn_requires_grad = (
+        attn_split.requires_grad  # type: ignore
+        if attn_is_concat
+        else any(x.requires_grad for x in attn_split)
+    )
+    lse_requires_grad = (
+        lse_split.requires_grad  # type: ignore
+        if lse_is_concat
+        else any(x.requires_grad for x in lse_split)
+    )
+    requires_grad = torch.is_grad_enabled() and (
+        attn_requires_grad or lse_requires_grad
+    )
+    if requires_grad and not write_lse:
+        raise ValueError("write_lse should be true if inputs require gradients.")
+
+    concat_path = attn_is_concat and lse_is_concat and not requires_grad
+    if concat_path:
+        attn_split = cast(torch.Tensor, attn_split)
+        lse_split = cast(torch.Tensor, lse_split)
+        if attn_split.ndim != lse_split.ndim + 1:
+            raise ValueError(
+                f"Incompatible input shapes: {attn_split.shape=}, {lse_split.shape=}"
+            )
+
+        is_bmhk = attn_split.ndim == 5
+        if is_bmhk:
+            attn_split = attn_split.unsqueeze(3)
+            lse_split = lse_split.unsqueeze(2)
+
+        num_chunks, B, M, G, H, Kq = attn_split.shape
+        num_chunks1, B1, G1, H1, M1 = lse_split.shape
+        if B != B1 or G != G1 or H != H1 or num_chunks != num_chunks1 or M != M:
+            raise ValueError(
+                f"Incompatible input shapes: {attn_split.shape=} {lse_split.shape=} "
+                f"{B}/{B1}, {G}/{G1}, {H}/{H1}, {num_chunks}/{num_chunks1}, {M}/{M}"
+            )
+
+        attn_split = attn_split.permute(1, 3, 4, 0, 2, 5)
+        lse_split = lse_split.permute(1, 2, 3, 0, 4)
+
+        device = attn_split.device
+        attn_dtype = attn_split.dtype
+        lse_dtype = lse_split.dtype
+    else:
+        if attn_is_concat:
+            attn_split = attn_split.unbind(0)  # type: ignore
+        if lse_is_concat:
+            lse_split = lse_split.unbind(0)  # type: ignore
+        num_chunks = len(attn_split)
+        if len(lse_split) != num_chunks:
+            raise ValueError(
+                f"Incompatible number of LSE and attention chunks: {len(attn_split)=}, {len(lse_split)=}"
+            )
+
+        attn_unsqueezed = []
+        lse_unsqueezed = []
+        is_bmhk = False
+        for i in range(num_chunks):
+            if attn_split[i].ndim != lse_split[i].ndim + 1:
+                raise ValueError(
+                    f"Incompatible input shapes for chunk {i}: {attn_split[i].shape=}, {lse_split[i].shape=}"
+                )
+
+            is_bmhk = attn_split[i].ndim == 4
+            if is_bmhk:
+                attn_unsqueezed.append(attn_split[i].unsqueeze(2))
+                lse_unsqueezed.append(lse_split[i].unsqueeze(1))
+            else:
+                attn_unsqueezed.append(attn_split[i])
+                lse_unsqueezed.append(lse_split[i])
+        attn_split, lse_split = attn_unsqueezed, lse_unsqueezed
+
+        B, M, G, H, Kq = attn_split[0].shape
+        B1, G1, H1, M1 = lse_split[0].shape
+        if B != B1 or G != G1 or H != H1 or M != M:
+            raise ValueError(
+                f"Incompatible input shapes: {attn_split[0].shape=}, {lse_split[0].shape=} "
+                f"{B}/{B1}, {G}/{G1}, {H}/{H1}, {M}/{M}"
+            )
+
+        for i in range(num_chunks):
+            if attn_split[i].shape != (B, M, G, H, Kq):
+                raise ValueError(
+                    f"Incompatible input shapes for attention chunk {i}: "
+                    f"{attn_split[i].shape=}, {(B, M, G, H, Kq)=}"
+                )
+            if lse_split[i].shape != (B, G, H, M):
+                raise ValueError(
+                    f"Incompatible input shapes for LSE chunk {i}: "
+                    f"{lse_split[i].shape=}, {(B, G, H, M)=}"
+                )
+
+            attn_split[i] = attn_split[i].permute(0, 2, 3, 1, 4)  # to (B, G, H, M, Kq)
+
+        device = attn_split[0].device
+        attn_dtype = attn_split[0].dtype
+        lse_dtype = lse_split[0].dtype
+
+    if concat_path:
+        attn_out = torch.empty(
+            B,
+            M,
+            G,
+            H,
+            Kq,
+            device=device,
+            dtype=output_dtype or attn_dtype,
+        )
+        if write_lse:
+            lse_out = torch.empty(
+                B,
+                G,
+                H,
+                M,
+                device=device,
+                dtype=lse_dtype,
+            )
+        else:
+            lse_out = None
+        triton_splitk.merge_attentions(attn_out, lse_out, attn_split, lse_split)  # type: ignore
+    else:
+        outs = triton_splitk.merge_attentions_varargs(
+            attn_split, lse_split, write_lse, output_dtype, B, M, G, H, Kq
+        )  # type: ignore
+        attn_out = outs[0]
+        lse_out = outs[1] if write_lse else None
+
+    if is_bmhk:
+        attn_out = attn_out[:, :, 0]
+        if lse_out is not None:
+            lse_out = lse_out[:, 0]
+
+    return attn_out, lse_out
+
+
+ALL_FW_OPS: List[Type[AttentionFwOpBase]] = [
+    cutlass.FwOp if torch.version.cuda else ck.FwOp,
+    cutlass_blackwell.FwOp,
+    flash.FwOp,
+    flash_mtia.FwOp,
+    flash3.FwOp,
+    triton_splitk.FwOp,
+]
+
+ALL_BW_OPS: List[Type[AttentionBwOpBase]] = [
+    cutlass.BwOp if torch.version.cuda else ck.BwOp,
+    cutlass_blackwell.BwOp,
+    flash.BwOp,
+    flash_mtia.BwOp,
+    flash3.BwOp,
+]
+
+__all__ = [
+    "AttentionBias",
+    "AttentionOp",
+    "AttentionOpBase",
+    "LowerTriangularMask",
+    "MemoryEfficientAttentionCutlassFwdFlashBwOp",
+    "MemoryEfficientAttentionCutlassOp",
+    "MemoryEfficientAttentionFlashAttentionOp",
+    "MemoryEfficientAttentionFlashMtiaAttentionOp",
+    "memory_efficient_attention",
+    "MemoryEfficientAttentionCkOp",
+    "MemoryEfficientAttentionCkDecoderOp",
+    "ALL_FW_OPS",
+    "ALL_BW_OPS",
+    "attn_bias",
+    "_get_use_fa3",
+    "_set_use_fa3",
+    "BlockDiagonalMask",
+]

--- a/mslk/attention/fmha/_triton/__init__.py
+++ b/mslk/attention/fmha/_triton/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe

--- a/mslk/attention/fmha/_triton/available.py
+++ b/mslk/attention/fmha/_triton/available.py
@@ -1,0 +1,49 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+import logging
+import os
+
+import torch
+
+
+logger = logging.getLogger("xformers")
+
+
+def compute_once(func):
+    value = None
+
+    def func_wrapper():
+        nonlocal value
+        if value is None:
+            value = func()
+        return value
+
+    return func_wrapper
+
+
+@compute_once
+def is_triton_available():
+    if os.environ.get("XFORMERS_ENABLE_TRITON", "0") == "1":
+        return True
+    if not torch.cuda.is_available():
+        return False
+    if os.environ.get("XFORMERS_FORCE_DISABLE_TRITON", "0") == "1":
+        return False
+    # We have many errors on V100 with recent triton versions
+    # Let's just drop support for triton kernels below A100
+    if torch.cuda.get_device_capability("cuda") < (8, 0):
+        return False
+    try:
+        import triton  # noqa
+
+        return True
+    except (ImportError, AttributeError):
+        logger.warning(
+            "A matching Triton is not available, some optimizations will not be enabled",
+            exc_info=True,
+        )
+        return False

--- a/mslk/attention/fmha/_triton/splitk_kernels.py
+++ b/mslk/attention/fmha/_triton/splitk_kernels.py
@@ -1,0 +1,1533 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import sys
+from typing import Callable, Dict, Tuple, Union
+
+import torch
+import triton
+import triton.language as tl
+
+from .vararg_kernel import unroll_varargs, VAR_ARGS_ARRAY
+
+# pyre-ignore-all-errors
+AUTOTUNER_KEY = [
+    "Z",
+    "H",
+    "G",
+    "N_CTX_Q",
+    "N_CTX_K",
+    "BLOCK_DMODEL",
+    "PACKED_PER_VAL",
+    "N_GROUPS",
+    "BLOCK_N_PER_SPLIT",
+    "PAGE_SIZE",
+]
+
+
+@triton.jit
+def _fwd_kernel_splitK(  # noqa: C901
+    Q,
+    K,
+    V,
+    sm_scale,
+    Out_splitK,  # [B, H, split_k, Mq, K]
+    LSE_splitk,  # [B, H, split_k, Mq]
+    block_tables,
+    Seq_len,
+    Seq_starts_k,
+    Seq_starts_q,
+    Seq_starts_q_multiplier,
+    additive_bias,
+    K_fp8_scale_shift,
+    V_fp8_scale_shift,
+    q_fp8_scale_shift,
+    stride_qz,
+    stride_qm,
+    stride_qg,
+    stride_qh,
+    stride_qk,
+    stride_kz,
+    stride_kn,
+    stride_kg,
+    stride_kh,
+    stride_kk,
+    stride_vz,
+    stride_vn,
+    stride_vg,
+    stride_vh,
+    stride_vk,
+    stride_osk_z,
+    stride_osk_g,
+    stride_osk_h,
+    stride_osk_s,
+    stride_osk_m,
+    stride_osk_k,
+    stride_lsek_z,
+    stride_lsek_g,
+    stride_lsek_h,
+    stride_lsek_s,
+    stride_lsek_m,
+    stride_blocktablesz,
+    stride_blocktablesl,
+    stride_bias_b,
+    stride_bias_g,
+    stride_bias_h,
+    stride_bias_qm,
+    stride_bias_km,
+    stride_k_fp8_scale_shift_z: tl.constexpr,
+    stride_k_fp8_scale_shift_n: tl.constexpr,
+    stride_k_fp8_scale_shift_g: tl.constexpr,
+    stride_k_fp8_scale_shift_h: tl.constexpr,
+    stride_v_fp8_scale_shift_z: tl.constexpr,
+    stride_v_fp8_scale_shift_n: tl.constexpr,
+    stride_v_fp8_scale_shift_g: tl.constexpr,
+    stride_v_fp8_scale_shift_h: tl.constexpr,
+    stride_q_fp8_scale_shift_z: tl.constexpr,
+    stride_q_fp8_scale_shift_m: tl.constexpr,
+    stride_q_fp8_scale_shift_g: tl.constexpr,
+    stride_q_fp8_scale_shift_h: tl.constexpr,
+    kv_cache_blocks_per_row: tl.constexpr,
+    Z: tl.constexpr,
+    N_CTX_Q: tl.constexpr,  # The number of queries
+    N_CTX_K: tl.constexpr,
+    BLOCK_N_PER_SPLIT: tl.constexpr,
+    H: tl.constexpr,
+    G: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    USE_SEQ_LEN: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr,
+    N_GROUPS: tl.constexpr,
+    # It's important that BOUNDS_CHECKS_N, BLOCK_M, BLOCK_N come at the end of
+    # the argument list, since they are provided by the heuristics/autotune decorator.
+    # Otherwise Triton throws IndexError
+    BOUNDS_CHECKS_N: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    IS_SPLITK: tl.constexpr,
+    SPLIT_K_EARLY_EXIT: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    IS_LOCAL: tl.constexpr,
+    NUM_QUERIES_CAUSAL: tl.constexpr,  # The N_CTX_Q queries are from this many sequence positions
+    USE_PAGED_ATTENTION: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    WINDOW_RIGHT: tl.constexpr,
+    WRITE_LSE: tl.constexpr,
+    HAS_ADDITIVE_BIAS: tl.constexpr,
+    NUM_PROGRAMS_DIM2_CONST: tl.constexpr,
+    IS_HIP: tl.constexpr,
+    QUANTIZE_PV_TO_FP8: tl.constexpr,
+    QUANTIZE_QK_TO_FP8: tl.constexpr,
+    USE_FP32_SCALES: tl.constexpr,
+):
+    """This kernel can accept non-quantized or int4-quantized keys/values.
+    PACKED_PER_VAL determines the quantization type:
+        - PACKED_PER_VAL == 1 means no quantization
+        - PACKED_PER_VAL == 8 means 4-bit quantization (8 packed quantized values inside one int32)
+    For the quantized case K/V should be int32 tensors.
+    Quantization can be row-wise (when N_GROUPS = 1) or group-wise with N_GROUPS = 2, 4, or 8.
+    Quantization coefficients are stored at the beginning of the row along the last dimension of K/V
+    So K[B, H, M, :] has a form
+    [   quant_coef0, quant_coef1, ...|
+        group0_quant_value0, group0_quant_value1,... |
+        group1_quant_value0, group1_quant_value1,...]
+    where each quant_coef is an int32 which should be interpreted as 2 packed float16: scale and offset.
+
+    Note: this kernel needs to be processed by unroll_varargs
+    before compilation. That will unroll variables marked with "VAR_ARGS_ARRAY" into lists.
+    See how FwOp.apply does it below.
+
+    Set IS_SPLITK=False to indicate the MHA result should be written directly.
+    No metadata will be written.
+    """
+    internal_dtype = (
+        tl.float64 if Out_splitK.dtype.element_ty is tl.float64 else tl.float32
+    )
+    tl.static_assert(
+        (PACKED_PER_VAL == 1 and tl.constexpr(K.dtype.element_ty != tl.int32))
+        or (
+            (PACKED_PER_VAL == 4 or PACKED_PER_VAL == 8)
+            and tl.constexpr(K.dtype.element_ty == tl.int32)
+        ),
+        f"Only int4 and fp8 quantization is supported, K/V should have dtype int32 in "
+        f"the quantized case: {PACKED_PER_VAL=} {tl.constexpr(K.dtype)=} {tl.constexpr(K.dtype.element_ty)=}",
+    )
+    tl.static_assert(
+        (((N_GROUPS == 1 or N_GROUPS == 2) or N_GROUPS == 4) or N_GROUPS == 8),
+        "Number of quantization groups can be 1 (row-wise quantization), 2, 4, or 8.",
+    )
+    tl.static_assert(
+        N_GROUPS == 1 or K_fp8_scale_shift is None,
+        f"Only row-wise fp8 quantization is supported, but got {N_GROUPS=} > 1.",
+    )
+    FP8_QUANTIZED: tl.constexpr = K_fp8_scale_shift is not None
+    INT4_QUANTIZED: tl.constexpr = PACKED_PER_VAL > 1 and not FP8_QUANTIZED
+    PACKED_D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // PACKED_PER_VAL // N_GROUPS
+    D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // N_GROUPS
+
+    start_m = tl.program_id(0)
+    off_zhg = tl.program_id(1)
+    off_z = off_zhg // (H * G)
+    off_hg = off_zhg % (H * G)
+    off_h = off_hg // G
+    off_g = off_hg % G
+    splitk_idx = tl.program_id(2)
+
+    if USE_SEQ_LEN:
+        kv_len = tl.load(Seq_len + off_z)
+        if SPLIT_K_EARLY_EXIT and kv_len == 0:
+            return
+    else:
+        kv_len = N_CTX_K
+
+    if Seq_starts_k is None:
+        start_kv_idx = 0
+    else:
+        start_kv_idx = tl.load(Seq_starts_k + off_z)
+        if USE_SEQ_LEN and PAGE_SIZE > 0:
+            # gappy with paged attention stores each "end" instead of each "length"
+            # because that's what FA3 needs.
+            kv_len -= start_kv_idx
+
+    if Seq_starts_q is None:
+        q_len = N_CTX_Q
+        queries_use_batch_dim = 1
+        off_m = 0
+    else:
+        queries_use_batch_dim = 0
+        off_m = tl.load(Seq_starts_q + off_z) * Seq_starts_q_multiplier
+        q_len = tl.load(Seq_starts_q + off_z + 1) * Seq_starts_q_multiplier - off_m
+        if q_len == 0:
+            return
+
+    k_base = K + off_h * stride_kh + off_g * stride_kg
+    v_base = V + off_h * stride_vh + off_g * stride_vg
+
+    if FP8_QUANTIZED:
+        k_fp8_scale_shift_base = (
+            K_fp8_scale_shift
+            + off_h * stride_k_fp8_scale_shift_h
+            + off_g * stride_k_fp8_scale_shift_g
+        )
+        v_fp8_scale_shift_base = (
+            V_fp8_scale_shift
+            + off_h * stride_v_fp8_scale_shift_h
+            + off_g * stride_v_fp8_scale_shift_g
+        )
+    else:
+        k_fp8_scale_shift_base = None
+        v_fp8_scale_shift_base = None
+
+    # Boundaries of split-k chunk
+    chunk_hi = (splitk_idx + 1) * BLOCK_N_PER_SPLIT
+    chunk_lo = splitk_idx * BLOCK_N_PER_SPLIT
+    ignore_in_first_block = 0
+    # For paged attention case K/V_block_ptr are defined inside the loop
+    # whereas for non-paged case they are defined before the loop.
+    if PAGE_SIZE > 0:
+        # Page contains several blocks
+        BLOCKS_IN_PAGE: tl.constexpr = PAGE_SIZE // BLOCK_N
+        # Align boundaries of split-k chunk to block boundaries
+        # In the last chunk, shift hi to the right, in the other chunks, shift it to the left
+        # TODO: Replace NUM_PROGRAMS_DIM2_CONST with tl.num_programs(2) after
+        # the next Triton upgrade.
+        is_last_chunk = splitk_idx == NUM_PROGRAMS_DIM2_CONST - 1
+        shift = BLOCK_N - 1 if is_last_chunk else 0
+        lo = (tl.maximum(chunk_lo, start_kv_idx) // BLOCK_N) * BLOCK_N
+        ignore_in_first_block = tl.maximum(0, (start_kv_idx - lo))
+        hi = ((chunk_hi + shift) // BLOCK_N) * BLOCK_N
+        hi = tl.minimum(hi, kv_len + start_kv_idx)
+        block_table = block_tables + stride_blocktablesz * off_z
+        # Offset in integer blocks
+        logical_block_idx = lo // BLOCK_N
+    else:
+        lo = chunk_lo
+        hi = tl.minimum(chunk_hi, kv_len)
+        if Seq_starts_k is not None:
+            k_base += start_kv_idx * stride_kn
+            v_base += start_kv_idx * stride_vn
+        else:
+            k_base += off_z * stride_kz
+            v_base += off_z * stride_vz
+        # Additional shift by 1 along the last dimension in the quantized case, since
+        # the first element along that dim contains packed quantization coefficients.
+        K_block_ptr = tl.make_block_ptr(
+            base=k_base + stride_kk * INT4_QUANTIZED * N_GROUPS,
+            shape=(PACKED_D_PER_GROUP, hi),
+            strides=(stride_kk, stride_kn),
+            offsets=(0, lo),
+            block_shape=(PACKED_D_PER_GROUP, BLOCK_N),
+            order=(0, 1),
+        )
+        V_block_ptr = tl.make_block_ptr(
+            base=v_base + stride_vk * INT4_QUANTIZED * N_GROUPS,
+            shape=(hi, PACKED_D_PER_GROUP if not QUANTIZE_PV_TO_FP8 else D_PER_GROUP),
+            strides=(stride_vn, stride_vk),
+            offsets=(lo, 0),
+            block_shape=(
+                BLOCK_N,
+                PACKED_D_PER_GROUP if not QUANTIZE_PV_TO_FP8 else D_PER_GROUP,
+            ),
+            order=(1, 0),
+        )
+
+        if INT4_QUANTIZED:
+            # Pointers to quantization coefficients. Even those they are 1D,
+            # we use block pointers here so the pointer arithmetic is in int64,
+            # as otherwise the offsets for V_scale_shift_block_ptr may overflow.
+            K_scale_shift_block_ptr = tl.make_block_ptr(
+                base=k_base,
+                shape=(1, hi),
+                strides=(stride_kk, stride_kn),
+                offsets=(0, lo),
+                block_shape=(1, BLOCK_N),
+                order=(0, 1),
+            )
+            V_scale_shift_block_ptr = tl.make_block_ptr(
+                base=v_base,
+                shape=(hi, 1),
+                strides=(stride_vn, stride_vk),
+                offsets=(lo, 0),
+                block_shape=(BLOCK_N, 1),
+                order=(1, 0),
+            )
+        elif FP8_QUANTIZED:
+            if Seq_starts_k is not None:
+                k_fp8_scale_shift_base += start_kv_idx * stride_k_fp8_scale_shift_n
+                v_fp8_scale_shift_base += start_kv_idx * stride_v_fp8_scale_shift_n
+            else:
+                k_fp8_scale_shift_base += off_z * stride_k_fp8_scale_shift_z
+                v_fp8_scale_shift_base += off_z * stride_v_fp8_scale_shift_z
+            K_scale_shift_block_ptr = tl.make_block_ptr(
+                base=k_fp8_scale_shift_base,
+                shape=(1, hi),
+                strides=(1, stride_k_fp8_scale_shift_n),
+                offsets=(0, lo),
+                block_shape=(1, BLOCK_N),
+                order=(0, 1),
+            )
+            V_scale_shift_block_ptr = tl.make_block_ptr(
+                base=v_fp8_scale_shift_base,
+                shape=(hi, 1),
+                strides=(stride_v_fp8_scale_shift_n, 1),
+                offsets=(lo, 0),
+                block_shape=(BLOCK_N, 1),
+                order=(1, 0),
+            )
+        else:
+            K_scale_shift_block_ptr = None
+            V_scale_shift_block_ptr = None
+
+        if HAS_ADDITIVE_BIAS:
+            additive_bias_block_ptr = tl.make_block_ptr(
+                base=additive_bias
+                + off_z * stride_bias_b
+                + off_g * stride_bias_g
+                + off_h * stride_bias_h,
+                shape=(N_CTX_Q, hi),
+                strides=(stride_bias_qm, stride_bias_km),
+                offsets=(start_m * BLOCK_M, lo),
+                block_shape=(BLOCK_M, BLOCK_N),
+                order=(0, 1),
+            )
+
+    if SPLIT_K_EARLY_EXIT and lo >= hi:
+        return
+
+    Q_block_ptr = tl.make_block_ptr(
+        base=Q
+        + off_m * stride_qm
+        + off_h * stride_qh
+        + off_z * stride_qz * queries_use_batch_dim
+        + off_g * stride_qg,
+        shape=(q_len, BLOCK_DMODEL),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, D_PER_GROUP),
+        order=(1, 0),
+    )
+
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    # Before compilation, this kernel will be processed by unroll_varargs.
+    # That turns tensors annotated as the one below into lists of tensors of length N_GROUPS.
+    # This is a solution for Triton native lack of support for lists of tensors.
+    acc: "VAR_ARGS_ARRAY"  # noqa: F821
+
+    for i in range(len(acc)):  # noqa: F821
+        acc[i] = tl.zeros([BLOCK_M, D_PER_GROUP], dtype=internal_dtype)  # noqa: F821
+    # scale sm_scale by log_2(e) and use
+    # 2^x instead of exp in the loop because CSE and LICM
+    # don't work as expected with `exp` in the loop
+    #
+    # We declare log2e as a constant with a precisely-specified type to guarantee that
+    # triton will use the exact same value in all instances below, rather than sometimes
+    # using float32 and sometimes using float64.  For more discussion see:
+    # https://github.com/triton-lang/triton/issues/5466
+    log2e = tl.full((), 1.44269504, tl.float32)
+    qk_scale = sm_scale * log2e
+    # load q: it will stay in SRAM throughout
+    q: "VAR_ARGS_ARRAY"  # noqa: F821
+
+    if QUANTIZE_QK_TO_FP8:
+        # Create a block pointer for q_scale
+        q_scale_block_ptr = tl.make_block_ptr(
+            base=q_fp8_scale_shift
+            + off_m * stride_q_fp8_scale_shift_m
+            + off_h * stride_q_fp8_scale_shift_h
+            + off_g * stride_q_fp8_scale_shift_g
+            + off_z * stride_q_fp8_scale_shift_z * queries_use_batch_dim,
+            shape=(q_len, 1),
+            strides=(stride_q_fp8_scale_shift_m, 1),
+            offsets=(start_m * BLOCK_M, 0),
+            block_shape=(BLOCK_M, 1),
+            order=(1, 0),
+        )
+
+        # For FP8 quantized query, load and dequantize
+        for i in range(len(acc)):  # noqa: F821
+            # Load quantized query
+            q_quantized = tl.load(  # noqa: F821
+                tl.advance(Q_block_ptr, (0, i * D_PER_GROUP)), boundary_check=(0,)
+            )
+
+            # Load q_scale for dequantization - q_scale is per row
+            q_scale = tl.load(
+                tl.advance(q_scale_block_ptr, (0, i * D_PER_GROUP)), boundary_check=(0,)
+            )
+            q[i] = q_quantized.to(Q.dtype.element_ty)  # noqa: F821
+    else:
+        # Regular query loading
+        for i in range(len(acc)):  # noqa: F821
+            q[i] = tl.load(  # noqa: F821
+                tl.advance(Q_block_ptr, (0, i * D_PER_GROUP)), boundary_check=(0,)
+            )
+
+    if IS_CAUSAL or IS_LOCAL:
+        # Why does the masking conditon below work as a causal mask?
+        # Assuming num_queries <= BLOCK_M:
+        # kv_pos = kv_start + range(0, BLOCK_N)
+        # q_offset = start_m * BLOCK_M + range(0, BLOCK_M)
+        # q_pos = kv_start + kv_len - num_queries + q_offset % num_queries
+        # mask = q_pos - kv_pos >= 0
+        # So the final masking condition is:
+        #   range(0, BLOCK_M) % num_queries - range(0, BLOCK_N) >= num_queries - kv_len
+
+        q_offset = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        diag_idx = (q_offset[:, None] % NUM_QUERIES_CAUSAL) - tl.arange(0, BLOCK_N)[
+            None, :
+        ]
+        diag_idx_shifted = tl.constexpr(diag_idx - NUM_QUERIES_CAUSAL + kv_len)
+
+    # loop over k, v and update accumulator
+    for start_n in range(lo, hi, BLOCK_N):
+        if PAGE_SIZE > 0:
+            # Offset in integer blocks from the beginning of the page
+            block_offset_in_page = logical_block_idx % BLOCKS_IN_PAGE
+            # Offset in integer pages
+            logical_page_idx = logical_block_idx // BLOCKS_IN_PAGE
+            physical_page_idx = tl.load(
+                block_table + stride_blocktablesl * logical_page_idx
+            ).to(tl.int32)
+            offset = physical_page_idx * PAGE_SIZE + block_offset_in_page * BLOCK_N
+
+            current_block_size = min(hi - start_n, BLOCK_N)
+            K_block_ptr = tl.make_block_ptr(
+                base=k_base + stride_kk * INT4_QUANTIZED * N_GROUPS,
+                shape=(PACKED_D_PER_GROUP, offset + current_block_size),
+                strides=(stride_kk, stride_kn),
+                offsets=(0, offset),
+                block_shape=(PACKED_D_PER_GROUP, BLOCK_N),
+                order=(0, 1),
+            )
+            V_block_ptr = tl.make_block_ptr(
+                base=v_base + stride_vk * INT4_QUANTIZED * N_GROUPS,
+                shape=(
+                    offset + current_block_size,
+                    PACKED_D_PER_GROUP if not QUANTIZE_PV_TO_FP8 else D_PER_GROUP,
+                ),
+                strides=(stride_vn, stride_vk),
+                offsets=(offset, 0),
+                block_shape=(
+                    BLOCK_N,
+                    PACKED_D_PER_GROUP if not QUANTIZE_PV_TO_FP8 else D_PER_GROUP,
+                ),
+                order=(1, 0),
+            )
+            if INT4_QUANTIZED:
+                # Pointers to quantization coefficients. Even those they are 1D,
+                # we use block pointers here so the pointer arithmetic is in int64,
+                # as otherwise the offsets for V_scale_shift_block_ptr may overflow.
+                K_scale_shift_block_ptr = tl.make_block_ptr(
+                    base=k_base,
+                    shape=(1, offset + current_block_size),
+                    strides=(stride_kk, stride_kn),
+                    offsets=(0, offset),
+                    block_shape=(1, BLOCK_N),
+                    order=(0, 1),
+                )
+                V_scale_shift_block_ptr = tl.make_block_ptr(
+                    base=v_base,
+                    shape=(offset + current_block_size, 1),
+                    strides=(stride_vn, stride_vk),
+                    offsets=(offset, 0),
+                    block_shape=(BLOCK_N, 1),
+                    order=(1, 0),
+                )
+            elif FP8_QUANTIZED:
+                K_scale_shift_block_ptr = tl.make_block_ptr(
+                    base=k_fp8_scale_shift_base,
+                    shape=(1, offset + current_block_size),
+                    strides=(1, stride_k_fp8_scale_shift_n),
+                    offsets=(0, offset),
+                    block_shape=(1, BLOCK_N),
+                    order=(0, 1),
+                )
+                V_scale_shift_block_ptr = tl.make_block_ptr(
+                    base=v_fp8_scale_shift_base,
+                    shape=(offset + current_block_size, 1),
+                    strides=(stride_v_fp8_scale_shift_n, 1),
+                    offsets=(offset, 0),
+                    block_shape=(BLOCK_N, 1),
+                    order=(1, 0),
+                )
+            else:
+                K_scale_shift_block_ptr = None
+                V_scale_shift_block_ptr = None
+            logical_block_idx += 1
+
+        k: "VAR_ARGS_ARRAY"  # noqa: F821
+        v: "VAR_ARGS_ARRAY"  # noqa: F821
+
+        if QUANTIZE_PV_TO_FP8:
+            v_dtype = tl.float8e4nv
+        else:
+            v_dtype = Q.dtype.element_ty
+        for i in range(len(acc)):  # noqa: F821
+            # Load and dequantize K/V with appropriate return values based on quantization flags
+            result = load_dequantize_k_v_group(  # noqa: F821
+                K_block_ptr,
+                V_block_ptr,
+                K_scale_shift_block_ptr,
+                V_scale_shift_block_ptr,
+                BOUNDS_CHECKS_N,
+                PACKED_PER_VAL,
+                PACKED_D_PER_GROUP,
+                FP8_QUANTIZED,
+                Q.dtype.element_ty,
+                v_dtype,
+                i,
+                IS_HIP,
+                QUANTIZE_PV_TO_FP8,
+                QUANTIZE_QK_TO_FP8,
+                USE_FP32_SCALES,
+            )
+
+            # Unpack results based on quantization configuration
+            if QUANTIZE_PV_TO_FP8 and QUANTIZE_QK_TO_FP8:
+                k[i], v[i], v_scale, k_scale = result  # noqa: F821
+            elif QUANTIZE_PV_TO_FP8:
+                k[i], v[i], v_scale = result  # noqa: F821
+            elif QUANTIZE_QK_TO_FP8:
+                k[i], v[i], k_scale = result  # noqa: F821
+            else:
+                k[i], v[i] = result  # noqa: F821
+        # -- compute qk ---
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        for i in range(len(acc)):  # noqa: F821
+            qk += tl.dot(q[i], k[i])  # noqa: F821
+
+        if QUANTIZE_QK_TO_FP8:
+            # Reshape k_scale for proper broadcasting with qk
+            # k_scale has shape (BLOCK_N,), we need to reshape it to (1, BLOCK_N)
+            # for proper broadcasting with qk of shape (BLOCK_M, BLOCK_N)
+            k_scale_reshaped = tl.reshape(k_scale, (1, BLOCK_N))
+
+            # Apply k_scale to qk
+            qk = qk * k_scale_reshaped
+            qk = qk * tl.reshape(q_scale, (BLOCK_M, 1))  # noqa: F821
+
+        # Apply qk_scale (scalar)
+        qk *= qk_scale
+
+        if start_n == lo and ignore_in_first_block > 0:
+            qk = tl.where(
+                tl.arange(0, BLOCK_N) < ignore_in_first_block, float("-inf"), qk
+            )
+
+        if HAS_ADDITIVE_BIAS:
+            loaded_bias = tl.load(
+                additive_bias_block_ptr,
+                boundary_check=(0, 1) if BOUNDS_CHECKS_N else (0,),
+            )
+            qk += loaded_bias.to(tl.float32) * log2e
+            additive_bias_block_ptr = tl.advance(additive_bias_block_ptr, (0, BLOCK_N))
+
+        # TODO: This is slow, and only needed at the last iteration.
+        # Maybe we can unroll the last iteration instead?
+        if BOUNDS_CHECKS_N:
+            qk = tl.where(tl.arange(0, BLOCK_N) < hi - start_n, qk, float("-inf"))
+        if IS_CAUSAL:
+            # -- apply the causal mask --
+            qk = tl.where(diag_idx_shifted >= start_n - start_kv_idx, qk, float("-inf"))
+        if IS_LOCAL:
+            # -- apply the local window size mask --
+            qk = tl.where(
+                diag_idx_shifted < start_n - start_kv_idx + WINDOW_LEFT + 1,
+                qk,
+                float("-inf"),
+            )
+            if not IS_CAUSAL and WINDOW_RIGHT >= 0:
+                qk = tl.where(
+                    diag_idx_shifted >= start_n - start_kv_idx - WINDOW_RIGHT,
+                    qk,
+                    float("-inf"),
+                )
+
+        # -- compute scaling constant ---
+        m_i_new = tl.maximum(m_i, tl.max(qk, 1))
+        alpha = tl.math.exp2(m_i - m_i_new)
+        p = tl.math.exp2(qk - m_i_new[:, None])
+        if HAS_ADDITIVE_BIAS or (IS_CAUSAL or IS_LOCAL):
+            # NOTE: It's possible that an entire block is masked out.
+            # if this is the case, `m_i_new=nan` and everything becomes nan
+            alpha = tl.where(m_i_new == float("-inf"), 0, alpha)
+            p = tl.where(m_i_new[:, None] == float("-inf"), 0, p)
+
+        # -- update m_i and l_i --
+        l_i = l_i * alpha + tl.sum(p, 1)
+        m_i = m_i_new
+        if not QUANTIZE_PV_TO_FP8:
+            p = p.to(v_dtype)
+        else:
+            # Apply v-scale to P
+            p = p * tl.trans(v_scale)
+
+            # Quantize P to FP8
+            MAX_FP8 = 448
+            amax = tl.max(p, axis=1)  # rowmax(P)
+            p_scale = tl.maximum(amax / MAX_FP8, 1e-9)
+            p_scaled = p / p_scale[:, None]
+            p_clamped = tl.clamp(p_scaled, 0, MAX_FP8)
+
+            # covert P to FP8
+            p = p_clamped.to(v_dtype, fp_downcast_rounding="rtne")
+
+        # -- scale and update acc --
+        for i in range(len(acc)):  # noqa: F821
+            acc[i] *= alpha[:, None]  # noqa: F821
+            if not QUANTIZE_PV_TO_FP8:
+                acc[i] += tl.dot(p, v[i])  # noqa: F821
+            else:
+                # Re-scale PV using p_scale
+                acc[i] += tl.dot(p, v[i]) * p_scale[:, None]  # noqa: F821
+
+        if not PAGE_SIZE:
+            # update pointers
+            K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+            V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+            if PACKED_PER_VAL > 1:
+                K_scale_shift_block_ptr = tl.advance(
+                    K_scale_shift_block_ptr, (0, BLOCK_N)
+                )
+                V_scale_shift_block_ptr = tl.advance(
+                    V_scale_shift_block_ptr, (BLOCK_N, 0)
+                )
+
+    # write back O
+    O_block_ptr = tl.make_block_ptr(
+        base=Out_splitK
+        + off_z.to(tl.int64) * stride_osk_z * queries_use_batch_dim
+        + off_m * stride_osk_m
+        + off_g * stride_osk_g
+        + off_h * stride_osk_h
+        + splitk_idx * stride_osk_s,
+        shape=(q_len, D_PER_GROUP),
+        strides=(stride_osk_m, 1),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, D_PER_GROUP),
+        order=(1, 0),
+    )
+    for i in range(len(acc)):  # noqa: F821
+        # If for the current batch element there are no tokens in the current split-k chunk (because
+        # seqlen is too short), l_i will be 0, so we need to make sure attention is filled with zeros and not NaNs.
+        attn_out = tl.where(l_i[:, None] == 0, 0.0, acc[i] / l_i[:, None])  # noqa: F821
+        tl.store(
+            tl.advance(O_block_ptr, (0, i * D_PER_GROUP)),
+            attn_out.to(Out_splitK.dtype.element_ty),  # noqa: F821
+            boundary_check=(0,),
+        )
+    if WRITE_LSE:
+        LSE_splitk_ptr = (
+            LSE_splitk
+            + off_z * stride_lsek_z * queries_use_batch_dim
+            + off_m * stride_lsek_m
+            + off_g * stride_lsek_g
+            + off_h * stride_lsek_h
+            + splitk_idx * stride_lsek_s
+            + (start_m * BLOCK_M + tl.arange(0, BLOCK_M)) * stride_lsek_m
+        )
+        mask = start_m * BLOCK_M + tl.arange(0, BLOCK_M) < q_len
+        # Can be float64 to improve numerics
+        lse_dtype = LSE_splitk.dtype.element_ty
+        tl.store(
+            LSE_splitk_ptr,
+            (tl.math.log2(l_i.to(lse_dtype)) + m_i.to(lse_dtype)) / log2e,
+            mask=mask,
+        )
+
+
+def gen_config(
+    block_m: int,
+    block_n: int,
+    stages: int,
+    warps: int,
+) -> triton.Config:
+    """A more compact way to define a triton.Config, so it fits on one line"""
+
+    return triton.Config(
+        {
+            "BLOCK_M": block_m,
+            "BLOCK_N": block_n,
+        },
+        num_stages=stages,
+        num_warps=warps,
+    )
+
+
+def _get_splitk_kernel(num_groups):
+    """
+    Kernel _fwd_kernel_splitK needs to be post-processed by unroll_varargs
+    to specialize it for a given number of quantization groups N_GROUPS
+    before we can apply triton.heuristics and triton.autotune, so we
+    don't do them as decorators.
+    """
+
+    _fwd_kernel_splitK_unrolled = unroll_varargs(_fwd_kernel_splitK, N=num_groups)
+    kernel = triton.heuristics(
+        {
+            "BOUNDS_CHECKS_N": lambda args: bool(
+                (args["BLOCK_N_PER_SPLIT"] % args["BLOCK_N"])
+                or (
+                    args["BLOCK_N_PER_SPLIT"] > 0
+                    and args["N_CTX_K"] % args["BLOCK_N_PER_SPLIT"]
+                )
+                or args["USE_SEQ_LEN"]
+            )
+        }
+    )(_fwd_kernel_splitK_unrolled)
+    return kernel
+
+
+def early_config_prune(configs, named_args, **kwargs):
+    use_paged_attention = kwargs["USE_PAGED_ATTENTION"]
+    page_size = kwargs["PAGE_SIZE"]
+    if use_paged_attention:
+        return list(
+            filter(lambda config: page_size % config.kwargs["BLOCK_N"] == 0, configs)
+        )
+    else:
+        return configs
+
+
+@functools.lru_cache(None)
+def autotune_kernel(kernel: Callable):
+    BLOCK_M_VALUES = [16, 32, 64, 128]
+    BLOCK_N_VALUES = [16, 32, 64, 128]
+    STAGES_VALUES = [1, 2] if torch.version.hip else [1, 2, 3]
+    WARPS_VALUES = [1, 2, 4, 8]
+
+    TRITON_CONFIGS = [
+        gen_config(block_m, block_n, stages, warps)
+        for block_m in BLOCK_M_VALUES
+        for block_n in BLOCK_N_VALUES
+        for stages in STAGES_VALUES
+        for warps in WARPS_VALUES
+        if block_n >= block_m
+    ]
+
+    kernel = triton.autotune(
+        configs=TRITON_CONFIGS,
+        key=AUTOTUNER_KEY,
+        use_cuda_graph=True,
+        prune_configs_by={
+            "early_config_prune": early_config_prune,
+        },
+    )(kernel)
+    return kernel
+
+
+# This object contains forward kernels wrapped into autotuner for different number
+# of quantization groups.
+_fwd_kernel_splitK_autotune: Dict[int, triton.runtime.Autotuner] = {}
+# The loop below:
+# - transforms the jitted kernel with unroll_varargs producing a new kernel of each value of num_groups
+# - wraps the kernel into triton.heuristics
+# - wraps kernel into Triton autotuner. Autotuning itself happens the first time the kernel is called
+if sys.version_info >= (3, 9):
+    # unroll_varargs requires Python 3.9+
+    for num_groups in [1, 2, 4, 8]:
+        _fwd_kernel_splitK_autotune[num_groups] = autotune_kernel(
+            _get_splitk_kernel(num_groups)
+        )
+
+    def get_autotuner_cache(
+        num_groups: int,
+    ) -> Dict[Tuple[Union[int, str]], triton.Config]:
+        """Returns a triton.runtime.autotuner.AutoTuner.cache object, which
+        represents mappings from kernel autotune keys (tuples describing kernel inputs)
+        to triton.Config
+        """
+        return _fwd_kernel_splitK_autotune[num_groups].cache
+
+    def set_autotuner_cache(
+        cache: Dict[Tuple[Union[int, str]], triton.Config], num_groups: int
+    ) -> None:
+        _fwd_kernel_splitK_autotune[num_groups].cache = cache
+
+
+@triton.jit
+def load_dequantize_k_v_group(
+    K_block_ptr,
+    V_block_ptr,
+    K_scale_shift_block_ptr,
+    V_scale_shift_block_ptr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr,
+    PACKED_D_PER_GROUP: tl.constexpr,
+    FP8_QUANTIZED: tl.constexpr,
+    q_dtype: tl.constexpr,
+    v_dtype: tl.constexpr,  # Q.dtype.element_ty
+    group_id: tl.constexpr,
+    IS_HIP: tl.constexpr,
+    QUANTIZE_PV_TO_FP8: tl.constexpr,
+    QUANTIZE_QK_TO_FP8: tl.constexpr,
+    USE_FP32_SCALES: tl.constexpr,
+):
+    """Load K/V for a given block. In case of int4/fp8-quantized K/V, dequantize them after loading.
+    If quantization is group-wise, use group_id to advance the pointers to the current group.
+
+    Returns:
+        - k, v: loaded and potentially dequantized tensors
+        - v_scale (optional): V scale factor if QUANTIZE_PV_TO_FP8 is True
+        - k_scale (optional): K scale factor if QUANTIZE_QK_TO_FP8 is True
+    """
+    # Advance to the current quantization group
+    K_block_ptr = tl.advance(K_block_ptr, (PACKED_D_PER_GROUP * group_id, 0))
+    V_block_ptr = tl.advance(
+        V_block_ptr,
+        (0, PACKED_D_PER_GROUP * group_id)
+        if not QUANTIZE_PV_TO_FP8
+        else (0, PACKED_D_PER_GROUP * PACKED_PER_VAL * group_id),
+    )
+
+    # -- load k, v --
+    k = tl.load(K_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ())
+    v = tl.load(V_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ())
+
+    # Initialize return values
+    # v_scale = None
+    # k_scale = None
+
+    if FP8_QUANTIZED:
+        k, v, v_scale, k_scale = _process_fp8_quantization(
+            k,
+            v,
+            K_scale_shift_block_ptr,
+            V_scale_shift_block_ptr,
+            BOUNDS_CHECKS_N,
+            PACKED_PER_VAL,
+            q_dtype,
+            v_dtype,
+            IS_HIP,
+            QUANTIZE_PV_TO_FP8,
+            QUANTIZE_QK_TO_FP8,
+            USE_FP32_SCALES,
+        )
+
+    elif PACKED_PER_VAL > 1:
+        # Int4 quantization.
+        k, v = _process_int4_quantization(
+            k,
+            v,
+            K_scale_shift_block_ptr,
+            V_scale_shift_block_ptr,
+            group_id,
+            BOUNDS_CHECKS_N,
+            PACKED_PER_VAL,
+            q_dtype,
+            IS_HIP,
+        )
+
+    # Return appropriate values based on quantization flags
+    if QUANTIZE_PV_TO_FP8 and QUANTIZE_QK_TO_FP8:
+        # Return both v_scale and k_scale for applying to P and K
+        return k, v, v_scale, k_scale
+    elif QUANTIZE_PV_TO_FP8:
+        # Return v_scale for applying v_scale to P
+        return k, v, v_scale
+    elif QUANTIZE_QK_TO_FP8:
+        # Return k_scale for applying k_scale to K
+        return k, v, k_scale
+    else:
+        return k, v
+
+
+@triton.jit
+def _process_fp8_quantization(
+    k,
+    v,
+    K_scale_shift_block_ptr,
+    V_scale_shift_block_ptr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr,
+    q_dtype: tl.constexpr,
+    v_dtype: tl.constexpr,
+    IS_HIP: tl.constexpr,
+    QUANTIZE_PV_TO_FP8: tl.constexpr,
+    QUANTIZE_QK_TO_FP8: tl.constexpr,
+    USE_FP32_SCALES: tl.constexpr,
+):
+    """Process FP8 quantization for K and V tensors."""
+    # Process V tensor
+    v_scale_shift = tl.load(
+        V_scale_shift_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ()
+    )
+    v_scale, v_shift = _extract_scale_shift(v_scale_shift, IS_HIP, USE_FP32_SCALES)
+    if not QUANTIZE_PV_TO_FP8:
+        v = dequantize(
+            v,
+            v_scale,
+            v_shift if not USE_FP32_SCALES else None,
+            PACKED_PER_VAL,
+            IS_HIP,
+            USE_FP32_SCALES,
+        ).to(v_dtype)
+    else:
+        # Do not dequantize V; V needs to be FP8 for PV.
+        tl.static_assert(PACKED_PER_VAL == 4, "Assert: int32 packs four FP8 values")
+
+    # Process K tensor
+    k_scale_shift = tl.load(
+        K_scale_shift_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ()
+    )
+    k_scale, k_shift = _extract_scale_shift(k_scale_shift, IS_HIP, USE_FP32_SCALES)
+    if IS_HIP:
+        if not QUANTIZE_QK_TO_FP8:
+            k = dequantize_k_hip(k, k_scale, k_shift, PACKED_PER_VAL).to(q_dtype)
+        else:
+            # For QUANTIZE_QK_TO_FP8, unpack int32 to 8-bit entries and interpret as fp8
+            tl.static_assert(PACKED_PER_VAL == 4, "Assert: int32 packs four FP8 values")
+    else:
+        if not QUANTIZE_QK_TO_FP8:
+            k_t = dequantize(
+                tl.trans(k),
+                tl.trans(k_scale),
+                tl.trans(k_shift) if not USE_FP32_SCALES else None,
+                PACKED_PER_VAL,
+                IS_HIP,
+                USE_FP32_SCALES,
+            ).to(q_dtype)
+            k = tl.trans(k_t)
+        else:
+            # For QUANTIZE_QK_TO_FP8, unpack int32 to 8-bit entries and interpret as fp8
+            tl.static_assert(PACKED_PER_VAL == 4, "Assert: int32 packs four FP8 values")
+            k_t = tl.trans(k)
+            k_t = _unpack_fp8_tensor(k_t, PACKED_PER_VAL, IS_HIP)
+            k = tl.trans(k_t)
+
+    return k, v, v_scale, k_scale
+
+
+@triton.jit
+def _extract_scale_shift(
+    scale_shift, IS_HIP: tl.constexpr, USE_FP32_SCALES: tl.constexpr
+):
+    """Extract scale and shift values from packed representation."""
+    if IS_HIP:
+        return cast_uint32_to_float(scale_shift)
+    elif USE_FP32_SCALES:
+        return scale_shift.to(tl.float32, bitcast=True), 0
+    else:
+        return cast_uint32_to_half2(scale_shift)
+
+
+@triton.jit
+def _unpack_fp8_tensor(x_, PACKED_PER_VAL: tl.constexpr, IS_HIP: tl.constexpr):
+    """Unpack FP8 K/V tensor from int32 packed representation."""
+    tl.static_assert(PACKED_PER_VAL == 4, "Assert: int32 packs four FP8 values")
+
+    BLOCK_DMODEL_PACKED: tl.constexpr = x_.shape[1]
+    BLOCK_N: tl.constexpr = x_.shape[0]
+    # Create bit offsets for unpacking (0, 8, 16, 24 bits)
+    offsets = tl.arange(0, PACKED_PER_VAL) * 8
+
+    # Extract 8-bit values by right-shifting and masking
+    unpacked_values = x_[:, :, None, :] >> offsets
+    unpacked_values = tl.reshape(
+        unpacked_values, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
+    )
+
+    # Convert to FP8 through bitcast
+    fp8_type = tl.float8e4b8 if IS_HIP else tl.float8e4nv
+    x_ = unpacked_values.to(tl.uint8).to(fp8_type, bitcast=True)
+
+    return x_
+
+
+@triton.jit
+def _process_int4_quantization(
+    k,
+    v,
+    K_scale_shift_block_ptr,
+    V_scale_shift_block_ptr,
+    group_id: tl.constexpr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr,
+    dtype: tl.constexpr,
+    IS_HIP: tl.constexpr,
+):
+    """Process INT4 quantization for K and V tensors."""
+    # Advance scale/shift pointers for INT4
+    K_scale_shift_block_ptr = tl.advance(K_scale_shift_block_ptr, (group_id, 0))
+    V_scale_shift_block_ptr = tl.advance(V_scale_shift_block_ptr, (0, group_id))
+
+    k_scale_shift = tl.load(
+        K_scale_shift_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ()
+    )
+    v_scale_shift = tl.load(
+        V_scale_shift_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ()
+    )
+    if IS_HIP:
+        k_scale, k_shift = cast_uint32_to_float(k_scale_shift)
+        v_scale, v_shift = cast_uint32_to_float(v_scale_shift)
+        v = dequantize(v, v_scale, v_shift, PACKED_PER_VAL, IS_HIP).to(dtype)
+        k = dequantize_k_hip(k, k_scale, k_shift, PACKED_PER_VAL).to(dtype)
+    else:
+        k_scale, k_shift = cast_uint32_to_half2(k_scale_shift)
+        v_scale, v_shift = cast_uint32_to_half2(v_scale_shift)
+        v = dequantize(v, v_scale, v_shift, PACKED_PER_VAL, IS_HIP).to(dtype)
+        k_t = dequantize(
+            tl.trans(k),
+            tl.trans(k_scale),
+            tl.trans(k_shift),
+            PACKED_PER_VAL,
+            IS_HIP,
+        ).to(dtype)
+        k = tl.trans(k_t)
+
+    return k, v
+
+
+@triton.jit
+def cast_uint64_to_float2(scale_shift):
+    """Using FP32 scales, so only extract one fp32 from the packed int64"""
+    scale = scale_shift & 0xFFFFFFFF
+    scale = scale.to(tl.uint32).to(tl.float32, bitcast=True)
+    return scale, 0
+
+
+@triton.jit
+def cast_uint32_to_half2(scale_shift):
+    """Extract two float16 packed into one int32"""
+    scale = scale_shift & 0xFFFF
+    shift = scale_shift >> 16
+    scale = scale.to(tl.uint16).to(tl.float16, bitcast=True)
+    shift = shift.to(tl.uint16).to(tl.float16, bitcast=True)
+    return scale, shift
+
+
+@triton.jit
+def cast_uint32_to_float(scale_shift):
+    """Extract two float16 packed into one int32 as float32"""
+    scale = scale_shift & 0xFFFF
+    shift = scale_shift >> 16
+    scale = scale.to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32)
+    shift = shift.to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32)
+    return scale, shift
+
+
+@triton.jit
+def dequantize_k_hip(
+    x_,
+    scale,
+    shift,
+    PACKED_PER_VAL: tl.constexpr,
+):
+    """PACKED_PER_VAL is the number of values packed into each element x_.
+    For example, for int4 quantization and x_ of type int32, PACKED_PER_VAL is 8.
+    """
+    # x_ : (BLOCK_N, D // PACKED_PER_VAL)
+    # scale: (BLOCK_N, 1)
+    # offsets: (PACKED_PER_VAL,)
+    BLOCK_N: tl.constexpr = x_.shape[1]
+    BLOCK_DMODEL_PACKED: tl.constexpr = x_.shape[0]
+    offsets = tl.arange(0, PACKED_PER_VAL) * (32 // PACKED_PER_VAL)
+    quant_offset = (
+        x_[:, None, :, :] >> offsets[:, None]
+    )  # (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
+
+    quant_offset = tl.reshape(
+        quant_offset, (BLOCK_DMODEL_PACKED * PACKED_PER_VAL, BLOCK_N)
+    )
+
+    if PACKED_PER_VAL == 4:
+        # FP8 quantization.
+        fp8_type = tl.float8e4b8 if torch.version.hip is not None else tl.float8e4nv
+        dequant = (
+            quant_offset.to(tl.uint8).to(fp8_type, bitcast=True).to(scale.dtype) * scale
+            + shift
+        )
+    else:
+        # Int4 quantization.
+        # Trick - instead of converting int4 to float16 we view it as float16
+        # and then multiply by 32768 * 512 == 2**24
+        quant_offset = (
+            (quant_offset & 0xF)
+            .to(tl.uint16)
+            .to(tl.float16, bitcast=True)
+            .to(tl.float32)
+        )
+        quant_offset = quant_offset * 32768.0
+        scale_512 = scale * 512
+
+        dequant = quant_offset * scale_512 + shift
+    return dequant
+
+
+@triton.jit
+def dequantize(
+    x_,
+    scale,
+    shift,
+    PACKED_PER_VAL: tl.constexpr,
+    IS_HIP: tl.constexpr,
+    USE_FP32_SCALES: tl.constexpr = False,
+):
+    """PACKED_PER_VAL is the number of values packed into each element x_.
+    For example, for int4 quantization and x_ of type int32, PACKED_PER_VAL is 8.
+    """
+    # x_ : (BLOCK_N, D // PACKED_PER_VAL)
+    # scale: (BLOCK_N, 1)
+    # offsets: (PACKED_PER_VAL,)
+    BLOCK_N: tl.constexpr = x_.shape[0]
+    BLOCK_DMODEL_PACKED: tl.constexpr = x_.shape[1]
+    offsets = tl.arange(0, PACKED_PER_VAL) * (32 // PACKED_PER_VAL)
+    quant_offset = (
+        x_[:, :, None, :] >> offsets
+    )  # (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
+
+    quant_offset = tl.reshape(
+        quant_offset, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
+    )
+    if PACKED_PER_VAL == 4:
+        # FP8 quantization.
+        fp8_type = tl.float8e4b8 if torch.version.hip is not None else tl.float8e4nv
+        dequant = (
+            quant_offset.to(tl.uint8).to(fp8_type, bitcast=True).to(scale.dtype) * scale
+        )
+        if not USE_FP32_SCALES:
+            # Use asymmetric quantization only for FP16 scales
+            dequant += shift
+    else:
+        # Int4 quantization.
+        # Trick - instead of converting int4 to float16 we view it as float16
+        # and then multiply by 32768 * 512 == 2**24
+        if IS_HIP:
+            # Do final math in float32 to avoid casting to bf16 on MI300. There
+            # no direct instructions for this so its less performant on this workload.
+            quant_offset = (
+                (quant_offset & 0xF)
+                .to(tl.uint16)
+                .to(tl.float16, bitcast=True)
+                .to(tl.float32)
+            )
+            quant_offset = quant_offset * 32768.0
+        else:
+            quant_offset = (
+                (quant_offset & 0xF).to(tl.uint16).to(tl.float16, bitcast=True)
+            )
+            quant_offset = (quant_offset * 32768.0).to(tl.float16)
+        scale_512 = scale * 512
+
+        dequant = quant_offset * scale_512
+        if not USE_FP32_SCALES:
+            # Use asymmetric quantization only for FP16 scales
+            dequant += shift
+    return dequant
+
+
+@triton.jit
+def _splitK_reduce(
+    Out_splitK,  # [B, G, H, split_k, Mq, K]
+    LSE_splitK,  # [B, G, H, split_k, Mq]
+    Out,  # [B, H, M, K]
+    LSE,  # [B, H, M]
+    split_k: tl.constexpr,
+    splitK_pow2: tl.constexpr,
+    stride_osk_z: tl.constexpr,
+    stride_osk_g: tl.constexpr,
+    stride_osk_h: tl.constexpr,
+    stride_osk_s: tl.constexpr,
+    stride_osk_m: tl.constexpr,
+    stride_osk_k: tl.constexpr,
+    stride_lsek_z: tl.constexpr,
+    stride_lsek_g: tl.constexpr,
+    stride_lsek_h: tl.constexpr,
+    stride_lsek_s: tl.constexpr,
+    stride_lsek_m: tl.constexpr,
+    stride_oz: tl.constexpr,
+    stride_og: tl.constexpr,
+    stride_oh: tl.constexpr,
+    stride_om: tl.constexpr,
+    stride_ok: tl.constexpr,
+    stride_lse_z: tl.constexpr,
+    stride_lse_g: tl.constexpr,
+    stride_lse_h: tl.constexpr,
+    stride_lse_m: tl.constexpr,
+    head_dim: tl.constexpr,
+    head_dim_pow_2: tl.constexpr,
+    H: tl.constexpr,
+    G: tl.constexpr,
+    WRITE_LSE: tl.constexpr,
+):
+    # grid = (M, B * G * H, 1)
+    off_m = tl.program_id(0).to(tl.int64)
+    off_zhg = tl.program_id(1).to(tl.int64)
+    off_z = off_zhg // (H * G)
+    off_h = (off_zhg // G) % H
+    off_g = off_zhg % G
+
+    head_dim_mask = tl.arange(0, head_dim_pow_2) < head_dim
+
+    Out_splitK_ptr = (
+        Out_splitK
+        + stride_osk_z * off_z
+        + stride_osk_g * off_g
+        + stride_osk_h * off_h
+        + stride_osk_m * off_m
+        + tl.arange(0, head_dim_pow_2)[None, :]
+        + stride_osk_s * tl.arange(0, splitK_pow2)[:, None]
+    )
+
+    LSE_splitK_ptr0 = (
+        LSE_splitK
+        + stride_lsek_z * off_z
+        + stride_lsek_g * off_g
+        + stride_lsek_h * off_h
+        + stride_lsek_m * off_m
+        + stride_lsek_s * tl.arange(0, splitK_pow2)
+    )
+
+    if splitK_pow2 > split_k:
+        mask_1d = tl.arange(0, splitK_pow2) < split_k
+        mask_2d = mask_1d[:, None] & head_dim_mask[None, :]
+        lse_splitk = tl.load(LSE_splitK_ptr0, mask=mask_1d, other=float("-inf"))
+        lse_max = tl.max(lse_splitk)
+        out_splitk = tl.load(
+            Out_splitK_ptr, mask=mask_2d, other=0
+        )  # (split_k, head_dim_pow_2)
+        lse_splitk = tl.load(
+            LSE_splitK_ptr0, mask=mask_1d, other=float("-inf")
+        )  # (split_k,)
+    else:
+        lse_splitk = tl.load(LSE_splitK_ptr0)
+        lse_max = tl.max(lse_splitk)
+        out_splitk = tl.load(Out_splitK_ptr)
+        lse_splitk = tl.load(LSE_splitK_ptr0)
+
+    sumexp_normalized_splitk = tl.math.exp2(
+        (lse_splitk - lse_max).to(tl.float32) * 1.44269504
+    )  # (split_k,)
+    sumexp_normalized = tl.sum(sumexp_normalized_splitk, axis=0)  # scalar
+    # Compute numerator
+    numerator_normalized = tl.sum(
+        out_splitk * sumexp_normalized_splitk[:, None], axis=0
+    )
+    acc = numerator_normalized / sumexp_normalized
+    acc = tl.where(lse_max == float("-inf"), 0.0, acc)
+
+    Out_ptr = (
+        Out
+        + stride_oz * off_z
+        + stride_oh * off_h
+        + stride_og * off_g
+        + stride_om * off_m
+        + tl.arange(0, head_dim_pow_2)
+    )
+    if acc.dtype is tl.float64 and Out.dtype.element_ty is not tl.float64:
+        # must avoid direct cast f64->f16
+        acc = acc.to(tl.float32)
+    tl.store(Out_ptr, acc, mask=head_dim_mask)
+
+    if WRITE_LSE:
+        l_ptrs = (
+            LSE
+            + off_z * stride_lse_z
+            + off_g * stride_lse_g
+            + off_h * stride_lse_h
+            + off_m * stride_lse_m
+        )
+        to_store = lse_max + tl.math.log2(sumexp_normalized) / 1.44269504
+        to_store = tl.where(lse_max == float("-inf"), lse_max, to_store)
+        tl.store(l_ptrs, to_store)
+
+
+@triton.jit
+def _splitK_reduce_varargs(
+    Out_splitK: "VAR_ARGS_ARRAY",  # list of [B, G, H, Mq, K];
+    LSE_splitK: "VAR_ARGS_ARRAY",  # list of [B, G, H, Mq]
+    Out,  # [B, G, H, M, K]
+    LSE,  # [B, G, H, M]
+    stride_osk_z: "VAR_ARGS_ARRAY",
+    stride_osk_g: "VAR_ARGS_ARRAY",
+    stride_osk_h: "VAR_ARGS_ARRAY",
+    stride_osk_m: "VAR_ARGS_ARRAY",
+    stride_osk_k: "VAR_ARGS_ARRAY",
+    stride_lsek_z: "VAR_ARGS_ARRAY",
+    stride_lsek_g: "VAR_ARGS_ARRAY",
+    stride_lsek_h: "VAR_ARGS_ARRAY",
+    stride_lsek_m: "VAR_ARGS_ARRAY",
+    stride_oz,
+    stride_og,
+    stride_oh,
+    stride_om,
+    stride_ok,
+    stride_lse_z,
+    stride_lse_g,
+    stride_lse_h,
+    stride_lse_m,
+    head_dim: tl.constexpr,
+    head_dim_pow_2: tl.constexpr,
+    H: tl.constexpr,
+    G: tl.constexpr,
+    WRITE_LSE: tl.constexpr,
+):
+    """
+    This version of reduce kernel takes attention and LSE of chunks as lists of tensors,
+    as opposed to _splitK_reduce, which takes each as a stacked tensor.
+    """
+    # grid = (M, B * G * H, 1)
+    off_m = tl.program_id(0).to(tl.int64)
+    off_zhg = tl.program_id(1).to(tl.int64)
+    off_z = off_zhg // (H * G)
+    off_h = (off_zhg // G) % H
+    off_g = off_zhg % G
+    head_dim_mask = tl.arange(0, head_dim_pow_2) < head_dim
+
+    out_splitk_offset: "VAR_ARGS_ARRAY"  # noqa: F821
+    for i in range(len(Out_splitK)):
+        out_splitk_offset[i] = (  # noqa: F821
+            stride_osk_z[i] * off_z  # type: ignore # noqa: F821
+            + stride_osk_g[i] * off_g
+            + stride_osk_h[i] * off_h
+            + stride_osk_m[i] * off_m
+            + tl.arange(0, head_dim_pow_2)
+        )
+    lse_splitk_offset: "VAR_ARGS_ARRAY"  # noqa: F821
+    for i in range(len(Out_splitK)):
+        lse_splitk_offset[i] = (  # noqa: F821
+            stride_lsek_z[i] * off_z  # type: ignore # noqa: F821
+            + stride_lsek_g[i] * off_g
+            + stride_lsek_h[i] * off_h
+            + stride_lsek_m[i] * off_m
+        )
+
+    lse_max = float("-inf")
+    for split_k_idx in range(len(Out_splitK)):  # type: ignore # noqa: F821
+        LSE_splitK_ptr = LSE_splitK[split_k_idx] + lse_splitk_offset[split_k_idx]  # type: ignore # noqa: F821
+        lse_splitk = tl.load(LSE_splitK_ptr)
+        lse_max = tl.maximum(lse_max, lse_splitk)
+
+    sumexp_normalized = 0.0
+    numerator_normalized = tl.zeros([head_dim_pow_2], dtype=tl.float32)
+
+    for split_k_idx in range(len(Out_splitK)):  # type: ignore # noqa: F821
+        out_splitk = tl.load(
+            Out_splitK[split_k_idx] + out_splitk_offset[split_k_idx],  # type: ignore # noqa: F821
+            mask=head_dim_mask,
+        )
+        lse_splitk = tl.load(LSE_splitK[split_k_idx] + lse_splitk_offset[split_k_idx])  # type: ignore # noqa: F821
+        # Compute denominator
+        sumexp_normalized_splitk = tl.math.exp2(
+            (lse_splitk - lse_max).to(tl.float32) * 1.44269504
+        )
+        sumexp_normalized += sumexp_normalized_splitk
+
+        # Compute numerator
+        numerator_normalized += out_splitk * sumexp_normalized_splitk
+
+    acc = numerator_normalized / sumexp_normalized
+    acc = tl.where(lse_max == float("-inf"), 0.0, acc)
+
+    Out_ptr = (
+        Out
+        + stride_oz * off_z
+        + stride_oh * off_h
+        + stride_og * off_g
+        + stride_om * off_m
+        + tl.arange(0, head_dim_pow_2)
+    )
+    if acc.dtype is tl.float64 and Out.dtype.element_ty is not tl.float64:
+        # must avoid direct cast f64->f16
+        acc = acc.to(tl.float32)
+    tl.store(Out_ptr, acc, mask=head_dim_mask)
+
+    if WRITE_LSE:
+        l_ptrs = (
+            LSE
+            + off_z * stride_lse_z
+            + off_g * stride_lse_g
+            + off_h * stride_lse_h
+            + off_m * stride_lse_m
+        )
+        to_store = lse_max + tl.math.log2(sumexp_normalized) / 1.44269504
+        to_store = tl.where(lse_max == float("-inf"), lse_max, to_store)
+        tl.store(l_ptrs, to_store)
+
+
+@triton.jit
+def _splitK_reduce_varargs_backward(
+    Out_splitK: "VAR_ARGS_ARRAY",  # list of [B, G, H, Mq, K];
+    LSE_splitK: "VAR_ARGS_ARRAY",  # list of [B, G, H, Mq]
+    Dout_splitK: "VAR_ARGS_ARRAY",  # gradients - same shape as the inputs themselves
+    DLSE_splitK: "VAR_ARGS_ARRAY",
+    Out,  # [B, G, H, M, K]
+    LSE,  # [B, G, H, M]
+    DOut,
+    DLSE,
+    # strides of chunked inputs: attention and LSE
+    stride_osk_z: "VAR_ARGS_ARRAY",
+    stride_osk_g: "VAR_ARGS_ARRAY",
+    stride_osk_h: "VAR_ARGS_ARRAY",
+    stride_osk_m: "VAR_ARGS_ARRAY",
+    stride_osk_k: "VAR_ARGS_ARRAY",
+    stride_lsek_z: "VAR_ARGS_ARRAY",
+    stride_lsek_g: "VAR_ARGS_ARRAY",
+    stride_lsek_h: "VAR_ARGS_ARRAY",
+    stride_lsek_m: "VAR_ARGS_ARRAY",
+    # strides of merged outputs: attention and LSE
+    stride_oz,
+    stride_og,
+    stride_oh,
+    stride_om,
+    stride_ok,
+    stride_lse_z,
+    stride_lse_g,
+    stride_lse_h,
+    stride_lse_m,
+    # strides of gradients
+    stride_doz,
+    stride_dog,
+    stride_doh,
+    stride_dom,
+    stride_dok,
+    stride_dlse_z,
+    stride_dlse_g,
+    stride_dlse_h,
+    stride_dlse_m,
+    BLOCK_SIZE: tl.constexpr,
+    H: tl.constexpr,
+    G: tl.constexpr,
+):
+    """
+    Backward for _splitK_reduce_varargs. Similar to forward, it takes
+    attention and LSE of chunks as lists of tensors,
+    and outputs the corresponding gradients in the same format.
+    """
+
+    # grid = (M, B * G * H, 1)
+    off_m = tl.program_id(0).to(tl.int64)
+    off_zhg = tl.program_id(1).to(tl.int64)
+    off_z = off_zhg // (H * G)
+    off_h = (off_zhg // G) % H
+    off_g = off_zhg % G
+
+    # Compute offsets inside each attention/LSE chunk.
+    # Note that each chunk can have different strides, so offsets can also be different.
+    out_splitk_offset: "VAR_ARGS_ARRAY"  # noqa: F821
+    for i in range(len(Out_splitK)):
+        out_splitk_offset[i] = (  # type: ignore # noqa: F821
+            stride_osk_z[i] * off_z
+            + stride_osk_g[i] * off_g
+            + stride_osk_h[i] * off_h
+            + stride_osk_m[i] * off_m
+            + tl.arange(0, BLOCK_SIZE)
+        )
+    lse_splitk_offset: "VAR_ARGS_ARRAY"  # noqa: F821
+    for i in range(len(Out_splitK)):
+        lse_splitk_offset[i] = (  # type: ignore # noqa: F821
+            stride_lsek_z[i] * off_z
+            + stride_lsek_g[i] * off_g
+            + stride_lsek_h[i] * off_h
+            + stride_lsek_m[i] * off_m
+        )
+
+    lse_max = float("-inf")
+    for split_k_idx in range(len(Out_splitK)):  # type: ignore # noqa: F821
+        LSE_splitK_ptr = LSE_splitK[split_k_idx] + lse_splitk_offset[split_k_idx]  # type: ignore # noqa: F821
+        lse_splitk = tl.load(LSE_splitK_ptr)
+        lse_max = tl.maximum(lse_max, lse_splitk)
+
+    # Load attention and the corresponding gradient
+    offset_out = (
+        stride_oz * off_z
+        + stride_oh * off_h
+        + stride_og * off_g
+        + stride_om * off_m
+        + tl.arange(0, BLOCK_SIZE)
+    )
+    offset_dout = (
+        stride_doz * off_z
+        + stride_doh * off_h
+        + stride_dog * off_g
+        + stride_dom * off_m
+        + tl.arange(0, BLOCK_SIZE)
+    )
+    out = tl.load(Out + offset_out)
+    dattn = tl.load(DOut + offset_dout)
+
+    # Load LSE and the corresponding gradient
+    offset_lse = (
+        stride_lse_z * off_z
+        + stride_lse_h * off_h
+        + stride_lse_g * off_g
+        + stride_lse_m * off_m
+    )
+    offset_dlse = (
+        stride_dlse_z * off_z
+        + stride_dlse_h * off_h
+        + stride_dlse_g * off_g
+        + stride_dlse_m * off_m
+    )
+    lse = tl.load(LSE + offset_lse)
+    dlse = tl.load(DLSE + offset_dlse)
+
+    for split_k_idx in range(len(Out_splitK)):  # type: ignore # noqa: F821
+        # Load attention and LSE of chunks
+        out_splitk = tl.load(Out_splitK[split_k_idx] + out_splitk_offset[split_k_idx])  # type: ignore # noqa: F821
+        lse_splitk = tl.load(LSE_splitK[split_k_idx] + lse_splitk_offset[split_k_idx])  # type: ignore # noqa: F821
+
+        # Pointers to save gradients of attention and LSE of chunks
+        dout_splitk_ptr = Dout_splitK[split_k_idx] + out_splitk_offset[split_k_idx]  # type: ignore # noqa: F821
+        dlse_splitk_ptr = DLSE_splitK[split_k_idx] + lse_splitk_offset[split_k_idx]  # type: ignore # noqa: F821
+
+        # dX/dattn_i = dX/dattn * dattn/dattn_i + dX/dlse * dlse/dattn_i, and dlse/dattn_i == 0
+        dattn_dattn_i = tl.exp(lse_splitk - lse_max) / tl.exp(lse - lse_max)
+        dX_dattn_i = dattn_dattn_i * dattn
+        tl.store(dout_splitk_ptr, dX_dattn_i)
+
+        dattn_dlse_i = (out_splitk - out) * dattn_dattn_i
+
+        # dX/dlse_i = dX/dattn * dattn/dlse_i + dX/dlse * dlse/dlse_i
+        dlse_dlse_i = dattn_dattn_i
+        dX_dlse_i = dlse_dlse_i * dlse + tl.sum(
+            dattn_dlse_i * dattn
+        )  # Sum is over the hidden dimension
+        tl.store(dlse_splitk_ptr, dX_dlse_i)

--- a/mslk/attention/fmha/_triton/vararg_kernel.py
+++ b/mslk/attention/fmha/_triton/vararg_kernel.py
@@ -1,0 +1,261 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+import ast
+import copy
+import functools
+import linecache
+import os
+import sys
+import tempfile
+from enum import Enum
+from typing import Any, Dict, List
+
+import triton
+
+
+class _ForLoopUnroller(ast.NodeTransformer):
+    def __init__(self, target, inline_variables, loop_iter):
+        self.loop_iter = loop_iter
+        self.target = target
+        self.inline_variables = inline_variables
+
+    def visit_Name(self, node):
+        if node.id != self.target:
+            return node
+        return ast.Name(str(self.loop_iter))
+
+    def visit_Subscript(self, node):
+        # Pattern-matching `value[slice]`
+        if (
+            isinstance(node.slice, ast.Name)
+            and node.slice.id == self.target
+            and isinstance(node.value, ast.Name)
+            and node.value.id in self.inline_variables
+        ):
+            return ast.Name(f"{node.value.id}{self.loop_iter}")
+        return node
+
+
+class _VisitorVarargKernel(ast.NodeTransformer):
+    def __init__(self, N):
+        self.inline_variables = set()
+        self.N = N
+
+    def visit_AnnAssign(self, node):
+        # Pattern-matching:
+        # var_name: "VAR_ARGS_ARRAY"
+        if (
+            node.value is None
+            and node.simple == 1
+            and isinstance(node.target, ast.Name)
+            and isinstance(node.annotation, ast.Constant)
+            and node.annotation.value == "VAR_ARGS_ARRAY"
+        ):
+            self.inline_variables.add(node.target.id)
+            return []
+        if node.value is not None:
+            node.value = self.visit(node.value)
+        if node.annotation is not None:
+            node.annotation = self.visit(node.annotation)
+        if node.target is not None:
+            node.target = self.visit(node.target)
+        return node
+
+    def visit_arguments(self, node):
+        # Replace `args` annotated with `VAR_ARGS_ARRAY`
+        new_args = []
+        for arg in node.args:
+            if (
+                arg.annotation is not None
+                and isinstance(arg.annotation, ast.Constant)
+                and arg.annotation.value == "VAR_ARGS_ARRAY"
+            ):
+                self.inline_variables.add(arg.arg)
+                new_args += [ast.arg(f"{arg.arg}{i}") for i in range(self.N)]
+                continue
+            new_args.append(arg)
+        if node.vararg is not None:
+            self.inline_variables.add(node.vararg.arg)
+            new_args += [ast.arg(f"{node.vararg.arg}{i}") for i in range(self.N)]
+            node.vararg = None
+            new_args += node.kwonlyargs
+            node.kwonlyargs = []
+        node.args = new_args
+        return node
+
+
+class _VisitorUnrollKernel(_VisitorVarargKernel):
+    def visit_For(self, node):
+        if (
+            not isinstance(node.iter, ast.Call)
+            or node.iter.func.id != "range"
+            or len(node.iter.args) != 1
+            or not isinstance(node.iter.args[0], ast.Call)
+            or node.iter.args[0].func.id != "len"
+            or len(node.iter.args[0].args) != 1
+            or node.iter.args[0].args[0].id not in self.inline_variables
+        ):
+            node.body = [self.visit(x) for x in node.body]
+            return node
+        # We know we have to modify this loop
+        new_nodes = []
+        for i in range(self.N):
+            unroller = _ForLoopUnroller(
+                target=node.target.id,
+                inline_variables=self.inline_variables,
+                loop_iter=i,
+            )
+            for body in node.body:
+                body = copy.deepcopy(body)
+                new_node = ast.fix_missing_locations(unroller.visit(body))
+                new_node = self.visit(new_node)
+                new_nodes.append(new_node)
+        return new_nodes
+
+
+class _VisitorConditionalKernel(_VisitorVarargKernel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.extra_nodes = None
+
+    def visit_Subscript(self, node):
+        if isinstance(node.value, ast.Subscript):
+            node.value = self.visit_Subscript(node.value)
+            return node
+        if not isinstance(node.value, ast.Name):
+            return node
+        if node.value.id in self.inline_variables and isinstance(node.slice, ast.Name):
+            # given `a[i]`, replace with `res`, where `res` is:
+            # a0 if i == 0 else a1 if i== 1 else a2 if i == 2 ...
+            if_statements = [None] * self.N
+            if_statements[-1] = ast.Name(f"{node.value.id}{self.N - 1}")
+
+            for i in reversed(range(self.N - 1)):
+                test = ast.Compare(node.slice, [ast.Eq()], [ast.Constant(i)])
+                body = ast.Name(f"{node.value.id}{i}")
+                if_statements[i] = ast.IfExp(
+                    test=test,
+                    body=body,
+                    orelse=if_statements[i + 1],
+                )
+
+            return if_statements[0]
+        return node
+
+    def visit_Call(self, node):
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "len"
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id in self.inline_variables
+        ):
+            return ast.Constant(self.N)
+        self.generic_visit(node)
+        return node
+
+
+# Hackfix to get access to get source-code for
+# `exec`-created functions - see https://stackoverflow.com/a/69668999
+_getlines_orig = None
+_FILENAME_TO_SRC: Dict[str, List[str]] = {}
+
+# Materializing the codegen to disk can be useful for external tools, e.g. ncu
+# Disabled by default because writing to disk at module import time is unexpected and error-prone.
+_should_materialize_codegen = os.environ.get("XFORMERS_MATERIALIZE_CODEGEN") == "1"
+_should_keep_materialized_source = os.environ.get("XFORMERS_KEEP_CODEGEN") == "1"
+_tmp_dir = None
+
+
+def _monkey_patched_getlines(filename, module_globals=None):
+    if filename in _FILENAME_TO_SRC:
+        return _FILENAME_TO_SRC[filename]
+    else:
+        return _getlines_orig(filename, module_globals)  # type: ignore
+
+
+class VarargMode(Enum):
+    UNROLL = "unroll"
+    CONDITIONAL = "conditional"
+
+
+@functools.lru_cache(None)
+def unroll_varargs(kernel, N: int, mode: VarargMode = VarargMode.UNROLL):
+    """
+    Specializes a triton kernel with variable number of inputs
+    to a specific number of inputs `N`.
+
+    `mode` can either be `UNROLL` or `CONDITIONAL`. Both options
+    implement the same functionality, but have different implementations
+    and can have different performance. In `UNROLL` mode, any loops that
+    loop over the varargs will be unrolled. In `CONDITIONAL` mode,
+    indexing into the list of varargs is replaced with conditional
+    statements like `a0 if i==0 else a1 if i==1 else a2...`.
+    `CONDITIONAL` mode is generally better if `N` is large, because it
+    generates a smaller triton kernel that should fit in the
+    instruction cache and will compile faster.
+
+    NOTE: Because it's quite costly to call `triton.jit`,
+    we cache the returned value with `lru_cache`
+    """
+    global _getlines_orig, _tmp_dir
+
+    k = triton.JITFunction(kernel.fn)
+    parsed = ast.parse(k.src)  # type: ignore
+    if mode == VarargMode.UNROLL:
+        nodeVisitor: _VisitorVarargKernel = _VisitorUnrollKernel(N=N)
+    elif mode == VarargMode.CONDITIONAL:
+        nodeVisitor = _VisitorConditionalKernel(N=N)
+    parsed = nodeVisitor.visit(parsed)
+    parsed = ast.fix_missing_locations(parsed)
+
+    # NOTE: `ast.unparse` requires python 3.9+
+    if (sys.version_info.major, sys.version_info.minor) <= (3, 8):
+        raise RuntimeError("Error: This functionality requires python 3.9 or above")
+    new_src = ast.unparse(parsed)  # type: ignore
+
+    # Now we want to `eval` the function, but we need all this
+    # boilerplate code to make sure triton can run `inspect.getsource`
+
+    fn_basename = f"unroll_varargs-{kernel.fn.__name__}-{mode.value}-{N}"
+    if _should_materialize_codegen:
+        if not _tmp_dir:
+            _tmp_dir = tempfile.TemporaryDirectory()
+        fn_filename = os.path.join(_tmp_dir.name, f"{fn_basename}.py")
+        if _should_keep_materialized_source:
+            # destroy the TemporaryDirectory object
+            _tmp_dir = None
+            # create path if not exists
+            os.makedirs(os.path.dirname(fn_filename), exist_ok=True)
+        with open(fn_filename, "w") as f:
+            f.write(new_src)
+    else:
+        # Patch `getlines` only the first time
+        if not _FILENAME_TO_SRC:
+            _getlines_orig = linecache.getlines
+            linecache.getlines = _monkey_patched_getlines
+        fn_filename = f"<{fn_basename}>"
+        _FILENAME_TO_SRC[fn_filename] = new_src.splitlines(keepends=True)
+
+    # Create function given source
+    code = compile(new_src, fn_filename, "exec")
+
+    _locals: Dict[str, Any] = {}
+    exec(code, kernel.fn.__globals__, _locals)
+    assert len(_locals) == 1, len(_locals)
+    fn = next(iter(_locals.values()))
+
+    jitted_fn = triton.jit(fn)
+    if not hasattr(jitted_fn, "_unsafe_update_src"):
+        # Triton older than 3.2
+        jitted_fn.src = new_src
+    return jitted_fn
+
+
+# Note: just import this to make mypy happy
+# when annotating variables with `VAR_ARGS_ARRAY`
+VAR_ARGS_ARRAY = List[Any]

--- a/mslk/attention/fmha/attn_bias.py
+++ b/mslk/attention/fmha/attn_bias.py
@@ -1,0 +1,2183 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+"""
+This file contains biases that can be used as the `attn_bias` argument in
+:attr:`xformers.ops.memory_efficient_attention`.
+Essentially, a bias is a Tensor which will be added to the ``Q @ K.t`` before
+computing the ``softmax``.
+
+
+The goal of having custom made classes (instead of dense tensors) is that
+we want to avoid having to load the biases from memory in the kernel, for
+performance reasons. We also want to be able to know before-hand which
+parts of the attention matrix we will need to compute (eg causal masks).
+
+
+Some very common biases are LowerTriangularMask and BlockDiagonalMask.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import (
+    Any,
+    cast,
+    ClassVar,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
+
+import torch
+
+
+def _to_device(t: torch.Tensor, device: torch.device) -> torch.Tensor:
+    if t.device == device:
+        return t
+    if device == torch.device("cpu"):
+        return t.to(device)
+
+    return t.to(device, non_blocking=True)
+
+
+def _to_device_tensor(seq: Sequence[int], dtype: torch.dtype, device: torch.device):
+    if device == torch.device("cpu"):
+        return torch.tensor(seq, dtype=dtype)
+
+    return torch.tensor(seq, dtype=dtype, pin_memory=True).to(device, non_blocking=True)
+
+
+class AttentionBias:
+    """Base class for a custom bias that can be applied \
+        as the attn_bias argument in
+    :attr:`xformers.ops.memory_efficient_attention`.
+
+    That function has the ability to add a tensor, the
+    attention bias, to the QK^T matrix before it is used
+    in the softmax part of the attention calculation.
+    The attention bias tensor with shape
+    (B or 1, n_queries, number of keys)
+    can be given as the attn_bias input.
+    The most common use case is for an attention bias is
+    to contain only zeros and negative infinities, which forms
+    a mask so that some queries only attend to some keys.
+
+    Children of this class define alternative things which can
+    be used as the attn_bias input to define an attention bias which
+    forms such a mask, for some common cases.
+
+    When using an :attr:`xformers.ops.AttentionBias`
+    instead of a :attr:`torch.Tensor`, the mask matrix does
+    not need to be materialized, and can be
+    hardcoded into some kernels for better performance.
+
+    See:
+
+    - :attr:`xformers.ops.fmha.attn_bias.LowerTriangularMask`
+    - :attr:`xformers.ops.fmha.attn_bias.LowerTriangularFromBottomRightMask`
+    - :attr:`xformers.ops.fmha.attn_bias.LowerTriangularMaskWithTensorBias`
+    - :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`
+    - :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`
+
+    """
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """
+        Materializes the bias as a `torch.Tensor`. This is very slow
+        and we don't attempt to make it fast. Only use for debugging/testing.
+
+        Shape should be like `[*, q_seqlen, k_seqlen]`
+        """
+        raise NotImplementedError()
+
+
+def _get_default_bias_device(device: Optional[torch.device] = None) -> torch.device:
+    if device is None:
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        if torch.mtia.is_available():
+            return torch.device("mtia")
+        return torch.device("cpu")
+    return device
+
+
+def _materialize_causal_mask(
+    shape: Tuple[int, ...],
+    dtype: torch.dtype = torch.float32,
+    device: Union[str, torch.device] = "cpu",
+    *,
+    window_size: Optional[int] = None,
+    from_bottomright: bool = False,
+) -> torch.Tensor:
+    create_as = dtype if dtype is not torch.bfloat16 else torch.float32
+    tensor = torch.full(  # type: ignore
+        shape,
+        dtype=create_as,
+        fill_value=1,
+        device=device,
+    )
+
+    num_queries, num_keys = shape[-2:]
+    shift = 0
+    if from_bottomright:
+        shift = num_keys - num_queries
+
+    mask = torch.tril(tensor, diagonal=shift).to(dtype)  # type: ignore
+    if window_size is not None:
+        mask = torch.triu(mask, diagonal=shift - window_size + 1)
+    mask = torch.log(mask)
+    return mask.to(dtype)
+
+
+class LowerTriangularMask(AttentionBias):
+    """
+    A lower-triangular (aka causal) mask
+
+    A query Q cannot attend to a key which is farther from the
+    initial key than Q is from the initial query.
+
+    See also :attr:`LowerTriangularFromBottomRightMask` if the number
+    of queries is not equal to the number of keys/values.
+    """
+
+    def to(self, device: torch.device) -> "LowerTriangularMask":
+        assert type(self) is LowerTriangularMask, "Please implement in subclass"
+        return self
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return _materialize_causal_mask(shape, dtype=dtype, device=device)
+
+    def add_bias(self, bias: torch.Tensor) -> "LowerTriangularMaskWithTensorBias":
+        """
+        Creates a new causal mask with an arbitrary ``torch.Tensor`` bias
+        """
+        return LowerTriangularMaskWithTensorBias(bias)
+
+
+@dataclass
+class LocalAttentionFromBottomRightMask(AttentionBias):
+    """
+    A local attention mask
+
+    The query at position :math:`q` can attend the key at position :math:`k` if
+    :math:`q - window\\_left <= k + s <= q + window\\_right`
+
+    With :math:`s = num\\_queries - num\\_keys`
+
+    :Example:
+
+    .. code-block:: python
+
+        import torch
+        from xformers.ops import fmha
+
+        bias = fmha.attn_bias.LocalAttentionFromBottomRightMask(window_left=1, window_right=2)
+        print(bias.materialize(shape=(4, 4)).exp())
+        print(bias.materialize(shape=(4, 5)).exp())
+
+    .. code-block:: text
+
+        # 4x4
+        tensor([[1., 1., 1., 0.],
+                [1., 1., 1., 1.],
+                [0., 1., 1., 1.],
+                [0., 0., 1., 1.]])
+
+        # 4x5
+        tensor([[1., 1., 1., 1., 0.],
+                [0., 1., 1., 1., 1.],
+                [0., 0., 1., 1., 1.],
+                [0., 0., 0., 1., 1.]])
+
+    :Illustration:
+
+    .. figure:: /_static/local_attn.png
+        :width: 240px
+
+        The total window size is :math:`window\\_left + 1 + window\\_right`
+    """
+
+    window_left: int
+    window_right: int
+
+    def to(self, device) -> "LocalAttentionFromBottomRightMask":
+        return self
+
+    def __post_init__(self) -> None:
+        if self.window_left < 0:
+            raise ValueError(
+                "Invalid window value passed to "
+                "`LocalAttentionFromBottomRightMask`: expected"
+                f"`window_left > 0` but got window_left={self.window_left}"
+            )
+        if self.window_right < 0:
+            raise ValueError(
+                "Invalid window value passed to "
+                "`LocalAttentionFromBottomRightMask`: expected"
+                f"`window_right > 0` but got window_right={self.window_right}"
+            )
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        create_as = dtype if dtype is not torch.bfloat16 else torch.float32
+        mask = torch.full(  # type: ignore
+            shape,
+            dtype=create_as,
+            fill_value=1,
+            device=device,
+        )
+
+        mask = _apply_locality_on_mask(mask, self.window_left, self.window_right)
+        mask = torch.log(mask)
+        return mask.to(dtype)
+
+
+class LowerTriangularFromBottomRightMask(AttentionBias):
+    """
+    A causal masking.
+
+    This mask is exactly the same as :attr:`LowerTriangularMask` when there is
+    the same number of queries and keys.
+    When the number of queries is different from the number of keys,
+    it is a triangular mask shifted so that the last query can attend to
+    the last key.
+    In other words, a query Q cannot attend to a key which is nearer the
+    final key than Q is to the final query.
+
+
+    .. figure:: /_static/causal_bottom_right.png
+
+        The difference between :attr:`LowerTriangularMask` (left) and
+        :attr:`LowerTriangularFromBottomRightMask` (right). They become
+        equivalent if the number of queries equals the number of keys.
+    """
+
+    def to(self, device: torch.device) -> "LowerTriangularFromBottomRightMask":
+        assert (
+            type(self) is LowerTriangularFromBottomRightMask
+        ), "Please implement in subclass"
+        return self
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return _materialize_causal_mask(
+            shape, dtype=dtype, device=device, from_bottomright=True
+        )
+
+    def make_local_attention(
+        self, window_size: int
+    ) -> "LowerTriangularFromBottomRightLocalAttentionMask":
+        """
+        Create a new bias which combines local + causal attention.
+
+        See :attr:`LowerTriangularFromBottomRightLocalAttentionMask`
+        """
+        return LowerTriangularFromBottomRightLocalAttentionMask(window_size)
+
+
+@dataclass
+class LowerTriangularFromBottomRightLocalAttentionMask(
+    LowerTriangularFromBottomRightMask
+):
+    """
+    A mask that combines both :attr:`LowerTriangularFromBottomRightMask` and
+    local attention.
+
+    A query whose distance from the final query is X cannot attend to a key
+    whose distance to the final key is either of:
+
+    * less than X (i.e. "causal attention", same as :attr:`LowerTriangularFromBottomRightMask`)
+    * greater than or equal to X + window_size (i.e. "local attention")
+
+
+    .. figure:: /_static/causal_bottom_right_local.png
+
+        The mask from :attr:`LowerTriangularFromBottomRightLocalAttentionMask`.
+        The green area is calculated, and the grey area is masked out.
+    """
+
+    _window_size: int
+
+    def to(
+        self, device: torch.device
+    ) -> "LowerTriangularFromBottomRightLocalAttentionMask":
+        assert (
+            type(self) is LowerTriangularFromBottomRightLocalAttentionMask
+        ), "Please implement in subclass"
+        return self
+
+    def __post_init__(self) -> None:
+        if self._window_size <= 0:
+            raise ValueError(
+                f"Expected `window_size > 0`, but window_size={self._window_size}"
+            )
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return _materialize_causal_mask(
+            shape,
+            dtype=dtype,
+            device=device,
+            window_size=self._window_size,
+            from_bottomright=True,
+        )
+
+
+class LowerTriangularMaskWithTensorBias(LowerTriangularMask):
+    """A lower-triangular (aka causal) mask with an additive bias"""
+
+    def __init__(self, bias: torch.Tensor) -> None:
+        self._bias = bias
+
+    def to(self, device: torch.device) -> "LowerTriangularMaskWithTensorBias":
+        assert (
+            type(self) is LowerTriangularMaskWithTensorBias
+        ), "Please implement in subclass"
+        return LowerTriangularMaskWithTensorBias(_to_device(self._bias, device))
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return super().materialize(shape, dtype=dtype, device=device) + self._bias
+
+
+@dataclass
+class _SeqLenInfo:
+    """
+    (Internal) Represents the division of a dimension into blocks.
+
+    For example, to represents a dimension of length 7 divided into
+    three blocks of lengths 2, 3 and 2, use `from_seqlength([2, 3, 2])`.
+    The members will be:
+        max_seqlen: 3
+        min_seqlen: 2
+        seqstart_py: [0, 2, 5, 7]
+        seqstart: torch.IntTensor([0, 2, 5, 7])
+    """
+
+    seqstart: torch.Tensor
+    max_seqlen: int
+    min_seqlen: int
+    seqstart_py: List[int]
+
+    def to(self, device: torch.device) -> "_SeqLenInfo":
+        assert type(self) is _SeqLenInfo, "Please implement in subclass"
+        if self.seqstart.device == device:
+            return self
+        return _SeqLenInfo(
+            seqstart=_to_device(self.seqstart, device),
+            max_seqlen=self.max_seqlen,
+            min_seqlen=self.min_seqlen,
+            seqstart_py=self.seqstart_py,
+        )
+
+    def intervals(self) -> Iterable[Tuple[int, int]]:
+        yield from zip(self.seqstart_py, self.seqstart_py[1:])
+
+    @classmethod
+    def _get_seqstart(
+        cls, seqlens: Iterable[int], *, device: torch.device
+    ) -> Tuple[int, int, List[int], torch.Tensor]:
+        """
+        Given sequence lengths, returns the min/max value and the sequence start
+        positions (offsets), with first element being 0 (returned in list and Tensor).
+        """
+
+        assert not isinstance(seqlens, torch.Tensor)
+        seqstart_py = [0]
+        max_seqlen = -1
+        min_seqlen = -1
+        for seqlen in seqlens:
+            min_seqlen = min(min_seqlen, seqlen) if min_seqlen != -1 else seqlen
+            max_seqlen = max(max_seqlen, seqlen)
+            seqstart_py.append(seqstart_py[len(seqstart_py) - 1] + seqlen)
+        seqstart = _to_device_tensor(seqstart_py, dtype=torch.int32, device=device)
+
+        return (min_seqlen, max_seqlen, seqstart_py, seqstart)
+
+    @classmethod
+    def from_seqlens(
+        cls, seqlens: Iterable[int], *, device: Optional[torch.device] = None
+    ) -> "_SeqLenInfo":
+        """
+        Input tensors are assumed to be in shape [B, M, *]
+        """
+        device = _get_default_bias_device(device)
+        min_seqlen, max_seqlen, seqstart_py, seqstart = cls._get_seqstart(
+            seqlens, device=device
+        )
+
+        return cls(
+            max_seqlen=max_seqlen,
+            min_seqlen=min_seqlen,
+            seqstart=seqstart,
+            seqstart_py=seqstart_py,
+        )
+
+    def from_seqlens_inplace(self, seqlens: Iterable[int]) -> None:
+        """
+        Perform in-place update. You can only update with the same shape.
+        Can be useful with CUDA graphs.
+        """
+        min_seqlen, max_seqlen, seqstart_py, seqstart = self._get_seqstart(
+            seqlens, device=self.seqstart.device
+        )
+
+        assert len(seqstart_py) == len(self.seqstart_py), (
+            f"Old / New len {len(self.seqstart_py)} / {len(seqstart)}, "
+            f"Contents {self.seqstart_py} / {seqstart}"
+        )
+        assert self.max_seqlen >= max_seqlen, (
+            f"For inplace update, new max_seqlen {max_seqlen} "
+            f"cannot exceed the previous max_seqlen {self.max_seqlen}"
+        )
+        for i in range(len(seqstart_py)):
+            self.seqstart_py[i] = seqstart_py[i]
+        self.seqstart.copy_(seqstart, non_blocking=True)
+
+    def split(
+        self, x: torch.Tensor, batch_sizes: Optional[Sequence[int]] = None
+    ) -> List[torch.Tensor]:
+        if self.seqstart_py[-1] != x.shape[1] or x.shape[0] != 1:
+            raise ValueError(
+                f"Invalid `torch.Tensor` of shape {x.shape}, expected format "
+                f"(B, M, *) with B=1 and M={self.seqstart_py[-1]}\n"
+                f" seqstart: {self.seqstart_py}"
+            )
+        if batch_sizes is None:
+            batch_sizes = [1] * (len(self.seqstart_py) - 1)
+        split_chunks = []
+        it = 0
+        for batch_size in batch_sizes:
+            split_chunks.append(
+                self.seqstart_py[it + batch_size] - self.seqstart_py[it]
+            )
+            it += batch_size
+        return [
+            tensor.reshape([bs, -1, *tensor.shape[2:]])
+            for bs, tensor in zip(batch_sizes, x.split(split_chunks, dim=1))
+        ]
+
+
+@dataclass
+class _PaddedSeqLenInfo(_SeqLenInfo):
+    """
+    (Internal)  Represents the division of a dimension into blocks which are
+    padded out to the same total length.
+
+    For example, to represent a dimension of length 12 with space for
+    three blocks of length 4, but where the occupied lengths are
+    2, 3 and 2, use `from_seqlens_padded([2, 3, 2], 4)`.
+
+    The layout along the dimension is
+
+     0 ─►  block 0
+           block 0
+           <space>
+           <space>
+     4 ─►  block 1
+           block 1
+           block 1
+           <space>
+     8 ─►  block 2
+           block 2
+           <space>
+           <space>
+    12 ─►
+
+    The members will be:
+        max_seqlen: 3
+        min_seqlen: 2
+        seqstart_py: [0, 4, 8, 12]
+        seqstart: torch.IntTensor([0, 4, 8, 12])
+        seqlen_py: [2, 3, 2]
+        seqlen: torch.IntTensor([2, 3, 2])
+        padding: 4
+    """
+
+    seqlen: torch.Tensor
+    seqlen_py: List[int]
+    padding: int
+    # From parent: seqstart[i] contains the start position
+    # of the i-th sequence
+    # seqstart: torch.Tensor
+
+    def __post_init__(self) -> None:
+        assert len(self.seqstart_py) == len(self.seqlen_py) + 1
+
+    def to(self, device: torch.device) -> "_PaddedSeqLenInfo":
+        assert type(self) is _PaddedSeqLenInfo, "Please implement in subclass"
+        if self.seqlen.device == device:
+            return self
+        return _PaddedSeqLenInfo(
+            # _SeqLenInfo
+            seqstart=_to_device(self.seqstart, device),
+            max_seqlen=self.max_seqlen,
+            min_seqlen=self.min_seqlen,
+            seqstart_py=self.seqstart_py,
+            # _PaddedSeqLenInfo
+            seqlen=_to_device(self.seqlen, device),
+            seqlen_py=self.seqlen_py,
+            padding=self.padding,
+        )
+
+    def intervals(self) -> Iterable[Tuple[int, int]]:
+        for (start, _), length in zip(super().intervals(), self.seqlen_py):
+            yield start, start + length
+
+    @classmethod
+    def from_seqlens(
+        cls, seqlens: Iterable[int], *, device: Optional[torch.device] = None
+    ) -> "_SeqLenInfo":
+        raise RuntimeError(
+            "Use either `_SeqLenInfo.from_seqlens` or `_PaddedSeqLenInfo.from_seqlens_padded`"
+        )
+
+    @classmethod
+    def from_seqlens_padded(
+        cls,
+        seqlens: Sequence[int],
+        padding: int,
+        *,
+        device: Optional[torch.device] = None,
+    ) -> "_PaddedSeqLenInfo":
+        """
+        Input tensors are assumed to be in shape [B, M, *]
+        seqstart = padding * torch.arange(batch_size)
+        """
+        assert not isinstance(seqlens, torch.Tensor)
+        assert all(
+            seqlen <= padding for seqlen in seqlens
+        ), f"Seqlens {seqlens} Padding {padding}"
+        device = _get_default_bias_device(device)
+        seqstart_py = list(range(0, len(seqlens) * padding + 1, padding))
+        seqlen = _to_device_tensor(seqlens, dtype=torch.int32, device=device)
+        return cls(
+            seqlen=seqlen,
+            seqlen_py=seqlens if isinstance(seqlens, list) else list(seqlens),
+            max_seqlen=max(seqlens),
+            min_seqlen=min(seqlens),
+            seqstart=_to_device_tensor(seqstart_py, dtype=torch.int32, device=device),
+            seqstart_py=seqstart_py,
+            padding=padding,
+        )
+
+    def from_seqlens_padded_inplace(self, seqlens: Sequence[int]) -> None:
+        """
+        Perform in-place update. You can only update with the same shape.
+        Can be useful with CUDA graphs.
+        Note: we don't update padding because they would have been already baked
+        into CUDA graphs during the generation.
+        """
+        assert not isinstance(seqlens, torch.Tensor)
+        assert all(
+            seqlen <= self.padding for seqlen in seqlens
+        ), f"Seqlens {seqlens} Padding {self.padding}"
+        seqlen_tensor = torch.tensor(seqlens, dtype=torch.int32)
+
+        assert len(self.seqlen_py) == len(seqlens), (
+            f"Old/New len {len(self.seqlen_py)} / {len(seqlens)}, "
+            f"Contents {self.seqlen_py} / {seqlens}"
+        )
+        assert self.max_seqlen >= max(seqlens), (
+            f"For inplace update, new max_seqlen {max(seqlens)} "
+            f"cannot exceed the previous max_seqlen {self.max_seqlen}"
+        )
+
+        for i in range(len(self.seqlen_py)):
+            self.seqlen_py[i] = seqlens[i]
+
+        self.seqlen.copy_(seqlen_tensor, non_blocking=True)
+
+    def split(
+        self, x: torch.Tensor, batch_sizes: Optional[Sequence[int]] = None
+    ) -> List[torch.Tensor]:
+        raise NotImplementedError("_PaddedSeqLenInfo.split")
+
+
+@dataclass
+class _GappySeqInfo(_SeqLenInfo):
+    """
+    (Internal) Flexible equivalent of _PaddedSeqLenInfo. There are two
+    distinct semantics.
+
+    (1) For non-paged masks:
+    Represents the division of a dimension into blocks which are
+    anywhere. Each just has a start and a length. The final start is the total
+    length of the dimension.
+
+    For example, to represent a dimension of length 14 like follows with
+    three occupied lengths of
+    6, 3 and 1, use `from_seqlens_padded([0, 7, 12, 14], [6, 3, 1])`.
+
+    The layout along the dimension is
+
+     0 ─►  block 0
+           block 0
+           block 0
+           block 0
+     4 ─►  block 0
+           block 0
+           <space>
+           block 1
+     8 ─►  block 1
+           block 1
+           <space>
+           <space>
+     12 ─► block 2
+           <space>
+
+    The members will be:
+        max_seqlen: 6
+        min_seqlen: 1
+        seqstart_py: [0, 7, 12, 14]
+        seqstart: torch.IntTensor([0, 7, 12, 14])
+        seqlen_py: [6, 3, 1]
+        seqlen: torch.IntTensor([6, 3, 1])
+
+    (2) For paged masks:
+    The notional space is divided into batch-size-many blocks.
+    seqstart and seqstart_py is an offset in the block, not in
+    the whole space, and the extra last element is not important.
+    And seqlen is the index of the last key in the block.
+    Otherwise as above.
+    """
+
+    seqlen: torch.Tensor
+    seqlen_py: Sequence[int]
+    # From parent: seqstart[i] contains the start position
+    # of the i-th sequence
+    # seqstart: torch.Tensor
+
+    def to(self, device: torch.device) -> "_GappySeqInfo":
+        assert type(self) is _GappySeqInfo, "Please implement in subclass"
+        if self.seqlen.device == device:
+            return self
+        return _GappySeqInfo(
+            # _SeqLenInfo
+            seqstart=_to_device(self.seqstart, device),
+            max_seqlen=self.max_seqlen,
+            min_seqlen=self.min_seqlen,
+            seqstart_py=self.seqstart_py,
+            # _GappySeqInfo
+            seqlen=_to_device(self.seqlen, device),
+            seqlen_py=self.seqlen_py,
+        )
+
+    def intervals(self) -> Iterable[Tuple[int, int]]:
+        for (start, _), length in zip(super().intervals(), self.seqlen_py):
+            yield start, start + length
+
+    @classmethod
+    def from_seqlens(
+        cls, seqlens: Iterable[int], *, device: Optional[torch.device] = None
+    ) -> "_SeqLenInfo":
+        raise NotImplementedError()
+
+    @classmethod
+    def from_seqlens_gappy(
+        cls,
+        seqstarts: Sequence[int],
+        seqlens: Sequence[int],
+        paged: bool,
+        *,
+        device: torch.device,
+    ) -> "_GappySeqInfo":
+        assert not isinstance(seqlens, torch.Tensor)
+        seqstart_py = list(seqstarts)
+        if len(seqlens) == 0:
+            raise ValueError("No elements")
+        if len(seqstarts) - len(seqlens) != 1:
+            raise ValueError(
+                f"len(seqstarts)={seqstarts} should be len(seqlens)={seqlens}"
+            )
+        max_seqlen = max(seqlens)
+        min_seqlen = min(seqlens)
+        if paged:
+            seqstart_py.append(-1)
+            seqlens = [i + j for i, j in zip(seqstart_py, seqlens)]
+        seqlen = _to_device_tensor(seqlens, dtype=torch.int32, device=device)
+        return cls(
+            seqlen=seqlen,
+            seqlen_py=seqlens,
+            max_seqlen=max_seqlen,
+            min_seqlen=min_seqlen,
+            seqstart=_to_device_tensor(seqstart_py, dtype=torch.int32, device=device),
+            seqstart_py=seqstart_py,
+        )
+
+    def split(
+        self, x: torch.Tensor, batch_sizes: Optional[Sequence[int]] = None
+    ) -> List[torch.Tensor]:
+        raise NotImplementedError("_GappySeqInfo.split")
+
+
+@dataclass
+class BlockDiagonalMask(AttentionBias):
+    """
+    A block-diagonal mask that can be passed as ``attn_bias``
+    argument to :attr:`xformers.ops.memory_efficient_attention`.
+
+    Queries and Keys are each divided into the same number of blocks.
+    Queries in block i only attend to keys in block i.
+
+    .. figure:: /_static/block_diag_bias.png
+
+        This bias can be used to handle a batch of sequences of
+        different lengths, via :attr:`BlockDiagonalMask.from_tensor_list`
+
+    :Example:
+
+    .. code-block:: python
+
+        import torch
+        from xformers.ops import fmha
+
+        K = 16
+        dtype = torch.float16
+        device = "cuda"
+        list_x = [
+            torch.randn([1, 3, 1, K], dtype=dtype, device=device),
+            torch.randn([1, 6, 1, K], dtype=dtype, device=device),
+            torch.randn([1, 2, 1, K], dtype=dtype, device=device),
+        ]
+        attn_bias, x = fmha.BlockDiagonalMask.from_tensor_list(list_x)
+        linear = torch.nn.Linear(K, K * 3).to(device=device, dtype=dtype)
+
+        q, k, v = linear(x).reshape([1, -1, 1, 3, K]).unbind(-2)
+        out = fmha.memory_efficient_attention(q, k, v, attn_bias=attn_bias)
+        list_out = attn_bias.split(out)
+        print(list_out[0].shape)  # [1, 3, 1, K]
+        assert tuple(list_out[0].shape) == (1, 3, 1, K)
+
+    """
+
+    q_seqinfo: _SeqLenInfo
+    k_seqinfo: _SeqLenInfo
+    _batch_sizes: Optional[Sequence[int]] = None
+
+    def to(self, device) -> "BlockDiagonalMask":
+        assert type(self) is BlockDiagonalMask, "Please implement in subclass"
+        return BlockDiagonalMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            _batch_sizes=self._batch_sizes,
+        )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return torch.zeros(
+            shape,
+            dtype=dtype,
+            device=device,
+        )
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        assert shape[-1] == self.k_seqinfo.seqstart_py[-1], (
+            shape[-1],
+            self.k_seqinfo.seqstart_py[-1],
+        )
+        assert shape[-2] == self.q_seqinfo.seqstart_py[-1], (
+            shape[-2],
+            self.q_seqinfo.seqstart_py[-1],
+        )
+        mask = torch.empty(shape[-2:], dtype=dtype, device=device)
+        mask.fill_(-math.inf)
+        for (q_start, q_end), (k_start, k_end) in zip(
+            self.q_seqinfo.intervals(),
+            self.k_seqinfo.intervals(),
+        ):
+            mask[q_start:q_end, k_start:k_end] = self._create_block_mask(
+                (q_end - q_start, k_end - k_start),
+                dtype=dtype,
+                device=device,
+            )
+        for _ in range(len(shape) - 2):
+            mask = mask.unsqueeze(0)
+        return mask.expand(shape)
+
+    @classmethod
+    def from_seqlens(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_seqlen: Optional[Sequence[int]] = None,
+        *,
+        device: Optional[torch.device] = None,
+    ) -> "BlockDiagonalMask":
+        """Creates a :attr:`BlockDiagonalMask` from a list of tensors lengths for query and key/value.
+
+        Args:
+            q_seqlen (Union[Sequence[int], torch.Tensor]): List or tensor of sequence lengths for query tensors
+            kv_seqlen (Union[Sequence[int], torch.Tensor], optional): List or tensor of sequence lengths for key/value.
+                    (Defaults to ``q_seqlen``.)
+        Returns:
+            BlockDiagonalMask
+        """
+        device = _get_default_bias_device(device)
+        assert kv_seqlen is None or len(q_seqlen) == len(kv_seqlen)
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen, device=device)
+        if kv_seqlen is None or q_seqlen == kv_seqlen:
+            k_seqinfo = q_seqinfo
+        else:
+            k_seqinfo = _SeqLenInfo.from_seqlens(kv_seqlen, device=device)
+        return cls(q_seqinfo=q_seqinfo, k_seqinfo=k_seqinfo)
+
+    @classmethod
+    def from_tensor_list(
+        cls,
+        tensors: Sequence[torch.Tensor],
+    ) -> Tuple["BlockDiagonalMask", torch.Tensor]:
+        """Creates a :attr:`BlockDiagonalMask` from a list of tensors, and returns the tensors
+        concatenated on the sequence length dimension
+
+        .. figure:: /_static/block_diag_cat_split.png
+
+            See also :attr:`BlockDiagonalMask.split` to split the returned
+            :attr:`torch.Tensor` back to a list of tensors of varying sequence length
+
+        Args:
+            tensors (Sequence[torch.Tensor]): A list of tensors of shape ``[B, M_i, *]``.
+                All tensors should have the same dimension and the same batch size ``B``, but
+                they can have different sequence length ``M``.
+
+        Returns:
+            Tuple[BlockDiagonalMask, torch.Tensor]: The corresponding bias for the attention
+            along with `tensors` concatenated on the sequence length dimension, with shape ``[1, sum_i{M_i}, *]``
+        """
+        batch_sizes = [tensor.shape[0] for tensor in tensors]
+        seqlens = []
+        for x in tensors:
+            for _ in range(x.shape[0]):
+                seqlens.append(x.shape[1])
+        block_diag = cls.from_seqlens(seqlens)
+        block_diag._batch_sizes = batch_sizes
+        tensors_bs1 = tuple(x.reshape([1, -1, *x.shape[2:]]) for x in tensors)
+        concat_tensors = torch.cat(tensors_bs1, dim=1)
+        return block_diag, concat_tensors
+
+    @classmethod
+    def from_tensor_lists_qkv(
+        cls,
+        tensors_q: Sequence[torch.Tensor],
+        tensors_k: Sequence[torch.Tensor],
+        tensors_v: Optional[Sequence[torch.Tensor]] = None,
+    ) -> Tuple["BlockDiagonalMask", torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        assert len(tensors_q) == len(tensors_k)
+        assert tensors_v is None or len(tensors_v) == len(tensors_q)
+        batch_sizes = [tensor.shape[0] for tensor in tensors_q]
+        q_seqlens, kv_seqlens = [], []
+        for i, (q, k) in enumerate(zip(tensors_q, tensors_k)):
+            assert q.shape[0] == k.shape[0]
+            q_seqlens += [q.shape[1]] * q.shape[0]
+            kv_seqlens += [k.shape[1]] * k.shape[0]
+            assert tensors_v is None or tensors_v[i].shape[:2] == k.shape[:2]
+        block_diag = cls.from_seqlens(q_seqlens, kv_seqlens)
+        block_diag._batch_sizes = batch_sizes
+        return (
+            block_diag,
+            torch.cat([x.reshape([1, -1, *x.shape[2:]]) for x in tensors_q], dim=1),
+            torch.cat([x.reshape([1, -1, *x.shape[2:]]) for x in tensors_k], dim=1),
+            torch.cat([x.reshape([1, -1, *x.shape[2:]]) for x in tensors_v], dim=1)
+            if tensors_v is not None
+            else None,
+        )
+
+    def split_queries(self, tensor: torch.Tensor) -> Sequence[torch.Tensor]:
+        return self.q_seqinfo.split(tensor, self._batch_sizes)
+
+    def split_kv(self, tensor: torch.Tensor) -> Sequence[torch.Tensor]:
+        return self.k_seqinfo.split(tensor, self._batch_sizes)
+
+    def split(self, tensor: torch.Tensor) -> Sequence[torch.Tensor]:
+        """The inverse operation of :attr:`BlockDiagonalCausalMask.from_tensor_list`
+
+        Args:
+            tensor (torch.Tensor): Tensor of tokens of shape ``[1, sum_i{M_i}, *]``
+
+        Returns:
+            Sequence[torch.Tensor]: A list of tokens with possibly different sequence lengths
+        """
+        assert self.q_seqinfo is self.k_seqinfo
+        return self.q_seqinfo.split(tensor, self._batch_sizes)
+
+    def make_causal(self) -> "BlockDiagonalCausalMask":
+        """Makes each block causal"""
+        return BlockDiagonalCausalMask(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=self.k_seqinfo,
+            _batch_sizes=self._batch_sizes,
+        )
+
+    def make_causal_from_bottomright(self) -> "BlockDiagonalCausalFromBottomRightMask":
+        """Makes each block causal with a possible non-causal prefix"""
+        return BlockDiagonalCausalFromBottomRightMask(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=self.k_seqinfo,
+            _batch_sizes=self._batch_sizes,
+        )
+
+    def make_local_attention(
+        self, window_size: int
+    ) -> "BlockDiagonalCausalLocalAttentionMask":
+        """Experimental: Makes each block causal with local attention"""
+        return BlockDiagonalCausalLocalAttentionMask(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=self.k_seqinfo,
+            _batch_sizes=self._batch_sizes,
+            _window_size=window_size,
+        )
+
+    def make_local_attention_from_bottomright(
+        self, window_size: int
+    ) -> "BlockDiagonalCausalLocalAttentionFromBottomRightMask":
+        """Experimental: Makes each block causal with local attention, start from bottom right"""
+        return BlockDiagonalCausalLocalAttentionFromBottomRightMask(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=self.k_seqinfo,
+            _batch_sizes=self._batch_sizes,
+            _window_size=window_size,
+        )
+
+
+@dataclass
+class BlockDiagonalCausalMask(BlockDiagonalMask):
+    """
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`, except that each block is causal.
+
+    Queries and Keys are each divided into the same number of blocks.
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which is farther from the initial key in block i than Q
+    is from the initial query in block i.
+    """
+
+    def to(self, device) -> "BlockDiagonalCausalMask":
+        assert type(self) is BlockDiagonalCausalMask, "Please implement in subclass"
+        return BlockDiagonalCausalMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            _batch_sizes=self._batch_sizes,
+        )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return LowerTriangularMask().materialize(
+            shape,
+            dtype=dtype,
+            device=device,
+        )
+
+
+@dataclass
+class BlockDiagonalCausalFromBottomRightMask(BlockDiagonalMask):
+    """
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`, except that each block is causal.
+    This mask allows for a non-causal prefix
+    NOTE: Each block should have `num_keys >= num_queries` otherwise the forward pass is not
+    defined (softmax of vector of `-inf` in the attention)
+
+    Queries and keys are each divided into the same number of blocks.
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which nearer the final key in block i than Q is to the
+    final query in block i.
+    """
+
+    def to(self, device) -> "BlockDiagonalCausalFromBottomRightMask":
+        assert (
+            type(self) is BlockDiagonalCausalFromBottomRightMask
+        ), "Please implement in subclass"
+        return BlockDiagonalCausalFromBottomRightMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            _batch_sizes=self._batch_sizes,
+        )
+
+    def __post_init__(self) -> None:
+        for i, ((q_start, q_end), (k_start, k_end)) in enumerate(
+            zip(
+                self.q_seqinfo.intervals(),
+                self.k_seqinfo.intervals(),
+            )
+        ):
+            num_queries = q_end - q_start
+            num_keys = k_end - k_start
+            if num_keys < num_queries:
+                raise ValueError(
+                    f"Block #{i} has num_keys={num_keys} and num_queries={num_queries}."
+                    " Expected `num_keys >= num_queries`"
+                )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return LowerTriangularFromBottomRightMask().materialize(
+            shape=shape, dtype=dtype, device=device
+        )
+
+
+@dataclass
+class BlockDiagonalPaddedKeysMask(AttentionBias):
+    """
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`,
+    except we support padding for k/v
+
+    The keys and values are divided into blocks which are padded out to
+    the same total length.
+    For example, if there is space for 12 keys, for three blocks of
+    max length 4, but we only want to use the first 2, 3 and 2
+    of each block, use `kv_padding=4` and `kv_seqlens=[2, 3, 2]`.
+    The queries are divided into blocks, without padding, of lengths given by
+    q_seqlen.
+
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which is not in use (i.e. in the padded area).
+    """
+
+    q_seqinfo: _SeqLenInfo
+    k_seqinfo: _PaddedSeqLenInfo
+
+    def to(self, device) -> "BlockDiagonalPaddedKeysMask":
+        assert type(self) is BlockDiagonalPaddedKeysMask, "Please implement in subclass"
+        return BlockDiagonalPaddedKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+        )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return torch.zeros([1], device=device, dtype=dtype)
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        if shape[-1] != self.k_seqinfo.seqstart_py[-1]:
+            raise ValueError("k shapes wrong")
+        if shape[-2] != self.q_seqinfo.seqstart_py[-1]:
+            raise ValueError("q shapes wrong")
+        mask = torch.empty(shape[-2:], dtype=dtype, device=device)
+        mask.fill_(-math.inf)
+        for (q_start, q_end), (k_start, k_end) in zip(
+            self.q_seqinfo.intervals(),
+            self.k_seqinfo.intervals(),
+        ):
+            mask[q_start:q_end, k_start:k_end] = self._create_block_mask(
+                (q_end - q_start, k_end - k_start),
+                dtype=dtype,
+                device=device,
+            )
+        for _ in range(len(shape) - 2):
+            mask = mask.unsqueeze(0)
+        return mask.expand(shape)
+
+    @classmethod
+    def from_seqlens(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_padding: int,
+        kv_seqlen: Sequence[int],
+        causal_diagonal: Any = None,
+        *,
+        device: Optional[torch.device] = None,
+    ) -> "BlockDiagonalPaddedKeysMask":
+        """Creates a :attr:`BlockDiagonalPaddedKeysMask` from a list of tensor
+        lengths for query and key/value.
+
+        Args:
+            q_seqlen (Sequence[int]): List or tensor of sequence lengths for query tensors
+            kv_padding (int): Padding for k/v - also an upperbound on each individual key length
+            kv_seqlen (Sequence[int]): List or tensor of sequence lengths for key/value.
+            causal_diagonal: unused, for BC only
+        Returns:
+            BlockDiagonalPaddedKeysMask
+        """
+        device = _get_default_bias_device(device)
+        assert kv_seqlen is None or len(q_seqlen) == len(kv_seqlen), (
+            q_seqlen,
+            kv_seqlen,
+        )
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen, device=device)
+        k_seqinfo = _PaddedSeqLenInfo.from_seqlens_padded(
+            kv_seqlen, kv_padding, device=device
+        )
+        return cls(q_seqinfo=q_seqinfo, k_seqinfo=k_seqinfo)
+
+    def make_paged(
+        self,
+        block_tables: torch.Tensor,
+        page_size: int,
+        paged_type: Type["PagedBlockDiagonalPaddedKeysMask"],
+    ) -> "PagedBlockDiagonalPaddedKeysMask":
+        paged_bias = paged_type(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=_PaddedSeqLenInfo(
+                seqstart=self.k_seqinfo.seqstart,
+                seqstart_py=self.k_seqinfo.seqstart_py,
+                seqlen=self.k_seqinfo.seqlen,
+                seqlen_py=self.k_seqinfo.seqlen_py,
+                padding=block_tables.shape[1] * page_size,
+                max_seqlen=self.k_seqinfo.max_seqlen,
+                min_seqlen=self.k_seqinfo.min_seqlen,
+            ),
+            block_tables=block_tables,
+            page_size=page_size,
+        )
+        return paged_bias
+
+    def make_local_attention(
+        self, window_left: int, window_right: int
+    ) -> "BlockDiagonalLocalAttentionPaddedKeysMask":
+        return BlockDiagonalLocalAttentionPaddedKeysMask(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=self.k_seqinfo,
+            window_left=window_left,
+            window_right=window_right,
+        )
+
+
+@dataclass
+class BlockDiagonalCausalWithOffsetPaddedKeysMask(BlockDiagonalPaddedKeysMask):
+    """
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`,
+    except an offset on causality is allowed for each block and we support padding for k/v
+
+    The keys and values are divided into blocks which are padded out to
+    the same total length.
+    For example, if there is space for 12 keys, for three blocks of
+    max length 4, but we only want to use the first 2, 3 and 2
+    of each block, use `kv_padding=4` and `kv_seqlens=[2, 3, 2]`.
+    The queries are divided into blocks, without padding, of lengths given by
+    q_seqlen.
+
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which is not in use (i.e. in the padded area),
+    nor one which is nearer to the final key in block i
+    than Q is to the final query in block i.
+    """
+
+    causal_diagonal: Any = None  # unused. Exists for BC only.
+
+    def to(self, device) -> "BlockDiagonalCausalWithOffsetPaddedKeysMask":
+        assert (
+            type(self) is BlockDiagonalCausalWithOffsetPaddedKeysMask
+        ), "Please implement in subclass"
+        return BlockDiagonalCausalWithOffsetPaddedKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+        )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return LowerTriangularFromBottomRightMask().materialize(
+            shape=shape, dtype=dtype, device=device
+        )
+
+    @classmethod
+    def from_seqlens(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_padding: int,
+        kv_seqlen: Sequence[int],
+        causal_diagonal: Any = None,
+        *,
+        device: Optional[torch.device] = None,
+    ) -> "BlockDiagonalCausalWithOffsetPaddedKeysMask":
+        """Creates a :attr:`BlockDiagonalCausalWithOffsetPaddedKeysMask` from a list of tensor
+        lengths for query and key/value.
+
+        Args:
+            q_seqlen (Sequence[int]): List or tensor of sequence lengths for query tensors
+            kv_padding (int): Padding for k/v - also an upperbound on each individual key length
+            kv_seqlen (Sequence[int]): List or tensor of sequence lengths for key/value.
+            causal_diagonal: unused, for BC only
+        Returns:
+            BlockDiagonalCausalWithOffsetPaddedKeysMask
+        """
+        assert kv_seqlen is None or len(q_seqlen) == len(kv_seqlen), (
+            q_seqlen,
+            kv_seqlen,
+        )
+        device = _get_default_bias_device(device)
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen, device=device)
+        k_seqinfo = _PaddedSeqLenInfo.from_seqlens_padded(
+            kv_seqlen, kv_padding, device=device
+        )
+        return cls(q_seqinfo=q_seqinfo, k_seqinfo=k_seqinfo)
+
+
+@dataclass
+class BlockDiagonalLocalAttentionPaddedKeysMask(BlockDiagonalPaddedKeysMask):
+    """
+    Like :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalLocalAttentionPaddedKeysMask`,
+    except that this is non-causal.
+
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which is not in use (i.e. in the padded area),
+    nor one whose distance to the final key in block i
+    is more than window_left further or window_right nearer
+    than Q is to the final query in block i.
+
+    A query attends to at most window_left + window_right - 1 keys.
+
+    NOTE that if window_right is 0, then this is like a
+    BlockDiagonalCausalLocalAttentionPaddedKeysMask whose window_size is equal to
+    window_left - 1.
+    """
+
+    window_left: int
+    window_right: int
+
+    def to(self, device) -> "BlockDiagonalLocalAttentionPaddedKeysMask":
+        assert (
+            type(self) is BlockDiagonalLocalAttentionPaddedKeysMask
+        ), "Please implement in subclass"
+        return BlockDiagonalLocalAttentionPaddedKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            window_left=self.window_left,
+            window_right=self.window_right,
+        )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return LocalAttentionFromBottomRightMask(
+            window_left=self.window_left, window_right=self.window_right
+        ).materialize(shape=shape, dtype=dtype, device=device)
+
+    @classmethod
+    def from_seqlens_local(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_padding: int,
+        kv_seqlen: Sequence[int],
+        window_left: int,
+        window_right: int,
+    ) -> "BlockDiagonalLocalAttentionPaddedKeysMask":
+        assert kv_seqlen is None or len(q_seqlen) == len(kv_seqlen), (
+            q_seqlen,
+            kv_seqlen,
+        )
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen)
+        k_seqinfo = _PaddedSeqLenInfo.from_seqlens_padded(kv_seqlen, kv_padding)
+        return cls(
+            q_seqinfo=q_seqinfo,
+            k_seqinfo=k_seqinfo,
+            window_left=window_left,
+            window_right=window_right,
+        )
+
+
+@dataclass
+class BlockDiagonalCausalLocalAttentionPaddedKeysMask(BlockDiagonalPaddedKeysMask):
+    """
+    Like :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask`,
+    except with a window size.
+
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which is not in use (i.e. in the padded area),
+    nor one which is nearer to the final key in block i
+    than Q is to the final query in block i, nor one that is at least
+    window_size further from the final key in block i than Q is
+    to the final query in block i.
+    """
+
+    _window_size: int
+
+    def to(self, device) -> "BlockDiagonalCausalLocalAttentionPaddedKeysMask":
+        assert (
+            type(self) is BlockDiagonalCausalLocalAttentionPaddedKeysMask
+        ), "Please implement in subclass"
+        return BlockDiagonalCausalLocalAttentionPaddedKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            _window_size=self._window_size,
+        )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return _materialize_causal_mask(
+            shape=shape,
+            dtype=dtype,
+            device=device,
+            window_size=self._window_size,
+            from_bottomright=True,
+        )
+
+    @classmethod
+    def from_seqlens_local(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_padding: int,
+        kv_seqlen: Sequence[int],
+        window_size: int,
+    ) -> "BlockDiagonalCausalLocalAttentionPaddedKeysMask":
+        assert kv_seqlen is None or len(q_seqlen) == len(kv_seqlen), (
+            q_seqlen,
+            kv_seqlen,
+        )
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen)
+        k_seqinfo = _PaddedSeqLenInfo.from_seqlens_padded(kv_seqlen, kv_padding)
+        return cls(q_seqinfo=q_seqinfo, k_seqinfo=k_seqinfo, _window_size=window_size)
+
+    # pyre-ignore[14]
+    def make_paged(
+        self,
+        block_tables: torch.Tensor,
+        page_size: int,
+        paged_type: Type["PagedBlockDiagonalCausalLocalPaddedKeysMask"],
+    ) -> "PagedBlockDiagonalCausalLocalPaddedKeysMask":
+        paged_bias = paged_type(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=_PaddedSeqLenInfo(
+                seqstart=self.k_seqinfo.seqstart,
+                seqstart_py=self.k_seqinfo.seqstart_py,
+                seqlen=self.k_seqinfo.seqlen,
+                seqlen_py=self.k_seqinfo.seqlen_py,
+                padding=block_tables.shape[1] * page_size,
+                max_seqlen=self.k_seqinfo.max_seqlen,
+                min_seqlen=self.k_seqinfo.min_seqlen,
+            ),
+            block_tables=block_tables,
+            page_size=page_size,
+            _window_size=self._window_size,
+        )
+        return paged_bias
+
+
+@dataclass
+class PagedBlockDiagonalPaddedKeysMask(AttentionBias):
+    """
+    Same as BlockDiagonalPaddedKeysMask, but for paged attention.
+    block_tables has shape [batch_size, max_num_pages] and K/V have shape
+    [1, max_num_pages * page_size, num_heads, head_dim]
+    or [1, max_num_pages * page_size, num_groups, num_heads, head_dim]
+    """
+
+    q_seqinfo: _SeqLenInfo
+    k_seqinfo: _PaddedSeqLenInfo
+    block_tables: torch.Tensor
+    page_size: int
+
+    _UNPAGED_TYPE: ClassVar[Type[BlockDiagonalPaddedKeysMask]] = (
+        BlockDiagonalPaddedKeysMask
+    )
+
+    def to(self, device: torch.device) -> "PagedBlockDiagonalPaddedKeysMask":
+        assert (
+            type(self) is PagedBlockDiagonalPaddedKeysMask
+        ), "Please implement in subclass"
+        return PagedBlockDiagonalPaddedKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            block_tables=_to_device(self.block_tables, device),
+            page_size=self.page_size,
+        )
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        # First create a non-paged mask, then cut individual pages and
+        # copy them to their places in the physical mask, using block tables
+
+        max_row_len = self.block_tables.shape[1] * self.page_size
+        bias_nonpaged = self._UNPAGED_TYPE(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=_PaddedSeqLenInfo.from_seqlens_padded(
+                self.k_seqinfo.seqlen_py, max_row_len
+            ),
+        )
+        mask_nonpaged = bias_nonpaged.materialize(shape, dtype, device)
+
+        n_used_blocks = cast(int, self.block_tables.max().item() + 1)
+        max_physical_len = n_used_blocks * self.page_size
+        mask_paged = torch.empty(
+            mask_nonpaged.shape[:-1] + (max_physical_len,), dtype=dtype, device=device
+        )
+        mask_paged.fill_(-math.inf)
+        for b, (q_start, q_end) in enumerate(self.q_seqinfo.intervals()):
+            for logical_page_idx in range(self.block_tables.shape[1]):
+                physical_page_idx = cast(
+                    int, self.block_tables[b][logical_page_idx].item()
+                )
+                k_logical_start = b * max_row_len + logical_page_idx * self.page_size
+                k_logical_end = k_logical_start + self.page_size
+                k_physical_start = physical_page_idx * self.page_size
+                k_physical_end = k_physical_start + self.page_size
+                mask_paged[..., q_start:q_end, k_physical_start:k_physical_end] = (
+                    mask_nonpaged[..., q_start:q_end, k_logical_start:k_logical_end]
+                )
+        return mask_paged
+
+    @classmethod
+    def from_seqlens(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_seqlen: Sequence[int],
+        block_tables: torch.Tensor,
+        page_size: int,
+        *,
+        device: Optional[torch.device] = None,
+    ) -> "PagedBlockDiagonalPaddedKeysMask":
+        """Creates a :attr:`PagedBlockDiagonalPaddedKeysMask` from a list of tensor
+        lengths for query and key/value.
+
+        Args:
+            q_seqlen (Sequence[int]): List or tensor of sequence lengths for query tensors
+            kv_padding (int): Padding for k/v - also an upperbound on each individual key length
+            kv_seqlen (Sequence[int]): List or tensor of sequence lengths for key/value.
+            causal_diagonal: unused, for BC only
+        Returns:
+            PagedBlockDiagonalPaddedKeysMask
+        """
+        assert len(q_seqlen) == len(kv_seqlen), (
+            q_seqlen,
+            kv_seqlen,
+        )
+        device = _get_default_bias_device(device)
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen, device=device)
+        k_seqinfo = _PaddedSeqLenInfo.from_seqlens_padded(
+            kv_seqlen, padding=block_tables.shape[1] * page_size, device=device
+        )
+        return cls(
+            q_seqinfo=q_seqinfo,
+            k_seqinfo=k_seqinfo,
+            block_tables=block_tables,
+            page_size=page_size,
+        )
+
+
+@dataclass
+class PagedBlockDiagonalCausalWithOffsetPaddedKeysMask(
+    PagedBlockDiagonalPaddedKeysMask
+):
+    """
+    Same as BlockDiagonalCausalWithOffsetPaddedKeysMask, but for paged attention.
+    block_tables has shape [batch_size, max_num_pages] and K/V have shape
+    [1, max_num_pages * page_size, num_heads, head_dim]
+    or [1, max_num_pages * page_size, num_groups, num_heads, head_dim]
+    """
+
+    _UNPAGED_TYPE = BlockDiagonalCausalWithOffsetPaddedKeysMask
+
+    def to(
+        self, device: torch.device
+    ) -> "PagedBlockDiagonalCausalWithOffsetPaddedKeysMask":
+        assert (
+            type(self) is PagedBlockDiagonalCausalWithOffsetPaddedKeysMask
+        ), "Please implement in subclass"
+        return PagedBlockDiagonalCausalWithOffsetPaddedKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            block_tables=_to_device(self.block_tables, device),
+            page_size=self.page_size,
+        )
+
+
+@dataclass
+class PagedBlockDiagonalCausalLocalPaddedKeysMask(PagedBlockDiagonalPaddedKeysMask):
+    """
+    Same as BlockDiagonalCausalLocalAttentionPaddedKeysMask, but for paged attention.
+    block_tables has shape [batch_size, max_num_pages] and K/V have shape
+    [1, max_num_pages * page_size, num_heads, head_dim]
+    or [1, max_num_pages * page_size, num_groups, num_heads, head_dim]
+    """
+
+    _window_size: int
+
+    _UNPAGED_TYPE: ClassVar[Type[BlockDiagonalCausalLocalAttentionPaddedKeysMask]] = (
+        BlockDiagonalCausalLocalAttentionPaddedKeysMask
+    )
+
+    def to(self, device: torch.device) -> "PagedBlockDiagonalCausalLocalPaddedKeysMask":
+        assert (
+            type(self) is PagedBlockDiagonalCausalLocalPaddedKeysMask
+        ), "Please implement in subclass"
+        return PagedBlockDiagonalCausalLocalPaddedKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            block_tables=_to_device(self.block_tables, device),
+            page_size=self.page_size,
+            _window_size=self._window_size,
+        )
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        # First create a non-paged mask, then cut individual pages and
+        # copy them to their places in the physical mask, using block tables
+
+        max_row_len = self.block_tables.shape[1] * self.page_size
+        bias_nonpaged = self._UNPAGED_TYPE(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=_PaddedSeqLenInfo.from_seqlens_padded(
+                self.k_seqinfo.seqlen_py, max_row_len
+            ),
+            _window_size=self._window_size,
+        )
+        mask_nonpaged = bias_nonpaged.materialize(shape, dtype, device)
+
+        n_used_blocks = cast(int, self.block_tables.max().item() + 1)
+        max_physical_len = n_used_blocks * self.page_size
+        mask_paged = torch.empty(
+            mask_nonpaged.shape[:-1] + (max_physical_len,), dtype=dtype, device=device
+        )
+        mask_paged.fill_(-math.inf)
+        for b, (q_start, q_end) in enumerate(self.q_seqinfo.intervals()):
+            for logical_page_idx in range(self.block_tables.shape[1]):
+                physical_page_idx = cast(
+                    int, self.block_tables[b][logical_page_idx].item()
+                )
+                k_logical_start = b * max_row_len + logical_page_idx * self.page_size
+                k_logical_end = k_logical_start + self.page_size
+                k_physical_start = physical_page_idx * self.page_size
+                k_physical_end = k_physical_start + self.page_size
+                mask_paged[..., q_start:q_end, k_physical_start:k_physical_end] = (
+                    mask_nonpaged[..., q_start:q_end, k_logical_start:k_logical_end]
+                )
+        return mask_paged
+
+    @classmethod
+    def from_seqlens_local(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_seqlen: Sequence[int],
+        block_tables: torch.Tensor,
+        page_size: int,
+        window_size: int,
+        *,
+        device: Optional[torch.device] = None,
+    ) -> "PagedBlockDiagonalCausalLocalPaddedKeysMask":
+        """Creates a :attr:`PagedBlockDiagonalCausalLocalPaddedKeysMask` from a list of tensor
+        lengths for query and key/value.
+
+        Args:
+            q_seqlen (Sequence[int]): List or tensor of sequence lengths for query tensors
+            kv_padding (int): Padding for k/v - also an upperbound on each individual key length
+            kv_seqlen (Sequence[int]): List or tensor of sequence lengths for key/value.
+            block_tables: table mapping logical pages to physical for paged attention.
+            page_size: size of each page for paged attention.
+            window_size: size of the window for sliding window attention.
+        Returns:
+            PagedBlockDiagonalCausalLocalPaddedKeysMask
+        """
+        assert len(q_seqlen) == len(kv_seqlen), (
+            q_seqlen,
+            kv_seqlen,
+        )
+        device = _get_default_bias_device(device)
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen, device=device)
+        k_seqinfo = _PaddedSeqLenInfo.from_seqlens_padded(
+            kv_seqlen, padding=block_tables.shape[1] * page_size, device=device
+        )
+        return cls(
+            q_seqinfo=q_seqinfo,
+            k_seqinfo=k_seqinfo,
+            block_tables=block_tables,
+            page_size=page_size,
+            _window_size=window_size,
+        )
+
+
+@dataclass
+class BlockDiagonalGappyKeysMask(AttentionBias):
+    """
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`,
+    except k/v is gappy.
+
+    A query Q in block i only attends to a key which is in block i.
+    """
+
+    q_seqinfo: _SeqLenInfo
+    k_seqinfo: _GappySeqInfo
+
+    def to(self, device: torch.device) -> "BlockDiagonalGappyKeysMask":
+        assert type(self) is BlockDiagonalGappyKeysMask, "Please implement in subclass"
+        return BlockDiagonalGappyKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+        )
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        if shape[-1] != self.k_seqinfo.seqstart_py[-1]:
+            raise ValueError("k shapes wrong", (shape, self.k_seqinfo))
+        if shape[-2] != self.q_seqinfo.seqstart_py[-1]:
+            raise ValueError("q shapes wrong", (shape, self.q_seqinfo))
+        mask = torch.empty(shape[-2:], dtype=dtype, device=device)
+        mask.fill_(-math.inf)
+        for (q_start, q_end), (k_start, k_end) in zip(
+            self.q_seqinfo.intervals(),
+            self.k_seqinfo.intervals(),
+        ):
+            mask[q_start:q_end, k_start:k_end] = 0
+        for _ in range(len(shape) - 2):
+            mask = mask.unsqueeze(0)
+        return mask.expand(shape)
+
+    @classmethod
+    def from_seqlens(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_seqstarts: Sequence[int],
+        kv_seqlen: Sequence[int],
+        *,
+        device: Optional[torch.device] = None,
+    ) -> "BlockDiagonalGappyKeysMask":
+        """Creates a :attr:`BlockDiagonalGappyKeysMask` from a list of tensor
+        lengths for query and key/value.
+        """
+        assert len(q_seqlen) == len(kv_seqlen), (
+            q_seqlen,
+            kv_seqlen,
+        )
+        device = _get_default_bias_device(device)
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen, device=device)
+        k_seqinfo = _GappySeqInfo.from_seqlens_gappy(
+            kv_seqstarts, kv_seqlen, False, device=device
+        )
+        return cls(q_seqinfo=q_seqinfo, k_seqinfo=k_seqinfo)
+
+    def make_paged(
+        self,
+        block_tables: torch.Tensor,
+        page_size: int,
+        notional_padding: int,
+        paged_type: Type["PagedBlockDiagonalGappyKeysMask"],
+    ) -> AttentionBias:
+        """
+        Assuming our keys actually live in separate blocks of length
+        notional_padding, convert to a Paged version, avoiding GPU syncs.
+        """
+        if notional_padding % page_size:
+            raise ValueError(
+                "Notional padding should be divisible by the page size,"
+                f" but got {notional_padding=}, {page_size=}."
+            )
+        max_row_len = block_tables.shape[1] * page_size
+        new_seqstarts_py = [
+            start - i * notional_padding
+            for i, start in enumerate(self.k_seqinfo.seqstart_py[:-1])
+        ]
+        new_seqstarts_py.append(-1)
+        assert all(
+            0 <= i < max_row_len for i in new_seqstarts_py[:-1]
+        ), f"{max_row_len=} {new_seqstarts_py=}"
+
+        # Sequence info is duplicated on CPU and GPU,
+        # but we process them independently to avoid GPU sync.
+        batch_size = len(self.k_seqinfo.seqlen_py)
+        notional_starts = notional_padding * torch.arange(
+            batch_size + 1,
+            device=block_tables.device,
+            dtype=torch.int32,
+        )
+        new_seqstarts = self.k_seqinfo.seqstart - notional_starts
+
+        new_seqlens_py = [
+            i + j for i, j in zip(new_seqstarts_py, self.k_seqinfo.seqlen_py)
+        ]
+        new_seqlens = self.k_seqinfo.seqlen + new_seqstarts[:-1]
+
+        k_seqinfo = _GappySeqInfo(
+            seqlen=new_seqlens,
+            seqlen_py=new_seqlens_py,
+            max_seqlen=self.k_seqinfo.max_seqlen,
+            min_seqlen=self.k_seqinfo.min_seqlen,
+            seqstart=new_seqstarts,
+            seqstart_py=new_seqstarts_py,
+        )
+        assert self.k_seqinfo.max_seqlen <= max_row_len
+        paged_bias = paged_type(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=k_seqinfo,
+            block_tables=block_tables,
+            page_size=page_size,
+        )
+        return paged_bias
+
+
+@dataclass
+class BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask(
+    BlockDiagonalGappyKeysMask
+):
+    """
+    Like :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalGappyKeysMask`,
+    except that this has local attention.
+
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which is not in use (i.e. in the padded area),
+    nor one whose distance to the final key in block i
+    is more than window_left further or window_right nearer
+    than Q is to the final query in block i.
+
+    A query attends to at most window_left + window_right - 1 keys.
+    """
+
+    window_left: int
+    window_right: int
+
+    def to(self, device) -> "BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask":
+        assert (
+            type(self) is BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask
+        ), "Please implement in subclass"
+        return BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            window_left=self.window_left,
+            window_right=self.window_right,
+        )
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        if shape[-1] != self.k_seqinfo.seqstart_py[-1]:
+            raise ValueError("k shapes wrong", (shape, self.k_seqinfo))
+        if shape[-2] != self.q_seqinfo.seqstart_py[-1]:
+            raise ValueError("q shapes wrong", (shape, self.q_seqinfo))
+        mask = torch.full(shape[-2:], fill_value=0, dtype=dtype, device=device)
+        for (q_start, q_end), (k_start, k_end) in zip(
+            self.q_seqinfo.intervals(),
+            self.k_seqinfo.intervals(),
+        ):
+            mask[q_start:q_end, k_start:k_end] = 1
+            # TODO insert locality condition
+            mask[q_start:q_end, k_start:k_end] = _apply_locality_on_mask(
+                mask[q_start:q_end, k_start:k_end], self.window_left, self.window_right
+            )
+        for _ in range(len(shape) - 2):
+            mask = mask.unsqueeze(0)
+        mask = mask.log()
+        return mask.expand(shape)
+
+    @classmethod
+    def from_seqlens_local_gappy(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_seqstarts: Sequence[int],
+        kv_seqlen: Sequence[int],
+        window_left: int,
+        window_right: int,
+        device: torch.device,
+    ) -> "BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask":
+        assert kv_seqlen is None or len(q_seqlen) == len(kv_seqlen), (
+            q_seqlen,
+            kv_seqlen,
+        )
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen)
+        k_seqinfo = _GappySeqInfo.from_seqlens_gappy(
+            kv_seqstarts, kv_seqlen, paged=False, device=device
+        )
+        return cls(
+            q_seqinfo=q_seqinfo,
+            k_seqinfo=k_seqinfo,
+            window_left=window_left,
+            window_right=window_right,
+        )
+
+
+@dataclass
+class BlockDiagonalCausalWithOffsetGappyKeysMask(BlockDiagonalGappyKeysMask):
+    """
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`,
+    except k/v is gappy.
+
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which is nearer to the final key in block i
+    than Q is to the final query in block i.
+    """
+
+    def to(self, device: torch.device) -> "BlockDiagonalCausalWithOffsetGappyKeysMask":
+        assert (
+            type(self) is BlockDiagonalCausalWithOffsetGappyKeysMask
+        ), "Please implement in subclass"
+        return BlockDiagonalCausalWithOffsetGappyKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+        )
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        if shape[-1] != self.k_seqinfo.seqstart_py[-1]:
+            raise ValueError("k shapes wrong")
+        if shape[-2] != self.q_seqinfo.seqstart_py[-1]:
+            raise ValueError("q shapes wrong")
+        mask = torch.empty(shape[-2:], dtype=dtype, device=device)
+        mask.fill_(-math.inf)
+        for (q_start, q_end), (k_start, k_end) in zip(
+            self.q_seqinfo.intervals(),
+            self.k_seqinfo.intervals(),
+        ):
+            mask[q_start:q_end, k_start:k_end] = (
+                LowerTriangularFromBottomRightMask().materialize(shape=(q_end - q_start, k_end - k_start), dtype=dtype, device=device)
+            )
+
+        for _ in range(len(shape) - 2):
+            mask = mask.unsqueeze(0)
+        return mask.expand(shape)
+
+
+@dataclass
+class PagedBlockDiagonalGappyKeysMask(AttentionBias):
+    """
+    Equivalent BlockDiagonalGappyKeysMask, but for paged attention.
+    block_tables has shape [batch_size, max_num_pages] and K/V have shape
+    [1, max_num_pages * page_size, num_heads, head_dim]
+    or [1, max_num_pages * page_size, num_groups, num_heads, head_dim]
+    """
+
+    q_seqinfo: _SeqLenInfo
+    k_seqinfo: _GappySeqInfo
+    block_tables: torch.Tensor
+    page_size: int
+
+    _UNPAGED_TYPE: ClassVar[Type[BlockDiagonalGappyKeysMask]] = (
+        BlockDiagonalGappyKeysMask
+    )
+
+    def to(self, device: torch.device) -> "PagedBlockDiagonalGappyKeysMask":
+        assert (
+            type(self) is PagedBlockDiagonalGappyKeysMask
+        ), "Please implement in subclass"
+        return PagedBlockDiagonalGappyKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            block_tables=_to_device(self.block_tables, device),
+            page_size=self.page_size,
+        )
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        # First create a non-paged mask, then cut individual pages and
+        # copy them to their places in the physical mask, using block tables
+
+        max_row_len = self.block_tables.shape[1] * self.page_size
+        new_seqstarts = [
+            start + i * max_row_len
+            for i, start in enumerate(self.k_seqinfo.seqstart_py[:-1])
+        ] + [shape[-1]]
+        new_seqlens = [
+            end - start
+            for start, end in zip(self.k_seqinfo.seqstart_py, self.k_seqinfo.seqlen_py)
+        ]
+        bias_nonpaged = self._UNPAGED_TYPE(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=_GappySeqInfo.from_seqlens_gappy(
+                new_seqstarts,
+                new_seqlens,
+                False,
+                device=torch.device(device),
+            ),
+        )
+        mask_nonpaged = bias_nonpaged.materialize(shape, dtype, device)
+
+        n_used_blocks = cast(int, self.block_tables.max().item() + 1)
+        max_physical_len = n_used_blocks * self.page_size
+        mask_paged = torch.empty(
+            mask_nonpaged.shape[:-1] + (max_physical_len,), dtype=dtype, device=device
+        )
+        mask_paged.fill_(-math.inf)
+        for b, (q_start, q_end) in enumerate(self.q_seqinfo.intervals()):
+            for logical_page_idx in range(self.block_tables.shape[1]):
+                physical_page_idx = cast(
+                    int, self.block_tables[b][logical_page_idx].item()
+                )
+                k_logical_start = b * max_row_len + logical_page_idx * self.page_size
+                k_logical_end = k_logical_start + self.page_size
+                k_physical_start = physical_page_idx * self.page_size
+                k_physical_end = k_physical_start + self.page_size
+                mask_paged[..., q_start:q_end, k_physical_start:k_physical_end] = (
+                    mask_nonpaged[..., q_start:q_end, k_logical_start:k_logical_end]
+                )
+        return mask_paged
+
+    @classmethod
+    def from_seqlens(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_seqstarts: Sequence[int],
+        kv_seqlen: Sequence[int],
+        block_tables: torch.Tensor,
+        page_size: int,
+        *,
+        device: Optional[torch.device] = None,
+    ) -> "PagedBlockDiagonalGappyKeysMask":
+        """Creates a :attr:`PagedBlockDiagonalGappyKeysMask` from a list of tensor
+        lengths for query and key/value.
+
+        Note that unlike :attr:`BlockDiagonalGappyKeysMask`, kv_seqstarts is
+        addressing in a different space for each batch element. For example
+        if you were doing a BlockDiagonalPaddedKeysMask with two batch
+        elements and padding=100, but wanted to change it so that the first
+        key is ignored, then you would use BlockDiagonalGappyKeysMask with kv_seqstarts
+        [1, 101, 200]. But if you were using PagedBlockDiagonalPaddedKeysMask
+        but wanted to ignore the first key, you would provide this function with
+        kv_seqstarts = [1, 1].
+        """
+        assert len(q_seqlen) == len(kv_seqlen) == len(kv_seqstarts), (
+            q_seqlen,
+            kv_seqlen,
+            kv_seqstarts,
+        )
+        device = block_tables.device if device is None else device
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen, device=device)
+        k_seqinfo = _GappySeqInfo.from_seqlens_gappy(
+            kv_seqstarts, kv_seqlen, True, device=device
+        )
+        return cls(
+            q_seqinfo=q_seqinfo,
+            k_seqinfo=k_seqinfo,
+            block_tables=block_tables,
+            page_size=page_size,
+        )
+
+
+@dataclass
+class PagedBlockDiagonalCausalWithOffsetGappyKeysMask(PagedBlockDiagonalGappyKeysMask):
+    """
+    Same as BlockDiagonalCausalWithOffsetGappyKeysMask, but for paged attention.
+    block_tables has shape [batch_size, max_num_pages] and K/V have shape
+    [1, max_num_pages * page_size, num_heads, head_dim] or
+    [1, max_num_pages * page_size, num_groups, num_heads, head_dim]
+    """
+
+    _UNPAGED_TYPE = BlockDiagonalCausalWithOffsetGappyKeysMask
+
+    def to(
+        self, device: torch.device
+    ) -> "PagedBlockDiagonalCausalWithOffsetGappyKeysMask":
+        assert (
+            type(self) is PagedBlockDiagonalCausalWithOffsetGappyKeysMask
+        ), "Please implement in subclass"
+        return PagedBlockDiagonalCausalWithOffsetGappyKeysMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            block_tables=_to_device(self.block_tables, device),
+            page_size=self.page_size,
+        )
+
+
+@dataclass
+class BlockDiagonalCausalLocalAttentionMask(BlockDiagonalCausalMask):
+    """
+    (Experimental feature)
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`.
+    This makes the mask "local" and the attention pattern banded.
+
+    The ith query in a block only attends to keys in its block with index
+    greater than i - window_size and less than or equal to i.
+    """
+
+    _window_size: int = 0  # forced due to inheritance and default arguments
+
+    def to(self, device) -> "BlockDiagonalCausalLocalAttentionMask":
+        assert (
+            type(self) is BlockDiagonalCausalLocalAttentionMask
+        ), "Please implement in subclass"
+        return BlockDiagonalCausalLocalAttentionMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            _batch_sizes=self._batch_sizes,
+            _window_size=self._window_size,
+        )
+
+    def __post_init__(self):
+        if self._window_size <= 0:
+            raise ValueError(
+                f"Expected `window_size > 0`, but window_size={self._window_size}"
+            )
+        q_seqlen = [
+            y - x
+            for x, y in zip(
+                self.q_seqinfo.seqstart_py[:-1], self.q_seqinfo.seqstart_py[1:]
+            )
+        ]
+        kv_seqlen = [
+            y - x
+            for x, y in zip(
+                self.k_seqinfo.seqstart_py[:-1], self.k_seqinfo.seqstart_py[1:]
+            )
+        ]
+        for q, k in zip(q_seqlen, kv_seqlen):
+            if q - self._window_size >= k:
+                # Each query only attends to keys no further than window_size back.
+                # When q > k + window_size, there will be a query for which the window doesn't reach any key.
+                raise RuntimeError(
+                    f"No keys are attended in q_seqlen {q} k_seqlen {k} with sliding window {self._window_size}"
+                )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return _materialize_causal_mask(
+            shape,
+            dtype=dtype,
+            device=device,
+            window_size=self._window_size,
+        )
+
+
+@dataclass
+class BlockDiagonalCausalLocalAttentionFromBottomRightMask(
+    BlockDiagonalCausalFromBottomRightMask
+):
+    """
+    (Experimental feature)
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`.
+    This makes the mask "local" and the attention pattern banded.
+
+    A query with distance j from the last query in its block only attends to
+    keys in the same block, and only those whose distance to the last key
+    in the block is greater than or equal to j and less than window_size + j.
+    """
+
+    _window_size: int = 0  # forced due to inheritance and default arguments
+
+    def to(self, device) -> "BlockDiagonalCausalLocalAttentionFromBottomRightMask":
+        assert (
+            type(self) is BlockDiagonalCausalLocalAttentionFromBottomRightMask
+        ), "Please implement in subclass"
+        return BlockDiagonalCausalLocalAttentionFromBottomRightMask(
+            q_seqinfo=self.q_seqinfo.to(device),
+            k_seqinfo=self.k_seqinfo.to(device),
+            _batch_sizes=self._batch_sizes,
+            _window_size=self._window_size,
+        )
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self._window_size <= 0:
+            raise ValueError(
+                f"Expected `window_size > 0`, but window_size={self._window_size}"
+            )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return _materialize_causal_mask(
+            shape,
+            dtype=dtype,
+            device=device,
+            window_size=self._window_size,
+            from_bottomright=True,
+        )
+
+
+torch._dynamo.allow_in_graph(LowerTriangularMask)
+torch._dynamo.allow_in_graph(LowerTriangularMaskWithTensorBias)
+
+VARLEN_BIASES = (
+    BlockDiagonalMask,
+    BlockDiagonalGappyKeysMask,
+    BlockDiagonalPaddedKeysMask,
+    PagedBlockDiagonalPaddedKeysMask,
+    PagedBlockDiagonalGappyKeysMask,
+)
+
+
+def _apply_locality_on_mask(mask: torch.Tensor, window_left: int, window_right: int):
+    """Assumes 0s and 1s. If you need -inf and 1, take a log."""
+    num_queries, num_keys = mask.shape[-2:]
+    shift = num_keys - num_queries
+
+    mask = torch.triu(mask, diagonal=shift - window_left)
+    mask = torch.tril(mask, diagonal=shift + window_right)
+    return mask

--- a/mslk/attention/fmha/attn_bias_utils.py
+++ b/mslk/attention/fmha/attn_bias_utils.py
@@ -1,0 +1,535 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+import math
+import random
+from typing import List, Optional, Sequence, Tuple, Type
+
+import torch
+
+from .. import fmha
+from .attn_bias import AttentionBias
+from .common import AttentionOpBase
+
+
+def _create_aligned_bias(*shape: int, **kwargs) -> torch.Tensor:
+    align_to = 8
+    return (
+        torch.randn(
+            (
+                *shape[:-1],
+                align_to * ((shape[-1] + align_to - 1) // align_to),
+            ),
+            **kwargs,
+        )
+        * 3
+    ).narrow(-1, 0, shape[-1])
+
+
+def create_attn_bias(  # noqa: C901
+    bias_type,
+    batch_size: int,
+    num_heads: int,
+    num_heads_groups: int,
+    q_len: int,
+    kv_len: int,
+    device,
+    dtype,
+    requires_grad: bool,
+    fmt: str,
+    op: Optional[Type[AttentionOpBase]] = None,
+    page_size: Optional[int] = None,
+):
+    if bias_type is None or isinstance(None, bias_type):
+        return None
+    r = random.Random("-".join(map(str, [batch_size, q_len, kv_len, dtype, fmt])))
+    window_size = {0: 3, 1: 128, 2: 300}[r.randint(0, 2)]
+    if bias_type is torch.Tensor:
+        if fmt == "BMK":
+            batch_size *= num_heads
+            num_heads = 1
+        if op is not None and issubclass(op, fmha.triton_splitk.FwOp):
+            attn_bias = (
+                torch.randn(
+                    (batch_size, num_heads_groups, num_heads, q_len, kv_len),
+                    device=device,
+                    dtype=dtype,
+                )
+                * 3
+            )
+            if fmt in ["BMK", "BMHK"]:
+                attn_bias = attn_bias[:, 0]
+        else:
+            attn_bias = _create_aligned_bias(
+                batch_size,
+                num_heads_groups,
+                num_heads,
+                q_len,
+                kv_len,
+                device=device,
+                dtype=dtype,
+            )
+
+            # make sure it also works if the first columns/rows are partially masked out
+            attn_bias[0, 0, 0, : q_len - 1, : kv_len - 1] = -math.inf
+            if fmt in ["BMK", "BMHK"]:
+                attn_bias = attn_bias[:, 0]
+
+        if requires_grad:
+            attn_bias.requires_grad_(True)
+        if fmt == "BMK":
+            attn_bias = attn_bias[:, 0]
+        return attn_bias
+    if bias_type is fmha.attn_bias.LowerTriangularMask:
+        return bias_type()
+    if bias_type is fmha.attn_bias.LowerTriangularFromBottomRightMask:
+        return bias_type()
+    if bias_type is fmha.attn_bias.LowerTriangularFromBottomRightLocalAttentionMask:
+        return bias_type(window_size)
+    if bias_type is fmha.attn_bias.LowerTriangularMaskWithTensorBias:
+        attn_bias = _create_aligned_bias(
+            batch_size,
+            num_heads_groups,
+            num_heads,
+            q_len,
+            kv_len,
+            device=device,
+            dtype=dtype,
+        )
+        if fmt in ["BMK", "BMHK"]:
+            attn_bias = attn_bias[:, 0]
+        if fmt == "BMK":
+            attn_bias = attn_bias[:, 0]
+        if requires_grad:
+            attn_bias.requires_grad_(True)
+        return fmha.attn_bias.LowerTriangularMaskWithTensorBias(attn_bias)
+    if bias_type in [
+        fmha.attn_bias.BlockDiagonalMask,
+        fmha.attn_bias.BlockDiagonalCausalMask,
+        fmha.attn_bias.BlockDiagonalCausalFromBottomRightMask,
+        fmha.attn_bias.BlockDiagonalCausalLocalAttentionMask,
+        fmha.attn_bias.BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    ]:
+        # These bias types are not supported in BMK format
+        assert fmt in ["BMGHK", "BMHK"]
+        max_q_minus_k = None
+        if bias_type in {
+            fmha.attn_bias.BlockDiagonalCausalFromBottomRightMask,
+            fmha.attn_bias.BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+        }:
+            max_q_minus_k = 0
+        elif bias_type == fmha.attn_bias.BlockDiagonalCausalLocalAttentionMask:
+            assert window_size is not None
+            max_q_minus_k = window_size - 1
+
+        block_diag = fmha.attn_bias.BlockDiagonalMask.from_seqlens(
+            *_rand_seqlens(
+                r,
+                batch_size,
+                q_len,
+                kv_len,
+                max_q_minus_k=max_q_minus_k,
+            )
+        )
+        if bias_type is fmha.attn_bias.BlockDiagonalCausalMask:
+            block_diag = block_diag.make_causal()
+        if bias_type in {
+            fmha.attn_bias.BlockDiagonalCausalLocalAttentionMask,
+            fmha.attn_bias.BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+        }:
+            block_diag = fmha.attn_bias.BlockDiagonalMask(
+                q_seqinfo=block_diag.q_seqinfo,
+                k_seqinfo=block_diag.k_seqinfo,
+                _batch_sizes=block_diag._batch_sizes,
+            )
+            assert window_size is not None
+            if bias_type is fmha.attn_bias.BlockDiagonalCausalLocalAttentionMask:
+                block_diag = block_diag.make_local_attention(window_size)
+            else:
+                block_diag = block_diag.make_local_attention_from_bottomright(
+                    window_size
+                )
+        if bias_type is fmha.attn_bias.BlockDiagonalCausalFromBottomRightMask:
+            block_diag = block_diag.make_causal_from_bottomright()
+        return block_diag
+    if bias_type in [
+        fmha.attn_bias.BlockDiagonalPaddedKeysMask,
+        fmha.attn_bias.BlockDiagonalLocalAttentionPaddedKeysMask,
+        fmha.attn_bias.BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+        fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+        fmha.attn_bias.PagedBlockDiagonalCausalLocalPaddedKeysMask,
+        fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+    ]:
+        assert fmt in ["BMHK", "BMGHK"]
+        q, k = _rand_seqlens_padded_k(r, batch_size, q_len, kv_len)
+        block_diag_type = (
+            bias_type._UNPAGED_TYPE
+            if issubclass(bias_type, fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask)
+            else bias_type
+        )
+        if bias_type in [
+            fmha.attn_bias.BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+            fmha.attn_bias.PagedBlockDiagonalCausalLocalPaddedKeysMask,
+        ]:
+            g_block_diag = block_diag_type.from_seqlens_local(  # type: ignore
+                q_seqlen=q,
+                kv_padding=kv_len,
+                kv_seqlen=k,
+                window_size=min(window_size, min(k)),
+            )
+        elif bias_type is fmha.attn_bias.BlockDiagonalLocalAttentionPaddedKeysMask:
+            g_block_diag = block_diag_type.from_seqlens_local(
+                q_seqlen=q,
+                kv_padding=kv_len,
+                kv_seqlen=k,
+                window_left=max(window_size, max(q)) + 1,
+                window_right=max(window_size, max(q)) + 1,
+            )
+        else:
+            g_block_diag = block_diag_type.from_seqlens(  # type: ignore
+                q_seqlen=q,
+                kv_padding=kv_len,  # type: ignore
+                kv_seqlen=k,
+            )
+        if issubclass(bias_type, fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask):
+            assert page_size is not None
+            pages_per_row = (kv_len + page_size - 1) // page_size
+            block_tables = torch.tensor(
+                r.sample(range(batch_size * pages_per_row), batch_size * pages_per_row),
+                device=device,
+                dtype=torch.int32,
+            ).reshape(batch_size, pages_per_row)
+            return g_block_diag.make_paged(
+                block_tables=block_tables, page_size=page_size, paged_type=bias_type
+            )
+        return g_block_diag
+    if bias_type in [
+        fmha.attn_bias.BlockDiagonalCausalWithOffsetGappyKeysMask,
+        fmha.attn_bias.BlockDiagonalGappyKeysMask,
+        fmha.attn_bias.BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask,
+    ]:
+        assert fmt in ["BMHK", "BMGHK"]
+        max_q_minus_k = (
+            None if bias_type is fmha.attn_bias.BlockDiagonalGappyKeysMask else 0
+        )
+        q, k = _rand_seqlens(r, batch_size, q_len, kv_len, max_q_minus_k)
+        total_kv_len = kv_len * batch_size
+        starts = [r.randint(0, total_kv_len - ki) for ki in k] + [total_kv_len]
+        if (
+            bias_type
+            is fmha.attn_bias.BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask
+        ):
+            return bias_type.from_seqlens_local_gappy(
+                q_seqlen=q,
+                kv_seqstarts=starts,
+                kv_seqlen=k,
+                window_left=r.randint(0, 5),
+                window_right=r.randint(0, 5),
+                device=device,
+            )
+
+        return bias_type.from_seqlens(
+            q_seqlen=q,
+            kv_seqstarts=starts,
+            kv_seqlen=k,
+        )
+    if issubclass(bias_type, fmha.attn_bias.PagedBlockDiagonalGappyKeysMask):
+        assert fmt in ["BMHK", "BMGHK"]
+        assert page_size is not None
+        pages_per_row = (kv_len + page_size - 1) // page_size
+        total_queries = q_len * batch_size
+        if issubclass(
+            bias_type, fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetGappyKeysMask
+        ):
+            q, k = _rand_seqlens_padded_k(r, batch_size, q_len, kv_len)
+        else:
+            q = _rand_maxed_partition(
+                r, total_queries, batch_size, total_queries, False
+            )
+            k = [r.randint(1, kv_len) for _ in range(batch_size)]
+        row_size = pages_per_row * page_size
+        starts = [row_size * i + r.randint(0, row_size - ki) for i, ki in enumerate(k)]
+        starts.append(pages_per_row * batch_size * page_size)
+        block_diag_type = bias_type._UNPAGED_TYPE  # type: ignore
+        g_block_diag = block_diag_type.from_seqlens(
+            q_seqlen=q,
+            kv_seqstarts=starts,
+            kv_seqlen=k,
+        )
+        block_tables = torch.tensor(
+            r.sample(range(batch_size * pages_per_row), batch_size * pages_per_row),
+            device=device,
+            dtype=torch.int32,
+        ).reshape(batch_size, pages_per_row)
+        return g_block_diag.make_paged(
+            block_tables=block_tables,
+            page_size=page_size,
+            paged_type=bias_type,
+            notional_padding=page_size * pages_per_row,
+        )
+    if bias_type == fmha.attn_bias.LocalAttentionFromBottomRightMask:
+        return bias_type(
+            window_left=r.randint(0, 5),
+            window_right=r.randint(0, 5),
+        )
+
+    raise AssertionError(f"Unsupported bias type: {bias_type}")
+
+
+def _rand_seqlens(
+    r: random.Random,
+    bs: int,
+    q_len: int,
+    kv_len: int,
+    max_q_minus_k: Optional[int],
+) -> Tuple[Sequence[int], Sequence[int]]:
+    """
+    Generates lists of lengths of query blocks and corresponding key blocks.
+    The total number of queries will be bs * q_len and the
+    total number of keys will be bs * kv_len.
+    max_q_minus_k: maximum allowed num_queries - num_keys.
+        For "bottom-right" masks it's 0, we need to have more keys than
+        queries, otherwise some queries have no keys to attend to.
+        For BlockDiagonalCausalMask it's None, there is no constraint
+        on num_queries - num_keys.
+        For BlockDiagonalCausalLocalAttentionMask it's equal
+        to the window size.
+    """
+    if max_q_minus_k == 0:
+        # In case max_q_minus_k > 0 the exact condition is
+        # kv_len >= q_len - max_q_minus_k * batch_size,
+        # but we can't check it without knowing the actual batch size,
+        # which is determined in the loop below.
+        assert kv_len >= q_len
+    q_len *= bs
+    kv_len *= bs
+    seqlens_q: List[int] = []
+    seqlens_k: List[int] = []
+
+    step_q = [max(1, q_len // 10), max(2, q_len // 2)]
+    step_k = [max(1, kv_len // 10), max(2, kv_len // 2)]
+    while sum(seqlens_q) < q_len and sum(seqlens_k) < kv_len:
+        if max_q_minus_k is None:
+            # Simple case - no constraint on the number of queries and keys.
+            num_queries = r.randrange(*step_q)
+            seqlens_q.append(num_queries)
+            seqlens_k.append(r.randrange(*step_k))
+        else:
+            # In this case we need to make sure num_queries - num_keys < max_q_minus_k holds for every batch element.
+            # To do this, when choosing num_queries and num_keys at a given step,
+            # we ensure two conditions are satisfied:
+            # 1) num_queries <= num_keys + max_q_minus_k for the current batch element
+            # 2) Same holds for the remaining keys and queries, i.e.
+            #    queries_left - num_queries <= keys_left - num_keys + max_q_minus_k
+            keys_left = kv_len - sum(seqlens_k, 0)
+            queries_left = q_len - sum(seqlens_q, 0)
+
+            assert (
+                keys_left >= queries_left - max_q_minus_k
+            ), f"{keys_left=} {queries_left=} {max_q_minus_k=} {kv_len=} {q_len=} {seqlens_k=} {seqlens_q=}"
+            # Limit num_queries from above: if num_queries > keys_left + max_q_minus_k,
+            # condition num_queries <= num_keys + max_q_minus_k can't be satisfied even if we take
+            # all the remaining keys
+            max_queries_to_take = min(queries_left, keys_left + max_q_minus_k)
+            num_queries = r.randrange(1, max_queries_to_take + 1)
+            seqlens_q.append(num_queries)
+
+            # Now we know num_queries, let's select num_keys.
+            # How many keys can we use for the current batch element so that
+            # for the remaining keys and values the constraint
+            # num_queries - num_keys < max_q_minus_k holds on the next step?
+            extra_keys_available = keys_left - queries_left + max_q_minus_k + 1
+            assert extra_keys_available >= 0
+            if extra_keys_available > 0:
+                seqlens_k.append(num_queries + r.randrange(0, extra_keys_available))
+            else:
+                seqlens_k.append(num_queries)
+    seqlens_q[-1] = q_len - sum(seqlens_q[:-1])
+    seqlens_k[-1] = kv_len - sum(seqlens_k[:-1])
+    return seqlens_q, seqlens_k
+
+
+def _rand_maxed_partition(
+    r: random.Random, total: int, n: int, mx: int, positive: bool = True
+) -> List[int]:
+    # returns list of n nonnegative integers less than mx summing to total
+    # NB: This is unfortunately biased towards evenly-split bins.
+    # If `positive`, outputs are positive
+    if positive:
+        total -= n
+        mx -= 1
+    idxs = r.sample(range(n * mx), total)
+    y = torch.zeros(n, mx, dtype=torch.int32)
+    y.flatten()[idxs] = 1
+    z = y.sum(1)
+    if positive:
+        z += 1
+    return z.tolist()
+
+
+def _rand_seqlens_padded_k(
+    r: random.Random, bs: int, q_len: int, kv_len: int
+) -> Tuple[Sequence[int], Sequence[int]]:
+    # This is for BlockDiagonalCausalWithOffsetPaddedKeysMask.
+    # we need q_seqlens and k_seqlens to be of len bsz.
+    # For each "batch element" there must be more keys than queries
+    # because this bias type is "bottom right" and so any extra queries
+    # will attend to nothing and have undefined result.
+    # In addition every element of k_seqlens must be <= kv_len
+    if q_len > kv_len:
+        raise ValueError("need more queries than keys")
+    if q_len == kv_len:
+        # all key slots are needed so we cannot have padding
+        q_seqlens = k_seqlens = [kv_len] * bs
+    else:
+        q_seqlens = _rand_maxed_partition(r, q_len * bs, bs, kv_len)
+        k_seqlens = [r.randint(i, kv_len) for i in q_seqlens]
+    return q_seqlens, k_seqlens
+
+
+def ref_attention(q, k, v, attn_bias=None, drop_mask=None, p=0.0, scale=None):
+    if q.ndim == 5:
+
+        def attn_bias_group(group: int):
+            if isinstance(attn_bias, torch.Tensor):
+                return attn_bias[:, group]
+            if isinstance(attn_bias, fmha.attn_bias.LowerTriangularMaskWithTensorBias):
+                return fmha.attn_bias.LowerTriangularMaskWithTensorBias(
+                    attn_bias._bias[:, group]
+                )
+            return attn_bias
+
+        return torch.stack(
+            [
+                ref_attention_bmhk(
+                    q[:, :, g],
+                    k[:, :, g],
+                    v[:, :, g],
+                    scale=scale,
+                    attn_bias=attn_bias_group(g),
+                )
+                for g in range(q.shape[2])
+            ],
+            dim=2,
+        )
+    if q.ndim == 4:
+        assert p == 0.0
+        return ref_attention_bmhk(q, k, v, scale=scale, attn_bias=attn_bias)
+    q = q.float()
+    k = k.float()
+    v = v.float()
+
+    scale = scale if scale is not None else (1 / q.shape[-1] ** 0.5)
+    q = q * scale
+
+    attn = q @ k.transpose(-2, -1)
+    if attn_bias is not None:
+        if isinstance(attn_bias, AttentionBias):
+            # Always create in B,H,Mq,Mk format
+            attn_bias_tensor = attn_bias.materialize(
+                (q.shape[0], 1, q.shape[1], k.shape[1]),
+                device=q.device,
+                dtype=torch.float32,
+            )
+        else:
+            attn_bias_tensor = attn_bias
+        if attn_bias_tensor.ndim == 4:
+            assert q.shape[0] == attn_bias_tensor.shape[0] * attn_bias_tensor.shape[1]
+            attn_bias_tensor = attn_bias_tensor.reshape(
+                [-1, *attn_bias_tensor.shape[2:]]
+            )
+        attn = attn + attn_bias_tensor.float()
+    attn = attn.softmax(-1)
+    if drop_mask is not None:
+        attn = attn * (drop_mask / (1 - p))
+    return attn @ v
+
+
+def ref_attention_bmhk(q, k, v, attn_bias, scale=None) -> torch.Tensor:
+    assert q.ndim == 4
+
+    def T(t):
+        return t.permute((0, 2, 1, 3)).reshape(
+            [t.shape[0] * t.shape[2], t.shape[1], t.shape[3]]
+        )
+
+    if isinstance(attn_bias, AttentionBias):
+        attn_bias = attn_bias.materialize(
+            (q.shape[0], q.shape[2], q.shape[1], k.shape[1]),
+            device=q.device,
+            dtype=torch.float32,
+        ).reshape([q.shape[0] * q.shape[2], q.shape[1], k.shape[1]])
+    out = ref_attention(T(q), T(k), T(v), attn_bias, scale=scale)
+    out = out.reshape([q.shape[0], q.shape[2], q.shape[1], v.shape[3]])
+    return out.permute((0, 2, 1, 3))
+
+
+def pack_kv_cache(
+    cache_k: torch.Tensor,
+    cache_v: torch.Tensor,
+    kv_seqlens: List[int],
+    BLOCK_N: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Create block tables and pages K/V cache for testing paged attention.
+    Args:
+        cache_k, cache_v: K/V caches, each of shape [B, MAX_T, H_kv, D].
+            Note that these tensors are unexpanded,
+            i.e. for multiquery case cache_k.shape[2] = 1
+        kv_seqlens: list of K/V sequence lengths
+        BLOCK_N: number of tokens per per paged attention block
+        B: batch size
+    Returns:
+        block_tables: [B, MAX_BLOCKS]
+        packed_cache_k: [1, total_len_rounded, H_kv, D]
+        packed_cache_v: [1, total_len_rounded, H_kv, D]
+    where total_len_rounded is a sum of K/V seqlens, each rounded up
+    to a multiple of BLOCK_N.
+    """
+
+    kv_seqlens_rounded = [(x + BLOCK_N - 1) // BLOCK_N * BLOCK_N for x in kv_seqlens]
+
+    total_len_rounded = sum(kv_seqlens_rounded)
+
+    B, MAX_T, H, D = cache_k.shape
+
+    packed_cache_k = torch.empty(
+        total_len_rounded, H, D, device=cache_k.device, dtype=cache_k.dtype
+    )
+    packed_cache_v = torch.empty(
+        total_len_rounded, H, D, device=cache_k.device, dtype=cache_k.dtype
+    )
+    seqstart = 0
+    for b in range(B):
+        packed_cache_k[seqstart : seqstart + kv_seqlens[b]] = cache_k[
+            b, : kv_seqlens[b]
+        ].clone()
+        packed_cache_v[seqstart : seqstart + kv_seqlens[b]] = cache_v[
+            b, : kv_seqlens[b]
+        ].clone()
+        seqstart += kv_seqlens_rounded[b]
+
+    num_blocks_per_row = (MAX_T + BLOCK_N - 1) // BLOCK_N
+    block_tables = (
+        torch.arange(num_blocks_per_row, device="cuda", dtype=torch.int32)
+        .unsqueeze(0)
+        .expand(B, num_blocks_per_row)
+    )
+    seqstarts = (
+        (
+            torch.tensor(kv_seqlens_rounded).cumsum(dim=0)
+            - torch.tensor(kv_seqlens_rounded)
+        )
+        .to(device="cuda")
+        .unsqueeze(1)
+    ) // BLOCK_N
+    block_tables = (block_tables + seqstarts).contiguous().to(dtype=torch.int32)
+    return (
+        block_tables,
+        packed_cache_k.unsqueeze(0),
+        packed_cache_v.unsqueeze(0),
+    )

--- a/mslk/attention/fmha/ck.py
+++ b/mslk/attention/fmha/ck.py
@@ -1,0 +1,507 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+
+from enum import Enum
+from typing import Any, Iterable, List, Mapping, Optional, Set, Tuple, Union
+
+import torch
+
+from . import attn_bias
+from .attn_bias import (
+    AttentionBias,
+    BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionMask,
+    BlockDiagonalCausalMask,
+    BlockDiagonalCausalWithOffsetGappyKeysMask,
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    BlockDiagonalGappyKeysMask,
+    BlockDiagonalMask,
+    BlockDiagonalPaddedKeysMask,
+    LowerTriangularFromBottomRightLocalAttentionMask,
+    LowerTriangularFromBottomRightMask,
+    LowerTriangularMask,
+    LowerTriangularMaskWithTensorBias,
+    PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+    PagedBlockDiagonalGappyKeysMask,
+    PagedBlockDiagonalPaddedKeysMask,
+)
+from .common import (
+    AttentionBwOpBase,
+    AttentionFwOpBase,
+    check_lastdim_alignment_stride1,
+    Context,
+    Gradients,
+    Inputs,
+)
+
+from .utils.op_common import get_operator, register_operator
+
+
+def _minimum_gemm_alignment(inp: Inputs) -> int:
+    return 1
+
+
+def _get_seqlen_info(
+    inp: Inputs,
+) -> Tuple[
+    Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor], int, int
+]:
+    attn_bias = inp.attn_bias
+    if isinstance(
+        attn_bias,
+        (
+            BlockDiagonalMask,
+            BlockDiagonalGappyKeysMask,
+            BlockDiagonalPaddedKeysMask,
+            BlockDiagonalCausalWithOffsetGappyKeysMask,
+            BlockDiagonalCausalWithOffsetPaddedKeysMask,
+            PagedBlockDiagonalPaddedKeysMask,
+            PagedBlockDiagonalGappyKeysMask,
+        ),
+    ):
+        attn_bias.k_seqinfo.to(inp.query.device)
+        attn_bias.q_seqinfo.to(inp.query.device)
+        seqstart_k = attn_bias.k_seqinfo.seqstart
+        seqstart_q = attn_bias.q_seqinfo.seqstart
+        max_seqlen_q = attn_bias.q_seqinfo.max_seqlen
+        max_seqlen_k = attn_bias.k_seqinfo.max_seqlen
+        seqlen = (
+            None
+            if isinstance(attn_bias, BlockDiagonalMask)
+            else attn_bias.k_seqinfo.seqlen
+        )
+    else:
+        seqstart_k = None
+        seqstart_q = None
+        max_seqlen_q = -1
+        max_seqlen_k = -1
+        seqlen = None
+
+    if isinstance(attn_bias, PagedBlockDiagonalGappyKeysMask):
+        assert seqstart_k is not None
+        assert seqlen is not None
+        seqstart_k = seqstart_k[:-1]
+        seqlen = seqlen - seqstart_k
+
+    return seqstart_k, seqstart_q, seqlen, max_seqlen_q, max_seqlen_k
+
+
+def _get_tensor_bias(
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]],
+) -> Optional[torch.Tensor]:
+    if isinstance(attn_bias, LowerTriangularMaskWithTensorBias):
+        return attn_bias._bias
+    if isinstance(attn_bias, torch.Tensor):
+        return attn_bias
+    return None
+
+
+def _check_bias_alignment(
+    reasons: List[str], attn_bias: Optional[Union[torch.Tensor, AttentionBias]]
+) -> None:
+    attn_bias_tensor = _get_tensor_bias(attn_bias)
+    if attn_bias_tensor is not None:
+        alignment = 128 // torch.finfo(attn_bias_tensor.dtype).bits
+        show_padding_hint = False
+        for d in range(attn_bias_tensor.ndim - 1):
+            if attn_bias_tensor.stride(d) % alignment != 0:
+                reasons.append(
+                    f"attn_bias.stride(-2) % {alignment} != 0 (attn_bias.stride() = {attn_bias_tensor.stride()})"
+                )
+                show_padding_hint = True
+        if show_padding_hint:
+            reasons.append(
+                """\
+HINT: To use an `attn_bias` with a sequence length that is not a multiple of 8, \
+you need to ensure memory is aligned by slicing a bigger tensor. \
+Example: use `attn_bias = torch.zeros([1, 1, 5, 8])[:,:,:,:5]` instead of `torch.zeros([1, 1, 5, 5])`"""
+            )
+        # We can have stride=0 sometimes if dimension=1
+        if attn_bias_tensor.stride(-1) > 1:
+            reasons.append(
+                f"attn_bias.stride(-1) > 1 (attn_bias.stride() = {attn_bias_tensor.stride()}) - "
+                "you should call `.contiguous()` on the bias"
+            )
+
+
+class _CustomMaskType(int, Enum):
+    """
+    (Matches CustomMaskType in C++.)
+    """
+
+    NoCustomMask = 0
+    CausalFromTopLeft = 1
+    CausalFromBottomRight = 2
+
+
+def _custom_mask_type(bias: Optional[Union[torch.Tensor, AttentionBias]]) -> int:
+    if isinstance(
+        bias,
+        (
+            LowerTriangularMask,
+            BlockDiagonalCausalMask,
+            BlockDiagonalCausalLocalAttentionMask,
+        ),
+    ):
+        return int(_CustomMaskType.CausalFromTopLeft)
+    if isinstance(
+        bias,
+        (
+            LowerTriangularFromBottomRightMask,
+            LowerTriangularFromBottomRightLocalAttentionMask,
+            attn_bias.BlockDiagonalCausalFromBottomRightMask,
+            BlockDiagonalCausalWithOffsetPaddedKeysMask,
+            BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+            PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+        ),
+    ):
+        return int(_CustomMaskType.CausalFromBottomRight)
+    return int(_CustomMaskType.NoCustomMask)
+
+
+@register_operator
+class FwOp(AttentionFwOpBase):
+    """xFormers' MHA kernel based on Composable Kernel."""
+
+    OPERATOR = get_operator("xformers", "efficient_attention_forward_ck")
+    SUPPORTED_DEVICES: Set[str] = {"cuda"}
+    SUPPORTED_DTYPES: Set[torch.dtype] = {torch.half, torch.bfloat16}
+    SUPPORTED_MAX_K = 512
+
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        torch.Tensor,
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        LowerTriangularMaskWithTensorBias,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        BlockDiagonalCausalWithOffsetGappyKeysMask,
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        BlockDiagonalGappyKeysMask,
+        BlockDiagonalPaddedKeysMask,
+        attn_bias.BlockDiagonalCausalFromBottomRightMask,
+        attn_bias.BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+        PagedBlockDiagonalPaddedKeysMask,
+        PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+        PagedBlockDiagonalGappyKeysMask,
+    )
+
+    SUPPORTS_DROPOUT = True
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_DIFFERENT_VALUE_EMBED = True
+    SUPPORTS_PARTIAL = True
+    SUPPORTS_BMGHK = True
+    VARLEN_LSE_PACKED = True
+    NAME = "ckF"
+
+    ERROR_ATOL: Mapping[torch.dtype, float] = {
+        torch.float: 3e-4,
+        torch.half: 6e-3,
+        torch.bfloat16: 2.8e-2,
+    }
+    ERROR_RTOL: Mapping[torch.dtype, float] = {
+        torch.float: 2e-5,
+        torch.half: 3e-3,
+        torch.bfloat16: 2e-2,
+    }
+
+    _TEST_K: List[int] = [
+        32,  # 64x64 kernel
+        96,
+        128,  # 64x128 kernel
+        256,  # 64x128 with accumulation in gmem
+        512,
+    ]
+
+    @classmethod
+    def apply(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        if type(inp.attn_bias) not in FwOp.SUPPORTED_ATTN_BIAS_TYPES:
+            raise NotImplementedError("Unsupported attn_bias type")
+        if inp.query.ndim in [1, 2, 3]:
+            raise NotImplementedError("Unsupported number of dimensions")
+        if inp.query.ndim in [4]:
+            return cls.apply_bmhk(inp, needs_gradient=needs_gradient)
+        assert inp.query.ndim == 5, f"query has shape {inp.query.shape}"
+        ctx: Optional[Context] = None
+
+        # when the input is expanded 5-D, the group dimension has zero stride
+        if inp.key.stride()[3] == 0:
+            assert (
+                inp.value.stride()[3] == 0
+            ), "key and value should be expanded in the same way"
+            k_shape = inp.key.size()
+            k_stride = inp.key.stride()
+            key = inp.key.as_strided(
+                (k_shape[0], k_shape[1], k_shape[2], k_shape[4]),
+                (k_stride[0], k_stride[1], k_stride[2], k_stride[4]),
+            )
+            v_shape = inp.value.size()
+            v_stride = inp.value.stride()
+            value = inp.value.as_strided(
+                (v_shape[0], v_shape[1], v_shape[2], v_shape[4]),
+                (v_stride[0], v_stride[1], v_stride[2], v_stride[4]),
+            )
+        else:
+            key = inp.key.flatten(2, 3)
+            value = inp.value.flatten(2, 3)
+
+        [_, _, G, Hq, _] = inp.query.shape
+        attn_bias_replace = inp.attn_bias
+        if isinstance(inp.attn_bias, LowerTriangularMaskWithTensorBias):
+            bias_tensor = _get_tensor_bias(inp.attn_bias)
+            if bias_tensor is not None and bias_tensor.ndim == 5:
+                attn_bias_replace = LowerTriangularMaskWithTensorBias(
+                    bias_tensor.flatten(1, 2)
+                )
+        elif isinstance(inp.attn_bias, torch.Tensor) and inp.attn_bias.ndim == 5:
+            attn_bias_replace = inp.attn_bias.flatten(1, 2)
+        inp = Inputs(
+            query=inp.query.flatten(2, 3),
+            key=key,
+            value=value,
+            attn_bias=attn_bias_replace,
+            p=inp.p,
+            scale=inp.scale,
+            output_dtype=inp.output_dtype,
+            is_partial=inp.is_partial,
+        )
+        out, ctx = cls.apply_bmhk(inp, needs_gradient=needs_gradient)
+        out = out.unflatten(2, (G, Hq))
+        if ctx is not None:
+            lse = ctx.lse.unflatten(1, (G, Hq))
+            ctx = Context(
+                lse=lse,
+                out=out,
+                op_bw=ctx.op_bw,
+                rng_state=ctx.rng_state,
+                qkv_share_storage=ctx.qkv_share_storage,
+            )
+
+        return out, ctx
+
+    @classmethod
+    def apply_bmhk(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        if type(inp.attn_bias) not in FwOp.SUPPORTED_ATTN_BIAS_TYPES:
+            raise NotImplementedError("Unsupported attn_bias type")
+        seqstart_k, seqstart_q, seqlen_k, max_seqlen_q, _ = _get_seqlen_info(inp)
+        out, lse, rng_seed, rng_offset = cls.OPERATOR(
+            query=inp.query,
+            key=inp.key,
+            value=inp.value,
+            attn_bias=_get_tensor_bias(inp.attn_bias),
+            seqstart_q=seqstart_q,
+            seqstart_k=seqstart_k,
+            max_seqlen_q=max_seqlen_q,
+            dropout_p=inp.p,
+            compute_logsumexp=needs_gradient,
+            custom_mask_type=_custom_mask_type(inp.attn_bias),
+            scale=inp.scale,
+            seqlen_k=seqlen_k,
+            window_size=(
+                inp.attn_bias._window_size
+                if isinstance(
+                    inp.attn_bias,
+                    (
+                        BlockDiagonalCausalLocalAttentionMask,
+                        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+                        LowerTriangularFromBottomRightLocalAttentionMask,
+                    ),
+                )
+                else None
+            ),
+            block_tables=(
+                inp.attn_bias.block_tables
+                if isinstance(
+                    inp.attn_bias,
+                    (
+                        PagedBlockDiagonalPaddedKeysMask,
+                        PagedBlockDiagonalGappyKeysMask,
+                    ),
+                )
+                else None
+            ),
+            page_size=(
+                inp.attn_bias.page_size
+                if isinstance(
+                    inp.attn_bias,
+                    (
+                        PagedBlockDiagonalPaddedKeysMask,
+                        PagedBlockDiagonalGappyKeysMask,
+                    ),
+                )
+                else None
+            ),
+        )
+
+        ctx: Optional[Context] = None
+        if needs_gradient:
+            ctx = Context(
+                out=out,
+                # lse=_post_process_lse(lse, inp, tuple(original_query_shape)),
+                lse=lse,
+                # cutlass forward is only compatible with cutlass backward if
+                # dropout is used (because of the way RNG states are passed and the
+                # way random numbers are generated during backward)
+                op_bw=BwOp if inp.p != 0 else None,
+            )
+            if inp.p != 0:
+                ctx.rng_state = torch.tensor(
+                    [rng_seed, rng_offset], dtype=torch.int64, device="cpu"
+                )
+        return out, ctx
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(FwOp, cls).not_supported_reasons(d)
+        matmul_alignment_mn = _minimum_gemm_alignment(d)
+        check_lastdim_alignment_stride1(reasons, "query", d.query, matmul_alignment_mn)
+        check_lastdim_alignment_stride1(reasons, "value", d.value, matmul_alignment_mn)
+        _check_bias_alignment(reasons, d.attn_bias)
+        return reasons
+
+
+@register_operator
+class BwOp(AttentionBwOpBase):
+    __doc__ = FwOp.__doc__
+
+    OPERATOR = get_operator("xformers", "efficient_attention_backward_ck")
+    SUPPORTED_DEVICES = FwOp.SUPPORTED_DEVICES
+    SUPPORTED_DTYPES = FwOp.SUPPORTED_DTYPES
+    SUPPORTED_MAX_K = 256
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        torch.Tensor,
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        # TODO: Fix handling of gradient through the fMHA autograd function
+        # LowerTriangularMaskWithTensorBias,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        attn_bias.BlockDiagonalCausalFromBottomRightMask,
+        attn_bias.BlockDiagonalCausalLocalAttentionMask,
+    )
+    SUPPORTS_ATTN_BIAS_GRAD = True
+    SUPPORTS_DROPOUT = FwOp.SUPPORTS_DROPOUT
+    SUPPORTS_CUSTOM_SCALE = FwOp.SUPPORTS_CUSTOM_SCALE
+    SUPPORTS_DIFFERENT_VALUE_EMBED = FwOp.SUPPORTS_DIFFERENT_VALUE_EMBED
+    SUPPORTS_UNPADDED_LSE = True
+    NAME = "ckB"
+
+    _TEST_K: List[int] = [
+        32,  # 64x64 kernel
+        64,
+        96,
+        128,  # 64x128/128x128 kernel
+        256,
+    ]
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(BwOp, cls).not_supported_reasons(d)
+        matmul_alignment_mn = _minimum_gemm_alignment(d)
+
+        check_lastdim_alignment_stride1(reasons, "query", d.query, matmul_alignment_mn)
+        check_lastdim_alignment_stride1(reasons, "key", d.key, matmul_alignment_mn)
+        check_lastdim_alignment_stride1(reasons, "value", d.value, matmul_alignment_mn)
+        _check_bias_alignment(reasons, d.attn_bias)
+        attn_bias_tensor = _get_tensor_bias(d.attn_bias)
+
+        # Backprop of gradient through broadcasted bias is not supported
+        if attn_bias_tensor is not None and attn_bias_tensor.requires_grad:
+            # Don't forget that inputs are either in BMK or BMHK!
+            if d.query.ndim == 3 and attn_bias_tensor.ndim == 3:
+                expected_bias_shape = (*d.query.shape[:2], d.key.shape[1])
+            else:
+                # bias is B H Mq Mk
+                expected_bias_shape = (
+                    d.query.shape[0],
+                    d.query.shape[2] if d.query.ndim == 4 else 1,
+                    d.query.shape[1],
+                    d.key.shape[1],
+                )
+            if tuple(attn_bias_tensor.shape) != expected_bias_shape:
+                reasons.append(
+                    "Broadcasting the `attn_bias` tensor is not supported "
+                    f"(shape: {tuple(attn_bias_tensor.shape)}"
+                    f"/ expected: {expected_bias_shape})"
+                )
+
+        return reasons
+
+    @classmethod
+    def apply(cls, ctx: Context, inp: Inputs, grad: torch.Tensor) -> Gradients:
+        if type(inp.attn_bias) not in BwOp.SUPPORTED_ATTN_BIAS_TYPES:
+            raise NotImplementedError("Unsupported attn_bias type")
+
+        seqstart_k, seqstart_q, seqlen_k, max_seqlen_q, max_seqlen_k = _get_seqlen_info(
+            inp
+        )
+        dtype = inp.query.dtype
+
+        rng_seed = rng_offset = 0
+        if inp.p != 0.0:
+            if (
+                ctx.rng_state is None
+                or ctx.rng_state.dtype != torch.int64
+                or ctx.rng_state.device.type != "cpu"
+                or ctx.rng_state.shape != (2,)
+            ):
+                raise NotImplementedError(f"Invalid rng_state: {ctx.rng_state}")
+            rng_seed, rng_offset = ctx.rng_state.tolist()
+
+        (grad_q, grad_k, grad_v, grad_bias) = cls.OPERATOR(
+            grad.to(dtype),
+            inp.query,
+            inp.key,
+            inp.value,
+            attn_bias=_get_tensor_bias(inp.attn_bias),
+            seqstart_q=seqstart_q,
+            seqstart_k=seqstart_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            seqlen_k=seqlen_k,
+            logsumexp=ctx.lse,
+            output=ctx.out.to(dtype),
+            dropout_p=inp.p,
+            # if not using dropout, seed and offset are irrelevant but still expected
+            # in function signature so just pass 0
+            # seed and offset could be None if a different FW op other than cutlass
+            # was used.
+            rng_seed=rng_seed,
+            rng_offset=rng_offset,
+            custom_mask_type=_custom_mask_type(inp.attn_bias),
+            scale=inp.scale,
+            window_size=(
+                inp.attn_bias._window_size
+                if isinstance(
+                    inp.attn_bias,
+                    (
+                        BlockDiagonalCausalLocalAttentionMask,
+                        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+                        LowerTriangularFromBottomRightLocalAttentionMask,
+                    ),
+                )
+                else None
+            ),
+        )
+
+        # c++/CUDA implementation returns an uninitialized tensor if bias doesn't
+        # require grad
+        if not (
+            isinstance(inp.attn_bias, torch.Tensor) and inp.attn_bias.requires_grad
+        ):
+            grad_bias = None
+
+        return Gradients(dq=grad_q, dk=grad_k, dv=grad_v, db=grad_bias)

--- a/mslk/attention/fmha/ck_decoder.py
+++ b/mslk/attention/fmha/ck_decoder.py
@@ -1,0 +1,141 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+from typing import Any, Iterable, List, Optional, Set, Tuple
+
+import torch
+
+from .attn_bias import BlockDiagonalCausalWithOffsetPaddedKeysMask
+from .common import AttentionFwOpBase, Context, Inputs
+
+from .utils.op_common import get_operator, register_operator
+
+
+@register_operator
+class FwOp(AttentionFwOpBase):
+    """
+    An operator optimized for K=256 (so the contiguous dim fits into registers).
+    Tested to work on MI250x.
+    """
+
+    OPERATOR = get_operator("xformers", "efficient_attention_forward_decoder_ck")
+    SUPPORTED_DEVICES: Set[str] = {"cuda"}
+    SUPPORTED_DTYPES: Set[torch.dtype] = {torch.half, torch.bfloat16, torch.float}
+    SUPPORTED_MAX_K: int = 256
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    )
+    SUPPORTS_DROPOUT = False
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_BMGHK = True
+    NAME = "ck_decoderF"
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:  # noqa: C901
+        reasons = super(FwOp, cls).not_supported_reasons(d)
+
+        attn_bias = d.attn_bias
+        if isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
+            if d.query.shape[0] != 1:
+                reasons.append(
+                    f"One formal batch element expected; got {d.query.shape[0]}"
+                )
+
+            if d.query.shape[-1] > cls.SUPPORTED_MAX_K:
+                reasons.append(
+                    f"Got head_dim={d.query.shape[-1]}; only head_dim<={cls.SUPPORTED_MAX_K} is supported for now."
+                )
+
+            threads_per_warp = 64  # TODO: ideally query the platform here
+            required_alignment = 0
+            head_dim = d.query.shape[-1]
+            for vec_size in (4, 2, 1):
+                if head_dim <= vec_size * threads_per_warp:
+                    required_alignment = vec_size
+
+            if not required_alignment:
+                reasons.append(f"Got head_dim={head_dim} which is too large")
+
+            if head_dim % required_alignment != 0:
+                reasons.append(
+                    f"Got head_dim={head_dim}; it needs to be divisible by {required_alignment}"
+                )
+
+            if d.key.stride(-1) != 1:
+                reasons.append("expect keys to have last dim contiguous")
+
+            if d.value.stride(-1) != 1:
+                reasons.append("expect values to have last dim contiguous")
+
+            q_starts = attn_bias.q_seqinfo.seqstart_py
+            padding = attn_bias.k_seqinfo.padding
+            bsz = d.key.shape[1] // padding
+            num_queries = d.query.shape[1] // bsz
+
+            if q_starts != list(range(0, 1 + bsz, num_queries)):
+                reasons.append("expect to have same num_queries in each batch")
+            if bsz != len(q_starts) - 1:
+                reasons.append("empty lanes not supported yet")
+
+            if attn_bias.k_seqinfo.padding > 8192:
+                reasons.append("key padding exceeds 8192")
+
+        return reasons
+
+    @classmethod
+    def apply(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        if needs_gradient:
+            raise NotImplementedError("backward pass is not supported")
+        attn_bias = inp.attn_bias
+        q, k, v = inp.get_qkv_in_bmghk()
+        if attn_bias is not None:
+            assert isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+            attn_bias.k_seqinfo.to(k.device)
+            attn_bias.q_seqinfo.to(q.device)
+            padding = attn_bias.k_seqinfo.padding
+            seq_positions_gpu = attn_bias.k_seqinfo.seqlen
+        else:
+            padding = k.shape[1]
+            seq_positions_gpu = None
+
+        if attn_bias is not None:
+            # key: (1, B * padding, G, 1 if multiquery else Hkv, D)
+            # value: like key
+            # query: (1, B * q_seqlen, G, Hq, D)
+            multiquery = k.stride(3) == 0
+            if multiquery:
+                key = k[0, :, :, :1].unflatten(0, (-1, padding))
+                value = v[0, :, :, :1].unflatten(0, (-1, padding))
+            else:
+                key = k[0].unflatten(0, (-1, padding))
+                value = v[0].unflatten(0, (-1, padding))
+            query = q[0].unflatten(0, (key.shape[0], -1))
+        else:
+            # key: (B, padding, G, 1 if multiquery else Hkv, D)
+            # value: like key
+            # query: (B, q_seqlen, G, Hq, D)
+            key = k
+            query = q
+            value = v
+
+        if inp.scale is not None:
+            qk_scale = inp.scale
+        else:
+            qk_scale = torch.rsqrt(
+                torch.tensor(key.shape[-1], dtype=torch.float32)
+            ).item()
+
+        out = cls.OPERATOR(
+            query=query,
+            key=key,
+            value=value,
+            seq_positions=seq_positions_gpu,
+            scale=qk_scale,
+        )
+        return out, None

--- a/mslk/attention/fmha/ck_splitk.py
+++ b/mslk/attention/fmha/ck_splitk.py
@@ -1,0 +1,204 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+from typing import Any, Iterable, List, Optional, Tuple
+
+import torch
+
+from .attn_bias import BlockDiagonalCausalWithOffsetPaddedKeysMask
+from .common import AttentionFwOpBase, check_lastdim_alignment_stride1, Context, Inputs
+
+from .utils.op_common import get_operator, register_operator
+
+
+@register_operator
+class FwOp(AttentionFwOpBase):
+    OPERATOR = get_operator("xformers", "efficient_attention_forward_decoder_splitk_ck")
+    SUPPORTED_DEVICES = {"cuda"}
+    SUPPORTED_DTYPES = {
+        torch.half,
+        torch.bfloat16,
+        torch.float,
+    }  # Those are dtypes of Q. In the quantized case K/V has dtype int32
+    SUPPORTED_MAX_K = 256
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    )
+    SUPPORTS_DROPOUT = False
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_BMGHK = True
+    NAME = "ck_splitKF"
+
+    SPLIT_K: Optional[int] = None
+    BLOCK_M = 16
+    BLOCK_N = 64
+
+    NUM_GROUPS = 1  # Default quantization is row-wise
+
+    @classmethod
+    def shape_not_supported_reasons(
+        cls, Mq: int, Mkv: int, K: int, Kv: int
+    ) -> List[str]:
+        reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+        # if K not in {16, 32, 64, 128}:
+        #     reasons.append(f"Embed dim {K} not supported")
+        return reasons
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(FwOp, cls).not_supported_reasons(d)
+        check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+        if d.key.dtype != torch.int32:
+            check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
+            check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
+        if cls.OPERATOR is None:
+            reasons.append("triton is not available")
+        if d.device.type == "cuda":
+            # Has only been tested on 8.0 / 9.0.
+            if torch.cuda.get_device_capability(d.device) < (7, 0):
+                reasons.append(
+                    "requires GPU with sm80 minimum compute capacity, e.g., A100/H100/L4"
+                )
+
+        q_len = d.query.shape[1]
+        if isinstance(d.attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
+            seqinfo = d.attn_bias.q_seqinfo
+            if q_len != seqinfo.seqstart_py[-1]:
+                reasons.append(
+                    f"Expected total {seqinfo.seqstart_py[-1]} queries not {q_len}"
+                )
+            q_len = seqinfo.min_seqlen
+            if q_len != seqinfo.max_seqlen:
+                reasons.append(
+                    "Variable query len is not supported in the presence of causal mask."
+                )
+
+        if d.key.ndim in [4, 5] and d.key.shape[-2] != 1:
+            if d.key.stride(-2) == 0 and d.value.stride(-2) == 0 and q_len > 1:
+                reasons.append("multiquery is only supported with query seqlen=1")
+
+        if d.attn_bias is not None and q_len > 1:
+            reasons.append(
+                "query with seqlen > 1 is not supported in the presence of causal mask"
+            )
+        return reasons
+
+    @classmethod
+    def get_split_k(cls, B: int, H: int, Mk: int) -> int:
+        """Heuristic for the number of splits"""
+        bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
+        split_k = max(Mk, 1024) // bh
+        max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128
+        while split_k > 0 and Mk / split_k < max_chunk_size:
+            split_k = split_k // 2
+        split_k = min(split_k, 64)
+        split_k = max(split_k, 1)
+        return split_k
+
+    @classmethod
+    def apply(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        attn_bias = inp.attn_bias
+        q, k, v = inp.get_qkv_in_bmghk()
+
+        if attn_bias is not None:
+            assert isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+            attn_bias.k_seqinfo.to(k.device)
+            attn_bias.q_seqinfo.to(q.device)
+            padding = attn_bias.k_seqinfo.padding
+            seq_positions_gpu = attn_bias.k_seqinfo.seqlen
+        else:
+            padding = k.shape[1]
+            seq_positions_gpu = None
+
+        if attn_bias is not None:
+            # key: (1, B * padding, G, 1 if multiquery else Hkv, D)
+            # value: like key
+            # query: (1, B * q_seqlen, G, Hq, D)
+            multiquery = k.stride(3) == 0
+            if multiquery:
+                key = k[0, :, :, :1].unflatten(0, (-1, padding))
+                value = v[0, :, :, :1].unflatten(0, (-1, padding))
+            else:
+                key = k[0].unflatten(0, (-1, padding))
+                value = v[0].unflatten(0, (-1, padding))
+            query = q[0].unflatten(0, (key.shape[0], -1))
+        else:
+            # key: (B, padding, G, 1 if multiquery else Hkv, D)
+            # value: like key
+            # query: (B, q_seqlen, G, Hq, D)
+            key = k
+            query = q
+            value = v
+
+        B, _, _, H, _ = query.shape
+        _, Mk, _, _, _ = key.shape
+
+        if cls.SPLIT_K is not None:
+            split_k = cls.SPLIT_K
+        else:
+            # Use heuristics
+            split_k = cls.get_split_k(B, H, Mk)
+
+        if inp.scale is not None:
+            qk_scale = inp.scale
+        else:
+            qk_scale = torch.rsqrt(
+                torch.tensor(k.shape[-1], dtype=torch.float32)
+            ).item()
+
+        out = cls.OPERATOR(
+            query=query,
+            key=key,
+            value=value,
+            seq_positions=seq_positions_gpu,
+            scale=qk_scale,
+            split_k=split_k,
+        )
+
+        return out, None
+
+
+class FwOp_S1(FwOp):
+    SPLIT_K = 1
+    NAME = "ck_splitK1"
+
+
+class FwOp_S2(FwOp):
+    SPLIT_K = 2
+    NAME = "ck_splitK2"
+
+
+class FwOp_S4(FwOp):
+    SPLIT_K = 4
+    NAME = "ck_splitK4"
+
+
+class FwOp_S8(FwOp):
+    SPLIT_K = 8
+    NAME = "ck_splitK8"
+
+
+class FwOp_S16(FwOp):
+    SPLIT_K = 16
+    NAME = "ck_splitK16"
+
+
+class FwOp_S32(FwOp):
+    SPLIT_K = 32
+    NAME = "ck_splitK32"
+
+
+class FwOp_S64(FwOp):
+    SPLIT_K = 64
+    NAME = "ck_splitK64"
+
+
+class FwOp_S128(FwOp):
+    SPLIT_K = 128
+    NAME = "ck_splitK128"

--- a/mslk/attention/fmha/common.py
+++ b/mslk/attention/fmha/common.py
@@ -1,0 +1,599 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+import math
+from dataclasses import dataclass
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
+
+import torch
+
+from .attn_bias import (
+    AttentionBias,
+    BlockDiagonalGappyKeysMask,
+    BlockDiagonalMask,
+    BlockDiagonalPaddedKeysMask,
+    LowerTriangularMask,
+    LowerTriangularMaskWithTensorBias,
+    PagedBlockDiagonalGappyKeysMask,
+    PagedBlockDiagonalPaddedKeysMask,
+)
+
+from .utils.cpp_lib import _built_with_cuda
+
+from .utils.op_common import BaseOperator
+
+
+def _is_bias_type_supported_in_BMK(attn_bias_type: Any) -> bool:
+    # NoneType
+    if isinstance(None, attn_bias_type):
+        return True
+    if attn_bias_type in [LowerTriangularMask, torch.Tensor]:
+        return True
+    return False
+
+
+def _attn_bias_apply(
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]],
+    op: Callable[[torch.Tensor], torch.Tensor],
+) -> Optional[Union[torch.Tensor, AttentionBias]]:
+    if isinstance(attn_bias, torch.Tensor):
+        return op(attn_bias)
+    if isinstance(attn_bias, LowerTriangularMaskWithTensorBias):
+        return LowerTriangularMaskWithTensorBias(op(attn_bias._bias))
+    return attn_bias
+
+
+class ScaledTensor(torch.Tensor):
+    __slots__ = ["scale", "dequant_func", "original_dtype"]
+
+    # Disabling custom torch function handling for this class
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    @staticmethod
+    def __new__(
+        cls,
+        data: torch.Tensor,
+        scale: torch.Tensor,
+        dequant_func: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+        original_dtype: torch.dtype,
+        require_grad: bool = False,
+    ) -> "ScaledTensor":
+        """
+        Creates a new ScaledTensor subclass instance.
+
+        Parameters:
+        - data: The underlying quantized tensor (e.g., int8, int4).
+        - scale: The scale tensor or scalar to be used for dequantization.
+        - dequant_func: A callable that applies dequantization, which takes both the data and scale as input.
+        - original_dtype: The data type before quantization (e.g., float32, float16).
+        - require_grad: Whether or not to track gradients (default: False for inference use).
+        """
+        # Use _make_subclass to create a new ScaledTensor instance, which is a subclass of torch.Tensor.
+        instance = torch.Tensor._make_subclass(cls, data, require_grad)
+
+        # Store the dequantization scale and function as attributes.
+        instance.scale = scale  # type: ignore
+        instance.dequant_func = dequant_func  # type: ignore
+
+        # Store the original data type of the tensor, so we can cast it back after dequantization.
+        instance.original_dtype = original_dtype  # type: ignore
+
+        # Return the new instance of ScaledTensor.
+        return instance
+
+    def dequantize(self) -> torch.Tensor:
+        """
+        Applies the custom dequantization function provided at the tensor's creation.
+        After dequantization, the data is cast back to its original data type.
+        """
+        # Explicitly create a new torch.Tensor to ensure the return type is torch.Tensor, not ScaledTensor.
+        data = torch.Tensor(self.float())
+
+        # Call the dequantization function, passing in the data and the scale.
+        dequantized_data = self.dequant_func(data, self.scale)  # type: ignore
+
+        # Cast the dequantized data back to the original data type.
+        return dequantized_data.to(self.original_dtype)  # type: ignore
+
+    def unpack(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Unpacks the ScaledTensor by returning its data and scale as a tuple.
+        Returns:
+        - A tuple of (data, scale), both of which are torch.Tensor objects.
+        """
+        return self.data, self.scale  # type: ignore
+
+    def __repr__(self):
+        """
+        Custom string representation for ScaledTensor.
+        """
+        return f"ScaledTensor(data={self.data}, scale={self.scale}, original_dtype={self.original_dtype})"
+
+
+def pack_fp8_tensorwise_per_head(
+    x: torch.Tensor, scale: Union[torch.Tensor, float], original_dtype
+) -> ScaledTensor:
+    """
+    Pack a tensor into a tensorwise fp8 ScaledTensor.
+    """
+    if isinstance(scale, float):
+        scale = torch.tensor([scale], device=x.device)
+
+    def dequant_func(x, scale):
+        return x * scale[:, None, :, None]
+
+    return ScaledTensor(
+        data=x,
+        scale=scale,
+        dequant_func=dequant_func,
+        original_dtype=original_dtype,
+    )
+
+
+@dataclass
+class Inputs:
+    """
+    Stores inputs to the `memory_efficient_attention` operators
+    """
+
+    query: torch.Tensor
+    key: torch.Tensor
+    value: torch.Tensor
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]] = None
+    p: float = 0.0
+    scale: Optional[float] = None
+    output_dtype: Optional[torch.dtype] = None
+    is_partial: bool = False
+    quantize_pv_to_fp8: bool = False
+    quantize_qk_to_fp8: bool = False
+    use_fp32_scales: bool = False
+
+    @property
+    def device(self) -> torch.device:
+        return self.query.device
+
+    @property
+    def scale_float(self) -> float:
+        return self.query.shape[-1] ** (-0.5) if self.scale is None else self.scale
+
+    def get_qkv_in_bmghk(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self.query.ndim == 5:
+            return self.query, self.key, self.value
+        if self.query.ndim == 4:
+            return (
+                self.query.unsqueeze(2),
+                self.key.unsqueeze(2),
+                self.value.unsqueeze(2),
+            )
+        if self.value.ndim == 3:
+            return (
+                self.query[:, :, None, None],
+                self.key[:, :, None, None],
+                self.value[:, :, None, None],
+            )
+        raise AssertionError
+
+    def normalize_bmhk(self) -> Tuple[int, ...]:
+        if self.query.ndim not in [3, 4, 5]:
+            raise ValueError(
+                f"Invalid shape for query: {self.query.shape}. "
+                "Expected shape [batch, seqlen, head_groups, num_heads_per_group, K]"
+                ", [batch, seqlen, num_heads, K], or [batch, seqlen, K]."
+            )
+        if self.value.dtype == torch.int32:
+            # Quantized K/V case, in which the last dims of Q and K are different.
+            # NB we currently don't have any implementations for quantized KV with
+            # SUPPORTS_DIFFERENT_VALUE_EMBED.
+            output_shape: Tuple[int, ...] = tuple(self.query.shape)
+        else:
+            output_shape = tuple(self.query.shape)[:-1] + (self.value.shape[-1],)
+        # Convert from legacy format
+        if self.query.ndim == 3:
+            self.query = self.query.unsqueeze(2)
+            self.key = self.key.unsqueeze(2)
+            self.value = self.value.unsqueeze(2)
+            self.attn_bias = _attn_bias_apply(
+                self.attn_bias, partial(torch.unsqueeze, dim=1)
+            )
+        return output_shape
+
+    def validate_inputs(self) -> None:  # noqa: C901
+        qkv = (self.query, self.key, self.value)
+        if self.query.ndim not in (3, 4, 5) or any(
+            x.ndim != self.query.ndim for x in qkv
+        ):
+            raise ValueError(
+                f"Query/Key/Value should all have BMGHK, BMHK or BMK shape.\n"
+                f"  query.shape: {self.query.shape}\n"
+                f"  key.shape  : {self.key.shape}\n"
+                f"  value.shape: {self.value.shape}"
+            )
+        if any(x.device != self.query.device for x in qkv):
+            raise ValueError("Query/Key/Value should all be on the same device")
+        if isinstance(
+            self.attn_bias,
+            (
+                BlockDiagonalMask,
+                BlockDiagonalPaddedKeysMask,
+                PagedBlockDiagonalPaddedKeysMask,
+                BlockDiagonalGappyKeysMask,
+                PagedBlockDiagonalGappyKeysMask,
+            ),
+        ):
+            bias_device = self.attn_bias.q_seqinfo.seqstart.device
+            if bias_device != self.query.device:
+                raise ValueError(
+                    f"Attention bias and Query/Key/Value should be on the same device\n"
+                    f"  query.device: {self.query.device}\n"
+                    f"  attn_bias   : {bias_device}\n"
+                )
+
+        quantized_dtypes = self.key.dtype == self.value.dtype == torch.int32
+        non_quantized_dtypes = all(x.dtype == self.query.dtype for x in qkv)
+        if not (quantized_dtypes or non_quantized_dtypes):
+            raise ValueError(
+                "Query/Key/Value should either all have the same dtype, or "
+                "(in the quantized case) Key/Value should have dtype torch.int32\n"
+                f"  query.dtype: {self.query.dtype}\n"
+                f"  key.dtype  : {self.key.dtype}\n"
+                f"  value.dtype: {self.value.dtype}"
+            )
+        # Biases with tensors attached are meant to be in BMHK format
+        # This would require to permute biases/gradients which can be expensive,
+        # so let's just forbid it - BMK is a legacy format anyway
+        if self.query.ndim == 3 and not _is_bias_type_supported_in_BMK(
+            type(self.attn_bias)
+        ):
+            raise ValueError(
+                f"Please provide inputs in BMHK format rather "
+                f"than BMK when using bias type `{type(self.attn_bias).__name__}`"
+            )
+        attn_bias_t: Optional[torch.Tensor] = None
+        if isinstance(self.attn_bias, LowerTriangularMaskWithTensorBias):
+            attn_bias_t = self.attn_bias._bias
+        elif isinstance(self.attn_bias, torch.Tensor):
+            attn_bias_t = self.attn_bias
+        if self.query.ndim == 4 and attn_bias_t is not None:
+            expected_shape = (
+                self.query.shape[0],
+                self.query.shape[2],
+                self.query.shape[1],
+                self.key.shape[1],
+            )
+            if attn_bias_t.shape != expected_shape:
+                raise ValueError(
+                    f"Invalid shape for attention bias: {attn_bias_t.shape} (expected {expected_shape})\n"
+                    f"  query.shape: {self.query.shape}\n"
+                    f"  key.shape  : {self.key.shape}\n"
+                    f"  value.shape: {self.value.shape}"
+                )
+        if isinstance(self.attn_bias, BlockDiagonalMask):
+            if any(x.shape[0] != 1 for x in qkv):
+                raise ValueError(
+                    f"Expected batch_size=1 when using block-diagonal bias\n"
+                    f"  query.shape: {self.query.shape}\n"
+                    f"  key.shape  : {self.key.shape}\n"
+                    f"  value.shape: {self.value.shape}"
+                )
+        if self.p < 0.0 or self.p > 1.0:
+            raise ValueError(f"Invalid dropout probability: p={self.p}")
+        # Check that shapes match between inputs
+        B, Mq = self.query.shape[:2]
+        K = self.query.shape[-1]
+        B, Mkv = self.key.shape[:2]
+        Kv = self.value.shape[-1]
+        quantized_kv_cache = self.value.dtype == torch.int32
+        key_embed_dim = Kv if quantized_kv_cache else K
+
+        valid_shapes = True
+        if self.query.ndim == 3:  # BMK
+            valid_shapes = (
+                self.query.shape == (B, Mq, K)
+                and self.key.shape == (B, Mkv, K)
+                and self.value.shape == (B, Mkv, Kv)
+            )
+        H = self.query.shape[-2]
+        if self.query.ndim == 4:  # BMHK
+            valid_shapes = (
+                self.query.shape == (B, Mq, H, K)
+                and self.key.shape == (B, Mkv, H, key_embed_dim)
+                and self.value.shape == (B, Mkv, H, Kv)
+            )
+        G = self.query.shape[2]
+        if self.query.ndim == 5:  # BMNHK
+            valid_shapes = (
+                self.query.shape == (B, Mq, G, H, K)
+                and self.key.shape == (B, Mkv, G, H, key_embed_dim)
+                and self.value.shape == (B, Mkv, G, H, Kv)
+            )
+        if not valid_shapes:
+            raise ValueError(
+                f"Incompatible shapes for attention inputs:\n"
+                f"  query.shape: {self.query.shape}\n"
+                f"  key.shape  : {self.key.shape}\n"
+                f"  value.shape: {self.value.shape}\n"
+                "HINT: We don't support broadcasting, please use `expand` "
+                "yourself before calling `memory_efficient_attention` if you need to"
+            )
+
+    def get_output_dtype(self) -> torch.dtype:
+        if self.output_dtype is None:
+            if self.is_partial and self.query.dtype is not torch.float64:
+                return torch.float32
+            return self.query.dtype
+        return self.output_dtype
+
+    @property
+    def nbytes(self) -> int:
+        """
+        Number of bytes in the input, not counting the attention bias.
+        """
+        return sum(
+            x.untyped_storage().nbytes() for x in [self.query, self.key, self.value]
+        )
+
+
+@dataclass
+class Context:
+    lse: torch.Tensor
+    out: torch.Tensor
+    # NOTE: If `rng_state` is set, `op_bw` should be set as well
+    # as the randomness is backend-dependant
+    op_bw: Optional[Type["AttentionBwOpBase"]] = None
+    rng_state: Optional[Any] = None
+    qkv_share_storage: bool = False
+
+    def get_padded_lse(self, pad_to: int, force_pad_inf: bool = False) -> torch.Tensor:
+        pad_amount = (pad_to - (self.lse.shape[2] % pad_to)) % pad_to
+        lse = self.lse
+        if pad_amount > 0:
+            if force_pad_inf:
+                lse = lse[:, :, : self.out.shape[1]]
+                pad_amount = (pad_to - (lse.shape[2] % pad_to)) % pad_to
+            lse = torch.nn.functional.pad(lse, [0, pad_amount], value=math.inf)
+        elif force_pad_inf and self.out.shape[1] != lse.shape[2]:
+            lse[:, :, self.out.shape[1] :].fill_(math.inf)
+        return lse
+
+
+@dataclass
+class Gradients:
+    dq: torch.Tensor
+    dk: torch.Tensor
+    dv: torch.Tensor
+    # bias gradient. None if there is no tensor bias or if it doesn't require grad
+    db: Optional[torch.Tensor] = None
+
+
+class AttentionOpBase(BaseOperator):
+    """Base class for any attention operator in xFormers
+
+    See:
+
+    - :attr:`xformers.ops.fmha.cutlass.FwOp`
+    - :attr:`xformers.ops.fmha.cutlass.BwOp`
+    - :attr:`xformers.ops.fmha.flash.FwOp`
+    - :attr:`xformers.ops.fmha.flash.BwOp`
+    - :attr:`xformers.ops.fmha.triton.FwOp`
+    - :attr:`xformers.ops.fmha.triton.BwOp`
+    """
+
+    OPERATOR: Any  # pyre-ignore[13]
+    SUPPORTED_DEVICES: Set[str]  # pyre-ignore[13]
+    CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (5, 0)
+    CUDA_MAXIMUM_COMPUTE_CAPABILITY: Optional[Tuple[int, int]] = None
+    SUPPORTED_DTYPES: Set[torch.dtype]  # pyre-ignore[13]
+    SUPPORTED_MAX_K: float  # pyre-ignore[13]
+    SUPPORTED_MIN_K: int = 0
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (type(None),)
+    SUPPORTS_DROPOUT: bool  # pyre-ignore[13]
+    SUPPORTS_CUSTOM_SCALE: bool = False
+    SUPPORTS_DIFFERENT_VALUE_EMBED: bool = False
+    SUPPORTS_OUTPUT_DTYPE: bool = False
+    SUPPORTS_PARTIAL: bool = False
+    IS_DETERMINISTIC: bool = True
+    SUPPORTS_BMGHK: bool = False
+    NAME: str  # pyre-ignore[13]
+    OPERATOR_CATEGORY = "memory_efficient_attention"
+    # Format for the LSE computed in the FW pass, and accepted in the BW pass,
+    # for BlockDiagonalMask and children.
+    # When using a varlen bias, both the FW and BW operators must have the
+    # same value for `VARLEN_LSE_PACKED`
+    VARLEN_LSE_PACKED: bool = True
+
+    _TEST_BATCH_SIZES: List[int] = [1, 300]
+    _TEST_K: List[int] = [32, 128]
+
+    @classmethod
+    def supports(cls, d: Inputs) -> bool:
+        return not cls.not_supported_reasons(d)
+
+    @classmethod
+    def shape_not_supported_reasons(
+        cls, Mq: int, Mkv: int, K: int, Kv: int
+    ) -> List[str]:
+        reasons = []
+        if not cls.SUPPORTS_DIFFERENT_VALUE_EMBED and K != Kv:
+            reasons.append("query.shape[-1] != value.shape[-1]")
+        if max(K, Kv) > cls.SUPPORTED_MAX_K:
+            reasons.append(
+                f"max(query.shape[-1], value.shape[-1]) > {cls.SUPPORTED_MAX_K}"
+            )
+        if min(K, Kv) < cls.SUPPORTED_MIN_K:
+            reasons.append(
+                f"min(query.shape[-1], value.shape[-1]) < {cls.SUPPORTED_MIN_K}"
+            )
+        return reasons
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:  # noqa: C901
+        """
+        Returns a list of reasons why this is not supported.
+        The kernel can run these inputs only if the returned list is empty
+        """
+        query_shape = d.query.shape
+        reasons = cls.shape_not_supported_reasons(
+            Mq=query_shape[1],
+            Mkv=d.key.shape[1],
+            K=query_shape[-1],
+            Kv=query_shape[-1] if d.value.dtype == torch.int32 else d.value.shape[-1],
+        )
+        device_type = d.query.device.type
+        dtype = d.query.dtype
+        if device_type not in cls.SUPPORTED_DEVICES:
+            reasons.append(f"device={device_type} (supported: {cls.SUPPORTED_DEVICES})")
+        if (
+            device_type == "cuda"
+            and not _built_with_cuda
+            and (torch.version.hip is None)
+        ):
+            reasons.append("xFormers wasn't build with CUDA support")
+        if device_type == "cuda" and (torch.version.hip is None):
+            device_capability = torch.cuda.get_device_capability(d.device)
+            if device_capability < cls.CUDA_MINIMUM_COMPUTE_CAPABILITY:
+                reasons.append(
+                    f"requires device with capability >= {cls.CUDA_MINIMUM_COMPUTE_CAPABILITY} "
+                    f"but your GPU has capability {device_capability} (too old)"
+                )
+            elif (
+                cls.CUDA_MAXIMUM_COMPUTE_CAPABILITY is not None
+                and device_capability > cls.CUDA_MAXIMUM_COMPUTE_CAPABILITY
+            ):
+                reasons.append(
+                    f"requires device with capability <= {cls.CUDA_MAXIMUM_COMPUTE_CAPABILITY} "
+                    f"but your GPU has capability {device_capability} (too new)"
+                )
+        if dtype not in cls.SUPPORTED_DTYPES:
+            reasons.append(f"dtype={dtype} (supported: {cls.SUPPORTED_DTYPES})")
+        if type(d.attn_bias) not in cls.SUPPORTED_ATTN_BIAS_TYPES:
+            reasons.append(f"attn_bias type is {type(d.attn_bias)}")
+        if not cls.SUPPORTS_OUTPUT_DTYPE:
+            if d.output_dtype is not None and d.output_dtype is not dtype:
+                reasons.append("Custom output dtype not supported")
+        if d.is_partial and not cls.SUPPORTS_PARTIAL:
+            reasons.append("Partial attention not supported")
+        if (d.p != 0.0) and not cls.SUPPORTS_DROPOUT:
+            reasons.append("dropout > 0.0")
+        if d.scale is not None and not cls.SUPPORTS_CUSTOM_SCALE:
+            reasons.append("has custom scale")
+        # bfloat16 is only supported on A100+ and MTIA
+        # ... although the kernels can still run and give the
+        # correct result
+        supports_bf16 = (
+            device_type.startswith("cuda")
+            and torch.cuda.get_device_capability(d.query.device)[0] >= 8
+        ) or device_type.startswith("mtia")
+        if dtype is torch.bfloat16 and not supports_bf16:
+            reasons.append("bf16 is only supported on A100+ GPUs and MTIA")
+        if not cls.is_available():
+            reasons.append(
+                "operator wasn't built - see `python -m xformers.info` for more info"
+            )
+        if not cls.IS_DETERMINISTIC and torch.are_deterministic_algorithms_enabled():
+            reasons.append(
+                "operator is non-deterministic, but `torch.use_deterministic_algorithms` is set"
+            )
+        if not cls.SUPPORTS_BMGHK and d.query.ndim == 5:
+            reasons.append("operator does not support BMGHK format")
+        return reasons
+
+
+class AttentionFwOpBase(AttentionOpBase):
+    ERROR_ATOL: Mapping[torch.dtype, float] = {
+        torch.float: 3e-4,
+        torch.half: 4e-3,
+        torch.bfloat16: 2e-2,
+    }
+    ERROR_RTOL: Mapping[torch.dtype, float] = {
+        torch.float: 2e-5,
+        torch.half: 4e-4,
+        torch.bfloat16: 5e-3,
+    }
+
+    @classmethod
+    def apply(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        raise NotImplementedError()
+
+
+class AttentionBwOpBase(AttentionOpBase):
+    # NOTE on tolerances: These are tested for `scales => (1/32)**0.5`
+    # In the BW pass, imprecisions accumulate in the Q@K.T recalculation
+    # These imprecisions are multiplied by the `scale` and then exponentiated
+    # So if the scale is too high, we get a lot of errors
+
+    ERROR_ATOL: Mapping[torch.dtype, float] = {
+        torch.float: 9e-4,
+        torch.half: 0.2,
+        torch.bfloat16: 0.9,
+    }
+    ERROR_RTOL: Mapping[torch.dtype, float] = {
+        torch.float: 1e-4,
+        torch.half: 2e-2,
+        torch.bfloat16: 0.1,
+    }
+    SUPPORTS_ATTN_BIAS_GRAD = False
+    SUPPORTS_PARTIAL = True
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(AttentionBwOpBase, cls).not_supported_reasons(d)
+        if (
+            isinstance(d.attn_bias, torch.Tensor)
+            and d.attn_bias.requires_grad
+            and not cls.SUPPORTS_ATTN_BIAS_GRAD
+        ):
+            reasons.append(
+                "Computing the bias gradient is not supported (attn_bias.requires_grad = True)"
+            )
+
+        return reasons
+
+    @classmethod
+    def apply(cls, ctx: Context, inp: Inputs, grad: torch.Tensor) -> Gradients:
+        raise NotImplementedError()
+
+
+AttentionOp = Tuple[
+    Optional[Type[AttentionFwOpBase]], Optional[Type[AttentionBwOpBase]]
+]
+
+
+def bmk2bmhk(tensor, num_heads: int) -> torch.Tensor:
+    if tensor.ndim == 4:
+        return tensor
+    return tensor.reshape(
+        [tensor.shape[0] // num_heads, num_heads, tensor.shape[1], tensor.shape[2]]
+    ).permute((0, 2, 1, 3))
+
+
+def check_lastdim_alignment_stride1(
+    reasons: List[str], name: str, x: torch.Tensor, alignment: int
+) -> None:
+    if x.shape[-1] % alignment != 0:
+        reasons.append(f"{name}.shape[-1] % {alignment} != 0")
+    elif x.stride(-2) % alignment != 0:
+        reasons.append(
+            f"{name}.stride(-2) % {alignment} != 0 ({name}.stride() = {x.stride()})"
+        )
+    # We can have stride=0 sometimes if dimension=1
+    if x.stride(-1) > 1:
+        reasons.append(
+            f"{name}.stride(-1) > 1 ({name}.stride() = {x.stride()}) - you should call `.contiguous()` on the input"
+        )

--- a/mslk/attention/fmha/cutlass.py
+++ b/mslk/attention/fmha/cutlass.py
@@ -1,0 +1,461 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+from dataclasses import replace
+from enum import Enum
+from functools import partial
+from typing import Any, Iterable, List, Optional, Set, Tuple, Union
+
+import torch
+
+from . import attn_bias
+from .attn_bias import (
+    AttentionBias,
+    BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionMask,
+    BlockDiagonalCausalMask,
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    BlockDiagonalMask,
+    LowerTriangularFromBottomRightLocalAttentionMask,
+    LowerTriangularFromBottomRightMask,
+    LowerTriangularMask,
+    LowerTriangularMaskWithTensorBias,
+)
+from .common import (
+    _attn_bias_apply,
+    AttentionBwOpBase,
+    AttentionFwOpBase,
+    check_lastdim_alignment_stride1,
+    Context,
+    Gradients,
+    Inputs,
+)
+from .torch_attention_compat import is_pt_cutlass_compatible
+
+from .utils.op_common import get_operator, register_operator
+
+
+def _uses_tensorcores(sm: int, is_half: bool) -> bool:
+    if sm >= 80:
+        return True
+    if sm >= 70:
+        return is_half
+    return False
+
+
+def _minimum_gemm_alignment(inp: Inputs) -> int:
+    if inp.device.type != "cuda":
+        return 1
+    cap = torch.cuda.get_device_capability(inp.device)
+    sm = cap[0] * 10 + cap[1]
+    bits_per_scalar = {torch.float: 32, torch.half: 16, torch.bfloat16: 16}[
+        inp.query.dtype
+    ]
+    uses_tensorcores = _uses_tensorcores(sm, bits_per_scalar == 16)
+    matmul_alignment_mn = 1
+    if sm >= 80:
+        matmul_alignment_mn = 4
+    if uses_tensorcores:
+        matmul_alignment_mn = max(matmul_alignment_mn, 128 // bits_per_scalar)
+    return matmul_alignment_mn
+
+
+def _get_seqlen_info(
+    inp: Inputs,
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], int, int]:
+    attn_bias = inp.attn_bias
+    if isinstance(
+        attn_bias, (BlockDiagonalMask, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+    ):
+        assert attn_bias.k_seqinfo.seqstart.device == inp.query.device
+        seqstart_k = attn_bias.k_seqinfo.seqstart
+        seqstart_q = attn_bias.q_seqinfo.seqstart
+        max_seqlen_q = attn_bias.q_seqinfo.max_seqlen
+        max_seqlen_k = attn_bias.k_seqinfo.max_seqlen
+    else:
+        seqstart_k = None
+        seqstart_q = None
+        max_seqlen_q = -1
+        max_seqlen_k = -1
+
+    return seqstart_k, seqstart_q, max_seqlen_q, max_seqlen_k
+
+
+def _get_tensor_bias(
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]],
+) -> Optional[torch.Tensor]:
+    if isinstance(attn_bias, LowerTriangularMaskWithTensorBias):
+        return attn_bias._bias
+    if isinstance(attn_bias, torch.Tensor):
+        return attn_bias
+    return None
+
+
+def _check_bias_alignment(
+    reasons: List[str], attn_bias: Optional[Union[torch.Tensor, AttentionBias]]
+) -> None:
+    attn_bias_tensor = _get_tensor_bias(attn_bias)
+    if attn_bias_tensor is not None:
+        alignment = 128 // torch.finfo(attn_bias_tensor.dtype).bits
+        show_padding_hint = False
+        for d in range(attn_bias_tensor.ndim - 1):
+            if attn_bias_tensor.stride(d) % alignment != 0:
+                reasons.append(
+                    f"attn_bias.stride(-2) % {alignment} != 0 (attn_bias.stride() = {attn_bias_tensor.stride()})"
+                )
+                show_padding_hint = True
+        if show_padding_hint:
+            reasons.append(
+                """\
+HINT: To use an `attn_bias` with a sequence length that is not a multiple of 8, \
+you need to ensure memory is aligned by slicing a bigger tensor. \
+Example: use `attn_bias = torch.zeros([1, 1, 5, 8])[:,:,:,:5]` instead of `torch.zeros([1, 1, 5, 5])`"""
+            )
+        # We can have stride=0 sometimes if dimension=1
+        if attn_bias_tensor.stride(-1) > 1:
+            reasons.append(
+                f"attn_bias.stride(-1) > 1 (attn_bias.stride() = {attn_bias_tensor.stride()}) - "
+                "you should call `.contiguous()` on the bias"
+            )
+
+
+class _CustomMaskType(int, Enum):
+    """
+    (Matches CustomMaskType in C++.)
+    """
+
+    NoCustomMask = 0
+    CausalFromTopLeft = 1
+    CausalFromBottomRight = 2
+
+
+def _custom_mask_type(bias: Optional[Union[torch.Tensor, AttentionBias]]) -> int:
+    if isinstance(
+        bias,
+        (
+            LowerTriangularMask,
+            BlockDiagonalCausalMask,
+            BlockDiagonalCausalLocalAttentionMask,
+        ),
+    ):
+        return int(_CustomMaskType.CausalFromTopLeft)
+    if isinstance(
+        bias,
+        (
+            LowerTriangularFromBottomRightMask,
+            LowerTriangularFromBottomRightLocalAttentionMask,
+            attn_bias.BlockDiagonalCausalFromBottomRightMask,
+            BlockDiagonalCausalWithOffsetPaddedKeysMask,
+            BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+        ),
+    ):
+        return int(_CustomMaskType.CausalFromBottomRight)
+    return int(_CustomMaskType.NoCustomMask)
+
+
+@register_operator
+class FwOp(AttentionFwOpBase):
+    """xFormers' MHA kernel based on CUTLASS.
+    Supports a large number of settings (including without TensorCores, f32 ...)
+    and GPUs as old as P100 (Sm60)
+    """
+
+    OPERATOR = (
+        get_operator("aten", "_efficient_attention_forward")
+        if is_pt_cutlass_compatible()
+        else None
+    )
+    CUDA_MAXIMUM_COMPUTE_CAPABILITY = (9, 0)
+    SUPPORTED_DEVICES: Set[str] = {"cuda"}
+    SUPPORTED_DTYPES: Set[torch.dtype] = {torch.float, torch.half, torch.bfloat16}
+    SUPPORTED_MAX_K = 65536
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        torch.Tensor,
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        LowerTriangularMaskWithTensorBias,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        attn_bias.BlockDiagonalCausalFromBottomRightMask,
+        attn_bias.BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    )
+    SUPPORTS_DROPOUT = True
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_DIFFERENT_VALUE_EMBED = True
+    SUPPORTS_BMGHK = True
+    VARLEN_LSE_PACKED = False
+    NAME = "cutlassF-pt"
+
+    _TEST_K: List[int] = [
+        32,  # 64x64 kernel
+        128,  # 64x128 kernel
+        256,  # 64x128 with accumulation in gmem
+    ]
+
+    @classmethod
+    def apply(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        if type(inp.attn_bias) not in FwOp.SUPPORTED_ATTN_BIAS_TYPES:
+            raise NotImplementedError("Unsupported attn_bias type")
+        if inp.query.ndim in [3, 4]:
+            return cls.apply_bmhk(inp, needs_gradient=needs_gradient)
+        assert inp.query.ndim == 5, f"query has shape {inp.query.shape}"
+        ctx: Optional[Context] = None
+        # XXX: Hackfix for BMGHK with H=1
+        # In that case we don't want to run G different streams because it adds
+        # some overhead
+        if inp.query.ndim == 5 and inp.query.shape[3] == 1:
+            slice_op = partial(torch.squeeze, dim=3)
+            inp = replace(
+                inp,
+                query=slice_op(inp.query),
+                key=slice_op(inp.key),
+                value=slice_op(inp.value),
+                attn_bias=_attn_bias_apply(
+                    inp.attn_bias, partial(torch.squeeze, dim=2)
+                ),
+            )
+            out, ctx = cls.apply_bmhk(inp, needs_gradient=needs_gradient)
+            out = out.unsqueeze(3)
+            if ctx is not None:
+                ctx = replace(ctx, lse=ctx.lse.unsqueeze(1), out=out)
+            return out, ctx
+
+        # Workaround until this is properly implemented in C++
+        # run each head group in a different stream
+        n_groups = inp.key.shape[2]
+        main_stream = torch.cuda.current_stream()
+        streams = [main_stream] + [
+            torch.cuda.Stream(device=inp.query.device) for _ in range(n_groups - 1)
+        ]
+        outs = []
+        for group, stream in enumerate(streams):
+            stream.wait_stream(main_stream)
+            with torch.cuda.stream(stream):
+                query = inp.query[:, :, group]
+                key = inp.key[:, :, group]
+                value = inp.value[:, :, group]
+                bias = _attn_bias_apply(
+                    inp.attn_bias, partial(torch.select, dim=1, index=group)
+                )
+                outs.append(
+                    cls.apply_bmhk(
+                        replace(inp, query=query, key=key, value=value, attn_bias=bias),
+                        needs_gradient=needs_gradient,
+                    )
+                )
+        for s in streams[1:]:
+            main_stream.wait_stream(s)
+        out = torch.stack([o[0] for o in outs], dim=2)
+        if needs_gradient:
+            ctx = Context(
+                out=out,
+                lse=torch.stack([o[1].lse for o in outs], dim=1),  # type: ignore
+                op_bw=outs[0][1].op_bw,  # type: ignore
+            )
+        return out, ctx
+
+    @classmethod
+    def apply_bmhk(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        if type(inp.attn_bias) not in FwOp.SUPPORTED_ATTN_BIAS_TYPES:
+            raise NotImplementedError("Unsupported attn_bias type")
+        seqstart_k, seqstart_q, max_seqlen_q, max_seqlen_k = _get_seqlen_info(inp)
+        out, lse, rng_seed, rng_offset, _, _ = cls.OPERATOR(
+            query=inp.query,
+            key=inp.key,
+            value=inp.value,
+            bias=_get_tensor_bias(inp.attn_bias),
+            cu_seqlens_q=seqstart_q,
+            cu_seqlens_k=seqstart_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            dropout_p=inp.p,
+            compute_log_sumexp=needs_gradient,
+            custom_mask_type=_custom_mask_type(inp.attn_bias),
+            scale=inp.scale,
+            seqlen_k=(
+                inp.attn_bias.k_seqinfo.seqlen
+                if isinstance(
+                    inp.attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask
+                )
+                else None
+            ),
+            window_size=(
+                inp.attn_bias._window_size
+                if isinstance(
+                    inp.attn_bias,
+                    (
+                        BlockDiagonalCausalLocalAttentionMask,
+                        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+                        LowerTriangularFromBottomRightLocalAttentionMask,
+                    ),
+                )
+                else None
+            ),
+        )
+        ctx: Optional[Context] = None
+        if needs_gradient:
+            ctx = Context(out=out, lse=lse)
+            if inp.p != 0:
+                # cutlass forward is only compatible with cutlass backward if
+                # dropout is used (because of the way RNG states are passed and the
+                # way random numbers are generated during backward)
+                ctx.rng_state = (rng_seed, rng_offset)
+                ctx.op_bw = BwOp
+        return out, ctx
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(FwOp, cls).not_supported_reasons(d)
+        matmul_alignment_mn = _minimum_gemm_alignment(d)
+        check_lastdim_alignment_stride1(reasons, "query", d.query, matmul_alignment_mn)
+        check_lastdim_alignment_stride1(reasons, "value", d.value, matmul_alignment_mn)
+        _check_bias_alignment(reasons, d.attn_bias)
+        return reasons
+
+
+@register_operator
+class BwOp(AttentionBwOpBase):
+    __doc__ = FwOp.__doc__
+
+    OPERATOR = (
+        get_operator("aten", "_efficient_attention_backward")
+        if is_pt_cutlass_compatible()
+        else None
+    )
+    CUDA_MAXIMUM_COMPUTE_CAPABILITY = FwOp.CUDA_MAXIMUM_COMPUTE_CAPABILITY
+    SUPPORTED_DEVICES = FwOp.SUPPORTED_DEVICES
+    SUPPORTED_DTYPES = FwOp.SUPPORTED_DTYPES
+    SUPPORTED_MAX_K = FwOp.SUPPORTED_MAX_K
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        torch.Tensor,
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        # TODO: Still some infs/nans in the BW pass for
+        # local + causal
+        # LowerTriangularFromBottomRightLocalAttentionMask,
+        # TODO: Fix handling of gradient through the fMHA autograd function
+        # LowerTriangularMaskWithTensorBias,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        attn_bias.BlockDiagonalCausalFromBottomRightMask,
+        attn_bias.BlockDiagonalCausalLocalAttentionMask,
+    )
+    SUPPORTS_ATTN_BIAS_GRAD = True
+    SUPPORTS_DROPOUT = FwOp.SUPPORTS_DROPOUT
+    SUPPORTS_CUSTOM_SCALE = FwOp.SUPPORTS_CUSTOM_SCALE
+    SUPPORTS_DIFFERENT_VALUE_EMBED = FwOp.SUPPORTS_DIFFERENT_VALUE_EMBED
+    VARLEN_LSE_PACKED = False
+    NAME = "cutlassB-pt"
+
+    _TEST_K: List[int] = [
+        32,  # 64x64 kernel
+        128,  # 64x128/128x128 kernel
+        256,  # 64x128 with accumulation in gmem
+    ]
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(BwOp, cls).not_supported_reasons(d)
+        matmul_alignment_mn = _minimum_gemm_alignment(d)
+
+        check_lastdim_alignment_stride1(reasons, "query", d.query, matmul_alignment_mn)
+        check_lastdim_alignment_stride1(reasons, "key", d.key, matmul_alignment_mn)
+        check_lastdim_alignment_stride1(reasons, "value", d.value, matmul_alignment_mn)
+        _check_bias_alignment(reasons, d.attn_bias)
+        attn_bias_tensor = _get_tensor_bias(d.attn_bias)
+
+        # Backprop of gradient through broadcasted bias is not supported
+        if attn_bias_tensor is not None and attn_bias_tensor.requires_grad:
+            # Don't forget that inputs are either in BMK or BMHK!
+            if d.query.ndim == 3 and attn_bias_tensor.ndim == 3:
+                expected_bias_shape = (*d.query.shape[:2], d.key.shape[1])
+            else:
+                # bias is B H Mq Mk
+                expected_bias_shape = (
+                    d.query.shape[0],
+                    d.query.shape[2] if d.query.ndim == 4 else 1,
+                    d.query.shape[1],
+                    d.key.shape[1],
+                )
+            if tuple(attn_bias_tensor.shape) != expected_bias_shape:
+                reasons.append(
+                    "Broadcasting the `attn_bias` tensor is not supported "
+                    f"(shape: {tuple(attn_bias_tensor.shape)}"
+                    f"/ expected: {expected_bias_shape})"
+                )
+        return reasons
+
+    @classmethod
+    def apply(cls, ctx: Context, inp: Inputs, grad: torch.Tensor) -> Gradients:
+        if type(inp.attn_bias) not in BwOp.SUPPORTED_ATTN_BIAS_TYPES:
+            raise NotImplementedError("Unsupported attn_bias type")
+
+        seqstart_k, seqstart_q, max_seqlen_q, max_seqlen_k = _get_seqlen_info(inp)
+        dtype = inp.query.dtype
+
+        rng_seed = rng_offset = torch.Tensor()
+        if inp.p != 0.0:
+            assert ctx.rng_state is not None
+            rng_seed, rng_offset = ctx.rng_state
+        tensor_bias = _get_tensor_bias(inp.attn_bias)
+
+        force_pad_inf = torch.cuda.get_device_capability(inp.query.device) == (7, 5)
+        (grad_q, grad_k, grad_v, grad_bias) = cls.OPERATOR(
+            grad.to(dtype),
+            inp.query,
+            inp.key,
+            inp.value,
+            bias=tensor_bias,
+            bias_requires_grad=(
+                tensor_bias.requires_grad if tensor_bias is not None else False
+            ),
+            cu_seqlens_q=seqstart_q,
+            cu_seqlens_k=seqstart_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            logsumexp=ctx.get_padded_lse(32, force_pad_inf=force_pad_inf),
+            out=ctx.out.to(dtype),
+            dropout_p=inp.p,
+            # if not using dropout, seed and offset are irrelevant but still expected
+            # in function signature so just pass 0
+            # seed and offset could be None if a different FW op other than cutlass
+            # was used.
+            philox_seed=rng_seed,
+            philox_offset=rng_offset,
+            custom_mask_type=_custom_mask_type(inp.attn_bias),
+            scale=inp.scale,
+            num_splits_key=None,  # Let C++ determine it
+            window_size=(
+                inp.attn_bias._window_size
+                if isinstance(
+                    inp.attn_bias,
+                    (
+                        BlockDiagonalCausalLocalAttentionMask,
+                        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+                        LowerTriangularFromBottomRightLocalAttentionMask,
+                    ),
+                )
+                else None
+            ),
+        )
+
+        # c++/CUDA implementation returns an uninitialized tensor if bias doesn't
+        # require grad
+        if not (
+            isinstance(inp.attn_bias, torch.Tensor) and inp.attn_bias.requires_grad
+        ):
+            grad_bias = None
+
+        return Gradients(dq=grad_q, dk=grad_k, dv=grad_v, db=grad_bias)

--- a/mslk/attention/fmha/cutlass_blackwell.py
+++ b/mslk/attention/fmha/cutlass_blackwell.py
@@ -1,0 +1,561 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+from typing import Any, Iterable, List, Optional, Set, Tuple, Union
+
+import torch
+
+from .attn_bias import (
+    AttentionBias,
+    BlockDiagonalCausalFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionMask,
+    BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+    BlockDiagonalCausalMask,
+    BlockDiagonalCausalWithOffsetGappyKeysMask,
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    BlockDiagonalGappyKeysMask,
+    BlockDiagonalLocalAttentionPaddedKeysMask,
+    BlockDiagonalMask,
+    BlockDiagonalPaddedKeysMask,
+    LocalAttentionFromBottomRightMask,
+    LowerTriangularFromBottomRightLocalAttentionMask,
+    LowerTriangularFromBottomRightMask,
+    LowerTriangularMask,
+)
+
+from .common import AttentionBwOpBase, AttentionFwOpBase, Context, Gradients, Inputs
+
+from .utils.op_common import register_operator
+
+
+def _get_operator(name: str):
+    def no_such_operator(*args, **kwargs):
+        raise RuntimeError(
+            "No such operator "
+            f"fbgemm_gpu.experimental.gen_ai.attention.cutlass_blackwell_fmha.{name} "
+            "- did you forget to build xformers with `python setup.py develop`?"
+        )
+
+    try:
+        # type: ignore
+        from fbgemm_gpu.experimental.gen_ai.attention.cutlass_blackwell_fmha import (
+            cutlass_blackwell_fmha_interface as fmha,
+        )
+
+        return getattr(fmha, name)
+    except (RuntimeError, ModuleNotFoundError):
+        return no_such_operator
+
+
+def _convert_input_format(
+    inp: Inputs,
+) -> Tuple[
+    Inputs,
+    Optional[torch.Tensor],
+    Optional[int],
+    Optional[torch.Tensor],
+    Optional[int],
+    Optional[torch.Tensor],
+]:
+    assert inp.query.ndim in (4, 5)
+    query, key, value = inp.query, inp.key, inp.value
+
+    attn_bias = inp.attn_bias
+    if isinstance(attn_bias, BlockDiagonalMask):
+        assert attn_bias.k_seqinfo.seqstart.device == inp.query.device
+        cu_seqlen_k = attn_bias.k_seqinfo.seqstart
+        cu_seqlen_q = attn_bias.q_seqinfo.seqstart
+        max_seqlen_q = attn_bias.q_seqinfo.max_seqlen
+        max_seqlen_k = attn_bias.k_seqinfo.max_seqlen
+        seqused_k = None
+    elif isinstance(
+        attn_bias,
+        (
+            BlockDiagonalPaddedKeysMask,
+            BlockDiagonalCausalWithOffsetPaddedKeysMask,
+            BlockDiagonalGappyKeysMask,
+            BlockDiagonalCausalWithOffsetGappyKeysMask,
+            BlockDiagonalLocalAttentionPaddedKeysMask,
+            BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+        ),
+    ):
+        assert attn_bias.k_seqinfo.seqstart.device == inp.query.device
+        cu_seqlen_k = attn_bias.k_seqinfo.seqstart
+        cu_seqlen_q = attn_bias.q_seqinfo.seqstart
+        max_seqlen_q = attn_bias.q_seqinfo.max_seqlen
+        max_seqlen_k = attn_bias.k_seqinfo.max_seqlen
+        # All these mask types inherit from classes that have seqlen attribute
+        seqused_k = attn_bias.k_seqinfo.seqlen
+        assert seqused_k is not None
+    else:
+        cu_seqlen_k = None
+        cu_seqlen_q = None
+        seqused_k = None
+        max_seqlen_q = None
+        max_seqlen_k = None
+
+    if query.ndim == 5:  # GQA
+        # Fold the group/head_in_group dimensions together
+        def fold(x):
+            # Either the head is replicated
+            if x.stride(3) == 0:
+                return x[:, :, :, 0]
+
+            # Or we reshape
+            return x.reshape(
+                [
+                    x.shape[0],
+                    x.shape[1],
+                    -1,
+                    x.shape[4],
+                ]
+            )
+
+        query = fold(query)
+        key = fold(key)
+        value = fold(value)
+
+    if cu_seqlen_k is not None and query.ndim == 4:
+        # Fold to 3D when using varlen
+        def fold(x):
+            assert x.shape[0] == 1
+            x = x.squeeze(0)
+            assert x.ndim == 3
+            if x.stride(1) == 0:
+                # BMHK for MQA with kv_head = 1
+                return x[:, 0, :].unsqueeze(1)
+            return x
+
+        query = fold(query)
+        key = fold(key)
+        value = fold(value)
+
+    new_inp = Inputs(
+        query=query,
+        key=key,
+        value=value,
+        attn_bias=attn_bias,
+        p=inp.p,
+        scale=inp.scale,
+        output_dtype=inp.output_dtype,
+        is_partial=inp.is_partial,
+    )
+    return new_inp, cu_seqlen_q, max_seqlen_q, cu_seqlen_k, max_seqlen_k, seqused_k
+
+
+def _is_seqlen_q_le_seqlen_k(
+    cu_seqlens_q_py: List[int], cu_seqlens_k_py: List[int]
+) -> bool:
+    if len(cu_seqlens_q_py) < 2 or len(cu_seqlens_k_py) < 2:
+        # The seqlens q and k info does not exist on CPU
+        return True
+    cu_seqlens_q = torch.as_tensor(cu_seqlens_q_py, dtype=torch.int, device="cpu")
+    cu_seqlens_k = torch.as_tensor(cu_seqlens_k_py, dtype=torch.int, device="cpu")
+    seqlens_q = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+    seqlens_k = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
+    return bool(torch.all(seqlens_k >= seqlens_q))
+
+
+def _is_causal(attn_bias: Optional[Union[torch.Tensor, AttentionBias]]) -> bool:
+    return isinstance(
+        attn_bias,
+        (
+            LowerTriangularMask,
+            BlockDiagonalCausalMask,
+            LowerTriangularFromBottomRightMask,
+            BlockDiagonalCausalFromBottomRightMask,
+            LowerTriangularFromBottomRightLocalAttentionMask,
+            BlockDiagonalCausalLocalAttentionMask,
+            BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+            BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+            BlockDiagonalCausalWithOffsetGappyKeysMask,
+            BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        ),
+    )
+
+
+def _is_bottom_right(attn_bias: Optional[Union[torch.Tensor, AttentionBias]]) -> bool:
+    return isinstance(
+        attn_bias,
+        (
+            LowerTriangularFromBottomRightMask,
+            BlockDiagonalCausalFromBottomRightMask,
+            LocalAttentionFromBottomRightMask,
+            BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+            BlockDiagonalCausalWithOffsetPaddedKeysMask,
+            BlockDiagonalLocalAttentionPaddedKeysMask,
+            BlockDiagonalCausalWithOffsetGappyKeysMask,
+            BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+        ),
+    )
+
+
+def _window_size(
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]],
+) -> Tuple[int, int]:
+    win_left = -1
+    win_right = -1
+    if isinstance(
+        attn_bias,
+        (
+            BlockDiagonalCausalLocalAttentionMask,
+            BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+            LowerTriangularFromBottomRightLocalAttentionMask,
+            BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+        ),
+    ):
+        win_left = attn_bias._window_size - 1
+    if isinstance(
+        attn_bias,
+        (
+            BlockDiagonalLocalAttentionPaddedKeysMask,
+            LocalAttentionFromBottomRightMask,
+        ),
+    ):
+        win_left = attn_bias.window_left
+        win_right = attn_bias.window_right
+    return (win_left, win_right)
+
+
+@register_operator
+class FwOp(AttentionFwOpBase):
+    OPERATOR = _get_operator("_cutlass_blackwell_fmha_forward")
+    SUPPORTED_DEVICES: Set[str] = {"cuda"}
+    SUPPORTED_DTYPES: Set[torch.dtype] = {torch.bfloat16, torch.float16}
+    SUPPORTED_MAX_K = 128
+    SUPPORTED_MIN_K = 64
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        BlockDiagonalCausalFromBottomRightMask,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        BlockDiagonalPaddedKeysMask,
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        BlockDiagonalGappyKeysMask,
+        BlockDiagonalCausalWithOffsetGappyKeysMask,
+        BlockDiagonalLocalAttentionPaddedKeysMask,
+        BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+        LocalAttentionFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    )
+    SUPPORTS_DROPOUT = False
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_DIFFERENT_VALUE_EMBED = False
+    SUPPORTS_BMGHK = True
+    VARLEN_LSE_PACKED = True
+    SUPPORTS_PARTIAL = False
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (10, 0)
+    NAME = "cutlassF-blackwell"
+
+    _TEST_K: List[int] = [64, 128]
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(FwOp, cls).not_supported_reasons(d)
+        attn_bias = d.attn_bias
+        if isinstance(attn_bias, BlockDiagonalCausalMask):
+            (
+                _,
+                cu_seqlens_q,
+                _,
+                cu_seqlens_k,
+                _,
+                _,
+            ) = _convert_input_format(d)
+            if not _is_seqlen_q_le_seqlen_k(
+                attn_bias.q_seqinfo.seqstart_py,
+                attn_bias.k_seqinfo.seqstart_py,
+            ):
+                reasons.append("seqlens_k must be >= seqlens_q")
+
+        if d.query.ndim < 4 or d.key.ndim < 4 or d.value.ndim < 4:
+            reasons.append("Only supports BMHK or BMGHK")
+
+        return reasons
+
+    @classmethod
+    def shape_not_supported_reasons(
+        cls, Mq: int, Mkv: int, K: int, Kv: int
+    ) -> List[str]:
+        reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+        if K not in [64, 128] or Kv not in [64, 128]:
+            reasons.append(f"Embed dim {K} not supported")
+        elif Mkv != 0 and Mq > Mkv:
+            reasons.append(f"Only support Mq ({Mq}) <= Mk ({Mkv})")
+        return reasons
+
+    @classmethod
+    def apply(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        q_shape = inp.query.shape
+        (
+            inp,
+            cu_seqlens_q,
+            max_seq_len_q,
+            cu_seqlens_k,
+            max_seq_len_k,
+            seqused_k,
+        ) = _convert_input_format(inp)
+
+        window_left, window_right = _window_size(inp.attn_bias)
+
+        if inp.query.numel() > 0 and inp.key.numel() > 0:
+            out, lse = cls.OPERATOR(
+                q=inp.query,
+                k=inp.key,
+                v=inp.value,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k=cu_seqlens_k,
+                seqlen_kv=seqused_k,
+                max_seq_len_q=max_seq_len_q,
+                max_seq_len_k=max_seq_len_k,
+                softmax_scale=inp.scale,
+                causal=_is_causal(inp.attn_bias),
+                window_left=window_left,
+                window_right=window_right,
+                bottom_right=_is_bottom_right(inp.attn_bias),
+            )
+        else:
+            out = torch.zeros_like(inp.query)
+            if cu_seqlens_q is None:
+                assert inp.query.ndim == 4
+                B, M, H, K = inp.query.shape
+                lse_shape = [B, H, M]
+            else:
+                assert inp.query.ndim == 3
+                M, H, K = inp.query.shape
+                lse_shape = [1, H, M]
+            lse = torch.zeros(*lse_shape, dtype=torch.float, device=out.device)
+        out = out.reshape(q_shape)
+        if not needs_gradient:
+            return out, None
+        return out, Context(out=out, lse=lse)
+
+
+@register_operator
+class FwOpDecode(AttentionFwOpBase):
+    """CUTLASS Blackwell decode kernel optimized for inference with sequence length 1.
+
+    This operator is specifically designed for the decode phase of autoregressive generation
+    where query length is 1.
+    """
+
+    OPERATOR = _get_operator("cutlass_blackwell_fmha_decode_forward")
+    SUPPORTED_DEVICES: Set[str] = {"cuda"}
+    SUPPORTED_DTYPES: Set[torch.dtype] = {torch.bfloat16}
+    SUPPORTED_MAX_K = 128
+    SUPPORTED_MIN_K = 64
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    )
+    SUPPORTS_DROPOUT = False
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_DIFFERENT_VALUE_EMBED = False
+    SUPPORTS_BMGHK = True
+    VARLEN_LSE_PACKED = True
+    SUPPORTS_PARTIAL = False
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (10, 0)
+    NAME = "cutlassF-blackwell-decode"
+
+    _TEST_K: List[int] = [64, 128]
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(FwOpDecode, cls).not_supported_reasons(d)
+        q_shape = d.query.shape
+        if q_shape[-2] > 16:
+            reasons.append(f"Max qHeads ({q_shape[-2]}) per KV head is > 16")
+        return reasons
+
+    @classmethod
+    def shape_not_supported_reasons(
+        cls, Mq: int, Mkv: int, K: int, Kv: int
+    ) -> List[str]:
+        reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+        if K not in [64, 128]:
+            reasons.append(f"Embed dim {K} not supported")
+        return reasons
+
+    @classmethod
+    def apply(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        q_shape = inp.query.shape
+        (
+            inp,
+            cu_seqlens_q,
+            max_seq_len_q,
+            cu_seqlens_k,
+            max_seq_len_k,
+            seqused_k,
+        ) = _convert_input_format(inp)
+
+        window_left, window_right = _window_size(inp.attn_bias)
+
+        if inp.query.numel() > 0 and inp.key.numel() > 0:
+            out, lse = cls.OPERATOR(
+                q=inp.query,
+                k=inp.key,
+                v=inp.value,
+                cu_seqlens_q=cu_seqlens_q,  # not used
+                cu_seqlens_k=cu_seqlens_k,  # not used
+                seqlen_kv=seqused_k,
+                max_seq_len_q=max_seq_len_q,  # not used
+                max_seq_len_k=max_seq_len_k,  # not used
+                softmax_scale=inp.scale,  # not used
+                causal=_is_causal(inp.attn_bias),
+                window_left=window_left,
+                window_right=window_right,
+                bottom_right=_is_bottom_right(inp.attn_bias),  # not used
+            )
+        else:
+            out = torch.zeros_like(inp.query)
+            if cu_seqlens_q is None:
+                assert inp.query.ndim == 4
+                B, M, H, K = inp.query.shape
+                # lse_shape = [B, H, M]
+            else:
+                assert inp.query.ndim == 3
+                M, H, K = inp.query.shape
+                # lse_shape = [1, H, M]
+            # lse = torch.zeros(*lse_shape, dtype=torch.float, device=out.device)
+        out = out.reshape(q_shape)
+        assert not needs_gradient, "FwOpDecode does not support gradient computation"
+        return out, None
+
+
+@register_operator
+class BwOp(AttentionBwOpBase):
+    __doc__ = FwOp.__doc__
+
+    OPERATOR = _get_operator("_cutlass_blackwell_fmha_backward")
+
+    SUPPORTED_DEVICES = FwOp.SUPPORTED_DEVICES
+    SUPPORTED_DTYPES = FwOp.SUPPORTED_DTYPES
+    SUPPORTED_MAX_K = FwOp.SUPPORTED_MAX_K
+    SUPPORTED_MIN_K = FwOp.SUPPORTED_MIN_K
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        BlockDiagonalCausalFromBottomRightMask,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        LocalAttentionFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    )
+    SUPPORTS_ATTN_BIAS_GRAD = False
+    SUPPORTS_DROPOUT = FwOp.SUPPORTS_DROPOUT
+    SUPPORTS_CUSTOM_SCALE = FwOp.SUPPORTS_CUSTOM_SCALE
+    SUPPORTS_DIFFERENT_VALUE_EMBED = False
+    SUPPORTS_BMGHK = False
+    VARLEN_LSE_PACKED = True
+    SUPPORTS_PARTIAL = False
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (10, 0)
+    NAME = "cutlassB-blackwell"
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(BwOp, cls).not_supported_reasons(d)
+        attn_bias = d.attn_bias
+        if isinstance(attn_bias, BlockDiagonalCausalMask):
+            (
+                _,
+                cu_seqlens_q,
+                _,
+                cu_seqlens_k,
+                _,
+                _,
+            ) = _convert_input_format(d)
+            if not _is_seqlen_q_le_seqlen_k(
+                attn_bias.q_seqinfo.seqstart_py,
+                attn_bias.k_seqinfo.seqstart_py,
+            ):
+                reasons.append("seqlens_k must be >= seqlens_q")
+
+        if d.query.ndim != 4 or d.key.ndim != 4 or d.value.ndim != 4:
+            reasons.append("Only supports BMHK format")
+
+        return reasons
+
+    @classmethod
+    def shape_not_supported_reasons(
+        cls, Mq: int, Mkv: int, K: int, Kv: int
+    ) -> List[str]:
+        reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+        if K not in [64, 128]:
+            reasons.append(f"Embed dim {K} not supported")
+        elif Mkv != 0 and Mq > Mkv:
+            reasons.append(f"Only support Mq ({Mq}) <= Mk ({Mkv})")
+        elif Mq < 8:
+            reasons.append(f"Only support Mq ({Mq}) >= 8")
+        return reasons
+
+    @classmethod
+    def apply(cls, ctx: Context, inp: Inputs, grad: torch.Tensor) -> Gradients:
+        assert inp.query.ndim == 4
+        dq_shape, dk_shape, dv_shape = inp.query.shape, inp.key.shape, inp.value.shape
+        (
+            inp,
+            cu_seqlens_q,
+            max_seq_len_q,
+            cu_seqlens_k,
+            max_seq_len_k,
+            _,
+        ) = _convert_input_format(inp)
+
+        window_left, window_right = _window_size(inp.attn_bias)
+
+        is_varlen = cu_seqlens_q is not None
+        if is_varlen:
+
+            def fold(x):
+                assert x.shape[0] == 1
+                x = x.squeeze(0)
+                assert x.ndim == 3
+                return x
+
+            grad = fold(grad)
+            ctx.out = fold(ctx.out)
+
+        if inp.query.numel() and inp.key.numel():
+            grads = Gradients(
+                *cls.OPERATOR(
+                    dout=grad,
+                    q=inp.query,
+                    k=inp.key,
+                    v=inp.value,
+                    out=ctx.out,
+                    softmax_lse=ctx.lse,
+                    cu_seqlens_q=cu_seqlens_q,
+                    cu_seqlens_k=cu_seqlens_k,
+                    max_seq_len_q=max_seq_len_q,
+                    max_seq_len_k=max_seq_len_k,
+                    causal=_is_causal(inp.attn_bias),
+                    window_left=window_left,
+                    window_right=window_right,
+                    bottom_right=_is_bottom_right(inp.attn_bias),
+                )
+            )
+        else:
+            grads = Gradients(
+                dq=torch.zeros_like(inp.query),
+                dk=torch.zeros_like(inp.key),
+                dv=torch.zeros_like(inp.value),
+            )
+
+        grads.dq = grads.dq.reshape(dq_shape)
+        grads.dk = grads.dk.reshape(dk_shape)
+        grads.dv = grads.dv.reshape(dv_shape)
+        return grads

--- a/mslk/attention/fmha/dispatch.py
+++ b/mslk/attention/fmha/dispatch.py
@@ -1,0 +1,223 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+
+import textwrap
+from collections import deque
+from typing import Any, List, Optional, Sequence, Tuple, Type, TypeVar
+
+import torch
+
+from . import attn_bias, ck, cutlass, flash, flash3, flash_mtia, triton_splitk
+from .common import AttentionBwOpBase, AttentionFwOpBase, Inputs
+
+T = TypeVar("T", Type[AttentionFwOpBase], Type[AttentionBwOpBase])
+
+
+try:
+    import mtia.host_runtime.torch_mtia.dynamic_library  # noqa  # type: ignore
+
+    # Use MTIA flash attention if the MTIA libraries are available
+    _USE_MTIA_FLASH_ATTENTION = True
+except (ImportError, OSError):
+    # Failed to load MTIA libraries, so don't use MTIA flash attention
+    _USE_MTIA_FLASH_ATTENTION = False
+
+
+_USE_FLASH_ATTENTION_3 = False
+
+
+def _set_use_fa3(use_flash_attention3: bool) -> None:
+    global _USE_FLASH_ATTENTION_3
+    _USE_FLASH_ATTENTION_3 = use_flash_attention3
+
+
+def _get_use_fa3() -> bool:
+    return _USE_FLASH_ATTENTION_3
+
+
+def fa3_available() -> bool:
+    has_valid_flash3 = flash3._C_flashattention3 is not None  # pyre-ignore[16]
+    is_90a = torch.version.cuda and torch.cuda.get_device_capability() >= (9, 0)
+    return has_valid_flash3 and is_90a
+
+
+def _format_inputs_description(inp: Inputs) -> str:
+    return f"""query       : shape={tuple(inp.query.shape)} ({inp.query.dtype})
+key         : shape={tuple(inp.key.shape)} ({inp.key.dtype})
+value       : shape={tuple(inp.value.shape)} ({inp.value.dtype})
+attn_bias   : {type(inp.attn_bias)}
+p           : {inp.p}"""
+
+
+def _ensure_op_supports_or_raise(exc_type, name: str, op, inp: Inputs) -> None:
+    reasons = op.not_supported_reasons(inp)
+    if not reasons:
+        return
+    raise exc_type(
+        f"""Operator `{name}` does not support inputs:
+{textwrap.indent(_format_inputs_description(inp), '     ')}
+{_format_not_supported_reasons(op, reasons)}"""
+    )
+
+
+def _format_not_supported_reasons(op, reasons: List[str]) -> str:
+    return f"`{op.NAME}` is not supported because:\n    " + "\n    ".join(reasons)
+
+
+def _run_priority_list(
+    name: str,
+    priority_list: Sequence[T],
+    inp: Inputs,
+    extra_op_reasons: Optional[List[Tuple[Any, List[str]]]] = None,
+) -> T:
+    not_supported_reasons: List[List[str]] = []
+    for op in priority_list:
+        not_supported = op.not_supported_reasons(inp)
+        if not not_supported:
+            return op
+        not_supported_reasons.append(not_supported)
+
+    # Let's write a nice message explaining what we tried and why it's not supported
+    msg = f"""No operator found for `{name}` with inputs:
+{textwrap.indent(_format_inputs_description(inp), '     ')}"""
+    for op, not_supported in zip(priority_list, not_supported_reasons):
+        msg += "\n" + _format_not_supported_reasons(op, not_supported)
+    if extra_op_reasons is not None:
+        for op, not_supported in extra_op_reasons:
+            msg += "\n" + _format_not_supported_reasons(op, not_supported)
+    raise NotImplementedError(msg)
+
+
+def _dispatch_fw_priority_list(
+    inp: Inputs, needs_gradient: bool
+) -> Sequence[Type[AttentionFwOpBase]]:
+    if torch.version.cuda:
+        flash3_op = [flash3.FwOp] if _get_use_fa3() else []
+        priority_list_ops = deque(
+            flash3_op
+            + [
+                flash.FwOp,
+                cutlass.FwOp,
+            ]
+        )
+    else:
+        priority_list_ops = deque(
+            [
+                ck.FwOp,
+            ]
+        )
+    priority_list_ops.append(triton_splitk.FwOp)
+    if not needs_gradient:
+        mqa_or_gqa = (
+            inp.key.ndim > 3 and inp.key.stride(-2) == 0 and inp.key.shape[-2] > 1
+        )
+        # Split-KV is useful with MQA
+        # for short Q-seqlen / long K-seqlen
+        if mqa_or_gqa and inp.query.shape[1] <= 32 and inp.key.shape[1] >= 256:
+            parallelism_BH = 0  # BMK
+            if inp.query.ndim == 3:
+                parallelism_BH = inp.query.shape[0]
+            elif inp.query.ndim == 4:  # BMHK
+                parallelism_BH = inp.query.shape[0] * inp.query.shape[2]
+            elif inp.query.ndim == 5:  # BMGHK
+                parallelism_BH = inp.query.shape[0] * inp.query.shape[2]
+            if (
+                parallelism_BH > 0
+                and parallelism_BH < 64
+                and not torch.mtia.is_available()
+            ):
+                # priority_list_ops.appendleft(ck_splitk.FwOp)
+                priority_list_ops.remove(triton_splitk.FwOp)
+                priority_list_ops.appendleft(triton_splitk.FwOp)
+                # Without variable seqlen flash is fastest
+                if torch.version.cuda and not isinstance(
+                    inp.attn_bias, attn_bias.BlockDiagonalMask
+                ):
+                    if _get_use_fa3():
+                        priority_list_ops.remove(flash3.FwOp)
+                    priority_list_ops.remove(flash.FwOp)
+                    priority_list_ops.appendleft(flash.FwOp)
+
+    # torch.mtia.is_available() cannot be called here because it isn't supported
+    # when tracing with PT2, so we simply add flash_mtia to the end if the MTIA
+    # dynamic library can be loaded
+    if _USE_MTIA_FLASH_ATTENTION:
+        priority_list_ops.append(flash_mtia.FwOp)
+
+    return priority_list_ops
+
+
+def _dispatch_fw(inp: Inputs, needs_gradient: bool) -> Type[AttentionFwOpBase]:
+    """Computes the best operator for forward
+
+    Raises:
+        NotImplementedError: if not operator was found
+
+    Returns:
+        AttentionOp: The best operator for the configuration
+    """
+    return _run_priority_list(
+        "memory_efficient_attention_forward",
+        _dispatch_fw_priority_list(inp, needs_gradient),
+        inp,
+    )
+
+
+def _is_cutlassB_faster_than_flash(inp: Inputs) -> bool:
+    return False
+
+
+def _dispatch_bw(
+    inp: Inputs, varlen_lse_packed: Optional[bool]
+) -> Type[AttentionBwOpBase]:
+    if torch.version.cuda:
+        priority_list_ops: List[Type[AttentionBwOpBase]] = [
+            flash.BwOp,
+            cutlass.BwOp,
+        ]
+        if _get_use_fa3():
+            priority_list_ops = [flash3.BwOp] + priority_list_ops
+    else:
+        priority_list_ops: List[Type[AttentionBwOpBase]] = [
+            ck.BwOp,
+        ]
+
+    # NOTE: If we have a variable seqlen `attn_bias`, we need to get a BW pass
+    # that supports the LSE format
+    # *unless* we are in the case where both formats are the same (bs=1)
+    extra_op_reasons = []
+    if (
+        isinstance(inp.attn_bias, attn_bias.VARLEN_BIASES)
+        and inp.attn_bias.q_seqinfo.seqstart.shape[0] > 2
+    ):
+        assert varlen_lse_packed is not None
+        for op in priority_list_ops:
+            if op.VARLEN_LSE_PACKED != varlen_lse_packed:
+                extra_op_reasons.append(
+                    (
+                        op,
+                        [
+                            f"LSE is in {'packed' if varlen_lse_packed else 'padded'} format"
+                        ],
+                    )
+                )
+        priority_list_ops = [
+            op for op in priority_list_ops if op.VARLEN_LSE_PACKED == varlen_lse_packed
+        ]
+    if torch.version.cuda and _is_cutlassB_faster_than_flash(inp):
+        priority_list_ops.remove(cutlass.BwOp)
+        priority_list_ops.insert(0, cutlass.BwOp)
+
+    # torch.mtia.is_available() cannot be called here because it isn't supported
+    # when tracing with PT2, so we simply add flash_mtia to the end if the MTIA
+    # dynamic library can be loaded
+    if _USE_MTIA_FLASH_ATTENTION:
+        priority_list_ops.append(flash_mtia.BwOp)
+
+    return _run_priority_list(
+        "memory_efficient_attention_backward", priority_list_ops, inp
+    )

--- a/mslk/attention/fmha/flash.py
+++ b/mslk/attention/fmha/flash.py
@@ -1,0 +1,862 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+
+import os
+from itertools import zip_longest
+from typing import Any, Iterable, List, Optional, Set, Tuple, Union
+
+import torch
+
+from .attn_bias import (
+    AttentionBias,
+    BlockDiagonalCausalFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionMask,
+    BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+    BlockDiagonalCausalMask,
+    BlockDiagonalCausalWithOffsetGappyKeysMask,
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    BlockDiagonalGappyKeysMask,
+    BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask,
+    BlockDiagonalLocalAttentionPaddedKeysMask,
+    BlockDiagonalMask,
+    BlockDiagonalPaddedKeysMask,
+    LocalAttentionFromBottomRightMask,
+    LowerTriangularFromBottomRightLocalAttentionMask,
+    LowerTriangularFromBottomRightMask,
+    LowerTriangularMask,
+    PagedBlockDiagonalCausalLocalPaddedKeysMask,
+    PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+    PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+    PagedBlockDiagonalGappyKeysMask,
+    PagedBlockDiagonalPaddedKeysMask,
+    VARLEN_BIASES,
+)
+from .common import (
+    AttentionBwOpBase,
+    AttentionFwOpBase,
+    check_lastdim_alignment_stride1,
+    Context,
+    Gradients,
+    Inputs,
+)
+from .torch_attention_compat import is_pt_flash_old
+
+from .utils.op_common import get_operator, register_operator
+
+FLASH_VERSION = "0.0.0"
+VARLEN_LSE_PACKED = False
+pt_flash_is_old = False
+_TRY_PT_FLASH_ATTN = torch.version.hip is None
+_USE_PT_FLASH_ATTN = False
+
+try:  # noqa: C901
+    try:
+        from xformers import _C_flashattention  # type: ignore[attr-defined]
+
+        try:
+            from xformers._cpp_lib import _build_metadata  # type: ignore[attr-defined]
+
+            if _build_metadata is not None:
+                FLASH_VERSION = _build_metadata.flash_version
+        except ImportError:
+            FLASH_VERSION = "unknown"
+
+        VARLEN_LSE_PACKED = True
+    except ImportError:
+        try:
+            import flash_attn
+            import flash_attn.flash_attn_interface
+
+            if hasattr(flash_attn.flash_attn_interface, "flash_attn_cuda"):
+                _C_flashattention = flash_attn.flash_attn_interface.flash_attn_cuda  # type: ignore[attr-defined]
+            else:
+                _C_flashattention = flash_attn.flash_attn_interface.flash_attn_gpu  # type: ignore[attr-defined]
+
+            FLASH_VERSION = flash_attn.__version__
+            FLASH_VER_MIN = (2, 6, 3)
+            FLASH_VER_LAST = (2, 8, 3)  # last supported, inclusive
+            flash_ver_parsed = tuple(int(s) for s in FLASH_VERSION.split(".")[:3])
+            if (
+                flash_ver_parsed < FLASH_VER_MIN or flash_ver_parsed > FLASH_VER_LAST
+            ) and os.environ.get("XFORMERS_IGNORE_FLASH_VERSION_CHECK", "0") != "1":
+                raise ImportError(
+                    f"Requires Flash-Attention version >={'.'.join([str(i) for i in FLASH_VER_MIN])},"
+                    f"<={'.'.join([str(i) for i in FLASH_VER_LAST])} "
+                    f"but got {FLASH_VERSION}."
+                )
+            VARLEN_LSE_PACKED = True
+        except ImportError as e:
+            if not _TRY_PT_FLASH_ATTN:
+                raise e
+            pt_flash_is_old = is_pt_flash_old(force=True) is True
+            FLASH_VERSION = torch.nn.attention._get_flash_version()  # type: ignore
+            VARLEN_LSE_PACKED = not pt_flash_is_old
+            _USE_PT_FLASH_ATTN = True
+
+    @torch.library.custom_op(
+        "mslk_flash::flash_fwd",
+        mutates_args=(),
+        device_types=["cuda"],
+    )
+    def _flash_fwd(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: Optional[torch.Tensor],
+        cu_seqlens_k: Optional[torch.Tensor],
+        seqused_k: Optional[torch.Tensor],
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        p: float,
+        softmax_scale: float,
+        is_causal: bool,
+        window_left: int,
+        window_right: int,
+        return_softmax: bool,
+        block_tables: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        softcap = 0.0
+        if _USE_PT_FLASH_ATTN:
+            ret = torch.ops.aten._flash_attention_forward(
+                query,
+                key,
+                value,
+                cu_seqlens_q,  # cum_seq_q
+                cu_seqlens_k,  # cum_seq_k
+                max_seqlen_q,  # max_q
+                max_seqlen_k,  # max_k
+                p,  # dropout_p
+                is_causal,
+                return_debug_mask=False,
+                scale=softmax_scale,
+                window_size_left=window_left,
+                window_size_right=window_right,
+                seqused_k=seqused_k,
+                alibi_slopes=None,  # alibi_slopes
+            )
+            if pt_flash_is_old:
+                (
+                    attention,
+                    logsumexp,
+                    philox_seed,
+                    philox_offset,
+                    _,
+                ) = ret
+                rng_state = torch.stack([philox_seed, philox_offset])
+            else:
+                attention, logsumexp, rng_state, _, _ = ret
+            return attention, logsumexp, rng_state
+        else:
+            if cu_seqlens_q is None:
+                assert cu_seqlens_k is None
+                assert seqused_k is None
+                out, softmax_lse, p, rng_state = _C_flashattention.fwd(
+                    query,
+                    key,
+                    value,
+                    None,  # out
+                    None,  # alibi_slopes
+                    p,
+                    softmax_scale,
+                    is_causal,
+                    window_left,  # window_size_left
+                    window_right,  # window_size_right
+                    softcap,
+                    return_softmax,
+                    None,  # rng
+                )
+            else:
+                out, softmax_lse, p, rng_state = _C_flashattention.varlen_fwd(
+                    query,
+                    key,
+                    value,
+                    None,  # out
+                    cu_seqlens_q,
+                    cu_seqlens_k,
+                    seqused_k,
+                    None,  # leftpad_k_
+                    block_tables,
+                    None,  # alibi_slopes
+                    max_seqlen_q,
+                    max_seqlen_k,
+                    p,
+                    softmax_scale,
+                    False,
+                    is_causal,
+                    window_left,
+                    window_right,
+                    softcap,
+                    return_softmax,
+                    None,  # gen
+                )
+        return out, softmax_lse, rng_state
+
+    @torch.library.register_fake("mslk_flash::flash_fwd")
+    def _flash_fwd_abstract(
+        query,
+        key,
+        value,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        seqused_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        p,
+        softmax_scale,
+        is_causal,
+        window_left,
+        window_right,
+        return_softmax,
+        block_tables,
+    ):
+        out = torch.empty_like(query)
+        if cu_seqlens_q is None:
+            B, M, H, K = query.shape
+            lse_shape = [B, H, M]  # XXXX ?
+        else:
+            M, H, K = query.shape
+            B = cu_seqlens_q.shape[0] - 1
+            if VARLEN_LSE_PACKED:
+                lse_shape = [H, M]
+            else:
+                lse_shape = [B, H, max_seqlen_q]
+        softmax_lse = torch.empty(lse_shape, device=query.device, dtype=torch.float32)
+        rng_state = torch.empty([2], device=query.device, dtype=torch.int64)
+        return out, softmax_lse, rng_state
+
+    @torch.library.custom_op(
+        "mslk_flash::flash_bwd",
+        mutates_args=(),
+        device_types=["cuda"],
+    )
+    def _flash_bwd(
+        grads_share_storage: bool,
+        grad: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        out: torch.Tensor,
+        lse: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        p: float,
+        softmax_scale: float,
+        is_causal: bool,
+        window_left: int,
+        window_right: int,
+        rng_state: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        softcap = 0.0
+        if _USE_PT_FLASH_ATTN:
+            assert softcap == 0.0
+            if rng_state is not None and pt_flash_is_old:
+                rng_state0 = rng_state[0]
+                rng_state1 = rng_state[1]
+            else:
+                rng_state0 = rng_state1 = rng_state
+            dq, dk, dv = torch.ops.aten._flash_attention_backward(
+                grad,
+                query,
+                key,
+                value,
+                out,
+                lse,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                p,
+                is_causal,
+                rng_state0,
+                rng_state1,
+                scale=softmax_scale,
+                window_size_left=window_left,
+                window_size_right=window_right,
+            )
+        else:
+            dq, dk, dv = _create_dq_dk_dv(grads_share_storage, query, key, value)
+            if cu_seqlens_k is None:
+                assert cu_seqlens_q is None
+                _C_flashattention.bwd(
+                    grad,
+                    query,
+                    key,
+                    value,
+                    out,
+                    lse,
+                    dq,
+                    dk,
+                    dv,
+                    None,  # alibi_slopes
+                    p,
+                    softmax_scale,
+                    is_causal,
+                    window_left,
+                    window_right,
+                    softcap,
+                    False,  # deterministic
+                    None,
+                    rng_state,
+                )
+            else:
+                _C_flashattention.varlen_bwd(
+                    grad,
+                    query,
+                    key,
+                    value,
+                    out,
+                    lse,
+                    dq,
+                    dk,
+                    dv,
+                    cu_seqlens_q,
+                    cu_seqlens_k,
+                    None,  # alibi_slopes
+                    max_seqlen_q,
+                    max_seqlen_k,
+                    p,
+                    softmax_scale,
+                    False,  # zero_tensors
+                    is_causal,
+                    window_left,
+                    window_right,
+                    softcap,
+                    False,  # deterministic
+                    None,
+                    rng_state,
+                )
+        return dq, dk, dv
+
+    @torch.library.register_fake("mslk_flash::flash_bwd")
+    def _flash_bwd_abstract(
+        grads_share_storage,
+        grad,
+        query,
+        key,
+        value,
+        *args,
+        **kwargs,
+    ):
+        return _create_dq_dk_dv(grads_share_storage, query, key, value)
+
+    def _create_dq_dk_dv(
+        grads_share_storage: bool, query, key, value
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        # Create dq,dk,dv
+        # If Q/K/V come from a single QKV tensor, let's put the gradient in the
+        # right strides, so we can avoid a `cat`
+        if grads_share_storage:
+            chunk = torch.empty(
+                (*query.shape[0:-2], 3, query.shape[-2], query.shape[-1]),
+                dtype=query.dtype,
+                device=query.device,
+            )
+            return chunk.select(-3, 0), chunk.select(-3, 1), chunk.select(-3, 2)
+        return torch.empty_like(query), torch.empty_like(key), torch.empty_like(value)
+
+except ImportError:
+    pass
+
+
+def _convert_input_format(
+    inp: Inputs,
+    supports_mqa: bool,
+    use_kvsplit: bool = False,
+) -> Tuple[
+    Inputs,
+    Optional[torch.Tensor],
+    int,
+    Optional[torch.Tensor],
+    int,
+    Optional[torch.Tensor],
+]:
+    assert inp.query.ndim in [4, 5]
+    query, key, value = inp.query, inp.key, inp.value
+    batch = query.shape[0]
+    seqlen_q = query.shape[1]
+    seqlen_kv = key.shape[1]
+    head_dim_q = query.shape[-1]
+    head_dim_v = value.shape[-1]
+
+    attn_bias = inp.attn_bias
+    if isinstance(attn_bias, BlockDiagonalMask):
+        assert attn_bias.k_seqinfo.seqstart.device == inp.query.device
+        cu_seqlen_k = attn_bias.k_seqinfo.seqstart
+        cu_seqlen_q = attn_bias.q_seqinfo.seqstart
+        max_seqlen_q = attn_bias.q_seqinfo.max_seqlen
+        max_seqlen_k = attn_bias.k_seqinfo.max_seqlen
+        seqused_k = None
+    elif isinstance(
+        attn_bias,
+        (
+            BlockDiagonalGappyKeysMask,
+            BlockDiagonalPaddedKeysMask,
+            PagedBlockDiagonalGappyKeysMask,
+            PagedBlockDiagonalPaddedKeysMask,
+        ),
+    ):
+        assert attn_bias.k_seqinfo.seqstart.device == inp.query.device
+        cu_seqlen_k = attn_bias.k_seqinfo.seqstart
+        cu_seqlen_q = attn_bias.q_seqinfo.seqstart
+        max_seqlen_q = attn_bias.q_seqinfo.max_seqlen
+        max_seqlen_k = attn_bias.k_seqinfo.max_seqlen
+        seqused_k = attn_bias.k_seqinfo.seqlen
+    else:
+        cu_seqlen_k = None
+        cu_seqlen_q = None
+        seqused_k = None
+        max_seqlen_q = inp.query.shape[1]
+        max_seqlen_k = inp.key.shape[1]
+
+    if query.ndim == 5:  # GQA
+        assert supports_mqa
+
+        # Fold the group/head_in_group dimensions together
+        def fold(x):
+            # Either the head is replicated
+            if x.stride(3) == 0:
+                return x[:, :, :, 0]
+            # Or we reshape
+            return x.reshape(
+                [
+                    x.shape[0],
+                    x.shape[1],
+                    -1,
+                    x.shape[4],
+                ]
+            )
+
+        query = fold(query)
+        key = fold(key)
+        value = fold(value)
+    # Optimize for MHA
+    if supports_mqa and key.ndim == 4 and key.stride(2) == 0 and value.stride(2) == 0:
+        key = key[:, :, :1]
+        value = value[:, :, :1]
+    # Initially we have `query.shape = [batch, seqlen, num_heads, head_dim_q]`
+    # We want format `[batch * seqlen, num_heads, head_dim_q]`
+    if cu_seqlen_k is not None:
+        query = query.reshape([batch * seqlen_q, -1, head_dim_q])
+        key = key.reshape([batch * seqlen_kv, -1, head_dim_q])
+        value = value.reshape([batch * seqlen_kv, -1, head_dim_v])
+        if isinstance(
+            attn_bias,
+            (PagedBlockDiagonalGappyKeysMask, PagedBlockDiagonalPaddedKeysMask),
+        ):
+            num_pages = value.shape[0] // attn_bias.page_size
+            key = key.view(num_pages, attn_bias.page_size, *key.shape[1:])
+            value = value.view(num_pages, attn_bias.page_size, *value.shape[1:])
+
+    new_inp = Inputs(
+        query=query,
+        key=key,
+        value=value,
+        attn_bias=attn_bias,
+        p=inp.p,
+        scale=inp.scale,
+        output_dtype=inp.output_dtype,
+        is_partial=inp.is_partial,
+    )
+    return new_inp, cu_seqlen_q, max_seqlen_q, cu_seqlen_k, max_seqlen_k, seqused_k
+
+
+def _is_causal(attn_bias: Optional[Union[torch.Tensor, AttentionBias]]) -> bool:
+    return isinstance(
+        attn_bias,
+        (
+            LowerTriangularMask,
+            LowerTriangularFromBottomRightMask,
+            LowerTriangularFromBottomRightLocalAttentionMask,
+            BlockDiagonalCausalMask,
+            BlockDiagonalCausalLocalAttentionMask,
+            PagedBlockDiagonalCausalLocalPaddedKeysMask,
+            BlockDiagonalCausalFromBottomRightMask,
+            BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+            BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+            BlockDiagonalCausalWithOffsetGappyKeysMask,
+            BlockDiagonalCausalWithOffsetPaddedKeysMask,
+            PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+            PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+        ),
+    )
+
+
+def _window_size(
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]],
+) -> Tuple[int, int]:
+    win_left = -1
+    win_right = -1
+    if isinstance(
+        attn_bias,
+        (
+            BlockDiagonalCausalLocalAttentionMask,
+            BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+            BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+            LowerTriangularFromBottomRightLocalAttentionMask,
+            PagedBlockDiagonalCausalLocalPaddedKeysMask,
+        ),
+    ):
+        win_left = attn_bias._window_size - 1
+    if isinstance(
+        attn_bias,
+        (
+            BlockDiagonalLocalAttentionPaddedKeysMask,
+            LocalAttentionFromBottomRightMask,
+            BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask,
+        ),
+    ):
+        win_left = attn_bias.window_left
+        win_right = attn_bias.window_right
+    return (win_left, win_right)
+
+
+def _check_needs_no_topleft(d: Inputs, reasons: List[str]) -> None:
+    # Flash does not support TopLeft, so only allow causal masks with TopLeft
+    # if each batch element has equal number of queries and keys.
+    attn_bias = d.attn_bias
+    if isinstance(attn_bias, BlockDiagonalCausalMask):
+        # Flash does not support TopLeft, so only allow BlockDiagonalCausalMask
+        # if each batch element has equal number of queries and keys.
+        for k_start, q_start in zip_longest(
+            attn_bias.k_seqinfo.seqstart_py, attn_bias.q_seqinfo.seqstart_py
+        ):
+            if k_start != q_start:
+                reasons.append(
+                    "Only support BlockDiagonalCausalMask if equal"
+                    " numbers of keys and queries"
+                )
+                break
+    elif isinstance(attn_bias, LowerTriangularMask):
+        if d.query.shape[1] != d.key.shape[1]:
+            reasons.append(
+                "Only support LowerTriangularMask if equal number of" "keys and queries"
+            )
+
+
+def _check_strides_for_bmghk(x: torch.Tensor, name: str, reasons: List[str]) -> None:
+    """
+    We want to be able to collapse the G/H dimensions together
+    """
+    if x.ndim == 5:
+        stride_g, stride_h = x.stride(2), x.stride(3)
+        if x.shape[2] == 1:
+            return
+        if x.shape[3] == 1 or stride_h == 0:
+            return
+        if stride_g != stride_h * x.shape[-2]:
+            reasons.append(
+                f"GQA is only supported when the G/H dimensions are contiguous\n"
+                f"    {name}.stride:  {x.stride()}\n"
+                f"    {name}.shape :  {list(x.shape)}"
+            )
+
+
+def _post_process_lse(
+    lse: torch.Tensor,
+    inp: Inputs,
+    original_query_shape: Tuple[int, ...],
+) -> torch.Tensor:
+    # Easy case: no varlen
+    if not isinstance(inp.attn_bias, VARLEN_BIASES):
+        if len(original_query_shape) == 5:
+            # [B, GH, M] => [B, G, H, M]
+            return lse.unflatten(1, original_query_shape[2:4])
+        return lse
+
+    # Already packed: just bring back the batch dimension
+    if VARLEN_LSE_PACKED:
+        if len(original_query_shape) == 5:
+            # (1, G, H, total_q)
+            return lse.unflatten(0, original_query_shape[2:4]).unsqueeze(0)
+        # (1, H, total_q)
+        return lse.unsqueeze(0)
+
+    if not inp.is_partial:
+        # (B, H, M)
+        return lse
+
+    # reshape from (B, G*H, max_seqlen) to (1, G*H, B*max_seqlen)
+    # Unfortunately this flatten is not just a view.
+    lse_hkm = lse.permute(1, 0, 2).flatten(start_dim=1)[None]
+    if len(original_query_shape) == 5:
+        return lse_hkm.unflatten(1, original_query_shape[2:4])
+    return lse_hkm
+
+
+@register_operator
+class FwOp(AttentionFwOpBase):
+    """Operator that computes memory-efficient attention using \
+        `Flash-Attention <https://github.com/HazyResearch/flash-attention>`_ \
+        implementation.
+    """
+
+    OPERATOR = get_operator("mslk_flash", "flash_fwd")
+    SUPPORTED_DEVICES: Set[str] = {"cuda"}
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (8, 0)
+    SUPPORTED_DTYPES: Set[torch.dtype] = {torch.half, torch.bfloat16}
+    SUPPORTED_MAX_K = 256
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+        BlockDiagonalLocalAttentionPaddedKeysMask,
+        BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+        BlockDiagonalCausalFromBottomRightMask,
+        BlockDiagonalCausalWithOffsetGappyKeysMask,
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        BlockDiagonalGappyKeysMask,
+        BlockDiagonalPaddedKeysMask,
+        LocalAttentionFromBottomRightMask,
+        PagedBlockDiagonalCausalLocalPaddedKeysMask,
+        PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+        PagedBlockDiagonalPaddedKeysMask,
+    )
+
+    SUPPORTS_DROPOUT = True
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_DIFFERENT_VALUE_EMBED = False
+    SUPPORTS_BMGHK = True
+    SUPPORTS_PARTIAL = True
+    VARLEN_LSE_PACKED = VARLEN_LSE_PACKED
+    NAME = f"fa2F@{FLASH_VERSION}-pt" if _USE_PT_FLASH_ATTN else f"fa2F@{FLASH_VERSION}"
+    VERSION = FLASH_VERSION
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(FwOp, cls).not_supported_reasons(d)
+        check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+        _check_needs_no_topleft(d, reasons)
+        _check_strides_for_bmghk(d.query, "query", reasons)
+        _check_strides_for_bmghk(d.key, "key", reasons)
+        _check_strides_for_bmghk(d.value, "value", reasons)
+
+        if (
+            d.is_partial
+            and not VARLEN_LSE_PACKED
+            and isinstance(d.attn_bias, VARLEN_BIASES)
+        ):
+            q_seqinfo = d.attn_bias.q_seqinfo
+            if q_seqinfo.min_seqlen != q_seqinfo.max_seqlen:
+                # Flash provides padded LSE which we don't handle.
+                reasons.append("partial attention with heterogeneous queries")
+
+        if isinstance(
+            d.attn_bias,
+            (PagedBlockDiagonalGappyKeysMask, PagedBlockDiagonalPaddedKeysMask),
+        ):
+            if d.attn_bias.page_size % 256 != 0:
+                reasons.append("Paged KV cache block size must be divisible by 256.")
+        return reasons
+
+    @classmethod
+    def apply(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        return_softmax = False
+        original_query_shape = inp.query.shape
+
+        out_shape = [
+            *inp.query.shape[:-1],
+            inp.value.shape[-1],
+        ]
+        # no cumulative seqlen
+        (
+            inp,
+            cu_seqlens_q,
+            max_seqlen_q,
+            cu_seqlens_k,
+            max_seqlen_k,
+            seqused_k,
+        ) = _convert_input_format(inp, supports_mqa=True)
+
+        if inp.query.numel() > 0 and inp.key.numel() > 0:
+            win_left, win_right = _window_size(inp.attn_bias)
+            block_tables = (
+                inp.attn_bias.block_tables
+                if isinstance(inp.attn_bias, PagedBlockDiagonalPaddedKeysMask)
+                else None
+            )
+            out, softmax_lse, rng_state = cls.OPERATOR(
+                inp.query,
+                inp.key,
+                inp.value,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                inp.p,
+                inp.scale_float,
+                _is_causal(inp.attn_bias),
+                window_left=win_left,
+                window_right=win_right,
+                return_softmax=return_softmax,
+                block_tables=block_tables,
+            )
+            out = out.reshape(out_shape)
+        else:
+            out = torch.zeros(out_shape, device=inp.query.device, dtype=inp.query.dtype)
+            rng_state = None
+            lse_shape = (
+                [inp.query.shape[2], inp.query.shape[0] * inp.query.shape[1]]
+                if VARLEN_LSE_PACKED and isinstance(inp.attn_bias, VARLEN_BIASES)
+                else [inp.query.shape[0], inp.query.shape[2], inp.query.shape[1]]
+            )
+            if inp.is_partial:
+                softmax_lse = torch.full(
+                    lse_shape,
+                    float("-inf"),
+                    device=inp.query.device,
+                    dtype=torch.float32,
+                )
+            else:
+                softmax_lse = torch.empty(
+                    lse_shape,
+                    device=inp.query.device,
+                    dtype=torch.float32,
+                )
+
+        if not needs_gradient:
+            return out, None
+        ctx = Context(
+            out=out,
+            lse=_post_process_lse(softmax_lse, inp, tuple(original_query_shape)),
+        )
+        if inp.p != 0.0:
+            ctx.op_bw = BwOp
+            ctx.rng_state = rng_state
+        return (out, ctx)
+
+
+@register_operator
+class BwOp(AttentionBwOpBase):
+    __doc__ = FwOp.__doc__
+
+    OPERATOR = get_operator("mslk_flash", "flash_bwd")
+    SUPPORTED_DEVICES = FwOp.SUPPORTED_DEVICES
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = FwOp.CUDA_MINIMUM_COMPUTE_CAPABILITY
+    SUPPORTED_DTYPES = FwOp.SUPPORTED_DTYPES
+    SUPPORTED_MAX_K = FwOp.SUPPORTED_MAX_K
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = tuple(
+        set(FwOp.SUPPORTED_ATTN_BIAS_TYPES).difference(
+            {
+                BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+                BlockDiagonalCausalWithOffsetGappyKeysMask,
+                BlockDiagonalCausalWithOffsetPaddedKeysMask,
+                BlockDiagonalLocalAttentionPaddedKeysMask,
+                BlockDiagonalGappyKeysMask,
+                BlockDiagonalPaddedKeysMask,
+                PagedBlockDiagonalCausalLocalPaddedKeysMask,
+                PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+                PagedBlockDiagonalPaddedKeysMask,
+            }
+        )
+    )
+    SUPPORTS_DROPOUT = FwOp.SUPPORTS_DROPOUT
+    SUPPORTS_CUSTOM_SCALE = FwOp.SUPPORTS_CUSTOM_SCALE
+    SUPPORTS_DIFFERENT_VALUE_EMBED = FwOp.SUPPORTS_DIFFERENT_VALUE_EMBED
+    IS_DETERMINISTIC = False
+    SUPPORTS_BMGHK = False  # NOTE: Don't forget to update fmha doc when changing this!
+    VARLEN_LSE_PACKED = VARLEN_LSE_PACKED
+    NAME = f"fa2B@{FLASH_VERSION}-pt" if _USE_PT_FLASH_ATTN else f"fa2B@{FLASH_VERSION}"
+    VERSION = FLASH_VERSION
+
+    MAX_HEADDIM_DROPOUT_SM8x = 224
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(BwOp, cls).not_supported_reasons(d)
+        check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+        _check_needs_no_topleft(d, reasons)
+        if d.device.type == "cuda":
+            # Due to limited shared-memory, some GPUs are limited in head dimension
+            device_capability = torch.cuda.get_device_capability(d.device)
+            is_sm80_or_sm90 = device_capability in [(8, 0), (9, 0)]
+            if (
+                max(d.key.shape[-1], d.query.shape[-1]) > cls.MAX_HEADDIM_DROPOUT_SM8x
+                and not is_sm80_or_sm90
+                and d.p != 0.0
+            ):
+                reasons.append(
+                    "requires a GPU with compute capability 8.0 "
+                    f"(A100) or 9.0 (H100) for dropout when 'query.shape[-1] > {cls.MAX_HEADDIM_DROPOUT_SM8x}'"
+                )
+        return reasons
+
+    @classmethod
+    def apply(cls, ctx: Context, inp: Inputs, grad: torch.Tensor) -> Gradients:
+        dq_shape, dk_shape, dv_shape = inp.query.shape, inp.key.shape, inp.value.shape
+        (
+            inp,
+            cu_seqlens_q,
+            max_seqlen_q,
+            cu_seqlens_k,
+            max_seqlen_k,
+            seqused_k,
+        ) = _convert_input_format(inp, supports_mqa=False)
+        # assert ctx.lse.is_contiguous()
+        assert seqused_k is None
+        ctx_lse = ctx.lse
+        if isinstance(inp.attn_bias, VARLEN_BIASES) and VARLEN_LSE_PACKED:
+            assert ctx_lse.shape[0] == 1
+            ctx_lse = ctx_lse[0]
+        else:
+            # NOTE: cutlass pads the last dimension, we need to slice it
+            assert ctx_lse.shape[2] >= max_seqlen_q
+            ctx_lse = ctx_lse[:, :, :max_seqlen_q].contiguous()
+        kernel_out_shape = [
+            *inp.query.shape[:-1],
+            inp.value.shape[-1],
+        ]
+        assert grad.dtype in cls.SUPPORTED_DTYPES
+
+        if inp.query.numel() and inp.key.numel():
+            win_left, win_right = _window_size(inp.attn_bias)
+            grads = Gradients(
+                *cls.OPERATOR(
+                    ctx.qkv_share_storage,
+                    grad.reshape(kernel_out_shape).contiguous(),
+                    inp.query,
+                    inp.key,
+                    inp.value,
+                    ctx.out.reshape(kernel_out_shape),
+                    ctx_lse,
+                    cu_seqlens_q,
+                    cu_seqlens_k,
+                    max_seqlen_q,
+                    max_seqlen_k,
+                    inp.p,
+                    inp.scale_float,
+                    _is_causal(inp.attn_bias),
+                    window_left=win_left,
+                    window_right=win_right,
+                    rng_state=ctx.rng_state if inp.p > 0.0 else None,
+                )
+            )
+        else:
+            grads = Gradients(
+                dq=torch.zeros_like(inp.query),
+                dk=torch.zeros_like(inp.key),
+                dv=torch.zeros_like(inp.value),
+            )
+        if grads.dq.numel() == 0:
+            grads.dk.zero_()
+            grads.dv.zero_()
+        if grads.dv.numel() == 0:
+            grads.dq.zero_()
+        grads.dq = grads.dq.reshape(dq_shape)
+        grads.dk = grads.dk.reshape(dk_shape)
+        grads.dv = grads.dv.reshape(dv_shape)
+        return grads

--- a/mslk/attention/fmha/flash3.py
+++ b/mslk/attention/fmha/flash3.py
@@ -1,0 +1,858 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+
+import os
+from typing import Any, Iterable, List, Optional, Sequence, Set, Tuple, TypeVar
+
+import torch
+from torch.utils.flop_counter import (
+    _unpack_flash_attention_nested_shapes,
+    register_flop_formula,
+)
+
+from .attn_bias import (
+    BlockDiagonalCausalFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionMask,
+    BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+    BlockDiagonalCausalMask,
+    BlockDiagonalCausalWithOffsetGappyKeysMask,
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    BlockDiagonalGappyKeysMask,
+    BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask,
+    BlockDiagonalLocalAttentionPaddedKeysMask,
+    BlockDiagonalMask,
+    BlockDiagonalPaddedKeysMask,
+    LocalAttentionFromBottomRightMask,
+    LowerTriangularFromBottomRightLocalAttentionMask,
+    LowerTriangularFromBottomRightMask,
+    LowerTriangularMask,
+    PagedBlockDiagonalCausalLocalPaddedKeysMask,
+    PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+    PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+    PagedBlockDiagonalGappyKeysMask,
+    PagedBlockDiagonalPaddedKeysMask,
+    VARLEN_BIASES,
+)
+from .common import (
+    AttentionBwOpBase,
+    AttentionFwOpBase,
+    check_lastdim_alignment_stride1,
+    Context,
+    Gradients,
+    Inputs,
+    ScaledTensor,
+)
+from .flash import (
+    _check_needs_no_topleft,
+    _convert_input_format,
+    _is_causal,
+    _post_process_lse,
+    _window_size,
+)
+
+from .utils.op_common import get_operator, register_operator
+
+FLASH_VERSION = "0.0.0"
+
+T = TypeVar("T")
+
+
+def maybe_contiguous(x: T) -> T:
+    return x.contiguous() if x is not None and x.stride(-1) != 1 else x  # type: ignore[attr-defined]
+
+
+try:
+    from xformers import _C_flashattention3  # type: ignore[attr-defined]
+
+    try:
+        from xformers._cpp_lib import _build_metadata  # type: ignore[attr-defined]
+
+        if _build_metadata is not None:
+            FLASH_VERSION = _build_metadata.flash_version
+    except ImportError:
+        FLASH_VERSION = "unknown"
+except ImportError:
+    try:
+        # type: ignore
+        from ai_codesign.gen_ai.flash_attention_v2.hopper.flash_attn_interface import (
+            flashattn_hopper_cuda as _C_flashattention3,
+        )
+    except ImportError:
+        # We end up here is arch is not 90a
+        _C_flashattention3 = None
+
+
+def _heuristic_kvsplit(
+    inp: Inputs,
+    enable_kvsplit_attn: bool,
+) -> bool:
+    atten_bias = inp.attn_bias
+
+    # make sure Q doesn't have varlen
+    # pyre-ignore Undefined attribute [16]
+    if atten_bias.q_seqinfo.min_seqlen != atten_bias.q_seqinfo.max_seqlen:  # type: ignore[union-attr]
+        return False
+
+    # filter out prefill case
+    # pyre-ignore Undefined attribute [16]
+    if atten_bias.q_seqinfo.max_seqlen == atten_bias.k_seqinfo.max_seqlen:  # type: ignore[union-attr]
+        return False
+
+    return enable_kvsplit_attn
+
+
+def mask_non_zeros(s_q: int, s_k: int, window_left: int, window_right: int) -> int:
+    # Exact formula for easy cases
+    if window_left < 0 and window_right < 0:  # full
+        return s_q * s_k
+    if window_left < 0 and window_right == 0:  # causal
+        # (from bottom right)
+        return (s_q * (s_q + 1)) // 2 + s_q * max(0, s_k - s_q)
+
+    # NOTE: Flops calculations here assume `s_q == s_k`
+    # otherwise the local attention computations are too involved
+    # See also https://docs.google.com/spreadsheets/d/1u1ItCZcHLArcqXLj7mwR4H1pI3lMKU1zlxCYi8JCYgk/edit?usp=sharing
+    if window_left < 0:
+        window_left = s_k
+    if window_right < 0:
+        window_right = s_k
+
+    # below the diagonal
+    # ┌───────┐
+    # │ ╲     │
+    # │  ╲    │ <- Upper triangle ("ut")
+    # │┄┄┄╲   │ <--- `lastq_ut`
+    # │╲   ╲  │
+    # │ ╲   ╲ │ <- Lower part
+    # │  ╲   ╲│
+    # └───────┘
+    mask_nz = min(s_q, s_k)  # diagonal
+    # Below diagonal (with `window_left`)
+    lastq_ut = min(window_left, s_q)
+    mask_nz += ((lastq_ut - 1) * lastq_ut) // 2  # upper triangle
+    mask_nz += (s_q - lastq_ut) * window_left  # lower part
+    # Above diagonal (with `window_right`)
+    # (counting rows from the bottom for symmetry)
+    firstq_bt = min(window_right + 1, s_q)
+    mask_nz += ((firstq_bt - 1) * firstq_bt) // 2  # bottom triangle
+    mask_nz += (s_q - firstq_bt) * window_right
+
+    return mask_nz
+
+
+# Copied from PyTorch, modified to support MQA/GQA and local attention
+# No need to take care of this for the bwd because we don't "unexpand" the keys
+# and values (in the fwd we expand to help with the seqlen/headdim swap trick).
+def sdpa_flop_count(
+    query_shape, key_shape, value_shape, window_left: int, window_right: int
+):
+    """
+    Count flops for self-attention.
+
+    NB: We can assume that value_shape == key_shape
+    """
+    b, h_q, s_q, d_q = query_shape
+    _b2, h_kv, s_k, _d2 = key_shape
+    _b3, _h2, _s3, d_v = value_shape
+    assert b == _b2 == _b3
+    assert h_kv == _h2
+    assert d_q == _d2
+    assert s_k == _s3
+    assert d_q == _d2
+    assert h_q % h_kv == 0
+    # How many values are computed in the attention?
+    mask_nz = mask_non_zeros(s_q, s_k, window_left, window_right)
+
+    # q@k.T
+    total_flops = 2 * b * h_q * d_q * mask_nz
+    # attn@v
+    total_flops += 2 * b * h_q * d_v * mask_nz
+    return total_flops
+
+
+if _C_flashattention3 is not None:  # noqa: C901
+    # Compatibility check for FAv3 APIs
+    EXPECTED_NUM_OF_ARGS = [
+        ("fwd", 33),
+        ("bwd", 22),
+    ]
+
+    import re
+
+    def count_args_from_doc(docstring) -> int:
+        # Use a regular expression to find the argument list inside parentheses
+        match = re.search(r"\((.*?)\)", docstring)
+        if match:
+            # Extract the argument list and split by commas
+            args_list = match.group(1).split(",")
+            # Count the number of arguments
+            return len(args_list)
+        else:
+            raise ValueError("No valid argument list found in the docstring.")
+
+    for name, num_of_args in EXPECTED_NUM_OF_ARGS:
+        num_of_args_from_doc = count_args_from_doc(
+            getattr(_C_flashattention3, name).__doc__
+        )
+        assert num_of_args_from_doc == num_of_args, (
+            f"Found func signature mismatch for {name}. Expected {num_of_args},"
+            f"actual: {num_of_args_from_doc} Please update the version of Flash Attention3."
+        )
+
+    # returns: out, q_padded, k_padded, v_padded, out_padded, softmax_lse, p
+    @torch.library.custom_op(
+        "mslk_flash3::flash_fwd", mutates_args=(), device_types=["cuda"]
+    )
+    def mha_fwd(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: Optional[torch.Tensor],
+        cu_seqlens_k: Optional[torch.Tensor],
+        seqused_k: Optional[torch.Tensor],
+        leftpad_k: Optional[torch.Tensor],
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        p: float,
+        softmax_scale: float,
+        is_causal: bool,
+        descale_q: Optional[torch.Tensor] = None,
+        descale_k: Optional[torch.Tensor] = None,
+        descale_v: Optional[torch.Tensor] = None,
+        block_table: Optional[torch.Tensor] = None,
+        use_kvsplit: bool = False,
+        window_left: int = -1,
+        window_right: int = -1,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        query, key = [maybe_contiguous(x) for x in (query, key)]
+        value = (
+            value.contiguous()
+            if value.stride(-1) != 1 and value.stride(-3) != 1
+            else value
+        )
+        cu_seqlens_q, cu_seqlens_k, seqused_k = [
+            maybe_contiguous(x) for x in (cu_seqlens_q, cu_seqlens_k, seqused_k)
+        ]
+        block_table = maybe_contiguous(block_table)
+
+        def _get_batch():
+            if cu_seqlens_q is not None:
+                return cu_seqlens_q.shape[0] - 1
+            return query.shape[0]
+
+        is_paged = block_table is not None
+        bs = _get_batch()
+        orig_query_shape = query.shape
+
+        pack_gqa = None
+        if use_kvsplit:
+            # For KV split, we need to make sure query in shape [batch, seqlen, num_heads, head_dim_q]
+            # to be compatible with `pack_gqa` feature
+            query = query.view(bs, -1, query.shape[-2], query.shape[-1])
+            cu_seqlens_q = None
+
+            # Auto-detect if we should use GQA parallel mode
+            if query.shape[1] <= 64 and query.shape[2] != key.shape[2]:
+                pack_gqa = True
+
+        assert _C_flashattention3 is not None
+        out, softmax_lse, *rest = _C_flashattention3.fwd(
+            query,
+            key,
+            value,
+            None,
+            None,  # k_new, v_new
+            None,  # qv
+            None,  # out
+            cu_seqlens_q,
+            cu_seqlens_k if not is_paged else None,
+            None,  # cu_seqlens_k_new
+            None,  # seqused_q
+            seqused_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            block_table,
+            None,  # kv_batch_idx
+            leftpad_k,
+            None,  # rotary_cos
+            None,  # rotary_sin
+            None,  # seqlens_rotary
+            descale_q,
+            descale_k,
+            descale_v,
+            softmax_scale,
+            is_causal,
+            window_left,
+            window_right,
+            0.0,  # softcap
+            not use_kvsplit,  # rotary_interleaved
+            None,  # scheduler_metadata
+            1 if not use_kvsplit else 0,  # num_splits
+            pack_gqa,  # pack_gqa
+            0,  # sm_margin
+        )
+
+        if query.shape != orig_query_shape:
+            # Reshape softmax_lse to match expected output format
+            num_heads_q = query.shape[-2]
+            orig_lse_shape = softmax_lse.shape
+            softmax_lse = softmax_lse.view(
+                orig_lse_shape[0], num_heads_q, -1, orig_lse_shape[2]
+            )
+            softmax_lse = softmax_lse.permute(1, 0, 2, 3).reshape(num_heads_q, -1)
+
+        return out, softmax_lse
+
+    @torch.library.register_fake("mslk_flash3::flash_fwd")
+    def mha_fwd_fake(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: Optional[torch.Tensor],
+        cu_seqlens_k: Optional[torch.Tensor],
+        seqused_k: Optional[torch.Tensor],
+        leftpad_k: Optional[torch.Tensor],
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        p: float,
+        softmax_scale: float,
+        is_causal: bool,
+        descale_q: Optional[torch.Tensor] = None,
+        descale_k: Optional[torch.Tensor] = None,
+        descale_v: Optional[torch.Tensor] = None,
+        block_table: Optional[torch.Tensor] = None,
+        use_kvsplit: bool = False,
+        window_left: int = -1,
+        window_right: int = -1,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        query_shape = query.shape
+        out_shape = (*query_shape[:-1], value.shape[-1])
+        if query.dtype == torch.float8_e4m3fn or query.dtype == torch.float8_e5m2:
+            out = query.new_empty(out_shape, dtype=torch.bfloat16)
+        else:
+            out = query.new_empty(out_shape)
+        # Query is (B, M, H, K) or (total_M, H, K)
+        # LSE is (B, H, M) or (H, total_M)
+        lse_shape = (
+            (query_shape[0], query_shape[2], query_shape[1])
+            if cu_seqlens_q is None
+            else (query_shape[1], query_shape[0])
+        )
+        lse = query.new_empty(lse_shape, dtype=torch.float32)
+        return out, lse
+
+    @register_flop_formula(torch.ops.mslk_flash3.flash_fwd, get_raw=True)
+    def mha_fwd_flops(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: Optional[torch.Tensor],
+        cu_seqlens_k: Optional[torch.Tensor],
+        seqused_k: Optional[torch.Tensor],
+        leftpad_k: Optional[torch.Tensor],
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        p: float,
+        softmax_scale: float,
+        is_causal: bool,
+        descale_q: Optional[torch.Tensor] = None,
+        descale_k: Optional[torch.Tensor] = None,
+        descale_v: Optional[torch.Tensor] = None,
+        block_table: Optional[torch.Tensor] = None,
+        use_kvsplit: bool = False,
+        window_left: int = -1,
+        window_right: int = -1,
+        # The FLOPs counter might pass more args (out_val, out_shape, ...)
+        *args,
+        **kwargs,
+    ):
+        assert 3 <= query.ndim <= 4
+        assert 3 <= key.ndim <= 4
+        assert 3 <= value.ndim <= 4
+        # This FLOP formula is used by torch.compile's partitioner "automatic
+        # activation checkpointing" (AutoAC) to decide which ops to preserve
+        # for backward or to recompute. However, this formula is data-dependent!
+        # This makes all invocations reuse the choices made based on the first
+        # inputs, which may be sub-optimal but also lead to inconsistent
+        # behavior across runs. In the presence of tensor parallelism it might
+        # also lead to deadlocks if AutoAC recomputes different collectives
+        # on different ranks. For distributed jobs it seems more robust to have
+        # all ranks always use the "worst case" FLOP estimate. Ranks are in
+        # lockstep anyways and will be going as fast as the slowest one.
+        if os.environ.get("XFORMERS_FLOP_FORMULA_WORST_CASE", "0") == "1":
+            cu_seqlens_q = cu_seqlens_k = max_seqlen_q = max_seqlen_k = None  # type: ignore[assignment]
+            query = query.unsqueeze(0) if query.ndim == 3 else query
+            key = key.unsqueeze(0) if key.ndim == 3 else key
+            value = value.unsqueeze(0) if value.ndim == 3 else value
+        sizes = _unpack_flash_attention_nested_shapes(
+            query=query.transpose(-2, -3) if query.ndim == 4 else query,
+            key=key.transpose(-2, -3) if key.ndim == 4 else key,
+            value=value.transpose(-2, -3) if value.ndim == 4 else value,
+            cum_seq_q=cu_seqlens_q,
+            cum_seq_k=cu_seqlens_k,
+            max_q=max_seqlen_q,
+            max_k=max_seqlen_k,
+        )
+        if is_causal:
+            window_right = 0
+        res = sum(
+            sdpa_flop_count(
+                query_shape,
+                key_shape,
+                value_shape,
+                window_left=window_left,
+                window_right=window_right,
+            )
+            for query_shape, key_shape, value_shape, _ in sizes
+        )
+        return res
+
+    def _create_dq_dk_dv(
+        grads_share_storage: bool, query, key, value
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        # Create dq,dk,dv
+        # If Q/K/V come from a single QKV tensor, let's put the gradient in the
+        # right strides, so we can avoid a `cat`
+        if grads_share_storage:
+            chunk = torch.empty(
+                (*query.shape[0:-2], 3, query.shape[-2], query.shape[-1]),
+                dtype=query.dtype,
+                device=query.device,
+            )
+            return chunk.select(-3, 0), chunk.select(-3, 1), chunk.select(-3, 2)
+        return torch.empty_like(query), torch.empty_like(key), torch.empty_like(value)
+
+    @torch.library.custom_op(
+        "mslk_flash3::flash_bwd", mutates_args=(), device_types=["cuda"]
+    )
+    def mha_bwd(
+        grads_share_storage: bool,
+        dout: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        out: torch.Tensor,
+        softmax_lse: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        softmax_scale: float,
+        is_causal: bool,
+        window_left: int,
+        window_right: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        dq, dk, dv = _create_dq_dk_dv(grads_share_storage, query, key, value)
+        is_deterministic = False
+        if cu_seqlens_q is None:
+            assert cu_seqlens_k is None
+
+        assert _C_flashattention3 is not None
+        dq, dk, dv, softmax_d, *rest = _C_flashattention3.bwd(
+            dout,
+            query,
+            key,
+            value,
+            out,
+            softmax_lse,
+            dq,
+            dk,
+            dv,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            None,  # seqused_q
+            None,  # seqused_k
+            max_seqlen_q,
+            max_seqlen_k,
+            softmax_scale,
+            is_causal,
+            window_left,
+            window_right,
+            0.0,  # not used, softcap
+            is_deterministic,
+            0,  # not used, sm_margin
+        )
+        return dq, dk, dv
+
+    @torch.library.register_fake("mslk_flash3::flash_bwd")
+    def mha_bwd_fake(
+        grads_share_storage: bool,
+        dout: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        out: torch.Tensor,
+        softmax_lse: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        softmax_scale: float,
+        is_causal: bool,
+        window_left: int,
+        window_right: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return _create_dq_dk_dv(grads_share_storage, query, key, value)
+
+    @register_flop_formula(torch.ops.mslk_flash3.flash_bwd, get_raw=True)
+    def mha_bwd_flops(
+        grads_share_storage: bool,
+        dout: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        out: torch.Tensor,
+        softmax_lse: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        softmax_scale: float,
+        is_causal: bool,
+        window_left: int,
+        window_right: int,
+        # The FLOPs counter might pass more args (out_val, out_shape, ...)
+        *args,
+        **kwargs,
+    ):
+        return (
+            5
+            * mha_fwd_flops(
+                query,
+                key,
+                value,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k=cu_seqlens_k,
+                seqused_k=None,
+                leftpad_k=None,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+                p=0.0,
+                softmax_scale=1.0,
+                is_causal=is_causal,
+                descale_q=None,
+                descale_k=None,
+                descale_v=None,
+                block_table=None,
+                use_kvsplit=False,
+                window_left=window_left,
+                window_right=window_right,
+            )
+            // 2
+        )
+
+
+@register_operator
+class FwOp(AttentionFwOpBase):
+    """Operator that computes memory-efficient attention using \
+        `Flash-Attention <https://github.com/HazyResearch/flash-attention>`_ \
+        implementation.
+    """
+
+    OPERATOR = get_operator("mslk_flash3", "flash_fwd")
+    SUPPORTED_DEVICES: Set[str] = {"cuda"}
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (9, 0)
+    CUDA_MAXIMUM_COMPUTE_CAPABILITY = (9, 0)
+    SUPPORTED_DTYPES: Set[torch.dtype] = {
+        torch.half,
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+    }
+    SUPPORTED_MAX_K = 256
+    SUPPORTED_MIN_K = 64
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+        BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+        BlockDiagonalCausalFromBottomRightMask,
+        BlockDiagonalCausalWithOffsetGappyKeysMask,
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        BlockDiagonalLocalAttentionPaddedKeysMask,
+        BlockDiagonalGappyKeysMask,
+        BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask,
+        BlockDiagonalPaddedKeysMask,
+        LocalAttentionFromBottomRightMask,
+        PagedBlockDiagonalCausalLocalPaddedKeysMask,
+        PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+        PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+        PagedBlockDiagonalGappyKeysMask,
+        PagedBlockDiagonalPaddedKeysMask,
+    )
+
+    SUPPORTS_DROPOUT = False
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_DIFFERENT_VALUE_EMBED = False
+    SUPPORTS_BMGHK = True
+    SUPPORTS_PARTIAL = True
+    UNPADDED_LSE = True
+    NAME = f"fa3F@{FLASH_VERSION}"
+    VERSION = FLASH_VERSION
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(FwOp, cls).not_supported_reasons(d)
+        check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+        if d.query.shape[-1] not in [64, 128, 192, 256]:
+            reasons.append("only head-dim 64, 128, 192 or 256 is supported")
+
+        _check_needs_no_topleft(d, reasons)
+
+        return reasons
+
+    @classmethod
+    def apply(
+        cls,
+        inp: Inputs,
+        needs_gradient: bool,
+        use_kvsplit: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        original_query_shape = inp.query.shape
+        out_shape = [
+            *inp.query.shape[:-1],
+            inp.value.shape[-1],
+        ]
+
+        def unpack_func(x) -> Tuple[torch.Tensor, Any]:
+            return x.unpack() if isinstance(x, ScaledTensor) else (x, None)
+
+        inp.query, descale_q = unpack_func(inp.query)
+        inp.key, descale_k = unpack_func(inp.key)
+        inp.value, descale_v = unpack_func(inp.value)
+        (
+            inp,
+            cu_seqlens_q,
+            max_seqlen_q,
+            cu_seqlens_k,
+            max_seqlen_k,
+            seqused_k,
+        ) = _convert_input_format(inp, supports_mqa=True, use_kvsplit=use_kvsplit)
+
+        q = inp.query
+        k = inp.key
+        v = inp.value
+
+        if inp.query.numel() > 0 and inp.key.numel() > 0:
+            win_left, win_right = _window_size(inp.attn_bias)
+            block_tables = (
+                inp.attn_bias.block_tables
+                if isinstance(
+                    inp.attn_bias,
+                    (PagedBlockDiagonalGappyKeysMask, PagedBlockDiagonalPaddedKeysMask),
+                )
+                else None
+            )
+            leftpad_k = None
+            if isinstance(inp.attn_bias, PagedBlockDiagonalGappyKeysMask):
+                assert cu_seqlens_q is not None
+                assert cu_seqlens_k is not None
+                if len(cu_seqlens_q) == len(cu_seqlens_k):
+                    # case #1: len(cu_seqlens_k) = batch_size + 1
+                    leftpad_k = cu_seqlens_k[:-1]
+                else:
+                    # case #2: len(cu_seqlens_k) = batch_size
+                    assert (
+                        len(cu_seqlens_q) - len(cu_seqlens_k) == 1
+                    ), f"{len(cu_seqlens_q)=} {len(cu_seqlens_k)=}"
+                    leftpad_k = cu_seqlens_k
+            out, softmax_lse = cls.OPERATOR(
+                q,
+                k,
+                v,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k=cu_seqlens_k,
+                seqused_k=seqused_k,
+                leftpad_k=leftpad_k,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+                p=inp.p,
+                softmax_scale=inp.scale_float,
+                is_causal=_is_causal(inp.attn_bias),
+                descale_q=descale_q,
+                descale_k=descale_k,
+                descale_v=descale_v,
+                block_table=block_tables,
+                use_kvsplit=use_kvsplit,
+                window_left=win_left,
+                window_right=win_right,
+            )
+            out = out.reshape(out_shape)
+        else:
+            out = torch.zeros(
+                inp.query.shape, device=inp.query.device, dtype=inp.query.dtype
+            )
+            if inp.is_partial:
+                softmax_lse = torch.full(
+                    [inp.query.shape[0], inp.query.shape[2], inp.query.shape[1]],
+                    float("-inf"),
+                    device=inp.query.device,
+                    dtype=torch.float32,
+                )
+            else:
+                softmax_lse = torch.empty(
+                    [inp.query.shape[0], inp.query.shape[2], inp.query.shape[1]],
+                    device=inp.query.device,
+                    dtype=torch.float32,
+                )
+
+        ctx = Context(
+            out=out,
+            lse=softmax_lse,
+        )
+
+        if not needs_gradient:
+            return out, None
+        ctx = Context(
+            out=out,
+            lse=_post_process_lse(softmax_lse, inp, tuple(original_query_shape)),
+        )
+        return (out, ctx)
+
+
+@register_operator
+class BwOp(AttentionBwOpBase):
+    __doc__ = FwOp.__doc__
+
+    OPERATOR = get_operator("mslk_flash3", "flash_bwd")
+    SUPPORTED_DEVICES = FwOp.SUPPORTED_DEVICES
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = FwOp.CUDA_MINIMUM_COMPUTE_CAPABILITY
+    CUDA_MAXIMUM_COMPUTE_CAPABILITY = FwOp.CUDA_MAXIMUM_COMPUTE_CAPABILITY
+    SUPPORTED_DTYPES = FwOp.SUPPORTED_DTYPES
+    SUPPORTED_MAX_K = FwOp.SUPPORTED_MAX_K
+    SUPPORTED_MIN_K = FwOp.SUPPORTED_MIN_K
+    SUPPORTED_ATTN_BIAS_TYPES = (
+        # Exclude padded or gappy masks, since seqused_k is not supported by the kernel.
+        type(None),
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+        BlockDiagonalCausalFromBottomRightMask,
+        LocalAttentionFromBottomRightMask,
+    )
+
+    SUPPORTS_DROPOUT = FwOp.SUPPORTS_DROPOUT
+    SUPPORTS_CUSTOM_SCALE = FwOp.SUPPORTS_CUSTOM_SCALE
+    SUPPORTS_DIFFERENT_VALUE_EMBED = FwOp.SUPPORTS_DIFFERENT_VALUE_EMBED
+    IS_DETERMINISTIC = False
+    SUPPORTS_BMGHK = False
+    SUPPORTS_LSE_FORMATS: Sequence[str] = ["", "varlen_flat"]
+    NAME = f"fa3B@{FLASH_VERSION}"
+    VERSION = FLASH_VERSION
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(BwOp, cls).not_supported_reasons(d)
+        check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+        _check_needs_no_topleft(d, reasons)
+        if d.query.shape[-1] not in [64, 128, 192, 256]:
+            reasons.append("only head-dim 64, 128, 192 or 256 is supported")
+
+        _check_needs_no_topleft(d, reasons)
+        return reasons
+
+    @classmethod
+    def apply(cls, ctx: Context, inp: Inputs, grad: torch.Tensor) -> Gradients:
+        dq_shape, dk_shape, dv_shape = inp.query.shape, inp.key.shape, inp.value.shape
+        (
+            inp,
+            cu_seqlens_q,
+            max_seqlen_q,
+            cu_seqlens_k,
+            max_seqlen_k,
+            _,  # seqused_k,
+        ) = _convert_input_format(inp, supports_mqa=False)
+        ctx_lse = ctx.lse
+
+        if isinstance(inp.attn_bias, VARLEN_BIASES):
+            assert ctx_lse.shape[0] == 1
+            ctx_lse = ctx_lse[0]
+        else:
+            # NOTE: cutlass pads the last dimension, we need to slice it
+            assert ctx_lse.shape[2] >= max_seqlen_q
+            ctx_lse = ctx_lse[:, :, :max_seqlen_q].contiguous()
+
+        kernel_out_shape = [
+            *inp.query.shape[:-1],
+            inp.value.shape[-1],
+        ]
+        assert grad.dtype in cls.SUPPORTED_DTYPES
+
+        if inp.query.numel() and inp.key.numel():
+            win_left, win_right = _window_size(inp.attn_bias)
+            dq, dk, dv = cls.OPERATOR(
+                ctx.qkv_share_storage,
+                grad.reshape(kernel_out_shape).contiguous(),
+                inp.query,
+                inp.key,
+                inp.value,
+                ctx.out.reshape(kernel_out_shape),
+                ctx.lse,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                window_left=win_left,
+                window_right=win_right,
+                softmax_scale=inp.scale_float,
+                is_causal=_is_causal(inp.attn_bias),
+            )
+            grads = Gradients(dq, dk, dv)
+        else:
+            grads = Gradients(
+                dq=torch.zeros_like(inp.query),
+                dk=torch.zeros_like(inp.key),
+                dv=torch.zeros_like(inp.value),
+            )
+
+        grads.dq = grads.dq.reshape(dq_shape)
+        grads.dk = grads.dk.reshape(dk_shape)
+        grads.dv = grads.dv.reshape(dv_shape)
+        return grads
+
+
+@register_operator
+class FwOp_KVSplit(FwOp):
+    """Operator that computes memory-efficient attention using \
+        `Flash-Attention3 <https://github.com/Dao-AILab/flash-attention/tree/main/hopper>`_ \
+        implementation with heuristic rules to dispatch decoding shapes to KVSplit Attention \
+    """
+
+    NAME = f"fa3F_splitKV@{FLASH_VERSION}"
+    enable_kvsplit_attn: bool = True
+
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        BlockDiagonalPaddedKeysMask,
+        BlockDiagonalCausalWithOffsetGappyKeysMask,
+        BlockDiagonalGappyKeysMask,
+        BlockDiagonalLocalAttentionPaddedKeysMask,
+        PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+        PagedBlockDiagonalGappyKeysMask,
+        PagedBlockDiagonalPaddedKeysMask,
+        PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+    )
+
+    @classmethod
+    def apply(  # type: ignore[override]
+        cls,
+        inp: Inputs,
+        needs_gradient: bool,
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        use_kvsplit = _heuristic_kvsplit(inp, cls.enable_kvsplit_attn)
+
+        return super().apply(inp, needs_gradient, use_kvsplit)

--- a/mslk/attention/fmha/flash_mtia.py
+++ b/mslk/attention/fmha/flash_mtia.py
@@ -1,0 +1,248 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+
+from typing import Any, Iterable, Mapping, Optional, Set, Tuple
+
+import torch
+
+from .attn_bias import (
+    BlockDiagonalCausalFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+    BlockDiagonalCausalLocalAttentionMask,
+    BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+    BlockDiagonalCausalMask,
+    BlockDiagonalCausalWithOffsetGappyKeysMask,
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    BlockDiagonalGappyKeysMask,
+    BlockDiagonalLocalAttentionPaddedKeysMask,
+    BlockDiagonalMask,
+    BlockDiagonalPaddedKeysMask,
+    LocalAttentionFromBottomRightMask,
+    LowerTriangularFromBottomRightLocalAttentionMask,
+    LowerTriangularFromBottomRightMask,
+    LowerTriangularMask,
+)
+
+from .flash import BwOp as BwOpCUDA, FwOp as FwOpCUDA
+
+from .utils.op_common import get_operator, register_operator
+
+try:
+    import mtia.host_runtime.torch_mtia.dynamic_library  # noqa  # type: ignore
+
+    @torch.library.custom_op(
+        "mslk_flash_mtia::flash_fwd",
+        mutates_args=(),
+        device_types=["mtia"],
+    )
+    def _flash_fwd(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: Optional[torch.Tensor],
+        cu_seqlens_k: Optional[torch.Tensor],
+        seqused_k: Optional[torch.Tensor],
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        p: float,
+        softmax_scale: float,
+        is_causal: bool,
+        window_left: int,
+        window_right: int,
+        return_softmax: bool,
+        block_tables: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        ret = torch.ops.aten._flash_attention_forward(
+            query,
+            key,
+            value,
+            cu_seqlens_q,  # cum_seq_q
+            cu_seqlens_k,  # cum_seq_k
+            max_seqlen_q,  # max_q
+            max_seqlen_k,  # max_k
+            p,  # dropout_p
+            is_causal,
+            return_debug_mask=False,
+            scale=softmax_scale,
+            window_size_left=window_left,
+            window_size_right=window_right,
+            seqused_k=seqused_k,
+            alibi_slopes=None,  # alibi_slopes
+        )
+        attention, logsumexp, rng_state, _, _ = ret
+        return attention, logsumexp, rng_state
+
+        @torch.library.register_fake("mslk_flash_mtia::flash_fwd")
+        def _flash_fwd_abstract(
+            query,
+            key,
+            value,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqused_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            p,
+            softmax_scale,
+            is_causal,
+            window_left,
+            window_right,
+            return_softmax,
+            block_tables,
+        ):
+            out = torch.empty_like(query)
+            if cu_seqlens_q is None:
+                B, M, H, K = query.shape
+                lse_shape = [B, H, M]  # XXXX ?
+            else:
+                M, H, K = query.shape
+                B = cu_seqlens_q.shape[0] - 1
+                lse_shape = [H, M]
+            softmax_lse = torch.empty(
+                lse_shape, device=query.device, dtype=torch.float32
+            )
+            rng_state = torch.empty([2], device=query.device, dtype=torch.int64)
+            return out, softmax_lse, rng_state
+
+    @torch.library.custom_op(
+        "mslk_flash_mtia::flash_bwd",
+        mutates_args=(),
+        device_types=["mtia"],
+    )
+    def _flash_bwd(
+        grads_share_storage: bool,
+        grad: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        out: torch.Tensor,
+        lse: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        p: float,
+        softmax_scale: float,
+        is_causal: bool,
+        window_left: int,
+        window_right: int,
+        rng_state: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        rng_state0 = rng_state1 = rng_state
+        dq, dk, dv = torch.ops.aten._flash_attention_backward(
+            grad,
+            query,
+            key,
+            value,
+            out,
+            lse,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            p,
+            is_causal,
+            rng_state0,
+            rng_state1,
+            scale=softmax_scale,
+            window_size_left=window_left,
+            window_size_right=window_right,
+        )
+        return dq, dk, dv
+
+    @torch.library.register_fake("mslk_flash_mtia::flash_bwd")
+    def _flash_bwd_abstract(
+        grads_share_storage,
+        grad,
+        query,
+        key,
+        value,
+        *args,
+        **kwargs,
+    ):
+        return _create_dq_dk_dv(grads_share_storage, query, key, value)
+
+except (ImportError, OSError):
+    pass
+
+
+def _create_dq_dk_dv(
+    grads_share_storage: bool, query, key, value
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    # Create dq,dk,dv
+    # If Q/K/V come from a single QKV tensor, let's put the gradient in the
+    # right strides, so we can avoid a `cat`
+    if grads_share_storage:
+        chunk = torch.empty(
+            (*query.shape[0:-2], 3, query.shape[-2], query.shape[-1]),
+            dtype=query.dtype,
+            device=query.device,
+        )
+        return chunk.select(-3, 0), chunk.select(-3, 1), chunk.select(-3, 2)
+    return torch.empty_like(query), torch.empty_like(key), torch.empty_like(value)
+
+
+FLASH_VERSION = torch.nn.attention._get_flash_version()  # noqa  # type: ignore
+
+
+@register_operator
+class FwOp(FwOpCUDA):
+    """Operator that computes memory-efficient attention using MTIA devicesa"""
+
+    OPERATOR = get_operator("mslk_flash_mtia", "flash_fwd")
+    SUPPORTED_DEVICES: Set[str] = {"mtia"}
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+        BlockDiagonalLocalAttentionPaddedKeysMask,
+        BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+        BlockDiagonalCausalFromBottomRightMask,
+        BlockDiagonalCausalWithOffsetGappyKeysMask,
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        BlockDiagonalGappyKeysMask,
+        BlockDiagonalPaddedKeysMask,
+        LocalAttentionFromBottomRightMask,
+    )
+    NAME = f"fa2F@{FLASH_VERSION}-mtia"
+
+    ERROR_ATOL: Mapping[torch.dtype, float] = {
+        torch.float: 3e-4,
+        torch.half: 7e-3,
+        torch.bfloat16: 2e-2,
+    }
+    ERROR_RTOL: Mapping[torch.dtype, float] = {
+        torch.float: 2e-5,
+        torch.half: 4e-4,
+        torch.bfloat16: 5e-3,
+    }
+
+
+@register_operator
+class BwOp(BwOpCUDA):
+    """Operator that computes memory-efficient attention using MTIA devicesa"""
+
+    OPERATOR = get_operator("mslk_flash_mtia", "flash_bwd")
+    SUPPORTED_DEVICES: Set[str] = {"mtia"}
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        LowerTriangularMask,
+        LowerTriangularFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+        BlockDiagonalCausalFromBottomRightMask,
+        LocalAttentionFromBottomRightMask,
+    )
+    NAME = f"fa2B@{FLASH_VERSION}-mtia"

--- a/mslk/attention/fmha/merge_training.py
+++ b/mslk/attention/fmha/merge_training.py
@@ -1,0 +1,191 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+from typing import Callable, Optional, Tuple, Type, Union
+
+import torch
+
+from .. import fmha
+
+
+"""
+Friendly wrapper around merge_attentions which works with autograd.
+
+Use as follows
+
+```
+partial1 = memory_efficient_attention_partial_autograd(q, k1, v1, ...)
+partial2 = memory_efficient_attention_partial_autograd(q, k2, v2, ...)
+attn_out = merge_attentions_autograd(partial1, partial2)
+```
+
+merge_attentions_autograd() can take any number of inputs. Note that
+partial1 and partial2 are not tensors, but rather objects of type
+`Partial`.
+
+If you have partial1 and you changed your mind and don't
+want to merge it with anything, you can do
+```
+attn_out = merge_attentions_autograd(partial1)
+```
+
+"""
+
+
+class _PartialFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: torch.autograd.function.FunctionCtx,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_bias: Optional[Union[torch.Tensor, fmha.AttentionBias]],
+        p: float = 0.0,
+        scale: Optional[float] = None,
+        op: Optional[Union[fmha.AttentionOp, Type[fmha.AttentionFwOpBase]]] = None,
+        output_dtype: Optional[torch.dtype] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        ctx.bias = attn_bias  # type: ignore
+        ctx.save_for_backward(query, key, value)
+        ctx.p = p  # type: ignore
+        ctx.scale = scale  # type: ignore
+        ctx.op = op[1] if isinstance(op, tuple) else None  # type: ignore
+        attn, lse = fmha.memory_efficient_attention_partial(
+            query, key, value, attn_bias, p, scale, op=op, output_dtype=output_dtype
+        )
+        placeholder = torch.empty_like(attn)
+        return attn, lse, placeholder
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_attn: torch.Tensor,
+        lse: torch.Tensor,
+        out: torch.Tensor,
+    ) -> Tuple[Optional[torch.Tensor], ...]:
+        query, key, value = ctx.saved_tensors  # type: ignore
+        grad_q, grad_k, grad_v = fmha.memory_efficient_attention_backward(
+            grad_attn,
+            out,
+            lse.contiguous(),
+            query,
+            key,
+            value,
+            ctx.bias,  # type: ignore
+            ctx.p,  # type: ignore
+            ctx.scale,  # type: ignore
+            op=ctx.op,  # type: ignore
+        )
+        return grad_q, grad_k, grad_v, None, None, None, None, None
+
+
+class _MergeFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: torch.autograd.function.FunctionCtx,
+        *inputs: torch.Tensor,
+    ) -> torch.Tensor:
+        ctx.length = len(inputs) // 3  # type: ignore
+        if ctx.length > 1:  # type: ignore
+            attns = inputs[::3]
+            lses = inputs[1::3]
+            out, lse = fmha.merge_attentions(attns, lses)
+            assert lse is not None
+        else:
+            out, lse = inputs[:2]
+        ctx.save_for_backward(out, lse)
+        return out
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: torch.autograd.function.FunctionCtx, grad_out: torch.Tensor
+    ) -> Tuple[Optional[torch.Tensor], ...]:
+        out, lse = ctx.saved_tensors  # type: ignore
+        return (grad_out, lse, out) * ctx.length  # type: ignore
+
+
+class Partial:
+    """
+    This class is used to represent a partial attention output, which is
+    returned by `memory_efficient_attention_partial_autograd`.
+
+    Attributes: (Do not access them directly, use the methods instead.)
+
+        _attn: torch.Tensor
+        _lse: torch.Tensor . (Its grad is the full LSE to be used by
+            the individual backward passes.)
+        _placeholder: torch.Tensor, whose grad is used for passing the full attention
+            output to the individual backward passes.
+    """
+
+    def __init__(
+        self,
+        attn: torch.Tensor,
+        lse: torch.Tensor,
+        placeholder: torch.Tensor,
+    ) -> None:
+        """
+        Internal use only
+        """
+        self._attn = attn
+        self._lse = lse
+        self._placeholder = placeholder
+
+    def is_bmghk(self) -> bool:
+        return self._attn.ndim == 5
+
+    def apply(self, fn: Callable[[torch.Tensor], torch.Tensor]) -> "Partial":
+        """
+        Applies fn to the attention output, as if we were a tensor.
+        fn must expect tensors of shape BMGHK or BMHK, but cannot actually
+        manipulate the K dimension (because the LSE doesn't have one).
+
+        For example, to slice on the sequence dimension, you might apply
+        `lambda x: x[:, start:end]`.
+        """
+        attn = fn(self._attn)
+        if self.is_bmghk():
+            rearranged = self._lse.permute(0, 3, 1, 2).unsqueeze(-1)
+            lse = fn(rearranged).squeeze(-1).permute(0, 2, 3, 1)
+        else:
+            rearranged = self._lse.permute(0, 2, 1).unsqueeze(-1)
+            lse = fn(rearranged).squeeze(-1).permute(0, 2, 1)
+        placeholder = fn(self._placeholder)
+        return self.__class__(attn, lse, placeholder)
+
+    def _tuple(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return self._attn, self._lse, self._placeholder
+
+
+def memory_efficient_attention_partial_autograd(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Optional[Union[torch.Tensor, fmha.AttentionBias]] = None,
+    p: float = 0.0,
+    scale: Optional[float] = None,
+    *,
+    op: Optional[Union[fmha.AttentionOp, Type[fmha.AttentionFwOpBase]]] = None,
+    output_dtype: Optional[torch.dtype] = None,
+) -> Partial:
+    """
+    Wrapper around `memory_efficient_attention_partial` which works with autograd.
+    Arguments are the same as for `memory_efficient_attention_partial`.
+    """
+    return Partial(
+        *_PartialFunc.apply(query, key, value, attn_bias, p, scale, op, output_dtype)
+    )
+
+
+def merge_attentions_autograd(
+    *partials: Partial,
+) -> torch.Tensor:
+    """
+    Wrapper around merge_attentions which works with autograd.
+    """
+    args = [i for part in partials for i in part._tuple()]
+    if len(args) == 0:
+        raise ValueError("No partials to merge")
+    return _MergeFunc.apply(*args)

--- a/mslk/attention/fmha/split_blocks_fairinternal.py
+++ b/mslk/attention/fmha/split_blocks_fairinternal.py
@@ -1,0 +1,328 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+from typing import List, Optional, Tuple, Union
+
+import torch
+
+from .attn_bias import (
+    _GappySeqInfo,
+    _PaddedSeqLenInfo,
+    _SeqLenInfo,
+    AttentionBias,
+    BlockDiagonalCausalWithOffsetGappyKeysMask,
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    BlockDiagonalGappyKeysMask,
+    BlockDiagonalPaddedKeysMask,
+    PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+    PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+    PagedBlockDiagonalGappyKeysMask,
+    PagedBlockDiagonalPaddedKeysMask,
+)
+
+
+def split_blocks_for_decoding_gpu_part(
+    input_bias: Union[
+        BlockDiagonalPaddedKeysMask, BlockDiagonalCausalWithOffsetPaddedKeysMask
+    ],
+    batchify_len: Optional[int],
+    block_tables: Optional[torch.Tensor] = None,
+    page_size: Optional[int] = None,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+    """
+    This is the gpu part of split_blocks_for_decoding,
+    which can be called in advance.
+    """
+    if batchify_len is None:
+        return None
+    assert batchify_len > 0
+    assert input_bias.q_seqinfo.min_seqlen == input_bias.q_seqinfo.max_seqlen
+
+    seqstart = input_bias.k_seqinfo.seqstart  # (B+1,)
+    seqlen = input_bias.k_seqinfo.seqlen  # (B,)
+
+    # compute raw block boundaries
+    k_ends = seqstart[:-1] + seqlen  # (B,)
+    # For non-speculative decoding, we have a causal bias here,
+    # which will always be from-bottom-right style.
+    # Q and K are aligned so that their last tokens are at the same position.
+    # If seqlen == batchify_len, the first token of the query is at position batchify_len - 1,
+    # and it can attend to all keys from the previous iRoPE chunk.
+    # The diagram shows that when seqlen == batchify_len == N and the bias is causal,
+    # Q can still attend to K from the previous chunk.
+    # -----------iRoPE chunk 0---------|---------iRoPE chunk 1---------------
+    #                             Q[0] |
+    # K[0] K[1] K[2] ... K[N-2] K[N-1] |
+
+    # For speculative decoding, we use this function for the prefix bias only.
+    # We are called with a non-causal bias.
+    # The query is positioned after the keys, and so when seqlen == batchify_len,
+    # the first token of the query is at position batchify_len.
+    # So it can't attend to any key from the previous chunk,
+    # so we want k_starts == k_ends => k_lens == 0.
+    # The diagram shows that when seqlen == batchify_len == N and the bias is non-causal,
+    # Q is located entirely in the next iRoPE chunk and can't attend to K[0] ... K[N-1].
+    # ------------iRoPE chunk 0---------------|---------iRoPE chunk 1---------
+    #                                         | Q[0] Q[1] Q[2]
+    # K[0] K[1] K[2] ... K[N-3] K[N-2] K[N-1] |
+
+    shift = int(isinstance(input_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask))
+    k_starts = (k_ends - shift) // batchify_len * batchify_len
+    k_starts = torch.where(seqlen == 0, k_ends, k_starts)
+    k_lens = k_ends - k_starts
+
+    if block_tables is None:
+        k_seqstarts = torch.cat([k_starts, seqstart[-1:]])
+    else:
+        k_seqstarts = (k_starts - seqstart[:-1]).clamp(min=0)
+        k_lens = k_lens + k_seqstarts
+
+    return k_seqstarts, k_lens
+
+
+def split_blocks_for_decoding(
+    input_bias: Union[
+        BlockDiagonalPaddedKeysMask, BlockDiagonalCausalWithOffsetPaddedKeysMask
+    ],
+    batchify_len: Optional[int],
+    block_tables: Optional[torch.Tensor] = None,
+    page_size: Optional[int] = None,
+    gpu_data: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
+) -> Optional[Union[BlockDiagonalGappyKeysMask, PagedBlockDiagonalGappyKeysMask]]:
+    """
+    For decoding, when query length is 1, we can represent iRoPE-batchified bias as a gappy bias.
+    This function can also be applied for speculative decoding, when query length is > 1,
+    but same across all batch elements. In this case we assume that query (draft) lies entirely
+    in one block/subsequence, not crossing the boundary. Cases when the query crosses the boundary
+    need to be handled separately by the caller.
+    """
+    if batchify_len is None:
+        return None
+    assert batchify_len > 0
+    assert input_bias.q_seqinfo.min_seqlen == input_bias.q_seqinfo.max_seqlen
+
+    if gpu_data is None:
+        gpu_data = split_blocks_for_decoding_gpu_part(
+            input_bias, batchify_len, block_tables, page_size
+        )
+        assert gpu_data is not None
+    k_seqstarts, k_lens = gpu_data
+
+    k_seqstarts_list = []
+    k_seqlens_list = []
+    k_seqlens_list_actual = []
+    B = len(input_bias.k_seqinfo.seqlen_py)
+    # About the shift, see the comment in split_blocks_for_decoding_gpu_part.
+    shift = int(isinstance(input_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask))
+    for i in range(B):
+        input_k_start_ = input_bias.k_seqinfo.seqstart_py[i]
+        input_k_len_ = input_bias.k_seqinfo.seqlen_py[i]
+        input_k_end_ = input_k_start_ + input_k_len_
+        k_seqstart = (input_k_end_ - shift) // batchify_len * batchify_len
+        if input_k_len_ == 0:
+            k_seqstart = input_k_end_
+        k_seqend = min(k_seqstart + batchify_len, input_k_end_)
+        k_len = k_seqend - k_seqstart
+        # NOTE: With chunked, `k_len` cannot exceed the original length `input_k_len_`, so we clamp it here.
+        k_len = min(k_len, input_k_len_)
+
+        if k_seqstart < 0:
+            k_len = k_seqstart = 0
+        k_seqstart = (
+            k_seqstart if block_tables is None else max(k_seqstart - input_k_start_, 0)
+        )
+        k_seqstarts_list.append(k_seqstart)
+        k_seqlens_list_actual.append(k_len)
+        k_seqlens_list.append(k_len if block_tables is None else k_len + k_seqstart)
+
+    OutBiasType = (
+        BlockDiagonalCausalWithOffsetGappyKeysMask
+        if isinstance(input_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+        else BlockDiagonalGappyKeysMask
+    )
+    PagedOutBiasType = (
+        PagedBlockDiagonalCausalWithOffsetGappyKeysMask
+        if isinstance(input_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+        else PagedBlockDiagonalGappyKeysMask
+    )
+    if block_tables is None:
+        k_seqstarts_list.append(input_bias.k_seqinfo.seqstart_py[-1])
+        return OutBiasType(
+            q_seqinfo=input_bias.q_seqinfo,
+            k_seqinfo=_GappySeqInfo(
+                seqstart_py=k_seqstarts_list,
+                seqstart=k_seqstarts,
+                seqlen=k_lens,
+                seqlen_py=k_seqlens_list,
+                min_seqlen=min(k_seqlens_list),
+                max_seqlen=max(k_seqlens_list),
+            ),
+        )
+    assert page_size is not None
+    return PagedOutBiasType(
+        q_seqinfo=input_bias.q_seqinfo,
+        k_seqinfo=_GappySeqInfo(
+            seqstart_py=k_seqstarts_list,
+            seqstart=k_seqstarts,
+            seqlen=k_lens,
+            seqlen_py=k_seqlens_list,
+            min_seqlen=min(k_seqlens_list_actual),
+            max_seqlen=max(k_seqlens_list_actual),
+        ),
+        block_tables=block_tables,
+        page_size=page_size,
+    )
+
+
+def split_blocks_for_prefill(
+    input_bias: BlockDiagonalPaddedKeysMask, batchify_len: Optional[int]
+) -> Optional[BlockDiagonalPaddedKeysMask]:
+    """
+    From
+    https://github.com/fairinternal/llm_inference/blob/11bbb2/llm_inference/models/disagg_transformer.py#L1955
+    """
+    if batchify_len is None:
+        return None
+    padding = input_bias.k_seqinfo.padding
+    assert padding % batchify_len == 0, f"{padding} % {batchify_len} != 0"
+    split_factor = padding // batchify_len
+    batch_size = len(input_bias.q_seqinfo.seqstart_py) - 1
+    new_batch_size = batch_size * split_factor
+    k_seqlen = input_bias.k_seqinfo.seqlen
+    q_seqlen = input_bias.q_seqinfo.seqstart[1:] - input_bias.q_seqinfo.seqstart[:-1]
+    k_seqlen_each = k_seqlen.repeat_interleave(split_factor, output_size=new_batch_size)
+    q_seqlen_each = q_seqlen.repeat_interleave(split_factor, output_size=new_batch_size)
+    res_seqlen_each = k_seqlen_each - q_seqlen_each
+    seqpos = torch.arange(
+        0, padding, batchify_len, device=k_seqlen.device, dtype=k_seqlen.dtype
+    )
+    seqpos_start = seqpos.repeat(batch_size)
+    k_lengths = (k_seqlen_each - seqpos_start).clamp(min=0, max=batchify_len)
+    res_lengths = (res_seqlen_each - seqpos_start).clamp(min=0, max=batchify_len)
+
+    k_seqstart = torch.arange(
+        0,
+        new_batch_size * batchify_len + 1,
+        batchify_len,
+        device=k_seqlen.device,
+        dtype=k_seqlen.dtype,
+    )
+    k_seqstart_py = list(range(0, new_batch_size * batchify_len + 1, batchify_len))
+    q_seqstart = torch.zeros_like(k_seqstart)
+    torch.cumsum(k_lengths - res_lengths, 0, out=q_seqstart[1:])
+
+    # start at 2 to avoid reshaping issues with
+    # https://github.com/Dao-AILab/flash-attention/blob/main/csrc/flash_attn/flash_api.cpp#L602
+    max_q_len = 2
+    min_q_len = 2
+    max_k_len = 0
+    q_seqstart_list: List[int] = [0]
+    k_seqlen_list: List[int] = []
+    for i in range(len(input_bias.k_seqinfo.seqlen)):
+        q_seqlen_ = (
+            input_bias.q_seqinfo.seqstart_py[i + 1]
+            - input_bias.q_seqinfo.seqstart_py[i]
+        )
+        k_seqlen_ = input_bias.k_seqinfo.seqlen_py[i]
+        res_seqlen_ = k_seqlen_ - q_seqlen_
+        for seqpos_ in range(0, padding, batchify_len):
+            k_chunk_size = max(min(k_seqlen_ - seqpos_, batchify_len), 0)
+            res_chunk_size = max(min(res_seqlen_ - seqpos_, batchify_len), 0)
+            q_chunk_size = k_chunk_size - res_chunk_size
+
+            q_seqstart_list.append(q_seqstart_list[-1] + q_chunk_size)
+            k_seqlen_list.append(k_chunk_size)
+            if q_chunk_size > max_q_len:
+                max_q_len = q_chunk_size
+            if q_chunk_size < min_q_len:
+                min_q_len = q_chunk_size
+            if k_chunk_size > max_k_len:
+                max_k_len = k_chunk_size
+
+    batchify_attn_bias = input_bias.__class__(
+        q_seqinfo=_SeqLenInfo(
+            seqstart=q_seqstart,
+            max_seqlen=max_q_len,
+            min_seqlen=min_q_len,
+            seqstart_py=q_seqstart_list,
+        ),
+        k_seqinfo=_PaddedSeqLenInfo(
+            seqstart=k_seqstart,
+            seqlen_py=k_seqlen_list,
+            seqlen=k_lengths,
+            padding=batchify_len,
+            seqstart_py=k_seqstart_py,
+            min_seqlen=0,
+            max_seqlen=max_k_len,
+        ),
+    )
+    return batchify_attn_bias
+
+
+def maybe_make_paged(
+    attn_bias: Optional[
+        Union[
+            BlockDiagonalPaddedKeysMask,
+            BlockDiagonalGappyKeysMask,
+        ]
+    ],
+    block_tables: Optional[torch.Tensor],
+    page_size: int,
+    notional_padding: Optional[int],
+) -> Optional[AttentionBias]:
+    """
+    Convert attention bias into its paged version if block_tables is not None.
+    Args:
+        attn_bias: input attention bias.
+        block_tables: table of shape [batch_size, max_pages_per_lane]
+                        redirecting from logical to physical pages.
+        page_size: number of tokens per page.
+        notional_padding: if input attention bias is gappy, it has
+            no notion of padding, sequence starts are arbitrary.
+            However, we need to know how to divide logical sequence space
+            into lanes corresponding to each row of block tables.
+            In other words, where is 0th block in i-th row of block table
+            located in the logical space?
+            This function assumes that it's located at i * notional_padding.
+            The value of notional_padding needs to be consisted which
+            padding used when block_tables was created.
+            For example, if a gappy bias was created from a padded bias
+            using split_blocks* functions, notional padding
+            should be equal to the padding of the original bias.
+    Returns:
+        Paged version of the original attention bias.
+    """
+    if attn_bias is None:
+        return None
+    if block_tables is None:
+        return attn_bias
+
+    attn_batch_size = len(attn_bias.k_seqinfo.seqlen)
+    if attn_batch_size != block_tables.shape[0]:
+        # In case of iRoPE each batch lane has been split into smaller chunks,
+        # so we need to reshape the block tables accordingly.
+        block_tables = block_tables.view(attn_batch_size, -1)
+    if isinstance(attn_bias, BlockDiagonalGappyKeysMask):
+        assert (
+            notional_padding is not None
+        ), "Notional padding must be specified to create gappy paged biases."
+        return attn_bias.make_paged(
+            block_tables=block_tables,
+            page_size=page_size,
+            notional_padding=notional_padding,
+            paged_type=PagedBlockDiagonalGappyKeysMask,
+        )
+    if isinstance(attn_bias, PagedBlockDiagonalGappyKeysMask):
+        return attn_bias
+    paged_type = (
+        PagedBlockDiagonalCausalWithOffsetPaddedKeysMask
+        if isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+        else PagedBlockDiagonalPaddedKeysMask
+    )
+    assert isinstance(attn_bias, BlockDiagonalPaddedKeysMask)
+    return attn_bias.make_paged(
+        block_tables=block_tables, page_size=page_size, paged_type=paged_type
+    )

--- a/mslk/attention/fmha/torch_attention_compat.py
+++ b/mslk/attention/fmha/torch_attention_compat.py
@@ -1,0 +1,153 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-strict
+
+from typing import Optional
+
+import torch
+from torch._C import parse_schema
+
+
+def is_pt_cutlass_compatible(force: bool = False) -> bool:
+    if torch.version.hip is not None:
+        if force:
+            raise ImportError("CUTLASS is not supported on ROCm")
+        return False
+    compatible = True
+
+    fwd_schema_str = (
+        "aten::_efficient_attention_forward(Tensor query, Tensor key, Tensor value, "
+        "Tensor? bias, Tensor? cu_seqlens_q, Tensor? cu_seqlens_k, SymInt? max_seqlen_q, "
+        "SymInt? max_seqlen_k, float dropout_p, int custom_mask_type, bool compute_log_sumexp=False, *, "
+        "float? scale=None, Tensor? seqlen_k=None, int? window_size=None) -> "
+        "(Tensor output, Tensor logsumexp, Tensor philox_seed, Tensor philox_offset, "
+        "SymInt max_seqlen_batch_q, SymInt max_seqlen_batch_k)"
+    )
+    expected_fwd_schema = parse_schema(fwd_schema_str)
+
+    current_schema = torch.ops.aten._efficient_attention_forward.default._schema
+    if not current_schema.is_backward_compatible_with(expected_fwd_schema):
+        compatible = False
+
+        if force:
+            raise ImportError(
+                f"Current Torch CUTLASS doesnt have a compatible aten::_efficient_attention_forward schema\n"
+                f"EXPECTED:\n{expected_fwd_schema}\n"
+                f"but GOT:\n{current_schema}"
+            )
+
+    bwd_schema_str = (
+        "aten::_efficient_attention_backward(Tensor grad_out_, Tensor query, Tensor key, Tensor value, "
+        "Tensor? bias, Tensor out, Tensor? cu_seqlens_q, Tensor? cu_seqlens_k, SymInt max_seqlen_q, "
+        "SymInt max_seqlen_k, Tensor logsumexp, float dropout_p, Tensor philox_seed, Tensor philox_offset, "
+        "int custom_mask_type, bool bias_requires_grad, *, float? scale=None, int? num_splits_key=None, "
+        "int? window_size=None, bool shared_storage_dqdkdv=False) -> (Tensor, Tensor, Tensor, Tensor)"
+    )
+
+    expected_bwd_schema = parse_schema(bwd_schema_str)
+
+    current_schema = torch.ops.aten._efficient_attention_backward.default._schema
+    if not current_schema.is_backward_compatible_with(expected_bwd_schema):
+        compatible = False
+
+        if force:
+            raise ImportError(
+                f"Current Torch CUTLASS doesnt have a compatible aten::_efficient_attention_backward schema\n"
+                f"EXPECTED:\n{expected_bwd_schema}\n"
+                f"but GOT:\n{current_schema}"
+            )
+
+    return compatible
+
+
+def is_pt_flash_old(force: bool) -> Optional[bool]:
+    """
+    Returns True if the current PyTorch version has the old Flash-Attention
+    ops instead of the new ones.
+    If it has none at all, raises an ImportError or returns None.
+    """
+    if not torch.backends.cuda.is_flash_attention_available():
+        if force:
+            raise ImportError("Flash SDP backend is disabled")
+        return None
+
+    if not hasattr(torch.nn, "attention") or not hasattr(
+        torch.nn.attention, "_get_flash_version"
+    ):
+        if force:
+            raise ImportError(
+                f"Current Torch {torch.__version__} doesnt implement "
+                "torch.nn.attention._get_flash_version()"
+            )
+        return None
+
+    FLASH_VERSION = torch.nn.attention._get_flash_version()
+
+    compatible = True
+
+    # old = before 25/2/2025
+    # https://github.com/pytorch/pytorch/commit/3ecfe6be256c585bcadf4c845d7119545444a222
+    old_fwd_schema_str = (
+        "aten::_flash_attention_forward(Tensor query, Tensor key, Tensor value, "
+        "Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, float dropout_p, "
+        "bool is_causal, bool return_debug_mask, *, float? scale=None, "
+        "SymInt? window_size_left=None, SymInt? window_size_right=None, "
+        "Tensor? seqused_k=None, Tensor? alibi_slopes=None) -> (Tensor output, Tensor softmax_logsumexp, "
+        "Tensor philox_seed, Tensor philox_offset, Tensor debug_attn_mask)"
+    )
+    fwd_schema_str = (
+        "aten::_flash_attention_forward(Tensor query, Tensor key, Tensor value, "
+        "Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, float dropout_p, "
+        "bool is_causal, bool return_debug_mask, *, float? scale=None, "
+        "SymInt? window_size_left=None, SymInt? window_size_right=None, "
+        "Tensor? seqused_k=None, Tensor? alibi_slopes=None) -> (Tensor output, Tensor softmax_logsumexp, "
+        "Tensor rng_state, Tensor unused, Tensor debug_attn_mask)"
+    )
+    expected_fwd_schema = parse_schema(fwd_schema_str)
+    expected_old_fwd_schema = parse_schema(old_fwd_schema_str)
+
+    current_schema = torch.ops.aten._flash_attention_forward.default._schema
+    old = current_schema.is_backward_compatible_with(expected_old_fwd_schema)
+    if not old and not current_schema.is_backward_compatible_with(expected_fwd_schema):
+        compatible = False
+
+        if force:
+            raise ImportError(
+                f"Current Torch with Flash-Attention {FLASH_VERSION} doesnt have "
+                "a compatible aten::_flash_attention_forward schema\n"
+                f"EXPECTED:\n{expected_old_fwd_schema}\n"
+                f"or:\n{expected_fwd_schema}\n"
+                f"but GOT:\n{current_schema}"
+            )
+
+    bwd_schema_old_str = (
+        "aten::_flash_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, "
+        "Tensor out, Tensor logsumexp, Tensor cum_seq_q, Tensor cum_seq_k, SymInt max_q, SymInt max_k, "
+        "float dropout_p, bool is_causal, Tensor philox_seed, Tensor philox_offset, *, float? scale=None, "
+        "SymInt? window_size_left=None, SymInt? window_size_right=None) -> (Tensor, Tensor, Tensor)"
+    )
+    bwd_schema_str = (
+        "aten::_flash_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, "
+        "Tensor out, Tensor logsumexp, Tensor cum_seq_q, Tensor cum_seq_k, SymInt max_q, SymInt max_k, "
+        "float dropout_p, bool is_causal, Tensor rng_state, Tensor unused, *, float? scale=None, "
+        "SymInt? window_size_left=None, SymInt? window_size_right=None) -> (Tensor, Tensor, Tensor)"
+    )
+    expected_bwd_schema = parse_schema(bwd_schema_old_str if old else bwd_schema_str)
+
+    current_schema = torch.ops.aten._flash_attention_backward.default._schema
+    if not current_schema.is_backward_compatible_with(expected_bwd_schema):
+        compatible = False
+
+        if force:
+            raise ImportError(
+                f"Current Torch with Flash-Attention {FLASH_VERSION} doesnt have "
+                "a compatible aten::_flash_attention_backward schema\n"
+                f"EXPECTED:\n{expected_bwd_schema}\n"
+                f"but GOT:\n{current_schema}"
+            )
+
+    if not compatible:
+        return None
+    return old

--- a/mslk/attention/fmha/tree_attention.py
+++ b/mslk/attention/fmha/tree_attention.py
@@ -1,0 +1,718 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-strict
+
+import itertools
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import List, Optional, Sequence, Tuple, Type
+
+import torch
+
+from .. import fmha
+
+from . import (
+    flash,
+    flash3,
+    memory_efficient_attention_forward_requires_grad,
+    memory_efficient_attention_partial,
+    merge_attentions,
+    triton_splitk,
+)
+from .attn_bias import (
+    AttentionBias,
+    PagedBlockDiagonalGappyKeysMask,
+    PagedBlockDiagonalPaddedKeysMask,
+)
+from .common import AttentionFwOpBase, pack_fp8_tensorwise_per_head
+from .dispatch import _get_use_fa3, fa3_available
+
+
+@dataclass
+class TreeAttnMetadata:
+    """
+    tree_choices: definition of the tree, tuples sorted by length, each corresponding
+        to a node. See the docstring of TreeAttnMetadata.from_tree_choices.
+    attention_bias: Medusa-style tree attention bias as an explicit tensor
+        of shape (tree_size, tree_size), where tree_size is the total number
+        of nodes in the tree. It can be used as a spec_attn_bias ("right"
+        or "suffix" attention part) in tree_attention.
+        See tree_attention_with_sync for a usage example.
+    tree_indices: 1D tensor of size tree_size which maps tree nodes to draft tokens.
+        Tree nodes are assumed to be in the same order as in tree_choices
+        (see TreeAttnMetadata.from_tree_choices).
+    retrieval_indices: a tensor of shape (number of leaves, depth + 1), where one
+        row corresponds to one path, and contains indices of the tree nodes
+        on that path. Paths are padded with -1 from the right.
+        The paths (row dim) are unsorted.
+    path_lengths: real lengths for each of the paths.
+    tree_seq_position_ids: 1D tensor of size tree_size which indicates which head
+        a node belongs to. Equivalently, it shows the sequence position of the
+        node within the corresponding path.
+    parent_node_indices: 1D tensor of size tree_size which for each node contains
+        position of its parent + 1. For root node(s) it contains 0.
+    child_node_indices: a tensor of shape (tree_size, max_num_children_per_node),
+        in which each row contains indices of children of the corresponding node.
+        Rows corresponding to nodes which have less than max_num_children_per_node
+        children are padded by repeating the last child index.
+        For leaf nodes the values are meaningless and filled with 0.
+    num_children_per_node: 1D tensor of size tree_size which contains the number of
+        children for each node.
+    candidate_idx: 1D tensor of size tree_size, contains index of each node among its "siblings".
+        Takes values from 0 to the number of children of the parent node minus 1.
+    num_nodes_per_level: 1D tensor of the number of nodes at each level (including root).
+    num_children_per_node_at_level: List of 1D tensors, each containing the number of children at the tree level.
+    subtree_size: List of integers, each containing the number of nodes in the subtree at the tree level.
+    Example:
+        Tree choices
+          `[(0,), (0, 0), (0, 1), (0, 2), (1,), (1, 0), (1, 1), (1, 2), (2,), (2, 0), (2, 1), (2, 2)]`
+        represents a tree that looks like this:
+            0
+            |-- 1
+            |   |-- 4
+            |   |-- 5
+            |   |-- 6
+            |
+            |-- 2
+            |   |-- 7
+            |   |-- 8
+            |   |-- 9
+            |
+            |-- 3
+                |-- 10
+                |-- 11
+                |-- 12
+
+        with TreeAttnMetadata
+            tree_indices=tensor([0, 1, 2, 3, 4, 5, 6, 4, 5, 6, 4, 5, 6])
+            retrieval_indices=tensor([[ 0,  1,  5],
+                                      [ 0,  2,  9],
+                                      [ 0,  3, 11],
+                                      [ 0,  1,  4],
+                                      [ 0,  2,  8],
+                                      [ 0,  3, 10],
+                                      [ 0,  1,  6],
+                                      [ 0,  2,  7],
+                                      [ 0,  3, 12]])
+            path_lengths=[3, 3, 3, 3, 3, 3, 3, 3, 3]
+            tree_seq_position_ids=tensor([0, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2])
+            child_node_indices=tensor([[ 0,  1,  2],
+                                       [ 3,  4,  5],
+                                       [ 6,  7,  8],
+                                       [ 9, 10, 11],
+                                       [ 0,  0,  0],
+                                       ...
+                                       [ 0,  0,  0]])
+            num_children_per_node=tensor([3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+            candidate_idx=tensor([0, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2])
+            num_nodes_per_level=tensor([1, 3, 3])
+            num_children_per_node_at_level=[tensor([3]), tensor([3, 3, 3]), tensor([0, 0, 0, 0, 0, 0, 0, 0, 0])]
+            subtree_sizes=[1, 4, 13]
+    """
+
+    tree_choices: Sequence[Tuple[int, ...]]
+    attention_bias: torch.Tensor
+    tree_indices: torch.Tensor
+    retrieval_indices: torch.Tensor
+    path_lengths: List[int]
+    tree_seq_position_ids: torch.Tensor
+    parent_node_indices: torch.Tensor
+    child_node_indices: torch.Tensor
+    num_children_per_node: torch.Tensor
+    candidate_idx: torch.Tensor
+    num_nodes_per_level: torch.Tensor
+    num_nodes_per_level_cpu: torch.Tensor
+    num_children_per_node_at_level: List[torch.Tensor]
+    num_children_per_node_at_level_cpu: List[torch.Tensor]
+    subtree_sizes: List[int]
+
+    @classmethod
+    @lru_cache
+    def from_tree_choices_cached(
+        cls,
+        tree_choices: Tuple[Tuple[int, ...]],
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
+    ) -> "TreeAttnMetadata":
+        return cls.from_tree_choices(tree_choices, dtype, device)
+
+    @classmethod
+    def from_tree_choices(
+        cls,
+        tree_choices: Sequence[Tuple[int, ...]],
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
+    ) -> "TreeAttnMetadata":
+        """
+        Args:
+            tree_choices: tree description in the style of
+                https://github.com/FasterDecoding/Medusa/blob/5e9805386/medusa/model/medusa_choices.py
+                A typical tree description would look like:
+                [(node0, node1, ...), (node0, node2), (node0, node3), (node1, node3), ..., (node0, node2, ..., nodeN)]
+                Every tuple is corresponds to one node in the tree, encoded as a path from one of the root nodes to the
+                node in question.
+                For example, a node encoded as (1, 0, 3, ..., 2) is understood as:
+                list all the root nodes and take node number 1
+                list all children of that node and take node number 0
+                list all children of that node and take node number 3
+                ...
+                list all children of that node and take node number 2 - that's the node encoded by this tuple.
+
+            dtype: data type of the output mask tensor.
+            device: device of the output tensors.
+        Returns:
+            TreeAttnMetadata object with all the fields.
+        """
+        # from https://github.com/SafeAILab/EAGLE/blob/e98fc7c/model/utils.py#L89C1-L117C1
+        sorted_tree_choices = sorted(tree_choices, key=lambda x: (len(x), x))
+        tree_len = len(sorted_tree_choices) + 1
+
+        depth_counts = _get_depth_counts(sorted_tree_choices)
+        tree_indices = _prepare_tree_indices(sorted_tree_choices, depth_counts, device)
+        retrieval_indices, path_lengths = _prepare_retrieval_indices(
+            sorted_tree_choices, device
+        )
+        tree_seq_position_ids = _prepare_tree_position_ids(
+            depth_counts, tree_len, device
+        )
+        tree_attn_mask = _prepare_tree_attn_bias(
+            sorted_tree_choices, depth_counts, dtype, device
+        )
+        parent_node_indices = _prepare_parent_node_indices(sorted_tree_choices, device)
+        child_node_indices, num_children_per_node = _prepare_child_node_indices(
+            sorted_tree_choices, device
+        )
+        candidate_idx = _prepare_candidate_idx(sorted_tree_choices, device)
+
+        num_nodes_per_level = _get_num_nodes_per_level(depth_counts, device)
+        num_nodes_per_level_cpu = num_nodes_per_level.cpu()
+        (
+            subtree_sizes,
+            num_children_per_node_at_level,
+        ) = _get_subtree_size_and_num_children_per_node_at_level(
+            num_nodes_per_level, num_children_per_node, device
+        )
+        num_children_per_node_at_level_cpu = [
+            row.cpu() for row in num_children_per_node_at_level
+        ]
+        return TreeAttnMetadata(
+            sorted_tree_choices,
+            tree_attn_mask,
+            tree_indices,
+            retrieval_indices,
+            path_lengths,
+            tree_seq_position_ids,
+            parent_node_indices,
+            child_node_indices,
+            num_children_per_node,
+            candidate_idx,
+            num_nodes_per_level,
+            num_nodes_per_level_cpu,
+            num_children_per_node_at_level,
+            num_children_per_node_at_level_cpu,
+            subtree_sizes,
+        )
+
+
+def _get_subtree_size_and_num_children_per_node_at_level(
+    num_nodes_per_level: torch.Tensor,
+    num_children_per_node: torch.Tensor,
+    device: Optional[torch.device] = None,
+) -> Tuple[List[int], List[torch.Tensor]]:
+    depth: int = len(num_nodes_per_level)
+    subtree_sizes: List[int] = [
+        1,
+    ]
+    num_children_per_node_at_level: List[torch.Tensor] = [
+        num_children_per_node[0].unsqueeze(0)
+    ]
+    for i in range(1, depth):
+        subtree_sizes.append(int(torch.sum(num_nodes_per_level[: (i + 1)])))
+        num_children_per_node_at_level.append(
+            num_children_per_node[subtree_sizes[i - 1] : subtree_sizes[i]]
+        )
+    return subtree_sizes, num_children_per_node_at_level
+
+
+def _get_depth_counts(sorted_tree_choices: List[Tuple[int, ...]]) -> List[int]:
+    # Initialize depth_counts to keep track of how many choices have a particular depth
+    depth_counts = []
+    prev_depth = 0
+    for path in sorted_tree_choices:
+        depth = len(path)
+        if depth != prev_depth:
+            depth_counts.append(0)
+        depth_counts[depth - 1] += 1
+        prev_depth = depth
+    return depth_counts
+
+
+def _get_num_nodes_per_level(
+    depth_counts: List[int], device: Optional[torch.device]
+) -> torch.Tensor:
+    depth_counts_tensor: torch.Tensor = torch.tensor([1] + depth_counts, device=device)
+    return depth_counts_tensor[depth_counts_tensor != 0]
+
+
+def _prepare_tree_attn_bias(
+    sorted_tree_choices: List[Tuple[int, ...]],
+    depth_counts: List[int],
+    dtype: Optional[torch.dtype],
+    device: Optional[torch.device],
+) -> torch.Tensor:
+    """
+    Construct a Medusa-style tree attention bias as an explicit tensor.
+    It can be used as a spec_attn_bias ("right" or "suffix" attention part)
+    in tree_attention. See run_tree_attention_inner in test for a usage example.
+    Args:
+        sorted_tree_choices: tree description in the style of
+            https://github.com/FasterDecoding/Medusa/blob/5e9805386/medusa/model/medusa_choices.py
+            A typical tree description would look like:
+            [(node0, node1, ...), (node0, node2), (node0, node3), (node1, node3), ..., (node0, node2, ..., nodeN)]
+            Every tuple is corresponds to one node in the tree, encoded as a path from one of the root nodes to the
+            node in question. Passed in sorted order.
+            For example, a node encoded as (1, 0, 3, ..., 2) is understood as:
+            list all the root nodes and take node number 1
+            list all children of that node and take node number 0
+            list all children of that node and take node number 3
+            ...
+            list all children of that node and take node number 2 - that's the node encoded by this tuple
+        depth_counts: a list of integers, where the i-th element is the number of choices with depth i.
+        dtype: data type of the output tensor.
+        device: device of the output tensor.
+    Returns:
+        attention bias of shape (tree_size, tree_size),
+        where tree_size is the total number of nodes in the tree.
+    """
+    # +1 comes from the addtional root node
+    tree_len = len(sorted_tree_choices) + 1
+    tree_attn_mask = torch.full(
+        (tree_len, tree_len), -torch.inf, device=device, dtype=dtype
+    )
+
+    mask_val = 0
+    for i in range(tree_len):
+        tree_attn_mask[i, i] = mask_val
+
+    tree_attn_mask[:, 0] = mask_val
+    start = 0
+    for i in range(len(depth_counts)):
+        for j in range(depth_counts[i]):
+            cur_tree_choice = sorted_tree_choices[start + j]
+            # retrieve ancestor position
+            if len(cur_tree_choice) == 1:
+                continue
+            ancestor_idx = []
+            for c in range(len(cur_tree_choice) - 1):
+                ancestor_idx.append(
+                    sorted_tree_choices.index(cur_tree_choice[: c + 1]) + 1
+                )
+            tree_attn_mask[j + start + 1, ancestor_idx] = mask_val
+        start += depth_counts[i]
+    return tree_attn_mask
+
+
+def _prepare_tree_indices(
+    sorted_tree_choices: List[Tuple[int, ...]],
+    depth_counts: List[int],
+    device: Optional[torch.device],
+) -> torch.Tensor:
+    """
+    Construct an index tensor for choices in the tree and their corresponding index in the draft tokens.
+    Args:
+        sorted_tree_choices: sorted from tree_choices input of prepare_tree_attn_metadata function
+        depth_counts: a list of integers, where the i-th element is the number of choices with depth i.
+        device: device of the output tensor.
+    Returns:
+        tree indices of shape (tree_len,). See docstring of TreeAttnMetadata for details.
+    """
+    # Generate tree indices for the tree_choices structure
+    # add root node from main head prediction to the tree_len
+    tree_len = len(sorted_tree_choices) + 1
+    tree_indices = torch.zeros(tree_len, device=device, dtype=torch.long)
+    tree_indices[0] = 0
+    start, max_idx_prev_level = 0, 0
+    for i in range(len(depth_counts)):
+        cur_offset = max_idx_prev_level
+        for j in range(depth_counts[i]):
+            cur_tree_choice = sorted_tree_choices[start + j]
+            tree_idx = cur_tree_choice[-1] + cur_offset + 1
+            tree_indices[start + j + 1] = tree_idx
+            max_idx_prev_level = max(tree_idx, max_idx_prev_level)
+        start += depth_counts[i]
+    return tree_indices
+
+
+def _prepare_retrieval_indices(
+    tree_choices: List[Tuple[int, ...]], device: Optional[torch.device]
+) -> Tuple[torch.Tensor, List[int]]:
+    """
+    Convert tree definition from the format used by Medusa and EAGLE (tree_choices, see docstring of
+    TreeAttnMetadata.from_tree_choices) to a list of paths:
+    [
+        (node_index0_path0, node_index1_path0, ...),
+        (node_index0_path1, node_index1_path1, ...),
+        ...
+    ]
+    where each value is an index of a node inside the corresponding level of a tree.
+    Returns:
+        retrieval indices of shape (number of leaves, depth + 1)
+        length of each path.
+    """
+    tree_depth = max(len(node) for node in tree_choices) + 1 if tree_choices else 1
+
+    leaves = set(tree_choices)
+
+    for node in tree_choices[::-1]:
+        if node[:-1] in leaves:
+            leaves.remove(node[:-1])
+
+    paths, path_lengths = [], []
+    for leaf in leaves:
+        path = [0] + [
+            tree_choices.index(leaf[:level]) + 1 for level in range(1, len(leaf) + 1)
+        ]
+        path_lengths.append(len(path))
+        paths.append(path + [-1] * (tree_depth - len(path)))
+    paths_tensor = torch.tensor(paths, dtype=torch.long, device=device)
+    return paths_tensor, path_lengths
+
+
+def _prepare_tree_position_ids(
+    depth_counts: List[int], tree_len: int, device: Optional[torch.device]
+) -> torch.Tensor:
+    """
+    Construct sequence position of each node within its path, can be used for positional embedding.
+    Args:
+        depth_counts: number of nodes at each of the levels of the tree.
+        tree_len: total number of nodes in the tree including the root.
+        device: device of the output tensor.
+    Returns:
+        tree position ids of shape (tree_len,). See docstring of TreeAttnMetadata for details.
+    """
+    tree_position_ids = torch.zeros(tree_len, dtype=torch.int32, device=device)
+    start = 0
+    for i in range(len(depth_counts)):
+        tree_position_ids[start + 1 : start + depth_counts[i] + 1] = i + 1
+        start += depth_counts[i]
+
+    return tree_position_ids
+
+
+def _prepare_parent_node_indices(
+    sorted_tree_choices: List[Tuple[int, ...]], device: Optional[torch.device]
+) -> torch.Tensor:
+    ancestor_idx = []
+    for cur_medusa_choice in sorted_tree_choices:
+        try:
+            ancestor_idx.append(sorted_tree_choices.index(cur_medusa_choice[:-1]) + 1)
+        except ValueError:
+            ancestor_idx.append(0)
+    return torch.tensor(ancestor_idx, dtype=torch.long, device=device)
+
+
+def _prepare_child_node_indices(
+    tree_choices: List[Tuple[int, ...]], device: Optional[torch.device]
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    res = []
+    num_children_per_node = []
+    for x in [()] + tree_choices:
+        curr_children = [
+            i
+            for i, y in enumerate(tree_choices)
+            if len(x) + 1 == len(y) and y[:-1] == x
+        ]
+        num_children_per_node.append(len(curr_children))
+        if curr_children:
+            res.append(curr_children)
+        else:
+            res.append([0])
+
+    # pad all children lists by repeating the last element
+    max_num_children = max(len(x) for x in res)
+    res = [x + x[-1:] * (max_num_children - len(x)) for x in res]
+
+    # Check that all nodes have the same number of children.
+    assert all(len(x) == len(res[0]) for x in res)
+    return (
+        torch.tensor(res, dtype=torch.long, device=device),
+        torch.tensor(num_children_per_node, dtype=torch.long, device=device),
+    )
+
+
+def _prepare_candidate_idx(
+    tree_choices: List[Tuple[int, ...]], device: Optional[torch.device]
+) -> torch.Tensor:
+    candidate_idx = [
+        sum(
+            curr_node[:-1] == another_node[:-1]
+            for another_node in tree_choices[:curr_node_idx]
+        )
+        for curr_node_idx, curr_node in enumerate(tree_choices)
+    ]
+    return torch.tensor(candidate_idx, dtype=torch.long, device=device)
+
+
+def use_triton_splitk_for_prefix(B: int, G: int, tree_size: int) -> bool:
+    """
+    Heuristic to decide whether to use Triton Split-k or default (Flash Attention) for prefix attention.
+    """
+    return (
+        (B * G <= 128 and tree_size <= 64)
+        or (B * G < 4 and tree_size < 100)
+        or B * G < 2
+    )
+
+
+def select_prefix_op(
+    B: int,
+    G: int,
+    tree_size: int,
+    autotune: bool,
+    attn_bias: AttentionBias,
+    kv_cache_dtype: torch.dtype,
+) -> Optional[Type[AttentionFwOpBase]]:
+    """
+    Heuristic to decide whether to use Triton Split-k or default (Flash Attention) for prefix attention.
+    """
+    triton_splitk_op = SplitKAutotune if autotune else triton_splitk.FwOp
+    if torch.version.hip:
+        # TODO: further tune heuristics once CK splitK is ready
+        return triton_splitk_op
+
+    # Triton Split-k is not present in the dispatcher list for some shapes.
+    # However, we need to dispatch to it if no other op is available.
+    # FA3 splitKV doesn't yet support gappy or paged biases.
+    fa3_splitkv_supported = isinstance(
+        attn_bias,
+        flash3.FwOp_KVSplit.SUPPORTED_ATTN_BIAS_TYPES,  # type: ignore
+    )
+    fa3_supported = isinstance(attn_bias, flash3.FwOp.SUPPORTED_ATTN_BIAS_TYPES)  # type: ignore
+    flash2_supported = isinstance(attn_bias, flash.FwOp.SUPPORTED_ATTN_BIAS_TYPES)  # type: ignore
+    if not (fa3_splitkv_supported or fa3_supported or flash2_supported):
+        return triton_splitk_op
+
+    assert torch.version.cuda
+    use_fa3 = _get_use_fa3() and fa3_available()
+    # override heuristics for quantized kv cache for decode
+    if kv_cache_dtype == torch.uint8:
+        return triton_splitk_op
+    # select FA3 when bs >= 64
+    if B >= 64 and use_fa3:
+        if fa3_splitkv_supported:
+            return flash3.FwOp_KVSplit
+        return flash3.FwOp
+    elif use_triton_splitk_for_prefix(B, G, tree_size):
+        return triton_splitk_op
+    else:
+        # use default heuristics from xformers
+        return None
+
+
+def tree_attention(
+    q: torch.Tensor,
+    spec_k: torch.Tensor,
+    spec_v: torch.Tensor,
+    cache_k: torch.Tensor,
+    cache_v: torch.Tensor,
+    spec_attn_bias: torch.Tensor,
+    prefix_attn_bias: AttentionBias,
+    prefix_op: Optional[Type[AttentionFwOpBase]] = None,
+    suffix_op: Optional[Type[AttentionFwOpBase]] = None,
+    autotune: bool = False,
+    quantized_kv_scales: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    q_fp8: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    Compute Medusa/EAGLE/Hydra-style tree attention.
+    Notice that this function takes as arguments biases for the left (prefix)
+    and right (speculative suffix) parts of the attention.
+    This way we avoid creating these biases on the fly, and
+    allow this function to be used in performance-critical decoding
+    jobs, including in CUDA graph mode. In the latter case one should
+    construct the biases once, and update prefix_attn_bias with
+    current seqlens before every graph replay; spec_attn_bias stays static,
+    as it's determined by the tree structure.
+    Args:
+        q: query from speculative tokens, of shape (B, tree_size_q, (G), H, D)
+        spec_k, spec_v: keys/values from speculative tokens, each of shape (B, tree_size_kv, (G), H, D).
+            If tree_size_q < tree_size_kv, we assume the end of the query sequence aligns with end the k/v sequence,
+            like in "from-bottom-right" attention masks. Such rectangular attention masks can be used when we are
+            adding new nodes to the tree, and want to avoid recomputing attention for the existing nodes. For example,
+            this can be used during draft token generation in EAGLE.
+        cache_k/cache_v: queries/keys/values from the existing context, each of shape (B, Mk, (G), H, D)
+        spec_attn_bias: attention bias of the "right" part of the attention (tree_size_q x spec tokens).
+            This would typically be a an explicit tensor mask, precomputed once and not changing during decoding
+        prefix_attn_bias: attention bias of the "left" part of the attention (tree_size_q x existing context).
+            This bias would typically be block-diagonal padded non-causal (BlockDiagonalPaddedKeysMask), and it
+            changes at every decoding step as K/V sequence lengths grow during decoding.
+        prefix_op: attention backend which will be passed to memory_efficient_attention to compute prefix attention.
+                   If None, will use Triton Split-K or Flash Attention depending on the heuristics.
+        suffix_op: same as prefix_op, but for the suffix.
+        autotune: If True, Triton Split-K will use autotuning when chosen
+            as a default backend for prefix/suffix attention.
+    Returns:
+        attention output of shape (B, tree_size_q, (G), H, D)
+
+    :Usage example:
+
+        See also tree_attention_with_sync in tests/test_tree_attention.py
+
+    .. code-block:: python
+
+        # Create an attention bias for the prefix part of the attention
+        prefix_attn_bias = BlockDiagonalPaddedKeysMask.from_seqlens(
+            q_seqlen=[tree_size_q for _ in range(B)], kv_seqlen=kv_lens, kv_padding=Mk
+        )
+        # Create an explit attention bias for the speculative part of the attention
+        spec_attn_bias = TreeAttnMetadata.from_tree_choices(tree_choices, q.dtype, q.device).attention_bias
+        attn_output = tree_attention(
+            q, spec_k, spec_v, cache_k, cache_v, spec_attn_bias, prefix_attn_bias
+        )
+    """
+
+    is_bmhk = q.ndim == 4
+    if is_bmhk:
+        q = q.unsqueeze(2)
+        spec_k, spec_v = spec_k.unsqueeze(2), spec_v.unsqueeze(2)
+        cache_k, cache_v = cache_k.unsqueeze(2), cache_v.unsqueeze(2)
+
+    B, tree_size_q, G, H, D = q.shape
+    Bkv, Mk, G1, H1, D1 = cache_k.shape
+    tree_size_q1, tree_size_kv = spec_attn_bias.shape
+    if isinstance(
+        prefix_attn_bias,
+        (PagedBlockDiagonalPaddedKeysMask, PagedBlockDiagonalGappyKeysMask),
+    ):
+        assert Bkv == 1
+    else:
+        assert Bkv == B
+
+    assert H == H1 and D == D1 and G == G1
+    assert cache_k.shape == cache_v.shape
+    assert (
+        tree_size_q1 == tree_size_q <= tree_size_kv
+    ), f"{tree_size_q1=} {tree_size_q=} {tree_size_kv=}"
+    assert (
+        q.shape[2:] == spec_k.shape[2:] == spec_v.shape[2:]
+    ), f"{q.shape=} {spec_k.shape=} {spec_v.shape=}"
+
+    spec_attn_bias = spec_attn_bias.expand(B, G, H, tree_size_q, tree_size_kv)
+
+    triton_splitk_op = SplitKAutotune if autotune else triton_splitk.FwOp
+
+    # TODO: improve this heuristic
+    if prefix_op is None:
+        prefix_op = select_prefix_op(
+            B, G, tree_size_kv, autotune, prefix_attn_bias, cache_k.dtype
+        )
+    if cache_k.dtype == torch.uint8:
+        assert quantized_kv_scales is not None
+        assert prefix_op is triton_splitk.FwOp
+        fp8_inp = triton_splitk.InputsFp8(
+            query=q.view(1, B * tree_size_q, G, H, D),
+            key=cache_k.view(1, Bkv * Mk, G, H, D).view(torch.int32),
+            value=cache_v.view(1, Bkv * Mk, G, H, D).view(torch.int32),
+            attn_bias=prefix_attn_bias,
+            k_fp8_scale_shift=quantized_kv_scales[0].view(1, Bkv * Mk, G, H),
+            v_fp8_scale_shift=quantized_kv_scales[1].view(1, Bkv * Mk, G, H),
+            is_partial=True,
+        )
+        out, ctx = fmha._memory_efficient_attention_forward_requires_grad(
+            fp8_inp,
+            op=prefix_op,
+        )
+        attn_prefix, lse_prefix = out, ctx.lse
+    elif cache_k.dtype == torch.float8_e4m3fn:
+        assert q_fp8 is not None
+        packed_q = pack_fp8_tensorwise_per_head(
+            q_fp8.view(1, B * tree_size_q, G, H, D),
+            q_fp8.scale,  # type: ignore
+            torch.bfloat16,
+        )
+        packed_k = pack_fp8_tensorwise_per_head(
+            cache_k.view(1, Bkv * Mk, G, H, D), cache_k.scale, torch.bfloat16
+        )
+        packed_v = pack_fp8_tensorwise_per_head(
+            cache_v.view(1, Bkv * Mk, G, H, D), cache_v.scale, torch.bfloat16
+        )
+        attn_prefix, lse_prefix = memory_efficient_attention_partial(
+            packed_q,
+            packed_k,
+            packed_v,
+            attn_bias=prefix_attn_bias,
+            op=fmha.flash3.FwOp_KVSplit,
+        )
+
+    else:
+        attn_prefix, lse_prefix = memory_efficient_attention_partial(
+            q.view(1, B * tree_size_q, G, H, D),
+            cache_k.view(1, Bkv * Mk, G, H, D),
+            cache_v.view(1, Bkv * Mk, G, H, D),
+            attn_bias=prefix_attn_bias,
+            op=prefix_op,
+        )
+    attn_prefix = attn_prefix.view(B, tree_size_q, G, H, D)
+    lse_prefix = lse_prefix.view(G, H, B, tree_size_q).permute(2, 0, 1, 3)
+
+    # attn_suffix ~ (B, tree_size_q, G, H, D)
+    # lse_suffix ~ (B, G, H, tree_size_q)
+    attn_suffix, lse_suffix = memory_efficient_attention_forward_requires_grad(
+        q,
+        spec_k,
+        spec_v,
+        attn_bias=spec_attn_bias,
+        op=suffix_op or triton_splitk_op,
+    )
+
+    # attn_output ~ [B, tree_size_q, G, H, D]
+    # attn input [B, M, G, H, Kq]
+    # lse input [B, G, H, M]
+    attn_output, _ = merge_attentions(
+        [attn_prefix, attn_suffix],
+        [lse_prefix, lse_suffix],
+        output_dtype=q.dtype,
+    )
+
+    if is_bmhk:
+        attn_output = attn_output.squeeze(2)
+    return attn_output
+
+
+class SplitKAutotune(triton_splitk.FwOp):
+    AUTOTUNE = True
+
+
+@lru_cache
+def construct_full_tree_choices(
+    tree_depth: int, branching: int
+) -> List[Tuple[int, ...]]:
+    """
+    Construct a full tree of a given depth where each node (except for leaves) has a given number of children.
+    The format is compatible with that used by Medusa and EAGLE:
+    https://github.com/FasterDecoding/Medusa/blob/5e98053/medusa/model/medusa_choices.py
+    For detailed description, see docstring of
+    xformers.ops.tree_attention.TreeAttnMetadata.from_tree_choices .
+    """
+    return construct_tree_choices(branching=[branching] * tree_depth)
+
+
+def construct_tree_choices(
+    branching: List[int],
+) -> List[Tuple[int, ...]]:
+    """
+    Construct a tree based on given branching factor for each non-root level.
+    """
+    choices: List[Tuple[int, ...]] = []
+    for i in range(len(branching)):
+        choices.extend(itertools.product(*[range(branching[k]) for k in range(i + 1)]))
+    return choices
+
+
+def get_full_tree_size(tree_depth: int, branching: int) -> int:
+    """
+    Number of nodes in a full tree of a given depth (including the root node) and branching factor.
+    """
+    return sum(branching**i for i in range(tree_depth))

--- a/mslk/attention/fmha/triton_splitk.py
+++ b/mslk/attention/fmha/triton_splitk.py
@@ -1,0 +1,1374 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+import functools
+import sys
+from dataclasses import dataclass
+from typing import (
+    Any,
+    cast,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+    Union,
+)
+
+import torch
+
+from ._triton.available import is_triton_available
+from .attn_bias import (
+    BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+    BlockDiagonalCausalWithOffsetGappyKeysMask,
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    BlockDiagonalGappyKeysMask,
+    BlockDiagonalLocalAttentionPaddedKeysMask,
+    BlockDiagonalPaddedKeysMask,
+    PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+    PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+    PagedBlockDiagonalGappyKeysMask,
+    PagedBlockDiagonalPaddedKeysMask,
+)
+from .common import AttentionFwOpBase, check_lastdim_alignment_stride1, Context, Inputs
+from .utils.op_common import register_operator
+
+
+def _strides(x: Optional[torch.Tensor], *stride_names: str):
+    if x is None:
+        return {f"stride_{name}": None for name in stride_names}
+    assert x.ndim == len(stride_names)
+    return {f"stride_{name}": s for name, s in zip(stride_names, x.stride())}
+
+
+def _is_supported_causal_bias(attn_bias: Any) -> bool:
+    return isinstance(
+        attn_bias,
+        (
+            BlockDiagonalCausalWithOffsetPaddedKeysMask,
+            BlockDiagonalCausalWithOffsetGappyKeysMask,
+            BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+            PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+            PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+        ),
+    )
+
+
+def _is_supported_local_bias(attn_bias: Any) -> bool:
+    return isinstance(
+        attn_bias,
+        (
+            BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+            BlockDiagonalLocalAttentionPaddedKeysMask,
+        ),
+    )
+
+
+def _is_supported_gappy_bias(attn_bias: Any) -> bool:
+    return isinstance(
+        attn_bias,
+        (
+            BlockDiagonalGappyKeysMask,
+            PagedBlockDiagonalGappyKeysMask,
+        ),
+    )
+
+
+def _is_supported_paged_bias(attn_bias: Any) -> bool:
+    return isinstance(
+        attn_bias,
+        (
+            PagedBlockDiagonalGappyKeysMask,
+            PagedBlockDiagonalPaddedKeysMask,
+        ),
+    )
+
+
+@dataclass
+class InputsFp8(Inputs):
+    """
+    Each of k/v_fp8_scales is an int32 tensor of shape (1, B * Mkv, Hq),
+    or (1, page_size * max_pages_per_lane, Hq) in the paged case.
+    Each int32 element contains two packed fp16 number
+    - scales and shifts for row-wise FP8 quantization.
+    """
+
+    k_fp8_scale_shift: Optional[torch.Tensor] = None
+    v_fp8_scale_shift: Optional[torch.Tensor] = None
+    q_fp8_scale_shift: Optional[torch.Tensor] = None
+    quantize_pv_to_fp8: bool = False
+    quantize_qk_to_fp8: bool = False
+
+    @property
+    def nbytes(self) -> int:
+        """
+        Number of bytes in the input, not counting the attention bias.
+        """
+        return (
+            super(InputsFp8, self).nbytes
+            + (
+                self.k_fp8_scale_shift.untyped_storage().nbytes()
+                if self.k_fp8_scale_shift is not None
+                else 0
+            )
+            + (
+                self.v_fp8_scale_shift.untyped_storage().nbytes()
+                if self.v_fp8_scale_shift is not None
+                else 0
+            )
+        )
+
+
+if TYPE_CHECKING or is_triton_available():
+    from ._triton.splitk_kernels import _fwd_kernel_splitK, _splitK_reduce
+else:
+    _fwd_kernel_splitK = None
+    _splitK_reduce = None
+
+
+def _is_cuda() -> bool:
+    return torch.version.cuda is not None
+
+
+def _is_cuda_at_least_sm80(device: torch.device) -> bool:
+    return _is_cuda() and torch.cuda.get_device_capability(device) >= (
+        8,
+        0,
+    )
+
+
+@register_operator
+class FwOp(AttentionFwOpBase):
+    """Flash-Attention with Split-K. Supports fused int4 and fp8 K/V quantization.
+    Quantized path will be taken if input K/V have type int32.
+
+    Int4 quantization can be row-wise or group-wise (when cls.NUM_GROUPS > 1) along
+    the last dimension of K and V. Currently 1, 2, 4, or 8 groups per row are supported.
+    Quantization coefficients (scale and shift) are represented as two
+    float16 constants per group, packed into int32. Quantization coefficients of
+    all groups are placed at the beginning of the row. So, if unquantized K/V have head
+    dimension D, the quantized versions have head dimension D // 8 + NUM_GROUPS
+    and dtype int32.
+    Pseudocode for dequantizing one row can look like:
+    group_size = D // 8
+    for i in range(NUM_GROUPS):
+        group_start = NUM_GROUPS + i * group_size
+        group_quant = K[..., group_start: group_start + group_size]
+        scale, shift = unpack_int32_into_float16x2(group_quant[0])
+        group_dequant = group_quant[..., 1:] * scale + shift
+    ...
+
+    For fp8 only row-wise quantization is supported. To use it, provide input of type
+    xformers.ops.fmha.triton_splitk.InputsFp8 (instead of the usual xformers.ops.fmha.Inputs) to
+    xformers.ops.fmha.triton_splitk.FwOp.apply or xformers.ops.fmha._memory_efficient_attention_forward.
+
+    This op uses Paged Attention when bias is one of the Paged* classes.
+    In this case bias has additional fields:
+    - block_tables of shape [batch_size, max_num_pages]
+    - K/V of shape [1, max_num_pages * page_size, num_heads, head_dim]
+      or [1, max_num_pages * page_size, num_groups, num_heads, head_dim]
+
+    The shape which the kernel takes the queries and the output
+    is quite different from the user interface. There are three
+    types of input (a) no bias / tensor bias, (b) variable q_len
+    (which is only for non causal) and (c) other bias objects.
+    From the interface to the kernel the following changes happen.
+
+    (0) In all cases, a group dimension may need to be added.
+
+    (1) For (c), a batch dimension is created, reshaping from (1, B*Mq, G, Hq, K)
+        to (B, Mq, G, Hq, K)
+
+    (2) For (a) and (c), in the case of multiquery (i.e. the head dimension
+        of keys and values is expanded), the head-swapping trick
+        reshaping from (B, Mq, G, Hq, K) to (B, M=Hq*Mq, G, H=1, K)
+
+    (3) For (b), in the case of multiquery, the head-swapping trick
+        trick, reshaping from (1, Mq, G, Hq, K) to (1, Mq*Hq, G, H=1, K)
+        Note here that Mq is a single long dimension which spans all the queries
+        in the batch, unlike in case (C). Also that Hq has to run faster than
+        Mq in order that the queries in a batch element remain evenly spaced.
+
+    In all cases, the shape as seen by the kernel is called (Bqq, Mqq, G, H, K).
+    The kernel operates on B batch elements and M queries per batch element.
+    """
+
+    OPERATOR = True
+    SUPPORTED_DEVICES = {"cuda"}
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (8, 0)
+    SUPPORTED_DTYPES = {
+        torch.half,
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+    }  # Those are dtypes of Q. In the quantized case K/V has dtype int32
+    SUPPORTED_MAX_K = 512
+    SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
+        type(None),
+        torch.Tensor,
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+        BlockDiagonalLocalAttentionPaddedKeysMask,
+        BlockDiagonalGappyKeysMask,
+        BlockDiagonalCausalWithOffsetGappyKeysMask,
+        BlockDiagonalPaddedKeysMask,
+        PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+        PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+        PagedBlockDiagonalGappyKeysMask,
+        PagedBlockDiagonalPaddedKeysMask,
+    )
+    SUPPORTS_DROPOUT = False
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_BMGHK = True
+    SUPPORTS_OUTPUT_DTYPE = True
+    SUPPORTS_PARTIAL = True
+    NAME = "triton_splitKF"
+
+    SPLIT_K: Optional[int] = None
+    MAX_BLOCK_M = 32
+
+    # Whether blocks attending to no part of a variable sequence length
+    # should exit early. This requires extra kernels to run beforehand
+    # to initialise the outputs.
+    # TODO: avoid these by making the reduce kernel work out it doesn't need
+    # to look at the irrelevant places.
+    SPLIT_K_EARLY_EXIT: bool = False
+
+    # Perform kernel-level Triton autotune
+    AUTOTUNE = False
+
+    NUM_GROUPS = 1  # Default quantization is row-wise
+    NUM_GROUPS_VALUES = [1, 2, 4, 8]
+
+    # Values below are used when autotune=False.
+    # Note that under certain conditions different values might be used, see the code just before the kernel launch.
+    BLOCK_M: int = 16  # When M > 1, different BLOCK_M can be used.
+    BLOCK_N: int = 64
+    # On AMD or for M > 1 different NUM_STAGES and NUM_WARPS can be used.
+    NUM_STAGES: int = 1
+    NUM_WARPS: int = 2
+
+    @classmethod
+    def shape_not_supported_reasons(
+        cls, Mq: int, Mkv: int, K: int, Kv: int
+    ) -> List[str]:
+        reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+        if K not in {16, 32, 64, 128, 256, 512}:
+            reasons.append(f"Embed dim {K} not supported")
+        return reasons
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:  # noqa: C901
+        reasons = super(FwOp, cls).not_supported_reasons(d)
+        if (sys.version_info.major, sys.version_info.minor) < (3, 9):
+            reasons.append("triton_splitk requires python 3.9 or above!")
+        check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+        if d.key.dtype != torch.int32:
+            check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
+            check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
+        if cls.OPERATOR is None:
+            reasons.append("triton is not available")
+        if d.device.type == "cuda":
+            # Has only been tested on 8.0 / 9.0.
+            if _is_cuda() and not _is_cuda_at_least_sm80(d.device):
+                reasons.append(
+                    "requires NVidia GPU with sm80 minimum compute capacity, e.g., A100/H100/L4"
+                )
+            # TODO: AMD GPU support matrix needs to be figured out. MI300X is tested to work.
+
+        q_len = d.query.shape[1]
+        is_block_diagonal = isinstance(
+            d.attn_bias, (BlockDiagonalPaddedKeysMask, BlockDiagonalGappyKeysMask)
+        )
+        is_paged = _is_supported_paged_bias(d.attn_bias)
+        is_causal = _is_supported_causal_bias(d.attn_bias)
+        is_local = _is_supported_local_bias(d.attn_bias)
+        if is_block_diagonal or is_paged:
+            seqinfo = d.attn_bias.q_seqinfo  # type: ignore
+            if q_len != seqinfo.seqstart_py[-1]:
+                reasons.append(
+                    f"Expected total {seqinfo.seqstart_py[-1]} queries not {q_len}"
+                )
+            q_len = seqinfo.max_seqlen
+            if is_causal and q_len != seqinfo.min_seqlen:
+                reasons.append(
+                    f"Variable query len is not supported for causal masks: got {seqinfo.max_seqlen=} {seqinfo.min_seqlen=}."
+                )
+            elif is_local and q_len != seqinfo.min_seqlen:
+                reasons.append(
+                    f"Variable query len is not supported for local masks: got {seqinfo.max_seqlen=} {seqinfo.min_seqlen=}."
+                )
+        if q_len > 16 and (is_causal or is_local):
+            # 16 is the minimum BLOCK_M which gets used
+            # XXX I don't really understand why this is needed.
+            reasons.append(
+                "Query length should not be larger than 16 for causal or local attention biases"
+            )
+
+        if is_paged:
+            page_size = d.attn_bias.page_size  # type: ignore
+            if d.key.shape[1] % page_size:
+                reasons.append(
+                    "For paged attention, key.shape[1] should be divisible "
+                    "by the page size, "
+                    f"but got {d.key.shape[1]=}, {page_size=}."
+                )
+            if page_size % cls.BLOCK_N:
+                reasons.append(
+                    "For paged attention, page size should be divisible "
+                    "by the block size, "
+                    f"but got {page_size=}, {cls.BLOCK_N=}."
+                )
+
+        if isinstance(d.attn_bias, torch.Tensor):
+            if d.attn_bias.ndim not in (4, 5):
+                reasons.append(
+                    "Additive attention bias has to have shape (B, G, H, Mq, Mkv) "
+                    f"or (B, H, Mq, Mkv), but got {d.attn_bias.shape}."
+                )
+            if cls.SPLIT_K is not None and cls.SPLIT_K > 1:
+                reasons.append(
+                    "Additive attention bias is not supported with split-k > 1."
+                )
+
+        return reasons
+
+    @classmethod
+    def get_split_k(
+        cls, B: int, G: int, H: int, Mk: int, Mq: int, page_size: int, is_paged=False
+    ) -> int:
+        """Heuristic for the number of splits"""
+        bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
+        if torch.version.hip:
+            split_k = max(Mk + bh - 1, 1024) // bh
+            max_chunk_size = 64
+            split_k_stop_val = max(1024 / (B * G * H), 1)
+            while split_k > 1 and Mk / (split_k - 1) < max_chunk_size:
+                split_k = split_k - 1
+
+            while split_k > split_k_stop_val:
+                split_k = split_k // 2
+
+            split_size = (Mk + split_k - 1) // max(split_k, 1)
+
+            chunk_size = split_size // max_chunk_size * max_chunk_size
+            if chunk_size < split_size:
+                split_k += 1
+
+            split_k_upper_bound = 512
+        else:
+            if Mq > 1 and B * G * H > 64:
+                return 1
+            split_k = max(Mk, 1024) // bh
+            max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128
+            split_k_stop_val = Mk / max_chunk_size
+            split_k_upper_bound = 64
+
+            while split_k > split_k_stop_val:
+                split_k = split_k // 2
+
+        split_k = min(split_k, split_k_upper_bound)
+        split_k = max(split_k, 1)
+
+        # makes no sense that split_size is larger than page_size
+        if is_paged and torch.version.hip:
+            split_size = (Mk + split_k - 1) // split_k
+            if split_size > page_size:
+                split_size = page_size
+                split_k = (Mk + split_size - 1) // split_size
+
+        return split_k
+
+    @classmethod
+    def get_kernel(cls):
+        from ._triton.splitk_kernels import (
+            _fwd_kernel_splitK_autotune,
+            _get_splitk_kernel,
+        )
+
+        if cls.AUTOTUNE:
+            return _fwd_kernel_splitK_autotune[cls.NUM_GROUPS]
+        else:
+            return _get_splitk_kernel(cls.NUM_GROUPS)
+
+    @classmethod
+    def get_fp8_scale_shift(
+        cls, inp: Inputs
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+        if not hasattr(inp, "k_fp8_scale_shift"):
+            return None, None, None
+        inp_ = cast(InputsFp8, inp)
+        k_fp8_scale_shift = inp_.k_fp8_scale_shift
+        v_fp8_scale_shift = inp_.v_fp8_scale_shift
+        q_fp8_scale_shift = inp_.q_fp8_scale_shift
+
+        assert k_fp8_scale_shift is not None
+        assert v_fp8_scale_shift is not None
+        if k_fp8_scale_shift.ndim == 3:
+            k_fp8 = k_fp8_scale_shift.unsqueeze(2)
+            v_fp8 = v_fp8_scale_shift.unsqueeze(2)
+            q_fp8 = (
+                None if q_fp8_scale_shift is None else q_fp8_scale_shift.unsqueeze(2)
+            )
+            return k_fp8, v_fp8, q_fp8
+        if k_fp8_scale_shift.ndim == 4:
+            return k_fp8_scale_shift, v_fp8_scale_shift, q_fp8_scale_shift
+        raise ValueError(
+            "FP8 scales have to be provided in BMH or BMGH format, "
+            f"but got {k_fp8_scale_shift.shape=}"
+        )
+
+    @classmethod
+    def get_extra_args(  # noqa: C901
+        cls,
+        *,
+        is_paged: bool,
+        B: int,
+        M: int,
+        Kkv: int,
+        Kq: int,
+        Mq: int,
+        split_k: int,
+        attn_bias: Any,
+        k_fp8_scale_shift: Any,
+    ) -> Dict[str, Any]:
+        BLOCK_M = cls.BLOCK_M
+        BLOCK_N = cls.BLOCK_N
+        if cls.AUTOTUNE:
+            extra_args = {}
+        else:
+            # TODO: remove this when autotuning on AMD is working
+            num_warps = cls.NUM_WARPS
+            num_stages = cls.NUM_STAGES
+            if torch.version.hip and attn_bias is not None:
+                # TODO: Double check paged.
+                mkv = attn_bias.k_seqinfo.max_seqlen
+                # TODO: Determine heuristics for paged attention
+                use_fp8_path = k_fp8_scale_shift is not None
+                if B == 1:
+                    if use_fp8_path:
+                        # Use specialized configs for FP8
+                        if mkv <= 256:
+                            BLOCK_N = 16
+                            num_warps = 4
+                            num_stages = 1
+                        elif mkv <= 2048:
+                            BLOCK_N = 32
+                            num_warps = 4
+                            num_stages = 1
+                        elif mkv <= 16384:
+                            BLOCK_N = 64
+                            num_warps = 4
+                            num_stages = 1
+                        elif mkv >= 131072:
+                            BLOCK_N = 128
+                            num_warps = 2
+                            num_stages = 1
+                        else:
+                            # Note: We don't have data for when transitioning num_wraps works well
+                            BLOCK_N = 64
+                            num_warps = 4
+                            num_stages = 1
+                    else:
+                        num_warps = 4
+                        num_stages = 1  # TODO num_stages = 0 gives better perf on AMD, but sometimes produces NaNs
+                        BLOCK_N = 32
+                elif B <= 4 and split_k <= 128:
+                    num_warps = 2
+                    num_stages = 1
+                    BLOCK_N = 32
+                elif B <= 16:
+                    if use_fp8_path:
+                        if mkv <= 256:
+                            BLOCK_N = 16
+                            num_warps = 4
+                            num_stages = 1
+                        elif mkv <= 4096:
+                            BLOCK_N = 32
+                            num_warps = 4
+                            num_stages = 1
+                        elif mkv <= 8192:
+                            BLOCK_N = 16
+                            num_warps = 2
+                            num_stages = 1
+                        elif mkv < 131072:
+                            # Note: This isn't benchmarked, but fp8 seems to scale well.
+                            BLOCK_N = 64
+                            num_warps = 1
+                            num_stages = 1
+                        else:
+                            BLOCK_N = 128
+                            num_warps = 1
+                            num_stages = 1
+                    else:
+                        if M < 16:
+                            num_warps = 2
+                            num_stages = 1
+                        else:
+                            num_warps = 1
+                            num_stages = 1
+                        BLOCK_N = 32
+                elif B <= 64 and use_fp8_path:
+                    if is_paged:
+                        num_stages = 1
+                        if mkv <= 256:
+                            BLOCK_N = 64
+                            num_warps = 8
+                        elif mkv <= 8192:
+                            BLOCK_N = 64
+                            num_warps = 1
+                        elif mkv <= 16384:
+                            BLOCK_N = 128
+                            num_warps = 2
+                        else:
+                            # Note: This isn't benchmarked, but fp8 seems to scale well.
+                            BLOCK_N = 128
+                            num_warps = 1
+                    else:
+                        if mkv <= 256:
+                            BLOCK_N = 16
+                            num_warps = 4
+                            num_stages = 1
+                        elif mkv < 131072:
+                            # Note: This isn't benchmarked, but fp8 seems to scale well.
+                            BLOCK_N = 64
+                            num_warps = 1
+                            num_stages = 1
+                        else:
+                            BLOCK_N = 128
+                            num_warps = 1
+                            num_stages = 1
+                elif B <= 128 and use_fp8_path:
+                    num_stages = 1
+                    if is_paged:
+                        if mkv <= 256:
+                            num_warps = 4
+                            BLOCK_N = 16
+                        elif mkv <= 2048:
+                            num_warps = 1
+                            BLOCK_N = 64
+                        elif mkv < 131072:
+                            num_warps = 2
+                            BLOCK_N = 128
+                        else:
+                            # Note: This isn't benchmarked, but fp8 seems to scale well.
+                            num_warps = 1
+                            BLOCK_N = 128
+                    else:
+                        if mkv <= 128:
+                            num_warps = 4
+                            BLOCK_N = 16
+                        else:
+                            num_warps = 1
+                            BLOCK_N = 64
+                elif B <= 256 and use_fp8_path:
+                    num_stages = 1
+                    if is_paged:
+                        if mkv <= 2048:
+                            num_warps = 1
+                            BLOCK_N = 64
+                        elif mkv < 131072:
+                            num_warps = 2
+                            BLOCK_N = 128
+                        else:
+                            # Note: This isn't benchmarked, but fp8 seems to scale well.
+                            num_warps = 1
+                            BLOCK_N = 128
+                    else:
+                        if mkv <= 256:
+                            num_warps = 2
+                            BLOCK_N = 32
+                        else:
+                            num_warps = 1
+                            BLOCK_N = 64
+                else:
+                    num_warps = 1
+                    num_stages = 1
+                    BLOCK_N = 64
+            else:
+                should_modify_warp_and_block = (
+                    Kkv == 128
+                    and Kq == 128
+                    and torch.cuda.get_device_capability() >= (8, 9)
+                )
+                if should_modify_warp_and_block:
+                    if Mq > 1:
+                        num_warps = 4
+                    # Choose minimal round block size which covers M.
+                    if M > 16:
+                        BLOCK_M = 32
+                    if M > 32:
+                        BLOCK_M = 64
+                    if M > 64:
+                        BLOCK_M = 128
+            extra_args = {
+                "BLOCK_M": BLOCK_M,
+                "BLOCK_N": BLOCK_N,
+                "num_warps": num_warps,
+                "num_stages": num_stages,
+            }
+        return extra_args
+
+    @classmethod
+    def apply(  # noqa: C901
+        cls,
+        inp: Inputs,
+        needs_gradient: bool,
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        """
+        Note that inp can be of type InputsFp8, in which case K/V are assumed to be row-wise FP8-quantized.
+        This is different from int4 quantization, where coefficients are kept together with the quantized
+        values at the beginning of each row, and inp has type Inputs.
+        """
+
+        output_dtype = inp.get_output_dtype()
+        # LSE may need higher precision than output
+        output_f64_lse = output_dtype in (torch.float32, torch.float64)
+        lse_dtype = torch.float64 if output_f64_lse else torch.float32
+
+        if inp.query.numel() == 0 or inp.key.numel() == 0:
+            out = torch.zeros_like(inp.query)
+            if needs_gradient:
+                lse_out = torch.full(
+                    (inp.query.shape[0],)
+                    + inp.query.shape[2:-1]
+                    + (inp.query.shape[1],),
+                    float("-inf"),
+                    device=inp.query.device,
+                    dtype=lse_dtype,
+                )
+                return out, Context(out=out, lse=lse_out)
+            return out, None
+
+        # Assert that if quantize_qk_to_fp8 is True, q_fp8_scale_shift must be provided
+        if hasattr(inp, "quantize_qk_to_fp8") and getattr(
+            inp, "quantize_qk_to_fp8", False
+        ):
+            assert (
+                hasattr(inp, "q_fp8_scale_shift") and inp.q_fp8_scale_shift is not None  # type: ignore
+            ), "q_fp8_scale_shift must be provided when quantize_qk_to_fp8 is True"
+
+        k_fp8_scale_shift, v_fp8_scale_shift, q_fp8_scale_shift = (
+            cls.get_fp8_scale_shift(inp)
+        )
+
+        if not isinstance(inp.attn_bias, torch.Tensor):
+            attn_bias_tensor = None
+            attn_bias = cast(
+                Optional[
+                    Union[
+                        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+                        BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+                        BlockDiagonalLocalAttentionPaddedKeysMask,
+                        BlockDiagonalGappyKeysMask,
+                        BlockDiagonalCausalWithOffsetGappyKeysMask,
+                        BlockDiagonalPaddedKeysMask,
+                        PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+                        PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+                        PagedBlockDiagonalGappyKeysMask,
+                        PagedBlockDiagonalPaddedKeysMask,
+                    ]
+                ],
+                inp.attn_bias,
+            )
+        else:
+            attn_bias_tensor = inp.attn_bias
+            attn_bias = None
+
+        seq_len = None
+        seq_starts_k = None
+        seq_starts_q = None
+        seq_starts_q_multiplier = None
+        q, k, v = inp.get_qkv_in_bmghk()
+        IS_CAUSAL = False
+        IS_LOCAL = False
+        NUM_QUERIES_CAUSAL = 1
+        variable_q = False
+        window_left = -1
+        window_right = -1
+
+        is_block_diagonal = isinstance(attn_bias, BlockDiagonalPaddedKeysMask)
+        is_gappy = _is_supported_gappy_bias(attn_bias)
+        is_paged = _is_supported_paged_bias(attn_bias)
+        if attn_bias is not None:
+            assert is_paged or is_block_diagonal or is_gappy
+            assert attn_bias.k_seqinfo.seqlen.device == inp.query.device
+            seq_len = attn_bias.k_seqinfo.seqlen
+            assert seq_len.stride(0) == 1
+            if is_gappy:
+                seq_starts_k = attn_bias.k_seqinfo.seqstart
+                assert seq_starts_k.stride(0) == 1
+            assert q.shape[0] == 1
+            B = len(seq_len)
+            G, Hq, Kq = q.shape[-3:]
+            # force a bool because triton cannot take np.bool_
+            multiple_q = bool(attn_bias.q_seqinfo.max_seqlen > 1)
+            IS_CAUSAL = multiple_q and _is_supported_causal_bias(attn_bias)
+            IS_LOCAL = _is_supported_local_bias(attn_bias)
+            variable_q = multiple_q and not IS_CAUSAL
+            Kkv = v.shape[-1]
+            if isinstance(attn_bias, BlockDiagonalLocalAttentionPaddedKeysMask):
+                window_left = attn_bias.window_left
+                window_right = attn_bias.window_right
+            elif isinstance(attn_bias, BlockDiagonalCausalLocalAttentionPaddedKeysMask):
+                window_left = attn_bias._window_size - 1
+
+            if variable_q:
+                seq_starts_q = attn_bias.q_seqinfo.seqstart
+                seq_starts_q_multiplier = 1
+                assert seq_starts_q.stride(0) == 1
+            else:
+                q = q.view(B, -1, G, Hq, Kq)
+                if q_fp8_scale_shift is not None:
+                    q_fp8_scale_shift = q_fp8_scale_shift.view(B, -1, G, Hq)
+
+            kv_shape = (1 if is_paged or is_gappy else B, -1, G, Hq, Kkv)
+            k = k.view(kv_shape)
+            v = v.view(kv_shape)
+            if k_fp8_scale_shift is not None and v_fp8_scale_shift is not None:
+                k_fp8_scale_shift = k_fp8_scale_shift.view(kv_shape[:-1])
+                v_fp8_scale_shift = v_fp8_scale_shift.view(kv_shape[:-1])
+
+            Mq = q.shape[1]
+            NUM_QUERIES_CAUSAL = Mq
+        else:
+            B, Mq, G, Hq, Kq = q.shape
+
+        if attn_bias_tensor is not None and attn_bias_tensor.ndim == 4:
+            # (B, H, Mq, Mkv) -> (B, G, H, Mq, Mkv)
+            attn_bias_tensor = attn_bias_tensor.unsqueeze(1)
+
+        # In the case of MQA/GQA, we make q have sequence length (H * Mq) and only one "head".
+        mqa_swap_seqlen_head = False
+        if (
+            k.shape[3] > 1
+            and k.stride(3) == 0
+            and v.stride(3) == 0
+            and attn_bias_tensor is None
+        ):
+            mqa_swap_seqlen_head = True
+            if q_fp8_scale_shift is not None:
+                assert (
+                    q_fp8_scale_shift.shape == q.shape[:-1]
+                ), f"{q.shape=}, {q_fp8_scale_shift.shape=}"
+                if variable_q:
+                    q_fp8_scale_shift = q_fp8_scale_shift.permute(0, 1, 3, 2).reshape(
+                        1, -1, G, 1
+                    )
+                else:
+                    q_fp8_scale_shift = q_fp8_scale_shift.permute(0, 3, 1, 2).reshape(
+                        q.shape[0], -1, G, 1
+                    )
+            if variable_q:
+                seq_starts_q_multiplier = Hq
+                assert q.shape[0] == 1
+                # The idea is Hq,Mq are reshaped to (M=Mq*Hq, H=1)
+                q = q.permute(0, 1, 3, 2, 4).reshape(1, -1, G, 1, Kq)
+            else:
+                # This is a copy iff Mq, G and H are all > 1.
+                # The idea is Hq,Mq are reshaped to (M=Hq*Mq, H=1)
+                q = q.permute(0, 3, 1, 2, 4).reshape(q.shape[0], -1, G, 1, Kq)
+            k = k[:, :, :, :1]
+            v = v[:, :, :, :1]
+            if k_fp8_scale_shift is not None and v_fp8_scale_shift is not None:
+                k_fp8_scale_shift = k_fp8_scale_shift[:, :, :, :1]
+                v_fp8_scale_shift = v_fp8_scale_shift[:, :, :, :1]
+
+        if k.dtype == torch.int32:
+            if k_fp8_scale_shift is not None:
+                Lk = k.shape[-1] * 4
+                PACKED_PER_VAL = 4
+            else:
+                # Quantized K/V
+                PACKED_PER_VAL = 8
+                Lk = (k.shape[-1] - cls.NUM_GROUPS) * 8
+        else:
+            Lk = k.shape[-1]
+            PACKED_PER_VAL = 1
+            assert cls.NUM_GROUPS == 1, f"{cls.NUM_GROUPS=}"
+
+        _, Mk, G, H, Kkv = k.shape
+        Bqq, Mqq, G, H, Kq = q.shape
+        assert Lk == Kq, f"Keys have head dim {Lk} but queries have head dim {Kq}"
+        if variable_q:
+            assert attn_bias is not None
+            assert seq_starts_q_multiplier is not None
+            M = attn_bias.q_seqinfo.max_seqlen * seq_starts_q_multiplier
+        else:
+            M = Mqq
+        page_size = inp.attn_bias.page_size if is_paged else 0  # type: ignore
+        block_tables = None
+        kv_cache_blocks_per_row = 0
+        if is_paged:
+            block_tables = inp.attn_bias.block_tables  # type: ignore
+            kv_cache_blocks_per_row = block_tables.shape[1]
+            Mk = block_tables.shape[1] * page_size
+        elif attn_bias is not None:
+            Mk = min(Mk, attn_bias.k_seqinfo.max_seqlen)
+
+        if cls.SPLIT_K is not None:
+            split_k = cls.SPLIT_K
+        else:
+            # Use heuristics
+            split_k = (
+                cls.get_split_k(B, G, H, Mk, Mq, page_size, is_paged)
+                if attn_bias_tensor is None
+                else 1
+            )
+
+        # M_ceil = Mqq rounded up to a multiple of MAX_BLOCK_M
+        M_ceil = (Mqq + cls.MAX_BLOCK_M - 1) // cls.MAX_BLOCK_M * cls.MAX_BLOCK_M
+        IS_SPLITK = split_k > 1  # or cls.autotune?
+        output_shape = (Bqq, Mq, G, Hq, Kq)
+        if IS_SPLITK:
+            o_splitk_dtype = (
+                torch.float64 if output_dtype == torch.float64 else torch.float32
+            )
+            if cls.SPLIT_K_EARLY_EXIT:
+                o_splitk = torch.zeros(
+                    [Bqq, G, H, split_k, M_ceil, Kq],
+                    dtype=o_splitk_dtype,
+                    device=q.device,
+                )
+            else:
+                o_splitk = torch.empty(
+                    [Bqq, G, H, split_k, M_ceil, Kq],
+                    dtype=o_splitk_dtype,
+                    device=q.device,
+                )
+        else:
+            o_splitk = torch.empty(
+                [Bqq, split_k, Mqq, G, H, Kq],
+                dtype=output_dtype,
+                device=q.device,
+            ).permute(0, 3, 4, 1, 2, 5)
+        lse, lse_splitk = None, None
+        if IS_SPLITK or needs_gradient:
+            if IS_SPLITK or output_f64_lse:
+                lse_splitk_dtype = torch.float64
+            else:
+                lse_splitk_dtype = torch.float32
+            if cls.SPLIT_K_EARLY_EXIT:
+                lse_splitk = torch.full(
+                    [Bqq, G, H, split_k, Mqq],
+                    -float("inf"),
+                    dtype=lse_splitk_dtype,
+                    device=q.device,
+                )
+            else:
+                lse_splitk = torch.empty(
+                    [Bqq, G, H, split_k, Mqq],
+                    dtype=lse_splitk_dtype,
+                    device=q.device,
+                )
+
+        def grid(META):
+            import triton
+
+            return triton.cdiv(M, META["BLOCK_M"]), B * G * H, split_k
+
+        split_size = (Mk + split_k - 1) // split_k
+        use_seq_len = seq_len is not None
+
+        kernel = cls.get_kernel()
+        extra_args = cls.get_extra_args(
+            is_paged=is_paged,
+            B=B,
+            M=M,
+            Kkv=Kkv,
+            Kq=Kq,
+            Mq=Mq,
+            split_k=split_k,
+            attn_bias=attn_bias,
+            k_fp8_scale_shift=k_fp8_scale_shift,
+        )
+
+        IS_HIP = torch.version.hip is not None
+
+        if inp.quantize_pv_to_fp8:
+            v = v.view(torch.int8)
+            v = v.view(torch.float8_e4m3fn)
+
+        kernel[grid](
+            Q=q,
+            K=k,
+            V=v,
+            sm_scale=inp.scale_float,
+            Out_splitK=o_splitk,
+            LSE_splitk=lse_splitk,
+            block_tables=block_tables,
+            Seq_len=seq_len,
+            Seq_starts_k=seq_starts_k,
+            Seq_starts_q=seq_starts_q,
+            Seq_starts_q_multiplier=seq_starts_q_multiplier,
+            additive_bias=attn_bias_tensor,
+            K_fp8_scale_shift=k_fp8_scale_shift,
+            V_fp8_scale_shift=v_fp8_scale_shift,
+            q_fp8_scale_shift=q_fp8_scale_shift,
+            **_strides(q, "qz", "qm", "qg", "qh", "qk"),
+            **_strides(k, "kz", "kn", "kg", "kh", "kk"),
+            **_strides(v, "vz", "vn", "vg", "vh", "vk"),
+            **_strides(o_splitk, "osk_z", "osk_g", "osk_h", "osk_s", "osk_m", "osk_k"),
+            **_strides(lse_splitk, "lsek_z", "lsek_g", "lsek_h", "lsek_s", "lsek_m"),
+            **_strides(block_tables, "blocktablesz", "blocktablesl"),
+            **_strides(
+                attn_bias_tensor, "bias_b", "bias_g", "bias_h", "bias_qm", "bias_km"
+            ),
+            **_strides(
+                k_fp8_scale_shift,
+                "k_fp8_scale_shift_z",
+                "k_fp8_scale_shift_n",
+                "k_fp8_scale_shift_g",
+                "k_fp8_scale_shift_h",
+            ),
+            **_strides(
+                v_fp8_scale_shift,
+                "v_fp8_scale_shift_z",
+                "v_fp8_scale_shift_n",
+                "v_fp8_scale_shift_g",
+                "v_fp8_scale_shift_h",
+            ),
+            **_strides(
+                q_fp8_scale_shift,
+                "q_fp8_scale_shift_z",
+                "q_fp8_scale_shift_m",
+                "q_fp8_scale_shift_g",
+                "q_fp8_scale_shift_h",
+            ),
+            kv_cache_blocks_per_row=kv_cache_blocks_per_row,
+            Z=B,
+            H=H,
+            G=G,
+            N_CTX_Q=M,
+            N_CTX_K=Mk,
+            BLOCK_N_PER_SPLIT=split_size,
+            BLOCK_DMODEL=Lk,
+            USE_SEQ_LEN=use_seq_len,
+            PACKED_PER_VAL=PACKED_PER_VAL,
+            N_GROUPS=cls.NUM_GROUPS,
+            IS_CAUSAL=IS_CAUSAL,
+            IS_LOCAL=IS_LOCAL,
+            NUM_QUERIES_CAUSAL=NUM_QUERIES_CAUSAL,
+            IS_SPLITK=IS_SPLITK,
+            SPLIT_K_EARLY_EXIT=cls.SPLIT_K_EARLY_EXIT,
+            USE_PAGED_ATTENTION=is_paged,
+            PAGE_SIZE=page_size,
+            WINDOW_LEFT=window_left,
+            WINDOW_RIGHT=window_right,
+            WRITE_LSE=IS_SPLITK or needs_gradient,
+            HAS_ADDITIVE_BIAS=attn_bias_tensor is not None,
+            NUM_PROGRAMS_DIM2_CONST=split_k,
+            IS_HIP=IS_HIP,
+            QUANTIZE_PV_TO_FP8=inp.quantize_pv_to_fp8,
+            QUANTIZE_QK_TO_FP8=inp.quantize_qk_to_fp8,
+            USE_FP32_SCALES=inp.use_fp32_scales,
+            **extra_args,
+        )
+        if not IS_SPLITK:
+            out = o_splitk[:, :, :, 0]  # Bqq, G, H, Mqq, Kq
+            if variable_q and mqa_swap_seqlen_head:
+                out = out.view(1, G, Mq, Hq, Kq).permute(0, 2, 1, 3, 4).contiguous()
+            else:
+                out = out.view(Bqq, G, Hq, Mq, Kq)
+                # This is a copy iff mqa_swap_seqlen_head and Mq, G and Hq are all > 1.
+                out = out.permute(0, 3, 1, 2, 4).contiguous()
+            if needs_gradient:
+                assert lse_splitk is not None
+                lse = lse_splitk[:, :, :, 0]  # Bqq, G, H, Mqq
+                if variable_q and mqa_swap_seqlen_head:
+                    lse = lse.view(1, G, Mq, Hq).permute(0, 1, 3, 2)
+                else:
+                    lse = lse.view(Bqq, G, Hq, Mq)
+                    if attn_bias is not None and not variable_q:
+                        lse = lse.permute(1, 2, 0, 3).reshape(1, G, Hq, B * Mq)
+            else:
+                lse = None
+
+            if inp.query.ndim == 4:
+                # BMGHK -> BMHK
+                assert G == 1
+                if lse is not None:
+                    lse = lse[:, 0]
+                out = out[:, :, 0]
+
+            if lse is None:
+                return out, None
+            return out, Context(out=out, lse=lse)
+
+        out = torch.empty(output_shape, device=q.device, dtype=output_dtype)
+
+        # Merge attention and LSE outputs from different split-k chunks
+        assert lse_splitk is not None
+        output_lse = None
+        if needs_gradient:
+            if attn_bias is None or variable_q:
+                output_lse = torch.empty(
+                    (Bqq, G, Hq, Mq), device=q.device, dtype=lse_dtype
+                )
+                lse = output_lse
+            else:
+                output_lse = torch.empty(
+                    (1, G, Hq, B * Mq), device=q.device, dtype=lse_dtype
+                )
+                lse = output_lse.view(G, Hq, B, Mq).permute(2, 0, 1, 3)
+
+        o_splitk = o_splitk[:, :, :, :, :Mqq]
+
+        if mqa_swap_seqlen_head:
+            if variable_q:
+                o_splitk = o_splitk.view(Bqq, G, split_k, Mq, Hq, Kq).permute(
+                    0, 1, 4, 2, 3, 5
+                )
+                lse_splitk = lse_splitk.view(Bqq, G, split_k, Mq, Hq).permute(
+                    0, 1, 4, 2, 3
+                )
+            else:
+                o_splitk = o_splitk.view(Bqq, G, split_k, Hq, Mq, Kq).permute(
+                    0, 1, 3, 2, 4, 5
+                )
+                lse_splitk = lse_splitk.view(Bqq, G, split_k, Hq, Mq).permute(
+                    0, 1, 3, 2, 4
+                )
+
+        merge_attentions(out, lse, o_splitk, lse_splitk)
+
+        if inp.query.ndim == 4:
+            # BMGHK -> BMHK
+            assert G == 1
+            out = out[:, :, 0]
+            if output_lse is not None:
+                output_lse = output_lse[:, 0]
+        if Mk == 0:
+            out.zero_()
+
+        if attn_bias is not None and not variable_q:
+            out = out.view(1, B * Mq, G, Hq, Kq)
+
+        if output_lse is None:
+            return out, None
+
+        return out, Context(out=out, lse=output_lse)
+
+    @classmethod
+    @functools.lru_cache
+    def get_operator(
+        cls,
+        splitk: int,
+        *,
+        block_m: Optional[int] = None,
+        block_n: Optional[int] = None,
+        num_warps: Optional[int] = None,
+        num_stages: Optional[int] = None,
+        split_k_early_exit: Optional[bool] = None,
+    ) -> Type[AttentionFwOpBase]:
+        kwargs = {
+            "NAME": f"triton_splitK{splitk}",
+            "SPLIT_K": splitk,
+        }
+        if block_m is not None:
+            kwargs["BLOCK_M"] = block_m
+        if block_n is not None:
+            kwargs["BLOCK_N"] = block_n
+        if num_warps is not None:
+            kwargs["NUM_WARPS"] = num_warps
+        if num_stages is not None:
+            kwargs["NUM_STAGES"] = num_stages
+        if split_k_early_exit is not None:
+            kwargs["SPLIT_K_EARLY_EXIT"] = split_k_early_exit
+        return type(
+            f"FwOp_S{splitk}",
+            (cls,),
+            kwargs,
+        )
+
+
+def merge_attentions(
+    attn_out: torch.Tensor,
+    lse_out: Optional[torch.Tensor],
+    attn_split: torch.Tensor,
+    lse_split: torch.Tensor,
+):
+    import triton
+
+    from ._triton.splitk_kernels import _splitK_reduce
+
+    B, M, G, H, Kq = attn_out.shape
+    B1, G1, H1, split_k, M1, Kq1 = attn_split.shape
+    B2, G2, H2, split_k1, M2 = lse_split.shape
+
+    assert (
+        B == B1 == B2
+        and G == G1 == G2
+        and H == H1 == H2
+        and M == M1 == M2
+        and Kq == Kq1
+    ), f"Incompatible shapes: {attn_out.shape=}, {attn_split.shape=}, {lse_split.shape=}"
+    assert (
+        split_k == split_k1
+    ), f"Incompatible shapes: {attn_split.shape=}, {lse_split.shape=}"
+    if lse_out is not None:
+        B3, G3, H3, M3 = lse_out.shape
+        assert (
+            B == B3 and G == G3 and H == H3 and M == M3
+        ), f"Incompatible shapes: {attn_out.shape=}, {lse_out.shape=}"
+
+    num_warps = 4 if B * G * H < 32 or torch.version.hip else 2
+    splitK_pow2 = triton.next_power_of_2(split_k)
+    head_dim = attn_out.shape[-1]
+    grid = (M, B * G * H, 1)
+    # pyre-ignore[28]
+    _splitK_reduce[grid](
+        attn_split,
+        lse_split,
+        attn_out,
+        lse_out,
+        split_k=split_k,
+        splitK_pow2=splitK_pow2,
+        **_strides(attn_split, "osk_z", "osk_g", "osk_h", "osk_s", "osk_m", "osk_k"),
+        **_strides(lse_split, "lsek_z", "lsek_g", "lsek_h", "lsek_s", "lsek_m"),
+        **_strides(attn_out, "oz", "om", "og", "oh", "ok"),
+        **_strides(lse_out, "lse_z", "lse_g", "lse_h", "lse_m"),
+        head_dim=head_dim,
+        head_dim_pow_2=triton.next_power_of_2(head_dim),
+        G=G,
+        H=H,
+        WRITE_LSE=lse_out is not None,
+        num_warps=num_warps,
+    )
+
+
+@torch.library.custom_op(
+    "mslk::fmha_merge_attentions_varargs",
+    mutates_args=(),
+    device_types=["cuda"],
+)
+def merge_attentions_varargs(
+    attn_split: Sequence[torch.Tensor],
+    lse_split: Sequence[torch.Tensor],
+    write_lse: bool,
+    output_dtype: Optional[torch.dtype],
+    B: int,
+    M: int,
+    G: int,
+    H: int,
+    Kq: int,
+) -> List[torch.Tensor]:
+    import triton
+
+    from ._triton.splitk_kernels import _splitK_reduce_varargs
+
+    from ._triton.vararg_kernel import unroll_varargs
+
+    attn_out = torch.empty(
+        (B, M, G, H, Kq),
+        device=attn_split[0].device,
+        dtype=output_dtype or attn_split[0].dtype,
+    )
+    if write_lse:
+        lse_out = torch.empty(
+            (B, G, H, M),
+            device=attn_split[0].device,
+            dtype=lse_split[0].dtype,
+        )
+    else:
+        lse_out = None
+    kernel_args, grid = _prepare_reduce_kernel_params(
+        attn_out, lse_out, attn_split, lse_split
+    )
+    reduce_kernel = unroll_varargs(_splitK_reduce_varargs, N=len(attn_split))
+    head_dim = attn_out.shape[-1]
+    reduce_kernel[grid](
+        *attn_split,
+        *lse_split,
+        Out=attn_out,
+        LSE=lse_out,
+        **kernel_args,
+        head_dim=head_dim,
+        head_dim_pow_2=triton.next_power_of_2(head_dim),
+        WRITE_LSE=lse_out is not None,
+    )
+    if write_lse:
+        assert lse_out is not None
+        return [attn_out, lse_out]
+    return [attn_out]
+
+
+@torch.library.register_fake("mslk::fmha_merge_attentions_varargs")
+def merge_attentions_varargs_fake(
+    attn_split: Sequence[torch.Tensor],
+    lse_split: Sequence[torch.Tensor],
+    write_lse: bool,
+    output_dtype: Optional[torch.dtype],
+    B: int,
+    M: int,
+    G: int,
+    H: int,
+    Kq: int,
+) -> List[torch.Tensor]:
+    attn_out = torch.empty(
+        (B, M, G, H, Kq),
+        device=attn_split[0].device,
+        dtype=output_dtype or attn_split[0].dtype,
+    )
+    if write_lse:
+        lse_out = torch.empty(
+            (B, G, H, M),
+            device=attn_split[0].device,
+            dtype=lse_split[0].dtype,
+        )
+        return [attn_out, lse_out]
+    return [attn_out]
+
+
+def _merge_attentions_backward(
+    ctx: torch.autograd.function.FunctionCtx,
+    grad: List[torch.Tensor],
+) -> Tuple[None, ...]:
+    raise NotImplementedError(
+        "Backward pass is not implemented for merge_attentions. "
+        "If it was, it would be easy to get wrong attention gradients, "
+        "because the gradients of the LSEs "
+        "don't get propagated by attention backward."
+    )
+
+
+merge_attentions_varargs.register_autograd(_merge_attentions_backward)
+
+
+@torch.library.custom_op(
+    "mslk::merge_attentions_varargs_backward",
+    mutates_args=(),
+    device_types=["cuda"],
+)
+def merge_attentions_varargs_backward(
+    attn_split: List[torch.Tensor],
+    lse_split: List[torch.Tensor],
+    attn_out: torch.Tensor,
+    lse_out: torch.Tensor,
+    grad_attn: torch.Tensor,
+    grad_lse: torch.Tensor,
+) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+    from ._triton.splitk_kernels import _splitK_reduce_varargs_backward
+    from ._triton.vararg_kernel import unroll_varargs
+
+    dattn_splitk = [torch.empty_like(x) for x in attn_split]
+    dlse_splitk = [torch.empty_like(x) for x in lse_split]
+
+    kernel_args, grid = _prepare_reduce_kernel_params(
+        attn_out, lse_out, attn_split, lse_split, grad_attn, grad_lse
+    )
+
+    reduce_kernel_backward = unroll_varargs(
+        _splitK_reduce_varargs_backward, N=len(attn_split)
+    )
+    reduce_kernel_backward[grid](
+        *attn_split,
+        *lse_split,
+        *dattn_splitk,
+        *dlse_splitk,
+        Out=attn_out,
+        LSE=lse_out,
+        DOut=grad_attn,
+        DLSE=grad_lse,
+        **kernel_args,
+        BLOCK_SIZE=attn_out.shape[-1],
+    )
+
+    return dattn_splitk, dlse_splitk
+
+
+@torch.library.register_fake("mslk::merge_attentions_varargs_backward")
+def merge_attentions_varargs_backward_fake(
+    attn_split: List[torch.Tensor],
+    lse_split: List[torch.Tensor],
+    attn_out: torch.Tensor,
+    lse_out: torch.Tensor,
+    grad_attn: torch.Tensor,
+    grad_lse: torch.Tensor,
+) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+    dattn_splitk = [torch.empty_like(x) for x in attn_split]
+    dlse_splitk = [torch.empty_like(x) for x in lse_split]
+    return dattn_splitk, dlse_splitk
+
+
+def _prepare_reduce_kernel_params(
+    attn_out: torch.Tensor,
+    lse_out: Optional[torch.Tensor],
+    attn_split: Sequence[torch.Tensor],
+    lse_split: Sequence[torch.Tensor],
+    grad_attn: Optional[torch.Tensor] = None,
+    grad_lse: Optional[torch.Tensor] = None,
+) -> Tuple[Dict[str, int], Tuple[int, int, int]]:
+    B, M, G, H, Kq = attn_out.shape
+    B1, G1, H1, M1, Kq1 = attn_split[0].shape
+    B2, G2, H2, M2 = lse_split[0].shape
+
+    assert (
+        B == B1 == B2
+        and G == G1 == G2
+        and H == H1 == H2
+        and M == M1 == M2
+        and Kq == Kq1
+    ), f"Incompatible shapes: {attn_out.shape=}, {attn_split[0].shape=}, {lse_split[0].shape=}"
+    if lse_out is not None:
+        B3, G3, H3, M3 = lse_out.shape
+        assert (
+            B == B3 and G == G3 and H == H3 and M == M3
+        ), f"Incompatible shapes: {attn_out.shape=}, {lse_out.shape=}"
+
+    attn_split_strides = {}
+    lse_split_strides = {}
+    for i in range(len(attn_split)):
+        attn_split_strides.update(
+            _strides(
+                attn_split[i],
+                "osk_z" + str(i),
+                "osk_g" + str(i),
+                "osk_h" + str(i),
+                "osk_m" + str(i),
+                "osk_k" + str(i),
+            )
+        )
+        lse_split_strides.update(
+            _strides(
+                lse_split[i],
+                "lsek_z" + str(i),
+                "lsek_g" + str(i),
+                "lsek_h" + str(i),
+                "lsek_m" + str(i),
+            )
+        )
+
+    num_warps = 4 if B * G * H < 32 or torch.version.hip else 2
+    grid = (M, B * G * H, 1)
+
+    kernel_args = {
+        "G": G,
+        "H": H,
+        "num_warps": num_warps,
+        **attn_split_strides,
+        **lse_split_strides,
+    }
+    kernel_args.update(_strides(attn_out, "oz", "om", "og", "oh", "ok"))
+    kernel_args.update(_strides(lse_out, "lse_z", "lse_g", "lse_h", "lse_m"))
+    if grad_attn is not None:
+        kernel_args.update(_strides(grad_attn, "doz", "dom", "dog", "doh", "dok"))
+        kernel_args.update(_strides(grad_lse, "dlse_z", "dlse_g", "dlse_h", "dlse_m"))
+    return kernel_args, grid
+
+
+FwOp_Map = {
+    k: FwOp.get_operator(k) for k in [1, 2, 4, 8, 16, 32, 48, 64, 72, 80, 96, 112, 128]
+}
+FwOp_S1 = FwOp_Map[1]
+FwOp_S2 = FwOp_Map[2]
+FwOp_S4 = FwOp_Map[4]
+FwOp_S8 = FwOp_Map[8]
+FwOp_S16 = FwOp_Map[16]
+FwOp_S32 = FwOp_Map[32]
+FwOp_S64 = FwOp_Map[64]
+FwOp_S128 = FwOp_Map[128]

--- a/mslk/attention/fmha/unbind.py
+++ b/mslk/attention/fmha/unbind.py
@@ -1,0 +1,129 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-strict
+from typing import List, Optional, Sequence, Tuple, Union
+
+import torch
+
+from .utils.op_common import _get_storage_base
+
+
+def get_stack_strides(
+    tensors: Sequence[torch.Tensor], dim: int
+) -> Optional[Tuple[Union[int, torch.SymInt], ...]]:
+    """
+    If the tensors are already stacked on dimension :code:`dim`, \
+        returns the strides of the stacked tensors. \
+        Otherwise returns :code:`None`.
+    """
+    if len(tensors) <= 1 or dim > tensors[0].ndim:
+        return None
+
+    final_stride = []
+    for i in range(tensors[0].ndim + 1):
+        if i == dim:
+            # PyTorch 2.5 messed up the type annotations for SymInt, but 2.6 will fix it
+            # https://github.com/pytorch/pytorch/issues/138478
+            final_stride.append(
+                tensors[1].storage_offset() - tensors[0].storage_offset()  # type: ignore[operator]
+            )
+            continue
+        if i > dim:
+            i -= 1
+        final_stride.append(tensors[0].stride(i))
+
+    storage_data_ptr: Optional[int] = None
+    for i, x in enumerate(tensors[1:]):
+        # Sanity checks
+        if x.shape != tensors[0].shape:
+            return None
+        if x.stride() != tensors[0].stride():
+            return None
+        # PyTorch 2.5 messed up the type annotations for SymInt, but 2.6 will fix it
+        # https://github.com/pytorch/pytorch/issues/138478
+        if (
+            x.storage_offset()
+            != tensors[0].storage_offset() + (i + 1) * final_stride[dim]  # type: ignore[operator]
+        ):
+            return None
+        if storage_data_ptr is None:
+            storage_data_ptr = _get_storage_base(tensors[0])
+        # Actual storage check
+        if _get_storage_base(x) != storage_data_ptr:
+            return None
+    return tuple(final_stride)
+
+
+def _stack_or_none_fw(
+    tensors: Union[Tuple[torch.Tensor, ...], List[torch.Tensor]],
+    dim: int,
+) -> Optional[torch.Tensor]:
+    strides = get_stack_strides(tensors, dim)
+    if strides is not None:
+        input_shape = list(tensors[0].shape)
+        input_shape.insert(dim, len(tensors))
+        return tensors[0].as_strided(input_shape, strides)
+    return None
+
+
+def _stack_fw(
+    tensors: Union[Tuple[torch.Tensor, ...], List[torch.Tensor]],
+    dim: int,
+) -> torch.Tensor:
+    out = _stack_or_none_fw(tensors, dim)
+    if out is None:
+        out = torch.stack(tensors, dim=dim)
+    return out
+
+
+class _Unbind(torch.autograd.Function):
+    """
+    See function `unbind`
+    """
+
+    @staticmethod
+    # type: ignore
+    def forward(ctx, x: torch.Tensor, dim: int):
+        ctx.dim = dim
+        return x.unbind(dim)
+
+    @classmethod
+    # type: ignore
+    def backward(cls, ctx, *tensors: torch.Tensor):
+        return _stack_fw(tensors, ctx.dim), None
+
+
+class _StackOrNone(torch.autograd.Function):
+    """
+    See function `stack_or_none`
+    """
+
+    @staticmethod
+    # type: ignore
+    def forward(ctx, dim: int, *tensors: torch.Tensor):
+        ctx.dim = dim
+        return _stack_or_none_fw(tensors, dim=dim)
+
+    @classmethod
+    # type: ignore
+    def backward(cls, ctx, grad: torch.Tensor):
+        return (None, *grad.unbind(dim=ctx.dim))
+
+
+def unbind(x: torch.Tensor, dim: int) -> Tuple[torch.Tensor, ...]:
+    """
+    Does exactly the same as :attr:`torch.unbind` for the forward.
+    In backward, avoids a :attr:`torch.cat` if the gradients
+    are already multiple views of the same storage
+    """
+    return _Unbind.apply(x, dim)
+
+
+def stack_or_none(tensors: Sequence[torch.Tensor], dim: int) -> torch.Tensor:
+    """
+    Does exactly the same as :attr:`torch.stack` if the tensors can be concatenated
+    without any memory operation. Otherwise returns None.
+    """
+    return _StackOrNone.apply(dim, *tensors)

--- a/mslk/attention/fmha/utils/__init__.py
+++ b/mslk/attention/fmha/utils/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe

--- a/mslk/attention/fmha/utils/bench.py
+++ b/mslk/attention/fmha/utils/bench.py
@@ -1,0 +1,73 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+from typing import Callable, List, Optional
+
+import torch
+
+
+# from https://github.com/openai/triton/blob/95d9b7f4ae21710dc899e1de6a579b2136ea4f3d/python/triton/testing.py#L19
+def do_bench_cudagraph(
+    fn: Callable, rep: int = 20, grad_to_none: Optional[List[torch.Tensor]] = None
+) -> float:
+    """
+    Benchmark the runtime of the provided function.
+    Args:
+        fn: Function to benchmark
+        rep: Repetition time (in ms)
+        grad_to_none: Reset the gradient of the provided tensor to None
+    Returns:
+        Benchmarked runtime in ms
+    """
+    if torch.cuda.current_stream() == torch.cuda.default_stream():
+        raise RuntimeError(
+            "Cannot capture graph in default stream. "
+            "Please use side stream in benchmark code."
+        )
+    # warmup
+    fn()
+    # step 1 - we estimate the amount of time the kernel call takes
+    # NOTE: this estimate isn't super accurate because the GPU isn't warmed up at this point
+    #       but it is probably good enough
+    if grad_to_none is not None:
+        for x in grad_to_none:
+            x.detach_()
+            x.requires_grad_(True)
+            x.grad = None
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        fn()
+    torch.cuda.synchronize()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    start_event.record()
+    g.replay()
+    end_event.record()
+    torch.cuda.synchronize()
+    estimate_ms = start_event.elapsed_time(end_event)
+    n_repeat = max(1, int(rep / estimate_ms))
+    # step 2 - construct a cuda graph with `n_repeat` unrolled function calls to minimize
+    # host overhead
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        for _i in range(n_repeat):
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
+            fn()
+    torch.cuda.synchronize()
+    # measure time and return
+    ret = []
+    n_retries = 10
+    for _ in range(n_retries):
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        g.replay()
+        end_event.record()
+        torch.cuda.synchronize()
+        ret += [start_event.elapsed_time(end_event) / n_repeat]
+    return torch.mean(torch.tensor(ret)).item()

--- a/mslk/attention/fmha/utils/cpp_lib.py
+++ b/mslk/attention/fmha/utils/cpp_lib.py
@@ -1,0 +1,147 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+import dataclasses
+import logging
+import os
+import platform
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import torch
+
+logger = logging.getLogger("mslk_fmha")
+
+UNAVAILABLE_FEATURES_MSG = "  Memory-efficient attention won't be available."
+
+
+@dataclasses.dataclass
+class _BuildInfo:
+    metadata: Dict[str, Any]
+
+    @property
+    def cuda_version(self) -> Optional[int]:
+        return self.metadata["version"]["cuda"]
+
+    @property
+    def hip_version(self) -> Optional[int]:
+        return self.metadata["version"]["hip"]
+
+    @property
+    def torch_version(self) -> str:
+        return self.metadata["version"]["torch"]
+
+    @property
+    def python_version(self) -> str:
+        return self.metadata["version"]["python"]
+
+    @property
+    def flash_version(self) -> str:
+        return self.metadata["version"].get("flash", "0.0.0")
+
+    @property
+    def use_torch_flash(self) -> bool:
+        return self.metadata["version"].get("use_torch_flash", False)
+
+    @property
+    def build_env(self) -> Dict[str, Any]:
+        return self.metadata["env"]
+
+
+class xFormersWasNotBuiltException(Exception):
+    def __str__(self) -> str:
+        return (
+            "Need to compile C++ extensions to use all fmha features.\n"
+            "    Please install xformers properly "
+            "(see https://github.com/facebookresearch/xformers#installing-xformers)\n"
+            + UNAVAILABLE_FEATURES_MSG
+        )
+
+
+class xFormersInvalidLibException(Exception):
+    def __init__(self, build_info: Optional[_BuildInfo]) -> None:
+        self.build_info = build_info
+
+    def __str__(self) -> str:
+        if self.build_info is None:
+            msg = "fmha was built for a different version of PyTorch or Python."
+        else:
+            msg = f"""fmha was built for:
+    PyTorch {self.build_info.torch_version} with CUDA {self.build_info.cuda_version} (you have {torch.__version__})
+    Python  {self.build_info.python_version} (you have {platform.python_version()})"""
+        return (
+            "fmha can't load C++/CUDA extensions. "
+            + msg
+            + "\n  Please reinstall mslk "
+            + UNAVAILABLE_FEATURES_MSG
+        )
+
+
+def _register_extensions():
+    import importlib
+    import os
+
+    import torch
+
+    # load the custom_op_library from the mslk directory
+    # and register the custom ops
+    lib_dir = str(Path(__file__).parent.parent.parent.parent)
+    if os.name == "nt":
+        # Register the main torchvision library location on the default DLL path
+        import ctypes
+        import sys
+
+        kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
+        with_load_library_flags = hasattr(kernel32, "AddDllDirectory")
+        prev_error_mode = kernel32.SetErrorMode(0x0001)
+
+        if with_load_library_flags:
+            kernel32.AddDllDirectory.restype = ctypes.c_void_p
+
+        if sys.version_info >= (3, 8):
+            os.add_dll_directory(lib_dir)
+        elif with_load_library_flags:
+            res = kernel32.AddDllDirectory(lib_dir)
+            if res is None:
+                err = ctypes.WinError(ctypes.get_last_error())
+                err.strerror += f' Error adding "{lib_dir}" to the DLL directories.'
+                raise err
+
+        kernel32.SetErrorMode(prev_error_mode)
+
+    loader_details = (
+        importlib.machinery.ExtensionFileLoader,
+        importlib.machinery.EXTENSION_SUFFIXES,
+    )
+
+    extfinder = importlib.machinery.FileFinder(lib_dir, loader_details)
+    if torch.version.hip and not hasattr(torch.version, "git_version"):
+        ext_specs = extfinder.find_spec("_C_hip")
+    else:
+        ext_specs = extfinder.find_spec("_C")
+    if ext_specs is None:
+        raise xFormersWasNotBuiltException()
+    try:
+        torch.ops.load_library(ext_specs.origin)
+    except OSError as exc:
+        raise xFormersInvalidLibException(None) from exc
+
+
+_cpp_library_load_exception = None
+
+try:
+    _register_extensions()
+except (xFormersInvalidLibException, xFormersWasNotBuiltException) as e:
+    ENV_VAR_FOR_DETAILS = "XFORMERS_MORE_DETAILS"
+    if os.environ.get(ENV_VAR_FOR_DETAILS, False):
+        logger.warning(f"WARNING[XFORMERS]: {e}", exc_info=e)
+    else:
+        logger.warning(
+            f"WARNING[XFORMERS]: {e}\n  Set {ENV_VAR_FOR_DETAILS}=1 for more details"
+        )
+    _cpp_library_load_exception = e
+
+_built_with_cuda = True  # XXXXX

--- a/mslk/attention/fmha/utils/op_common.py
+++ b/mslk/attention/fmha/utils/op_common.py
@@ -1,0 +1,64 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+from typing import Any, Dict, List, Type, TypeVar
+
+import torch
+
+
+def get_operator(library: str, name: str):
+    def no_such_operator(*args, **kwargs):
+        raise RuntimeError(
+            f"No such operator {library}::{name} - did you forget to build xformers with `python setup.py develop`?"
+        )
+
+    try:
+        return getattr(getattr(torch.ops, library), name)
+    except (RuntimeError, AttributeError):
+        return no_such_operator
+
+
+def get_xformers_operator(name: str):
+    return get_operator("xformers", name)
+
+
+class BaseOperator:
+    OPERATOR: Any  # pyre-ignore[13]
+    NAME: str  # pyre-ignore[13]
+    OPERATOR_CATEGORY: str  # pyre-ignore[13]
+
+    @classmethod
+    def is_available(cls) -> bool:
+        # cls.OPERATOR can be either a kernel or a Triton Autotuner object, which doesn't have __name__
+        if (
+            cls.OPERATOR is None
+            or getattr(cls.OPERATOR, "__name__", "") == "no_such_operator"
+        ):
+            return False
+        return True
+
+
+OPERATORS_REGISTRY: List[Type[BaseOperator]] = []
+FUNC_TO_XFORMERS_OPERATOR: Dict[Any, Type[BaseOperator]] = {}
+
+ClsT = TypeVar("ClsT")
+
+
+def register_operator(cls: ClsT) -> ClsT:
+    OPERATORS_REGISTRY.append(cls)  # type: ignore
+    FUNC_TO_XFORMERS_OPERATOR[cls.OPERATOR] = cls  # type: ignore
+    return cls
+
+
+# post-2.0, avoids a warning
+# (`torch.Tensor.storage` will also be deleted in the future)
+_GET_TENSOR_STORAGE = getattr(torch.Tensor, "untyped_storage", None)
+if _GET_TENSOR_STORAGE is None:  # pre-2.0, `untyped_storage` didn't exist
+    _GET_TENSOR_STORAGE = torch.Tensor.storage
+
+
+def _get_storage_base(x: torch.Tensor) -> int:
+    return _GET_TENSOR_STORAGE(x).data_ptr()  # type: ignore

--- a/test/attention/fmha/__init__.py
+++ b/test/attention/fmha/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-strict

--- a/test/attention/fmha/multiprocessing_utils.py
+++ b/test/attention/fmha/multiprocessing_utils.py
@@ -1,0 +1,211 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+import concurrent
+import gc
+import multiprocessing
+import os
+import signal
+from tempfile import _TemporaryFileWrapper, NamedTemporaryFile
+from typing import Dict, List, Tuple
+
+import torch
+
+
+class SafeMpContext(multiprocessing.context.BaseContext):
+    def __init__(self) -> None:
+        self.mp_context = multiprocessing.get_context("spawn")
+        self.processes: List[multiprocessing.context.SpawnProcess] = []
+
+    def Process(self, *args, **kwargs) -> multiprocessing.context.SpawnProcess:
+        p = self.mp_context.Process(*args, **kwargs)
+        p.daemon = True
+        self.processes.append(p)
+        return p
+
+    def kill_all_processes(self):
+        for p in self.processes:
+            p.terminate()
+            p.join(1)
+
+            # (https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.exitcode)
+            # Even though the python documentation seems to say that after joining the exitcode should
+            # become set, this is not what we have observed in practice. We therefore loop until it
+            # becomes set.
+            while p.exitcode is None:
+                p.kill()
+                p.join()
+
+            assert p.exitcode is not None, f"{p} is still alive"
+
+    def log_bad_exit_codes(self):
+        for rank, p in enumerate(self.processes):
+            if p.exitcode == 0:
+                continue
+            if p.exitcode < 0:
+                try:
+                    signal_desc = f" (signal {signal.Signals(-p.exitcode).name})"
+                except ValueError:
+                    signal_desc = " (unrecognized signal)"
+            else:
+                signal_desc = ""
+            print(
+                f"Child process for rank #{rank} with PID {p.pid} exited with code {p.exitcode}{signal_desc}"
+            )
+
+    def __getattr__(self, name: str):
+        return getattr(self.mp_context, name)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.kill_all_processes()
+        self.log_bad_exit_codes()
+
+
+def init_process_group(init_method: str, rank: int, world_size: int):
+    torch._C._set_print_stack_traces_on_fatal_signal(True)
+
+    if torch.cuda.device_count() >= world_size:
+        backend = "nccl"
+        torch.cuda.set_device(rank)
+    else:
+        # Use Gloo instead of NCCL so that we can run on a single GPU
+        backend = "gloo"
+
+    torch.distributed.init_process_group(
+        backend=backend,
+        world_size=world_size,
+        rank=rank,
+        init_method=init_method,
+    )
+
+
+def _launch_subprocesses_fn_wrapper(
+    init_method: str,
+    rank: int,
+    world_size: int,
+    parent_env_vars: Dict[str, str],
+    user_fn,
+    args,
+    kwargs,
+):
+    # This function initializes the environment for spawned subprocesses by capturing and applying the current
+    # environment variables from the parent process. By clearing and then updating `os.environ` with `parent_env_vars`,
+    # we ensure that each spawned subprocess starts with an environment that mirrors the parent process at the time
+    # of job submission. This approach guarantees consistency across subprocesses, reflecting the latest state of the
+    # parent's environment variables even/especially when reusing the subprocesses for subsequent job executions.
+    os.environ.clear()
+    os.environ.update(parent_env_vars)
+
+    # Check if the process group is already initialized
+    if not torch.distributed.is_initialized():
+        init_process_group(init_method, rank, world_size)
+    try:
+        return user_fn(*args, **kwargs)
+    finally:
+        # should free all memory used by PyTorch in the subprocesses
+        gc.collect()
+        torch.cuda.empty_cache()
+
+
+# Global dictionary to keep track of executors and temporary files
+EXECUTORS_AND_FILES: Dict[
+    int, Tuple[_TemporaryFileWrapper, concurrent.futures.ProcessPoolExecutor]
+] = {}
+
+
+def get_global_pool_allocator(
+    world_size: int,
+) -> Tuple[_TemporaryFileWrapper, concurrent.futures.ProcessPoolExecutor]:
+    if world_size not in EXECUTORS_AND_FILES:
+        rdv = NamedTemporaryFile(mode="w+b", buffering=-1, delete=False)
+        mp_context = SafeMpContext()
+
+        executor = concurrent.futures.ProcessPoolExecutor(
+            max_workers=world_size, mp_context=mp_context
+        )
+
+        # Add the executor and temporary file to the global list
+        EXECUTORS_AND_FILES[world_size] = (rdv, executor)
+    else:
+        rdv, executor = EXECUTORS_AND_FILES[world_size]
+
+    return rdv, executor
+
+
+class ProcessPoolExecutorManager:
+    def __init__(self, world_size: int):
+        self.world_size = world_size
+
+    def __enter__(self):
+        # when you start a subprocess you want to free memory used by PyTorch in the main process,
+        # so the subprocess can have memory
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        self.rdv, self.executor = get_global_pool_allocator(self.world_size)
+        return self
+
+    def submit(self, fn, *args, **kwargs):
+        return self.executor.submit(fn, *args, **kwargs)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # One of the subprocesses jobs has failed
+        if exc_val:
+            # We want to avoid killing the processes while the executor was thinking that they were
+            # still up and healthy (as this may have unintended consequences, such as the executor
+            # restarting the processes, or reporting spurious errors).
+            # Set the internal state of the executor and call cancel() on each issued task that is
+            # not executing
+            self.executor.shutdown(wait=False, cancel_futures=True)
+
+            # Kill all remaining subprocesses
+            mp_context = self.executor._mp_context
+            mp_context.kill_all_processes()
+            mp_context.log_bad_exit_codes()
+
+            # We want to wait for all the futures to complete, so we need to shutdown twice
+            self.executor.shutdown(wait=True)
+
+            # Close the temporary file
+            self.rdv.close()
+
+            # Remove the executor from the global list.
+            # This will recreate it next time a test is requiring this world_size
+            assert self.world_size in EXECUTORS_AND_FILES
+            del EXECUTORS_AND_FILES[self.world_size]
+
+            print(
+                f"Shutdown and remove the executor after subprocesses error. Executors cnt: {len(EXECUTORS_AND_FILES)}"
+            )
+
+
+def launch_subprocesses(world_size: int, fn, *args, **kwargs):
+    # This custom manager allows each test execution to enter/exit the following context.
+    # When entering the context, it creates/reuses a new/existing ProcessPoolExecutor with the given world size.
+    # The context also allows to detect an exception upon exit, in which case it will kill all spawned processes,
+    # delete the manager, recreate the manager upon following request and respawn processes.
+    with ProcessPoolExecutorManager(world_size) as manager:
+        futures = [
+            manager.submit(
+                _launch_subprocesses_fn_wrapper,
+                init_method=f"file://{manager.rdv.name}",
+                rank=rank,
+                world_size=world_size,
+                parent_env_vars=dict(os.environ),
+                user_fn=fn,
+                args=args,
+                kwargs=kwargs,
+            )
+            for rank in range(world_size)
+        ]
+        done, _ = concurrent.futures.wait(
+            futures, return_when=concurrent.futures.FIRST_EXCEPTION
+        )
+        for f in done:
+            f.result()

--- a/test/attention/fmha/readme_test_on_rocm.txt
+++ b/test/attention/fmha/readme_test_on_rocm.txt
@@ -1,0 +1,10 @@
+   1. #> pip install -e ./
+
+   2. verify testing for generic fmha inference on ROCM
+
+      #> pytest tests/test_mem_eff_attention.py::test_forward
+
+   3. verify testing for decoder fmha inference on ROCM
+
+      #> pytest tests/test_mem_eff_attention.py::test_decoder
+      #> pytest tests/test_mem_eff_attention.py::test_splitk_decoder

--- a/test/attention/fmha/test_fmha_flop_formula.py
+++ b/test/attention/fmha/test_fmha_flop_formula.py
@@ -1,0 +1,158 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+# pyre-ignore-all-errors[29]
+
+
+from typing import Optional, Tuple, Type
+
+import pytest
+import torch
+
+from mslk.attention import fmha
+
+from .utils import disable_on_rocm, ref_attention_bmhk_for_test
+
+compute_capability = (0, 0)
+if torch.cuda.is_available():
+    compute_capability = torch.cuda.get_device_capability("cuda")
+sm90_or_better_only = pytest.mark.skipif(
+    compute_capability < (9, 0), reason="requires sm90+"
+)
+
+
+@disable_on_rocm
+@sm90_or_better_only
+@pytest.mark.parametrize(
+    "B,Mq,Mkv,Hq,Hkv,Kqk,Kv",
+    [
+        pytest.param(3, 13, 17, 7, 7, 128, 128, id="regular"),
+        pytest.param(3, 13, 17, 7, 1, 128, 128, id="mqa"),
+        # pytest.param(3, 13, 17, 21, 7, 128, 128, id="gqa"),  # unsupported
+    ],
+)
+@pytest.mark.parametrize(
+    "op",
+    [
+        (fmha.flash3.FwOp, fmha.flash3.BwOp),
+    ],
+    ids=lambda op: f"{op[0].NAME}-{op[1].NAME}",
+)
+@pytest.mark.parametrize("causal", [False, True], ids=["full", "causal"])
+@pytest.mark.parametrize("varseq", [False, True], ids=["batched", "varseq"])
+@pytest.mark.parametrize("worst_case", [False, True], ids=["tight", "loose"])
+def test_flop_formula(  # noqa: C901
+    B: int,
+    Mq: int,
+    Mkv: int,
+    Hq: int,
+    Hkv: int,
+    Kqk: int,
+    Kv: int,
+    op: Tuple[Type[fmha.AttentionFwOpBase], Type[fmha.AttentionBwOpBase]],
+    causal: bool,
+    varseq: bool,
+    worst_case: bool,
+    monkeypatch,
+):
+    if (op[0] is fmha.flash3.FwOp and not op[0].is_available()) or (
+        op[1] is fmha.flash3.BwOp and not op[1].is_available()
+    ):
+        pytest.skip("Flash3 not available")
+    dtype = torch.float16
+
+    if varseq:
+        B = 1
+    if causal:
+        Mkv = Mq
+
+    # No MQA/GQA in the reference impl
+    ref_q = torch.randn(
+        [B, Mq, Hq, Kqk], dtype=dtype, device="cuda", requires_grad=True
+    )
+    ref_k = torch.randn(
+        [B, Mkv, Hq, Kqk], dtype=dtype, device="cuda", requires_grad=True
+    )
+    ref_v = torch.randn(
+        [B, Mkv, Hq, Kv], dtype=dtype, device="cuda", requires_grad=True
+    )
+
+    with torch.utils.flop_counter.FlopCounterMode(display=False) as fc:
+        ref_out = ref_attention_bmhk_for_test(ref_q, ref_k, ref_v, attn_bias=None)
+    ref_fwd_flops = fc.get_total_flops()
+    with torch.utils.flop_counter.FlopCounterMode(display=False) as fc:
+        ref_out.backward(torch.randn_like(ref_out))
+    ref_bwd_flops = fc.get_total_flops()
+
+    q = torch.randn([B, Mq, Hq, Kqk], dtype=dtype, device="cuda", requires_grad=True)
+    k = torch.randn([B, Mkv, Hkv, Kqk], dtype=dtype, device="cuda", requires_grad=True)
+    v = torch.randn([B, Mkv, Hkv, Kv], dtype=dtype, device="cuda", requires_grad=True)
+
+    if Hkv == 1:
+        k = k.expand(-1, -1, Hq, -1)
+        v = v.expand(-1, -1, Hq, -1)
+    elif 1 < Hkv < Hq:
+        G = Hq // Hkv
+        q = q.unflatten(2, (Hkv, -1))
+        k = k.unflatten(2, (Hkv, -1)).expand(-1, -1, -1, G, -1)
+        v = v.unflatten(2, (Hkv, -1)).expand(-1, -1, -1, G, -1)
+
+    seqlens = ()
+    if varseq:
+        seqlens = ([5, Mq - 5], [5, Mkv - 5])
+
+    bias: Optional[fmha.attn_bias.AttentionBias]
+    if varseq and causal:
+        bias = fmha.attn_bias.BlockDiagonalCausalFromBottomRightMask.from_seqlens(
+            *seqlens
+        )
+    elif varseq:
+        bias = fmha.attn_bias.BlockDiagonalMask.from_seqlens(*seqlens)
+    elif causal:
+        bias = fmha.attn_bias.LowerTriangularMask()
+    else:
+        bias = None
+
+    bias_for_flops: Optional[fmha.attn_bias.AttentionBias] = None
+    if worst_case:
+        if causal:
+            bias_for_flops = fmha.attn_bias.LowerTriangularMask()
+    else:
+        bias_for_flops = bias
+    if bias_for_flops is not None:
+        flops_div = Mkv * Mq
+        flops_mul = (
+            (bias_for_flops.materialize((Mq, Mkv), device="cpu") == 0)
+            .int()
+            .sum()
+            .item()
+        )
+        ref_fwd_flops = ref_fwd_flops * flops_mul // flops_div
+        ref_bwd_flops = ref_bwd_flops * flops_mul // flops_div
+
+    if worst_case:
+        monkeypatch.setenv("XFORMERS_FLOP_FORMULA_WORST_CASE", "1")
+    else:
+        # We disable it explicitly in case it's set in the user's environment
+        monkeypatch.setenv("XFORMERS_FLOP_FORMULA_WORST_CASE", "0")
+
+    with torch.utils.flop_counter.FlopCounterMode(display=False) as fc:
+        out = fmha.memory_efficient_attention(q, k, v, op=op, attn_bias=bias)
+    assert fc.get_total_flops() == ref_fwd_flops
+
+    with torch.utils.flop_counter.FlopCounterMode(display=False) as fc:
+        out.backward(torch.randn_like(out))
+    # Flash's backward recomputes the first matmul of the fwd.
+    assert fc.get_total_flops() == ref_bwd_flops + ref_fwd_flops / 2
+
+
+def test_mask_nonzeros() -> None:
+    assert fmha.flash3.mask_non_zeros(13, 17, -1, 0) == 143
+    assert fmha.flash3.mask_non_zeros(13, 17, -1, -1) == 221
+
+    assert fmha.flash3.mask_non_zeros(8, 8, 32, 32) == 64
+    assert fmha.flash3.mask_non_zeros(8, 8, 4, 3) == 48
+    assert fmha.flash3.mask_non_zeros(8, 8, 4, 0) == 30
+    assert fmha.flash3.mask_non_zeros(8, 8, -1, -1) == 64

--- a/test/attention/fmha/test_fmha_merge_attentions.py
+++ b/test/attention/fmha/test_fmha_merge_attentions.py
@@ -1,0 +1,729 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+# pyre-ignore-all-errors[29]
+
+import hashlib
+import math
+from typing import Callable, List, Optional, Tuple, Type
+
+import pytest
+import torch
+from mslk.attention import fmha
+from mslk.attention.fmha.common import AttentionFwOpBase
+from mslk.attention.fmha.merge_training import (
+    memory_efficient_attention_partial_autograd,
+    merge_attentions_autograd,
+    Partial,
+)
+
+from .utils import assert_allclose, disable_on_rocm
+
+compute_capability = (0, 0)
+if torch.cuda.is_available():
+    compute_capability = torch.cuda.get_device_capability("cuda")
+sm80_or_better_only = pytest.mark.skipif(
+    compute_capability < (8, 0), reason="requires sm90+"
+)
+sm90_or_better_only = pytest.mark.skipif(
+    compute_capability < (9, 0), reason="requires sm90+"
+)
+
+
+# This temporary working is necessary because the MTIA test collection might not happen
+# on the same device as the device the tests are actually executed on. If test collection
+# is done on a device without MTIA, the supported masks will contain masks that MTIA support
+# and the corresponding tests will get collected. But when it comes time to actually run the
+# tests, the mask won't be supported because it is run on an actual MTIA device.
+def get_supported_attn_bias_types(op):
+    supported_attn_bias_types = op.SUPPORTED_ATTN_BIAS_TYPES
+
+    try:
+        import mtia.host_runtime.torch_mtia.dynamic_library  # noqa  # type: ignore
+
+        supported_attn_bias_types = [
+            b
+            for b in supported_attn_bias_types
+            if not issubclass(
+                b,
+                (
+                    fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+                    fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                ),
+            )
+        ]
+    except (ImportError, OSError):
+        pass
+
+    return supported_attn_bias_types
+
+
+@disable_on_rocm
+@sm80_or_better_only
+@pytest.mark.parametrize(
+    "op",
+    [
+        fmha.triton_splitk.FwOp,
+        fmha.flash.FwOp,
+        fmha.flash3.FwOp,
+        None,
+    ],
+    ids=lambda op: "None" if op is None else op.NAME,
+)
+@pytest.mark.parametrize("G,H", [(1, 11), (7, 1), (1, 1), (7, 11), (None, 11)])
+@pytest.mark.parametrize(
+    "write_lse", (False, True), ids=lambda x: "write_lse" if x else ""
+)
+@pytest.mark.parametrize(
+    "stack_inputs", (False, True), ids=lambda x: "stack_inputs" if x else ""
+)
+def test_merge_attentions_nobias(
+    write_lse: bool,
+    stack_inputs: bool,
+    op: Type[AttentionFwOpBase],
+    G: Optional[int],
+    H: int,
+):
+    """
+    Merging the same attention twice shouldn't change anything.
+    This also tests the shape of the lse output of each permitted op.
+    """
+    if op is fmha.flash3.FwOp and not op.is_available():
+        pytest.skip("Flash3 not available")
+    B, Mq, K = 13, 3, 192
+    if op is fmha.triton_splitk.FwOp:
+        K = 128
+    case_name = str((write_lse, G, H, stack_inputs)).encode("ascii")
+    # patternlint-disable-next-line poor-choice-of-hash-function
+    many_keys = hashlib.md5(case_name).digest()[0] % 2
+    M = [5, 100000][many_keys]
+    if op is None or torch.bfloat16 in op.SUPPORTED_DTYPES:
+        dtype = torch.bfloat16
+    else:
+        dtype = next(iter(op.SUPPORTED_DTYPES))
+    if dtype == torch.float8_e4m3fn:
+        pytest.skip("float8 not supported")
+    if G is None:
+        q = 3 * torch.rand(B, Mq, H, K, dtype=dtype, device="cuda")
+        k = (3 * torch.rand(B, M, 1, K, dtype=dtype, device="cuda")).expand(B, M, H, K)
+        v = (3 * torch.rand(B, M, 1, K, dtype=dtype, device="cuda")).expand(B, M, H, K)
+    else:
+        q = 3 * torch.rand(B, Mq, G, H, K, dtype=dtype, device="cuda")
+        k = (3 * torch.rand(B, M, G, 1, K, dtype=dtype, device="cuda")).expand(
+            B, M, G, H, K
+        )
+        v = (3 * torch.rand(B, M, G, 1, K, dtype=dtype, device="cuda")).expand(
+            B, M, G, H, K
+        )
+    out1, lse1 = fmha.memory_efficient_attention_partial(q, k, v, op=op)
+    assert out1.shape == q.shape
+    M_ceil = lse1.shape[-1]
+    assert M_ceil >= Mq
+    assert lse1.shape == (B, H, M_ceil) if G is None else (B, G, H, M_ceil)
+    lse1 = lse1[..., :Mq]
+
+    attn_chunks = [out1, out1]
+    lse_chunks = [lse1, lse1]
+    attn_chunks_ = torch.stack(attn_chunks) if stack_inputs else attn_chunks
+    lse_chunks_ = torch.stack(lse_chunks) if stack_inputs else lse_chunks
+    out, lse = fmha.merge_attentions(attn_chunks_, lse_chunks_, write_lse=write_lse)  # type: ignore
+    assert out.shape == out1.shape
+    assert_allclose(out1, out, rtol=1e-3, atol=1e-3, msg="out")
+    if write_lse:
+        assert lse is not None
+        assert lse.shape[:-1] == lse1.shape[:-1]
+        assert_allclose(
+            lse1[..., :Mq] + math.log(2), lse[..., :Mq], rtol=1e-3, atol=1e-3, msg="lse"
+        )
+    else:
+        assert lse is None
+
+
+@disable_on_rocm
+@sm80_or_better_only
+@pytest.mark.parametrize(
+    "dtype,op",
+    [
+        (torch.bfloat16, fmha.triton_splitk.FwOp_S1),
+        # Cutlass's LSE is not consistent
+        # (torch.float32, fmha.cutlass.FwOp),
+        (torch.bfloat16, fmha.flash.FwOp),
+    ],
+    ids=lambda o: f"{o.NAME}" if hasattr(o, "NAME") else str(o),
+)
+@pytest.mark.parametrize("num_queries", [1])
+@pytest.mark.parametrize("bmghk", [True, False], ids=lambda x: "bmghk" if x else "")
+def test_partial_paged(
+    dtype: torch.dtype, op: Type[AttentionFwOpBase], num_queries: int, bmghk: bool
+):
+    B = 128
+    N_H_L = 8
+    D_H = 128
+    page_size = 256
+    G = 2 if bmghk else 1
+    block_tables = torch.zeros((B, 1), dtype=torch.int32, device="cuda")
+    torch.manual_seed(1)
+    output_dtype = torch.float32 if op.SUPPORTS_OUTPUT_DTYPE else None
+
+    B_T = num_queries * B
+
+    q = torch.randn((1, B_T, G, N_H_L, D_H), dtype=dtype, device="cuda")
+    k = torch.randn((1, page_size, G, 1, D_H), dtype=dtype, device="cuda")
+    v = torch.randn_like(k)
+    k = k.expand(1, page_size, G, N_H_L, D_H)
+    v = v.expand(1, page_size, G, N_H_L, D_H)
+    if not bmghk:
+        q = q[:, :, 0]
+        k = k[:, :, 0]
+        v = v[:, :, 0]
+
+    attn_bias = (
+        fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+            q_seqlen=[num_queries] * B,
+            kv_seqlen=[1] + ([100] * (B - 1)),
+            page_size=page_size,
+            block_tables=block_tables,
+        )
+    )
+
+    if attn_bias not in get_supported_attn_bias_types(op):
+        pytest.skip("Not supported bias")
+
+    attn_chunk, lse_chunk = fmha.memory_efficient_attention_partial(
+        q,
+        k,
+        v,
+        attn_bias,
+        op=op,
+        output_dtype=output_dtype,
+    )
+    if bmghk:
+        assert attn_chunk.shape == (1, B_T, G, N_H_L, D_H)
+        assert lse_chunk.shape == (
+            1,
+            G,
+            N_H_L,
+            B_T,
+        ), f"{lse_chunk.shape=}, {(1, G, N_H_L, B_T)=}"
+    else:
+        assert attn_chunk.shape == (1, B_T, N_H_L, D_H)
+        assert lse_chunk.shape == (
+            1,
+            N_H_L,
+            B_T,
+        ), f"{lse_chunk.shape=}, {(1, N_H_L, B_T)=}"
+
+
+@disable_on_rocm
+@sm80_or_better_only
+@pytest.mark.parametrize(
+    "dtype,op",
+    [
+        (torch.bfloat16, fmha.triton_splitk.FwOp_S1),
+        (torch.bfloat16, fmha.triton_splitk.FwOp_S32),
+        # Cutlass's LSE is not consistent
+        # (torch.float32, fmha.cutlass.FwOp),
+        (torch.bfloat16, fmha.flash.FwOp),
+    ],
+    ids=lambda o: f"{o.NAME}" if hasattr(o, "NAME") else str(o),
+)
+@pytest.mark.parametrize("num_queries", [1, 2])
+@pytest.mark.parametrize("bmghk", [True, False], ids=lambda x: "bmghk" if x else "")
+@pytest.mark.parametrize(
+    "stack_inputs", (False, True), ids=lambda x: "stack_inputs" if x else ""
+)
+def test_merge_attentions_decoding(
+    dtype: torch.dtype,
+    op: Type[AttentionFwOpBase],
+    num_queries: int,
+    bmghk: bool,
+    stack_inputs: bool,
+):
+    """
+    Compute decoding attention on chunks of K/V and merge them together.
+    Compare with computing attention on the whole K/V.
+    """
+    MAX_T = 8192
+    B = 128
+    N_H_L = 8
+    D_H = 128
+    G = 2 if bmghk else 1
+    torch.manual_seed(1)
+    output_dtype = torch.float32 if op.SUPPORTS_OUTPUT_DTYPE else None
+
+    num_chunks = 10
+
+    chunk_starts = sorted(
+        torch.randint(low=1, high=MAX_T // 2, size=(num_chunks,)).tolist()
+    )
+    chunk_starts[0] = 0
+    chunk_starts.append(MAX_T)
+
+    # We construct sequences so that even the last chunk has a non-empty part of every sequence
+    # as long as the number of queries.
+    # Otherwise the corresponding LSE will be -inf and that'll propagate to the whole sum.
+    # It is possible to teach the kernel to ignore infinite LSEs, but in practical use cases
+    # of merging attention, e.g. a batch of sequences with a common prefix, this condition should be satisfied.
+    k_lens = torch.randint(
+        low=chunk_starts[-2] + num_queries, high=MAX_T, size=(B,)
+    ).tolist()
+    q_lens = [num_queries] * B
+    B_T = num_queries * B
+
+    q = torch.randn((1, B_T, G, N_H_L, D_H), dtype=dtype, device="cuda")
+    k = torch.randn((B, MAX_T, G, 1, D_H), dtype=dtype, device="cuda")
+    v = torch.randn_like(k)
+    if not bmghk:
+        q = q[:, :, 0]
+
+    # Compute per-chunk attention
+    chunks_output: List[Tuple[torch.Tensor, torch.Tensor]] = []
+    for i in range(num_chunks):
+        chunk_start, chunk_end = chunk_starts[i], chunk_starts[i + 1]
+        k_chunk = k[:, chunk_start:chunk_end, ...]
+        v_chunk = v[:, chunk_start:chunk_end, ...]
+        axk = k_chunk.reshape(-1, G, 1, D_H).expand(1, -1, G, N_H_L, D_H)
+        axv = v_chunk.reshape(-1, G, 1, D_H).expand(1, -1, G, N_H_L, D_H)
+        if not bmghk:
+            axk = axk[:, :, 0]
+            axv = axv[:, :, 0]
+
+        bias_type = fmha.attn_bias.BlockDiagonalPaddedKeysMask
+        if i + 1 == num_chunks:
+            bias_type = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask
+        attn_bias = bias_type.from_seqlens(
+            q_seqlen=q_lens,
+            kv_padding=chunk_end - chunk_start,
+            kv_seqlen=[max(min(x, chunk_end) - chunk_start, 0) for x in k_lens],
+        )
+
+        attn_chunk, lse_chunk = fmha.memory_efficient_attention_partial(
+            q,
+            axk,
+            axv,
+            attn_bias,
+            op=op,
+            output_dtype=output_dtype,
+        )
+        if bmghk:
+            assert attn_chunk.shape == (1, B_T, G, N_H_L, D_H)
+            assert lse_chunk.shape == (1, G, N_H_L, B_T)
+        else:
+            assert attn_chunk.shape == (1, B_T, N_H_L, D_H)
+            assert lse_chunk.shape == (1, N_H_L, B_T)
+        chunks_output.append((attn_chunk, lse_chunk))
+
+    # Merge attention from all chunks
+    attn_split = [attn_chunk for attn_chunk, _ in chunks_output]
+    lse_split = [lse_chunk for _, lse_chunk in chunks_output]
+    if stack_inputs:
+        attn_out, lse_out = fmha.merge_attentions(
+            torch.stack(attn_split), torch.stack(lse_split), output_dtype=dtype
+        )
+    else:
+        attn_out, lse_out = fmha.merge_attentions(
+            attn_split, lse_split, output_dtype=dtype
+        )
+    assert lse_out is not None
+
+    # Compute attention on the full K/V
+    attn_bias = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+        q_seqlen=q_lens,
+        kv_padding=MAX_T,
+        kv_seqlen=k_lens,
+    )
+    axk = k.view(1, -1, G, 1, D_H).expand(1, -1, G, N_H_L, D_H)
+    axv = v.view(1, -1, G, 1, D_H).expand(1, -1, G, N_H_L, D_H)
+    if not bmghk:
+        axk = axk[:, :, 0]
+        axv = axv[:, :, 0]
+    attn_full, lse_full = fmha.memory_efficient_attention_partial(
+        q,
+        axk,
+        axv,
+        attn_bias,
+        op=op,
+        output_dtype=output_dtype,
+    )
+
+    assert_allclose(
+        lse_out.to(lse_full.dtype), lse_full, rtol=1e-3, atol=1e-3, msg="lse"
+    )
+    assert_allclose(
+        attn_out.to(attn_full.dtype), attn_full, rtol=1e-3, atol=1e-3, msg="out"
+    )
+
+    attn_full2 = fmha.memory_efficient_attention_forward(
+        q,
+        axk,
+        axv,
+        attn_bias,
+        op=op,
+        output_dtype=output_dtype,
+    )
+    assert_allclose(attn_full2, attn_full, rtol=1e-3, atol=1e-3, msg="out2")
+
+
+@disable_on_rocm
+@sm80_or_better_only
+@pytest.mark.parametrize(
+    "dtype,op",
+    [
+        (torch.bfloat16, fmha.triton_splitk.FwOp_S1),
+        (torch.bfloat16, fmha.triton_splitk.FwOp_S32),
+    ],
+    ids=lambda o: f"{o.NAME}" if hasattr(o, "NAME") else str(o),
+)
+@pytest.mark.parametrize("gqa", [False, True], ids=lambda x: "gqa" if x else "")
+def test_merge_attentions_sharedinput(
+    dtype: torch.dtype,
+    op: Type[AttentionFwOpBase],
+    gqa: bool,
+):
+    """
+    Compute decoding attention on chunks of K/V and merge them together.
+    Compare with computing attention on the whole K/V.
+    """
+    MAX_T = 8192
+    N_H_L = 16
+    D_H = 128
+    G = 2
+    torch.manual_seed(1)
+    output_dtype = torch.float32 if op.SUPPORTS_OUTPUT_DTYPE else None
+
+    shared_length = 20
+    full_lengths = [30, 35, 40]
+
+    attn_bias = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+        q_seqlen=[1, 1, 1],
+        kv_padding=MAX_T,
+        kv_seqlen=full_lengths,
+    )
+    attn_bias1 = fmha.attn_bias.BlockDiagonalPaddedKeysMask.from_seqlens(
+        q_seqlen=[2, 1],
+        kv_padding=MAX_T,
+        kv_seqlen=[shared_length, 0],
+    )
+    attn_bias2 = fmha.attn_bias.BlockDiagonalGappyKeysMask.from_seqlens(
+        q_seqlen=[1, 1, 1],
+        kv_seqstarts=[shared_length, MAX_T + shared_length, 2 * MAX_T, 3 * MAX_T],
+        kv_seqlen=[
+            full_lengths[0] - shared_length,
+            full_lengths[1] - shared_length,
+            full_lengths[2],
+        ],
+    )
+
+    q = torch.randn((1, 3, G, N_H_L, D_H), dtype=dtype, device="cuda")
+    k = torch.randn((3, MAX_T, G, 1 if gqa else N_H_L, D_H), dtype=dtype, device="cuda")
+    v = torch.randn_like(k)
+    k[1, :shared_length] = k[0, :shared_length]
+    v[1, :shared_length] = v[0, :shared_length]
+    k = k.flatten(end_dim=1)[None]
+    v = v.flatten(end_dim=1)[None]
+    k = k.expand((1, 3 * MAX_T, G, N_H_L, D_H))
+    v = v.expand((1, 3 * MAX_T, G, N_H_L, D_H))
+
+    attn_chunk1, lse_chunk1 = fmha.memory_efficient_attention_partial(
+        q,
+        k,
+        v,
+        attn_bias1,
+        op=op,
+        output_dtype=output_dtype,
+    )
+    assert attn_chunk1.shape == (1, 3, G, N_H_L, D_H)
+    assert lse_chunk1.shape == (1, G, N_H_L, 3)
+    if gqa:
+        attn_chunk1a, lse_chunk1a = fmha.memory_efficient_attention_partial(
+            q,
+            k.contiguous(),
+            v,
+            attn_bias1,
+            op=op,
+            output_dtype=output_dtype,
+        )
+        assert attn_chunk1a.shape == (1, 3, G, N_H_L, D_H)
+        assert lse_chunk1a.shape == (1, G, N_H_L, 3)
+        assert_allclose(
+            attn_chunk1a.nan_to_num(0, 0, 0), attn_chunk1.nan_to_num(0, 0, 0)
+        )
+        assert_allclose(lse_chunk1a.nan_to_num(0, 0, 0), lse_chunk1.nan_to_num(0, 0, 0))
+
+    attn_chunk2, lse_chunk2 = fmha.memory_efficient_attention_partial(
+        q,
+        k,
+        v,
+        attn_bias2,
+        op=op,
+        output_dtype=output_dtype,
+    )
+    assert attn_chunk2.shape == (1, 3, G, N_H_L, D_H)
+    assert lse_chunk2.shape == (1, G, N_H_L, 3)
+    # Merge attention from all chunks
+
+    attn_out, lse_out = fmha.merge_attentions(
+        [attn_chunk1, attn_chunk2],
+        [lse_chunk1, lse_chunk2],
+        output_dtype=dtype,  # type: ignore
+    )
+    assert lse_out is not None
+
+    # Compute attention on the full K/V
+    attn_full, lse_full = fmha.memory_efficient_attention_partial(
+        q,
+        k,
+        v,
+        attn_bias,
+        op=op,
+        output_dtype=output_dtype,
+    )
+    assert_allclose(
+        attn_out.to(attn_full.dtype), attn_full, rtol=1e-2, atol=2e-3, msg="out"
+    )
+    assert_allclose(
+        lse_out.to(lse_full.dtype), lse_full, rtol=1e-3, atol=1e-3, msg="lse"
+    )
+
+
+@sm80_or_better_only
+@pytest.mark.parametrize("bmghk", (False, True))
+def test_merge_attentions_against_ref(bmghk: bool):
+    split_k = 16
+    B = 12
+    M = 137
+    G = 2 if bmghk else 1
+    N_H_L = 8
+    D_H = 128
+    dtype = torch.float32
+
+    attn_split = torch.randn([split_k, B, M, G, N_H_L, D_H], dtype=dtype, device="cuda")
+    lse_split = torch.randn([split_k, B, G, N_H_L, M], dtype=dtype, device="cuda")
+
+    if not bmghk:
+        attn_split = attn_split[:, :, :, 0]
+        lse_split = lse_split[:, :, 0]
+
+    attn_out_ref, lse_out_ref = _merge_attentions_ref(attn_split, lse_split)
+    attn_out, lse_out = fmha.merge_attentions(attn_split, lse_split)
+
+    torch.testing.assert_close(lse_out, lse_out_ref, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(attn_out, attn_out_ref, rtol=1e-4, atol=1e-4)
+
+
+def _merge_attentions_ref(attn_split, lse_split):
+    """
+    attn_split: [split_k, B, M, (G,) H, Kq]
+    lse_split: [split_k, B, (G,) H, M]
+    """
+    is_bmghk = len(attn_split.shape) == 6
+    if not is_bmghk:
+        attn_split = attn_split.unsqueeze(3)
+        lse_split = lse_split.unsqueeze(2)
+
+    lse_split = lse_split[..., None].moveaxis(4, 2)  # [split_k, B, M, G, H, 1]
+
+    lse_max, _ = torch.max(lse_split, dim=0)  # [B, M, G, H, 1]
+    sumexp_normalized = torch.exp(lse_split - lse_max)  # [split_k, B, M, G, H, 1]
+    denominator = sumexp_normalized.sum(dim=0)  # [B, M, G, H, 1]
+    numerator = (sumexp_normalized * attn_split).sum(dim=0)  # [B, M, G, H, K]
+
+    attn_out = numerator / denominator  # [B, M_ceil, G, H, Kq]
+    lse_out = lse_max + torch.log(denominator)
+    lse_out = lse_out.squeeze(4).permute(0, 2, 3, 1)  # [B, G, H, M]
+
+    if not is_bmghk:
+        attn_out = attn_out.squeeze(2)
+        lse_out = lse_out.squeeze(1)
+
+    return attn_out, lse_out
+
+
+@sm80_or_better_only
+def test_merge_attention_with_compile() -> None:
+    op = fmha.flash3.FwOp
+    if not op.is_available():
+        pytest.skip("Op is not available")
+    dtype = torch.bfloat16
+    B, M, H, K = 1, 256, 2, 128
+    q, k, v = [
+        (3 * torch.rand(B, M, H, K, dtype=dtype, device="cuda")) for _ in range(3)
+    ]
+
+    out1, lse1 = fmha.memory_efficient_attention_partial(q, k, v, op=op)
+
+    def run_code() -> torch.Tensor:
+        out, _ = fmha.merge_attentions([out1], [lse1], write_lse=True)
+        return out
+
+    out_ref = run_code()
+    out_c = torch.compile(run_code, fullgraph=True)()
+
+    assert torch.allclose(out_ref, out_c, atol=1e-2, rtol=1e-2)
+
+    q.requires_grad_(True)
+    out1, lse1 = fmha.memory_efficient_attention_partial(q, k, v, op=op)
+    loss = fmha.merge_attentions([out1], [lse1])[0].sum()
+    with pytest.raises(
+        NotImplementedError,
+        match="Backward pass is not implemented for merge_attentions",
+    ):
+        loss.backward()
+
+
+@sm80_or_better_only
+def test_merge_training():
+    torch.manual_seed(1)
+    B, M, H, K = 1, 50, 1, 128
+    dtype = torch.bfloat16
+    op = (fmha.flash3.FwOp, fmha.flash3.BwOp)
+    q = 3 * torch.rand((B, M, H, K), device="cuda", dtype=dtype)
+    k = 3 * torch.rand((B, M, H, K), device="cuda", dtype=dtype)
+    v = 3 * torch.rand((B, M, H, K), device="cuda", dtype=dtype)
+    grad_out = 3 * torch.rand((B, M, H, K), device="cuda", dtype=dtype)
+
+    total_attention, (q_grad, k_grad, v_grad) = torch.autograd.functional.vjp(
+        fmha.memory_efficient_attention, (q, k, v), grad_out
+    )
+
+    def total_attn_via_Partial(q_, k_, v_):
+        return merge_attentions_autograd(
+            memory_efficient_attention_partial_autograd(q_, k_, v_)
+        )
+
+    attn, (q_grad_, k_grad_, v_grad_) = torch.autograd.functional.vjp(
+        total_attn_via_Partial, (q, k, v), grad_out
+    )
+
+    assert_allclose(attn, total_attention, rtol=1e-1, atol=1e-3, msg="out")
+    assert_allclose(k_grad_, k_grad, rtol=1e-2, atol=1e-3, msg="dk_")
+    assert_allclose(q_grad_, q_grad, rtol=1e-2, atol=1e-3, msg="dq_")
+    assert_allclose(v_grad_, v_grad, rtol=1e-2, atol=1e-3, msg="dv_")
+
+    def attn_via_Partial(q_, k_, v_):
+        split = M // 2
+        k1 = k_[:, :split]
+        k2 = k_[:, split:]
+        v1 = v_[:, :split]
+        v2 = v_[:, split:]
+
+        partial1 = memory_efficient_attention_partial_autograd(q_, k1, v1, op=op)
+        partial2 = memory_efficient_attention_partial_autograd(q_, k2, v2, op=op)
+        return merge_attentions_autograd(partial1, partial2)
+
+    merged, (q_grad_, k_grad_, v_grad_) = torch.autograd.functional.vjp(
+        attn_via_Partial, (q, k, v), grad_out
+    )
+    assert_allclose(
+        merged.to(total_attention.dtype),
+        total_attention,
+        rtol=1e-1,
+        atol=1e-3,
+        msg="out",
+    )
+    assert_allclose(k_grad_, k_grad, rtol=0.1, atol=0.9, msg="dk")
+    assert_allclose(q_grad_, q_grad, rtol=0.1, atol=0.9, msg="dq")
+    assert_allclose(v_grad_, v_grad, rtol=0.1, atol=0.9, msg="dv")
+
+
+def _pad_seqdim(partial: Partial, left: int, right: int) -> Partial:
+    padding = (0, 0) * (3 if partial.is_bmghk() else 2) + (left, right)
+    return partial.apply(lambda x: torch.nn.functional.pad(x, padding))
+
+
+def _slice(partial: Partial, a: int, b: int) -> Partial:
+    return partial.apply(lambda x: x[:, a:b])
+
+
+@sm80_or_better_only
+def test_merge_training_compile():
+    torch.manual_seed(1)
+    B, M, H, K = 1, 50, 1, 128
+    dtype = torch.bfloat16
+    q = 3 * torch.rand((B, M, H, K), device="cuda", dtype=dtype)
+    k = 3 * torch.rand((B, M, H, K), device="cuda", dtype=dtype)
+    v = 3 * torch.rand((B, M, H, K), device="cuda", dtype=dtype)
+
+    def f(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> torch.Tensor:
+        k1 = k[:, : M // 2]
+        k2 = k[:, M // 2 :]
+        v1 = v[:, : M // 2]
+        v2 = v[:, M // 2 :]
+        partial1 = memory_efficient_attention_partial_autograd(q, k1, v1)
+        partial2 = memory_efficient_attention_partial_autograd(q, k2, v2)
+        partial2 = _pad_seqdim(_pad_seqdim(partial2, 2, 3), -2, -3)
+        partial2 = _slice(_pad_seqdim(partial2, 2, 3), 2, -3)
+        merged = merge_attentions_autograd(partial1, partial2)
+        return merged.sum()
+
+    out, grads = torch.autograd.functional.vjp(f, (q, k, v))
+    outc, gradsc = torch.autograd.functional.vjp(
+        torch.compile(fullgraph=True)(f), (q, k, v)
+    )
+    assert_allclose(out, outc, rtol=1e-1, atol=1e-3)
+    for i, (grad, gradc) in enumerate(zip(grads, gradsc)):
+        assert_allclose(grad, gradc, rtol=1e-1, atol=1e-3, msg=f"grad{i}")
+
+    def g(q: torch.Tensor, k1: torch.Tensor, v1: torch.Tensor) -> torch.Tensor:
+        partial1 = memory_efficient_attention_partial_autograd(q, k1, v1)
+        return merge_attentions_autograd(partial1).sum()
+
+    out, grads = torch.autograd.functional.vjp(g, (q, k, v))
+    outc, gradsc = torch.autograd.functional.vjp(
+        torch.compile(fullgraph=True)(g), (q, k, v)
+    )
+    assert_allclose(out, outc, rtol=1e-1, atol=1e-3)
+    for i, (grad, gradc) in enumerate(zip(grads, gradsc)):
+        assert_allclose(grad, gradc, rtol=1e-1, atol=1e-3, msg=f"grad{i}")
+
+
+@sm80_or_better_only
+def test_merge_training_zilch():
+    with pytest.raises(ValueError, match="No partials to merge"):
+        merge_attentions_autograd()
+
+
+@sm80_or_better_only
+def test_merge_training_undilate():
+    torch.manual_seed(1)
+
+    def undilate(factor: int) -> Callable[[torch.Tensor], torch.Tensor]:
+        """
+        For a given factor, operate on BMHK attention output as follows:
+        If sequence length is M and there are H * factor heads,
+        redistribute so there are H heads and each
+        original sequence position is factor times inflated.
+        """
+
+        def inner(x: torch.Tensor) -> torch.Tensor:
+            M = x.shape[1]
+            H = x.shape[2] // factor
+            return x.flatten(1, 2).unflatten(1, (M * factor, H))
+
+        return inner
+
+    B, M, F, H, K = 1, 2, 3, 5, 128
+    dtype = torch.bfloat16
+    q = 3 * torch.rand((B, M, F * H, K), device="cuda", dtype=dtype)
+    k = 3 * torch.rand((B, M, F * H, K), device="cuda", dtype=dtype)
+    v = 3 * torch.rand((B, M, F * H, K), device="cuda", dtype=dtype)
+
+    bias = fmha.BlockDiagonalMask.from_seqlens([1] * M)
+    partial = memory_efficient_attention_partial_autograd(q, k, v, bias)
+
+    q = q.reshape(B, M * F, H, K)
+    k = k.reshape(B, M * F, H, K)
+    v = v.reshape(B, M * F, H, K)
+
+    bias = fmha.BlockDiagonalMask.from_seqlens([1] * (M * F))
+    expected = memory_efficient_attention_partial_autograd(q, k, v, bias)
+    undilated = partial.apply(undilate(F))
+
+    assert_allclose(undilated._attn, expected._attn)
+    assert_allclose(undilated._lse, expected._lse)

--- a/test/attention/fmha/test_fmha_split_blocks_fairinternal.py
+++ b/test/attention/fmha/test_fmha_split_blocks_fairinternal.py
@@ -1,0 +1,260 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+import pytest
+import torch
+
+from mslk.attention import fmha
+from mslk.attention.fmha.split_blocks_fairinternal import (
+    split_blocks_for_decoding,
+    split_blocks_for_prefill,
+)
+
+from .utils import cuda_only
+
+compute_capability = (0, 0)
+if torch.cuda.is_available():
+    compute_capability = torch.cuda.get_device_capability("cuda")
+sm80_or_better_only = pytest.mark.skipif(
+    torch.version.cuda is not None and compute_capability < (8, 0),
+    reason="requires sm80+",
+)
+
+
+def test_split_blocks_for_decoding():
+    torch.manual_seed(0)
+    max_len_kv = 2048
+    B = 64
+    local_attention_len = 512
+    seqlens = torch.randint(
+        max_len_kv, size=(B,), device=torch._C._get_accelerator().type
+    )
+    seqlens[4] = 0
+    attn_bias = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+        q_seqlen=[1] * B, kv_seqlen=seqlens.tolist(), kv_padding=max_len_kv
+    )
+    chunked_bias = split_blocks_for_decoding(attn_bias, local_attention_len)
+    assert chunked_bias.q_seqinfo.seqstart_py == list(range(B + 1))
+    assert chunked_bias.k_seqinfo.seqlen.tolist() == chunked_bias.k_seqinfo.seqlen_py
+    assert (
+        chunked_bias.k_seqinfo.seqstart.tolist() == chunked_bias.k_seqinfo.seqstart_py
+    )
+    assert (chunked_bias.k_seqinfo.seqlen <= local_attention_len).all()
+    assert (chunked_bias.k_seqinfo.seqstart >= attn_bias.k_seqinfo.seqstart).all()
+
+
+def test_split_blocks_for_decoding_with_paged():
+    torch.manual_seed(0)
+    max_len_kv = 2048
+    B = 16
+    local_attention_len = 512
+    seqlens = torch.randint(
+        max_len_kv, size=(B,), device=torch._C._get_accelerator().type
+    )
+    # test the case with zero lengths:
+    # - set last 3 seqlen to 0
+    seqlens[-2] = seqlens[-1] = seqlens[0] = 0
+
+    page_size = 256
+    num_pages = 64
+
+    page_table = torch.zeros((B, num_pages), dtype=torch.int32, device="cuda")
+
+    attn_bias = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+        q_seqlen=[1] * B, kv_seqlen=seqlens.tolist(), kv_padding=max_len_kv
+    )
+    chunked_bias = split_blocks_for_decoding(
+        attn_bias, local_attention_len, block_tables=page_table, page_size=page_size
+    )
+
+    # for paged + gappy, the length is the last post, instead of the real length
+
+    k_seqlen = chunked_bias.k_seqinfo.seqlen
+    k_seqstart = chunked_bias.k_seqinfo.seqstart
+    k_seqlen_py = chunked_bias.k_seqinfo.seqlen_py
+    k_seqstart_py = chunked_bias.k_seqinfo.seqstart_py
+
+    paged_gappy_length = k_seqlen - k_seqstart
+
+    assert (paged_gappy_length <= local_attention_len).all()
+    assert (paged_gappy_length >= 0).all()
+    assert (k_seqstart >= 0).all()  # check the zero length case
+    assert len(k_seqstart) == len(k_seqlen) == B
+    assert k_seqlen.tolist() == k_seqlen_py
+    assert k_seqstart.tolist() == k_seqstart_py
+
+
+if not torch.version.hip and compute_capability >= (9, 0):
+    decode_ops = [fmha.triton_splitk.FwOp, fmha.flash3.FwOp, fmha.flash3.FwOp_KVSplit]
+else:
+    decode_ops = [fmha.triton_splitk.FwOp]
+
+
+@cuda_only
+@sm80_or_better_only
+@pytest.mark.parametrize(
+    "spec_decoding", [False, True], ids=lambda x: "spec" if x else ""
+)
+@pytest.mark.parametrize("paged", [False, True], ids=lambda x: "paged" if x else "")
+@pytest.mark.parametrize(
+    "decoding_op",
+    decode_ops,
+    ids=lambda x: x.__name__,
+)
+def test_split_blocks_decoding_vs_prefill(spec_decoding, paged, decoding_op):
+    """
+    We should be able to use the prefill split-blocks algo for decoding, and get the same attention output.
+    """
+    torch.manual_seed(0)
+    if torch.version.hip:
+        op = fmha.ck.FwOp
+    elif fmha.flash.FwOp.VARLEN_LSE_PACKED:
+        # Modern enough flash attention
+        op = fmha.flash.FwOp
+    else:
+        pytest.skip("We have op to test with")
+        raise AssertionError
+
+    AttnBias = (
+        fmha.attn_bias.BlockDiagonalPaddedKeysMask
+        if spec_decoding
+        else fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask
+    )
+    PagedAttnBias = (
+        fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask
+        if spec_decoding
+        else fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetPaddedKeysMask
+    )
+
+    dtype = torch.bfloat16
+    nheads_kv = 1
+    nheads_q = 8
+    seq_len_q = 5 if spec_decoding else 1
+    head_dim = 128
+    max_len_kv = 2048
+    B = 64
+    local_attention_len = 512
+    seqlens = torch.randint(
+        low=seq_len_q,
+        high=max_len_kv,
+        size=(B,),
+        device=torch._C._get_accelerator().type,
+    )
+
+    if not spec_decoding:
+        # Here we introduce corner cases when the query is close to the boundaries of two iRoPE chunks.
+        # In particular, for spec decoding, when the query (aka draft) length > 1, special care
+        # needs to be taken when the draft crosses the boundary - see the comment in
+        # split_blocks_fairinternal.split_blocks_for_decoding_gpu_part.
+        # Function split_blocks_for_prefill doesn't handle this case correctly,
+        # so we skip these corner cases for spec decoding.
+        seqlens[3] = local_attention_len * 2  # corner cases
+        # seqlens[4] = local_attention_len * 2  + 3 # reproduces cross boundary case
+        seqlens[2] = local_attention_len
+    if spec_decoding:
+        # Ensure no cross-boundary attention
+        non_compliant_mask = (seqlens >= seq_len_q) & (
+            seqlens % local_attention_len < seq_len_q
+        )
+        adjustment = (seqlens % local_attention_len) * non_compliant_mask
+        seqlens -= adjustment
+    attn_bias = AttnBias.from_seqlens(
+        q_seqlen=[seq_len_q] * B, kv_seqlen=seqlens.tolist(), kv_padding=max_len_kv
+    )
+    if paged:
+        page_size = 256
+        block_tables = torch.arange(
+            B * max_len_kv // page_size, device="cuda", dtype=torch.int32
+        ).reshape(B, -1)
+    else:
+        page_size = None
+        block_tables = None
+    chunked_bias_decoding = split_blocks_for_decoding(
+        attn_bias, local_attention_len, block_tables, page_size
+    )
+    chunked_bias_prefill = split_blocks_for_prefill(attn_bias, local_attention_len)
+    prefill_attn_to_use = chunked_bias_prefill
+    if paged:
+        attn_batch_size = len(chunked_bias_prefill.k_seqinfo.seqlen)
+        if attn_batch_size != block_tables.shape[0]:
+            block_tables = block_tables.view(attn_batch_size, -1)
+        prefill_attn_to_use = chunked_bias_prefill.make_paged(
+            block_tables,
+            page_size,
+            paged_type=PagedAttnBias,
+        )
+
+    if type(chunked_bias_decoding) not in decoding_op.SUPPORTED_ATTN_BIAS_TYPES:
+        pytest.skip(
+            f"Decoding op {decoding_op.NAME} doesn't support bias {type(chunked_bias_decoding)}"
+        )
+    if type(prefill_attn_to_use) not in op.SUPPORTED_ATTN_BIAS_TYPES:
+        pytest.skip(
+            f"Prefill op {op.NAME} doesn't support bias {type(prefill_attn_to_use)}"
+        )
+
+    # The only difference between attention biases should be that the bias computed
+    # using split_blocks_for_prefill contains elements with query len 0.
+    decoding_q_lens = [b - a for a, b in chunked_bias_decoding.q_seqinfo.intervals()]
+    prefill_q_lens = [b - a for a, b in prefill_attn_to_use.q_seqinfo.intervals()]
+    assert [x for x in prefill_q_lens if x > 0] == decoding_q_lens
+    if paged:
+        # seqlen_py is the end of the sequence, not the length
+        decoding_k_lens = [
+            a - b
+            for a, b in zip(
+                chunked_bias_decoding.k_seqinfo.seqlen_py,
+                chunked_bias_decoding.k_seqinfo.seqstart_py,
+            )
+        ]
+    else:
+        decoding_k_lens = chunked_bias_decoding.k_seqinfo.seqlen_py
+    filtered_prefill_k_lens = [
+        x
+        for x, y in zip(prefill_attn_to_use.k_seqinfo.seqlen_py, prefill_q_lens)
+        if y > 0
+    ]
+    assert decoding_k_lens == filtered_prefill_k_lens
+
+    q = torch.randn(
+        B,
+        seq_len_q,
+        nheads_q,
+        head_dim,
+        device=torch._C._get_accelerator().type,
+        dtype=dtype,
+    )
+    k = torch.randn(
+        B,
+        max_len_kv,
+        nheads_kv,
+        head_dim,
+        device=torch._C._get_accelerator().type,
+        dtype=dtype,
+    )
+    v = torch.randn(
+        B,
+        max_len_kv,
+        nheads_kv,
+        head_dim,
+        device=torch._C._get_accelerator().type,
+        dtype=dtype,
+    )
+
+    xq = q.view(1, -1, nheads_q, head_dim)
+    xk = k.view(1, -1, nheads_kv, head_dim).expand(1, -1, nheads_q, -1)
+    xv = v.view(1, -1, nheads_kv, head_dim).expand(1, -1, nheads_q, -1)
+
+    out_dec, lse_dec = fmha.memory_efficient_attention_forward_requires_grad(
+        xq, xk, xv, chunked_bias_decoding, op=decoding_op
+    )
+
+    out_prefill, lse_prefill = fmha.memory_efficient_attention_forward_requires_grad(
+        xq, xk, xv, prefill_attn_to_use, op=op
+    )
+
+    torch.testing.assert_close(out_dec, out_prefill, rtol=1e-4, atol=5e-3)
+    torch.testing.assert_close(lse_dec, lse_prefill, rtol=1e-4, atol=1e-4)

--- a/test/attention/fmha/test_mem_eff_attention.py
+++ b/test/attention/fmha/test_mem_eff_attention.py
@@ -1,0 +1,3435 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+# pyre-ignore-all-errors[29]
+
+import logging
+import math
+import random
+from contextlib import nullcontext
+from typing import Any, List, Optional, Sequence, Tuple, Type, TypeVar
+
+import pytest
+import torch
+
+try:
+    from mtia.re.re_unittest_lib import init_mtia_device  # type: ignore
+
+    init_mtia_device()
+except ImportError:
+    # Failed to load MTIA libraries, so just keep going without MTIA devices
+    pass
+
+from mslk.attention import fmha
+from mslk.attention.fmha import ALL_BW_OPS, ALL_FW_OPS
+from mslk.attention.fmha.attn_bias_utils import create_attn_bias, pack_kv_cache
+from mslk.attention.fmha.common import (
+    AttentionFwOpBase,
+    AttentionOpBase,
+    pack_fp8_tensorwise_per_head,
+)
+from mslk.attention.fmha.dispatch import _dispatch_fw_priority_list
+from mslk.attention.fmha.unbind import unbind
+from scipy.stats import binomtest  # type: ignore
+from torch.utils.checkpoint import checkpoint
+
+from .utils import (
+    add_q_fp8_to_inputs,
+    assert_allclose,
+    construct_fp8_attention_inputs,
+    cuda_only,
+    cuda_or_mtia_only,
+    disable_on_mtia,
+    disable_on_rocm,
+    disable_tf32,
+    ref_attention_bmhk_for_test,
+    ref_attention_for_test,
+    rocm_only,
+    use_cpu_ref,
+)
+
+compute_capability = (0, 0)
+if torch.cuda.is_available():
+    compute_capability = torch.cuda.get_device_capability("cuda")
+sm70_or_better_only = pytest.mark.skipif(
+    torch.version.cuda is not None and compute_capability < (7, 0),
+    reason="requires sm70+",
+)
+sm75_or_better_only = pytest.mark.skipif(
+    torch.version.cuda is not None and compute_capability < (7, 5),
+    reason="requires sm75+",
+)
+sm80_or_better_only = pytest.mark.skipif(
+    torch.version.cuda is not None and compute_capability < (8, 0),
+    reason="requires sm80+",
+)
+sm90_or_better_only = pytest.mark.skipif(
+    compute_capability < (9, 0),
+    reason="requires sm90+",
+)
+sm100_or_better_only = pytest.mark.skipif(
+    compute_capability < (10, 0), reason="requires sm100+"
+)
+skip_if_sm100_or_better = pytest.mark.skipif(
+    compute_capability >= (10, 0), reason="not supported on Blackwell"
+)
+
+skip_if_rocm = pytest.mark.skipif(
+    torch.version.hip is not None, reason="not supported on ROCm"
+)
+_devices = ["cpu"]
+_devices += ["cuda"] if torch.cuda.is_available() else []
+
+try:
+    import mtia.host_runtime.torch_mtia.dynamic_library  # noqa  # type: ignore
+
+    # torch.mtia.is_available() will not work here, since test collection can be done
+    # on a machine without MTIA devices
+    _devices.append("mtia")
+except (ImportError, OSError):
+    # Failed to load MTIA libraries, so just keep going without MTIA devices
+    pass
+
+T = TypeVar(
+    "T", Type[fmha.common.AttentionFwOpBase], Type[fmha.common.AttentionBwOpBase]
+)
+
+logger = logging.getLogger("xformers")
+
+
+def _filter_unsupported_ops(ops: Sequence[T]) -> List[T]:
+    return [
+        op
+        for op in ops
+        if (
+            "cpu" in op.SUPPORTED_DEVICES
+            or "mtia" in op.SUPPORTED_DEVICES
+            or (
+                op.CUDA_MINIMUM_COMPUTE_CAPABILITY <= compute_capability
+                and (
+                    (max_cap := op.CUDA_MAXIMUM_COMPUTE_CAPABILITY) is None
+                    or max_cap >= compute_capability
+                )
+            )
+        )
+        and op.is_available()
+    ]
+
+
+ALL_FW_OPS = _filter_unsupported_ops(ALL_FW_OPS)
+ALL_BW_OPS = _filter_unsupported_ops(ALL_BW_OPS)
+
+
+def sample_random_supported_fw(
+    inp: fmha.Inputs, seed, op_bw: Type[fmha.common.AttentionBwOpBase]
+) -> Type[fmha.common.AttentionFwOpBase]:
+    r = random.Random(seed)
+    fw_ops = list(ALL_FW_OPS)
+    if op_bw == fmha.cutlass_blackwell.BwOp:
+        fw_ops = [fmha.cutlass_blackwell.FwOp, fmha.flash.FwOp]
+    if (
+        isinstance(inp.attn_bias, fmha.attn_bias.VARLEN_BIASES)
+        and inp.attn_bias.q_seqinfo.seqstart.shape[0] > 2
+    ):
+        fw_ops = [
+            op for op in fw_ops if op.VARLEN_LSE_PACKED == op_bw.VARLEN_LSE_PACKED
+        ]
+    r.shuffle(fw_ops)
+    for op in fw_ops:
+        if op.supports(inp):
+            return op
+    raise NotImplementedError(f"Could not find a FW operator for: {inp}")
+
+
+def generate_test_shapes_B_Mq_Mkv_H_K_Kv(op):  # noqa: C901
+    shapes = []
+    for B in op._TEST_BATCH_SIZES:
+        for Mq in [32, 256]:
+            for Mkv in [32, 64, 256, 1024]:
+                for K in op._TEST_K:
+                    shapes.append((B, Mq, Mkv, 1, K, K))
+        Mq = 256
+        Mkv = 128
+        K = 32
+        H = 1
+        # Weird values of parameters
+        for M in [2, 3, 15, 31, 32, 34, 68, 72, 90, 132, 136]:
+            shapes.append((B, M, Mkv, H, K, K))
+            shapes.append((B, Mq, M, H, K, K))
+        Ks = [1, 2, 3, 31, 34, 36, 38, 40, 64, 80, 160, 256 + 2, 256 + 8, 512]
+        for _K in Ks:
+            if op.SUPPORTED_MIN_K <= _K <= op.SUPPORTED_MAX_K:
+                shapes.append((B, Mq, Mkv, H, _K, _K))
+        # Different value for K / Kv
+        if op.SUPPORTS_DIFFERENT_VALUE_EMBED:
+            for _K in [32, 36, 64, 256 + 8]:
+                shapes.append((B, Mq, Mkv, H, K, _K))
+                shapes.append((B, Mq, Mkv, H, _K, K))
+        # Exotic sizes
+        for K in op._TEST_K:
+            shapes.append((B, 16, 1024, H, K, K))
+            shapes.append((B, 1024, 16, H, K, K))
+        # Some number of heads
+        for H in [3, 5, 12]:
+            shapes.append((max(1, B // H), Mq, Mkv, H, K, K))
+    # Filter-out not supported shapes
+    shapes = [
+        shape
+        for shape in shapes
+        if len(
+            op.shape_not_supported_reasons(
+                Mq=shape[1], Mkv=shape[2], K=shape[4], Kv=shape[5]
+            )
+        )
+        == 0
+    ]
+    # Add some random shapes
+    if op in [
+        fmha.cutlass.FwOp,
+        fmha.cutlass.BwOp,
+        fmha.cutlass_blackwell.FwOp,
+        fmha.cutlass_blackwell.BwOp,
+        fmha.flash.BwOp,
+        fmha.ck.FwOp,
+    ]:
+        K_CHOICES = [8 * i for i in range(1, 256 // 8)]
+        r = random.Random(0)
+        found_count = 0
+        while found_count < 200:
+            B = r.randint(1, 400)
+            Mq = r.randint(1, 500)
+            Mkv = r.randint(1, 500)
+            H = r.randint(2, 11)
+            B = max(B // H, 1)
+            K = r.choice(K_CHOICES)
+            Kv = r.choice(K_CHOICES)
+            if not op.SUPPORTS_DIFFERENT_VALUE_EMBED:
+                Kv = K
+            if len(op.shape_not_supported_reasons(Mq, Mkv, K, Kv)):
+                continue
+            found_count += 1
+            shapes.append((B, Mq, Mkv, H, K, Kv))
+    return shapes
+
+
+def make_id(op, device, dtype, bias_type, *shape):
+    return (
+        f"{op.NAME}-{device}-{str(dtype)}-{bias_type.__name__}"
+        f"-{'-'.join([str(s) for s in shape])}"
+    )
+
+
+# This temporary working is necessary because the MTIA test collection might not happen
+# on the same device as the device the tests are actually executed on. If test collection
+# is done on a device without MTIA, the supported masks will contain masks that MTIA support
+# and the corresponding tests will get collected. But when it comes time to actually run the
+# tests, the mask won't be supported because it is run on an actual MTIA device.
+def get_supported_attn_bias_types(op):
+    supported_attn_bias_types = op.SUPPORTED_ATTN_BIAS_TYPES
+
+    try:
+        import mtia.host_runtime.torch_mtia.dynamic_library  # noqa
+
+        supported_attn_bias_types = [
+            b
+            for b in supported_attn_bias_types
+            if not issubclass(
+                b,
+                (
+                    fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+                    fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                ),
+            )
+        ]
+    except (ImportError, OSError):
+        pass
+
+    return supported_attn_bias_types
+
+
+def _generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(  # noqa: C901
+    ops_list: Sequence[Type[fmha.AttentionOpBase]], max_shapes_per_op: int = 65000
+):
+    r = random.Random(0)
+    combination = []
+    for op in ops_list:
+        op_count = 0
+        # Sort list of masks, so it's deterministic across runs
+        LIST_MASKS = sorted(get_supported_attn_bias_types(op), key=str)
+        for shape in generate_test_shapes_B_Mq_Mkv_H_K_Kv(op):
+            has_one = False
+            for device in _devices:
+                if device not in op.SUPPORTED_DEVICES:
+                    continue
+                # Sort set of dtypes to make it deterministic across runs
+                for dtype in sorted(op.SUPPORTED_DTYPES, key=str):
+                    # "normal_kernel_cuda" not implemented for 'Float8_e4m3fn'
+                    if dtype in [torch.float8_e4m3fn]:
+                        continue
+                    bias_type = r.choice(LIST_MASKS)
+                    # Avoid using too much memory
+                    B, Mq, Mkv, H, K, Kv = shape
+                    if bias_type not in [
+                        type(None),
+                        fmha.attn_bias.LowerTriangularMask,
+                    ]:
+                        B = min(B, 12)
+
+                        if bias_type in {
+                            fmha.attn_bias.BlockDiagonalCausalFromBottomRightMask,
+                            fmha.attn_bias.BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+                        }:
+                            Mq, Mkv = min(Mkv, Mq), max(Mkv, Mq) + 2
+                        elif bias_type in {
+                            fmha.attn_bias.BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+                            fmha.attn_bias.BlockDiagonalLocalAttentionPaddedKeysMask,
+                            fmha.attn_bias.BlockDiagonalCausalWithOffsetGappyKeysMask,
+                            fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask,
+                            fmha.attn_bias.BlockDiagonalPaddedKeysMask,
+                            fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+                            fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                            fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+                            fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+                        }:
+                            Mq, Mkv = min(Mkv, Mq), max(Mkv, Mq)
+                    new_shape = (B, Mq, Mkv, H, K, Kv)
+                    combination.append((op, device, dtype, bias_type, *new_shape))
+                    has_one = True
+            if has_one:
+                op_count += 1
+            if op_count > max_shapes_per_op:
+                break
+        # Some specific shapes for which we want to run without any mask
+        bias_type = type(None)
+        for shape in (
+            # Some strides/dims don't fit on an uint16
+            (1, 128, 128, 300, 128, 128),
+            (13, 1, 67, 200, 8, 8),
+            (1, 1 + 2**16, 4, 1, 8, 8),
+            (1, 4, 1 + 2**16, 1, 8, 8),
+            # TODO: Some strides don't fit on an uint32
+            # Crashes on Flash, Errors on Cutlass
+            # (1, 1, 64000, 300, 128, 128)
+        ):
+            for device in _devices:
+                if device not in op.SUPPORTED_DEVICES:
+                    continue
+                # Sort set of dtypes to make it deterministic across runs
+                for dtype in sorted(op.SUPPORTED_DTYPES, key=str):
+                    # "normal_kernel_cuda" not implemented for 'Float8_e4m3fn'
+                    if dtype in [torch.float8_e4m3fn]:
+                        continue
+                    combination.append((op, device, dtype, bias_type, *shape))
+    return {
+        "argvalues": combination,
+        "ids": [make_id(*c) for c in combination],
+    }
+
+
+parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv = pytest.mark.parametrize(
+    "opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    **_generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(ALL_FW_OPS),
+)
+parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs = pytest.mark.parametrize(
+    "opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    **_generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(ALL_FW_OPS, max_shapes_per_op=1),
+)
+parametrize_opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv = pytest.mark.parametrize(
+    "opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    **_generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(ALL_BW_OPS),
+)
+parametrize_opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs = pytest.mark.parametrize(
+    "opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    **_generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(ALL_BW_OPS, max_shapes_per_op=1),
+)
+
+
+def _rand_partition(r: random.Random, total: int, n: int) -> List[int]:
+    # returns list of n nonnegative integers summing to total
+    idx = {0, total}
+    while len(idx) < n + 1:
+        idx.add(r.randint(1, total - 1))
+    s = sorted(idx)
+    return [e - b for b, e in zip(s[:-1], s[1:])]
+
+
+def get_bias_grad(attn_bias, clear: bool = False) -> Optional[torch.Tensor]:
+    tensor_with_grad: Optional[torch.Tensor] = None
+    if isinstance(attn_bias, torch.Tensor):
+        tensor_with_grad = attn_bias
+    if tensor_with_grad is not None:
+        grad = tensor_with_grad.grad
+        if clear:
+            tensor_with_grad.grad = None
+        return grad
+    return None
+
+
+def create_tensors(  # noqa: C901
+    op: Optional[Type[AttentionOpBase]],
+    device,
+    dtype,
+    attn_bias_type,
+    B,
+    q_len,
+    kv_len,
+    h,
+    k,
+    kv,
+    *,
+    attn_bias_requires_grad: bool = False,
+    fmt: str = "BMK",
+    g: int = 1,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Any]:
+    torch.manual_seed(B * q_len + kv_len * k + kv)
+
+    mask_is_bottom_right = attn_bias_type is not None and issubclass(
+        attn_bias_type,
+        (
+            fmha.attn_bias.LowerTriangularFromBottomRightMask,
+            fmha.attn_bias.LowerTriangularFromBottomRightLocalAttentionMask,
+            fmha.attn_bias.BlockDiagonalCausalFromBottomRightMask,
+            fmha.attn_bias.BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+            fmha.attn_bias.BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask,
+            fmha.attn_bias.BlockDiagonalCausalLocalAttentionMask,
+            fmha.attn_bias.LocalAttentionFromBottomRightMask,
+            fmha.attn_bias.PagedBlockDiagonalCausalLocalPaddedKeysMask,
+        ),
+    )
+    if mask_is_bottom_right and q_len > kv_len:
+        # Bottom-right attention and local-attention masks require q_len <= kv_len
+        kv_len = q_len
+
+    if attn_bias_type is not None and issubclass(
+        attn_bias_type,
+        (
+            fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+            fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+        ),
+    ):
+        page_size_choices = [256, 512]
+        if op is not None and issubclass(op, fmha.triton_splitk.FwOp):
+            # TODO: enable small pages for flash attention when that's implemented
+            page_size_choices.extend([64, 128])
+        page_size = random.choice(page_size_choices)
+        kv_len_paged = (kv_len + page_size - 1) // page_size * page_size
+    else:
+        kv_len_paged = kv_len
+        page_size = None
+
+    scale = 3
+    if fmt == "BMK":
+        query = torch.randn((B * h, q_len, k), device=device, dtype=dtype)
+        key = torch.randn((B * h, kv_len_paged, k), device=device, dtype=dtype)
+        value = torch.randn((B * h, kv_len_paged, kv), device=device, dtype=dtype)
+    elif fmt == "BMHK":
+        query = torch.randn((B, q_len, h, k), device=device, dtype=dtype)
+        key = torch.randn((B, kv_len_paged, h, k), device=device, dtype=dtype)
+        value = torch.randn((B, kv_len_paged, h, kv), device=device, dtype=dtype)
+    else:
+        assert fmt == "BMGHK"
+        query = torch.randn((B, q_len, g, h, k), device=device, dtype=dtype)
+        key = torch.randn((B, kv_len_paged, g, 1, k), device=device, dtype=dtype)
+        value = torch.randn((B, kv_len_paged, g, 1, kv), device=device, dtype=dtype)
+
+    for x in [query, key, value]:
+        x.mul_(scale)
+
+    if fmt == "BMGHK":
+        # Expand - after the in-place mul
+        key = key.expand((B, kv_len_paged, g, h, k))
+        value = value.expand((B, kv_len_paged, g, h, k))
+
+    if fmt == "BMK" and not fmha.common._is_bias_type_supported_in_BMK(attn_bias_type):
+        attn_bias_type = None
+    attn_bias = None
+    if attn_bias_type is not None:
+        attn_bias = create_attn_bias(
+            attn_bias_type,
+            batch_size=B,
+            num_heads=h,
+            num_heads_groups=g,
+            q_len=q_len,
+            kv_len=kv_len,
+            dtype=dtype,
+            device=device,
+            requires_grad=attn_bias_requires_grad,
+            fmt=fmt,
+            op=op,
+            page_size=page_size,
+        )
+        if isinstance(
+            attn_bias,
+            (
+                fmha.attn_bias.BlockDiagonalMask,
+                fmha.attn_bias.BlockDiagonalGappyKeysMask,
+                fmha.attn_bias.BlockDiagonalPaddedKeysMask,
+                fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+                fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+            ),
+        ):
+            query, key, value = [
+                x.reshape([1, -1, *x.shape[2:]]) for x in [query, key, value]
+            ]
+
+    inputs = fmha.Inputs(query=query, key=key, value=value, attn_bias=attn_bias)
+    if op is not None:
+        reasons = op.not_supported_reasons(inputs)
+        if reasons:
+            err_msg = f"{op.NAME}: unsupported ({'/'.join(reasons)})"
+            # Ensure we free memory to avoid OOMs
+            del query, key, value, attn_bias, inputs
+            pytest.skip(err_msg)
+    return query, key, value, attn_bias
+
+
+def bmhk2bmk(tensor) -> torch.Tensor:
+    return (
+        tensor.permute((0, 2, 1, 3))
+        .contiguous()
+        .view([tensor.shape[0] * tensor.shape[2], tensor.shape[1], tensor.shape[3]])
+    )
+
+
+def bmk2bmhk(tensor, num_heads: int) -> torch.Tensor:
+    return tensor.reshape([-1, num_heads, tensor.shape[1], tensor.shape[2]]).permute(
+        (0, 2, 1, 3)
+    )
+
+
+def nanify_oob_seqlen(x: torch.Tensor) -> torch.Tensor:
+    align_to = 256
+    if x.shape[1] % align_to == 0:
+        return x
+    pad = [0, 0] * x.ndim
+    pad[-3] = align_to - (x.shape[1] % align_to)
+    x_pad = torch.nn.functional.pad(x, pad, value=math.nan)
+    return x_pad[:, : x.shape[1]]
+
+
+@pytest.mark.parametrize("fmt", ["BMK", "BMHK"])
+@pytest.mark.parametrize("packed", [False, True])
+@parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+def test_forward(opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, packed, fmt, **kwargs):
+    (
+        op,
+        device,
+        dtype,
+        bias_type,
+        batch_size,
+        q_len,
+        kv_len,
+        h,
+        k,
+        kv,
+    ) = opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+    if packed and issubclass(
+        bias_type,
+        (
+            fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+            fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+        ),
+    ):
+        pytest.skip(
+            "packed doesn't make sense with paged attention, since q has different shape than k/v"
+        )
+    if packed and not (k == kv and q_len == kv_len):
+        pytest.skip(
+            f"packed incompatible with `k ({k}) != kv ({kv})` or `q_len ({q_len}) != kv_len ({kv_len})`"
+        )
+    if fmt == "BMK" and not fmha.common._is_bias_type_supported_in_BMK(bias_type):
+        pytest.skip("BMK incompatible with this bias")
+
+    if op is fmha.ck.FwOp:
+        if (k > 256 or kv > 256) and issubclass(
+            bias_type,
+            (
+                fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+            ),
+        ):
+            pytest.skip("ck.FwOp hdim-512 is not supported when Paged-KVCache is used!")
+
+    query, key, value, attn_bias = create_tensors(
+        *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+        fmt="BMHK" if packed else fmt,
+        **kwargs,
+    )
+    if attn_bias is not None:
+        assert type(attn_bias.to(query.device)) is type(attn_bias)
+
+    if packed:
+        c = torch.stack([query, key, value], 2)
+        if fmt == "BMK":
+            # bm3hk -> 3bhmk -> 3Bmk
+            c = c.permute(2, 0, 3, 1, 4).view([3, -1, q_len, k])
+            query, key, value = c[0], c[1], c[2]
+            # Re-create bias in the right format
+            attn_bias = create_attn_bias(
+                bias_type=bias_type,
+                batch_size=batch_size,
+                num_heads=h,
+                num_heads_groups=1,
+                q_len=q_len,
+                kv_len=kv_len,
+                device=device,
+                dtype=dtype,
+                requires_grad=False,
+                fmt=fmt,
+                op=op,
+            )
+        elif fmt == "BMHK":
+            # bm3hk -> 3 x bmhk
+            query, key, value = unbind(c, 2)
+        else:
+            raise AssertionError(f"Unsupport fmt {fmt} with packing")
+        assert not query.is_contiguous()
+
+    out = fmha.memory_efficient_attention_forward(query, key, value, attn_bias, op=op)
+    assert not out.isnan().any(), ("Output has NaNs", attn_bias)
+    out2 = fmha.memory_efficient_attention_forward(
+        nanify_oob_seqlen(query),
+        nanify_oob_seqlen(key),
+        nanify_oob_seqlen(value),
+        attn_bias,
+        op=op,
+    )
+    assert not out2.isnan().any(), "Output has NaNs - most likely reading out-of-bounds"
+    assert torch.allclose(out, out2, atol=0.0, rtol=0.0), (
+        "Non-deterministic behavior",
+        attn_bias,
+    )
+
+    ref = ref_attention_for_test(query, key, value, attn_bias)
+    assert out.shape == ref.shape, out.shape
+    assert_allclose(
+        out.float(),
+        ref,
+        atol=op.ERROR_ATOL[dtype],
+        rtol=op.ERROR_RTOL.get(dtype, 1e-5),
+    )
+
+
+def _block_diag_reshape_lse(
+    lse: torch.Tensor, q_seqinfo: fmha.attn_bias._SeqLenInfo
+) -> torch.Tensor:
+    """LSE can be padded, let's remove the padding"""
+    parts = []
+    for slice, (start, end) in zip(lse.unbind(0), q_seqinfo.intervals()):
+        parts.append(slice[:, : end - start])
+    return torch.cat(parts, dim=1).unsqueeze(0)
+
+
+@disable_tf32
+@parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+def test_logsumexp(opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv):
+    (
+        op,
+        device,
+        dtype,
+        bias_type,
+        batch_size,
+        q_len,
+        kv_len,
+        h,
+        k,
+        kv,
+    ) = opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+
+    if op is fmha.ck.FwOp:
+        if issubclass(
+            bias_type,
+            (
+                fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+            ),
+        ):
+            pytest.skip(
+                "With ck.FwOp Paged-KVCache has some problem with forward training!"
+            )
+
+    query, key, value, attn_bias = create_tensors(
+        *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+        fmt="BMHK",
+    )
+
+    _out, lse = fmha.memory_efficient_attention_forward_requires_grad(
+        query,
+        key,
+        value,
+        op=op,
+        attn_bias=attn_bias,
+    )
+    query = query.transpose(1, 2)
+    key = key.transpose(1, 2)
+    attn = (query.float() / k**0.5) @ key.float().transpose(-2, -1)
+    if attn_bias is not None:
+        if isinstance(
+            attn_bias,
+            fmha.attn_bias.AttentionBias,
+        ):
+            bias_shape = (1, 1, query.shape[2], key.shape[2])
+            tensor_bias = attn_bias.materialize(
+                bias_shape,
+                device=query.device,
+                dtype=torch.float32,
+            )
+        else:
+            assert type(attn_bias) is torch.Tensor
+            tensor_bias = attn_bias
+        attn = attn + tensor_bias.float()
+    ref_lse = attn.logsumexp(-1)
+    if isinstance(attn_bias, fmha.attn_bias.VARLEN_BIASES):
+        # Convert to packed format if not already the case
+        if not op.VARLEN_LSE_PACKED:
+            lse = _block_diag_reshape_lse(lse, attn_bias.q_seqinfo)
+    if op is fmha.cutlass.FwOp:
+        # CUTLASS kernel pads the last dimention of LSE to 32
+        lse = lse[:, :, : ref_lse.shape[2]]
+    if op is fmha.ck.FwOp:
+        # relax numerical tolerance for CK FwOp
+        assert_allclose(lse, ref_lse, atol=2e-4, rtol=2e-4)
+    else:
+        assert_allclose(lse, ref_lse, atol=2e-4)
+
+
+@cuda_or_mtia_only
+@pytest.mark.parametrize(
+    "op",
+    _filter_unsupported_ops(
+        [
+            fmha.cutlass.FwOp,
+            fmha.cutlass_blackwell.FwOp,
+            fmha.flash.FwOp,
+            fmha.flash_mtia.FwOp,
+        ]
+    ),
+)
+def test_logsumexp_mqa(op: Type[AttentionFwOpBase]):
+    device = torch._C._get_accelerator().type
+
+    if not op.is_available():
+        pytest.skip("not available")
+
+    if device not in op.SUPPORTED_DEVICES:
+        pytest.skip(f"{op} is not supported on {device}")
+
+    if device == "cuda" and op.CUDA_MINIMUM_COMPUTE_CAPABILITY > compute_capability:
+        skip_reason = (
+            f"requires device with capability >= {op.CUDA_MINIMUM_COMPUTE_CAPABILITY} "
+            f"but your GPU has capability {compute_capability} (too old)"
+        )
+        pytest.skip(skip_reason)
+
+    dtype = torch.float16
+    s = 3
+    query = torch.randn([1, 1, 32, 128], dtype=dtype, device=device) * s
+    key = (torch.randn([1, 16, 1, 128], dtype=dtype, device=device) * s).expand(
+        -1, -1, 32, -1
+    )
+    value = (torch.randn([1, 16, 1, 128], dtype=dtype, device=device) * s).expand(
+        -1, -1, 32, -1
+    )
+    assert key.stride(2) == 0
+
+    _, lse = fmha.memory_efficient_attention_forward_requires_grad(
+        query,
+        key,
+        value,
+        op=op,
+    )
+    query, key, value = [x[0].transpose(0, 1) for x in [query, key, value]]
+    attn = (query.float() / query.shape[-1] ** 0.5) @ key.float().transpose(-2, -1)
+    ref_lse = attn.logsumexp(-1)
+    assert_allclose(lse[0, :, 0], ref_lse[:, 0], atol=2e-4)
+
+
+@disable_tf32
+@pytest.mark.parametrize("fmt", ["BMK", "BMHK"])
+@pytest.mark.parametrize("grad_out_contiguous", [False, True])
+@parametrize_opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+def test_backward(  # noqa: C901
+    opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+    grad_out_contiguous,
+    fmt,
+):
+    (
+        op_bw,
+        device,
+        dtype,
+        bias_type,
+        batch_size,
+        q_len,
+        kv_len,
+        h,
+        k,
+        kv,
+    ) = opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+
+    # Big batch sizes can be slow on MTIA, especially older devices because
+    # it doesn't have attention fast paths. Testing on very big batch sizes
+    # doesn't meaningfully increase our test coverage here, as long as most
+    # permutations of parameters are tested on lower batch sizes.
+    if device.startswith("mtia") and batch_size >= 11:
+        pytest.skip("Skipping big batch test cases on MTIA")
+
+    attn_bias_requires_grad = (
+        random.Random(q_len + kv_len * batch_size).randint(0, 1) > 0
+    )
+    query, key, value, attn_bias = create_tensors(
+        *opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+        attn_bias_requires_grad=attn_bias_requires_grad,
+        fmt=fmt,
+    )
+
+    # To understand why we do this, check the comment on the
+    # `AttentionBwOpBase` class
+    scale = None
+    if op_bw.SUPPORTS_CUSTOM_SCALE and query.shape[-1] < 32:
+        scale = (1 / 32) ** 0.5
+    op_fw = (
+        sample_random_supported_fw(
+            fmha.Inputs(query=query, key=key, value=value, attn_bias=attn_bias),
+            seed=q_len * kv + kv_len * k,
+            op_bw=op_bw,
+        )
+        if op_bw != fmha.cutlass.BwOp
+        else fmha.cutlass.FwOp
+    )
+
+    if op_bw == fmha.ck.BwOp:
+        op_fw = fmha.ck.FwOp
+        if dtype == torch.bfloat16:
+            # bfloat16 testing can be enabled by export ENABLE_HIP_FMHA_RTN_BF16_CONVERT=1 when
+            # building xformers and get accurate results
+            pytest.skip(
+                "CK Fmha backward for bfloat16 currently is not very accurate for some cases!"
+            )
+        if not grad_out_contiguous:
+            pytest.skip("CK Fmha does not support non-contiguous layout for grad_out!")
+        if k % 2 != 0:
+            pytest.skip(
+                "CK Fmha currently requires the headdim size of query input be an even value!"
+            )
+
+    qkv = None
+
+    if (
+        fmt == "BMHK"
+        and query.shape[3] == value.shape[3]
+        and query.shape[1] == value.shape[1]
+    ):
+        qkv = torch.stack([query, key, value], 2)
+        qkv.requires_grad_(True)
+        # bm3hk -> 3 x bmhk
+        query, key, value = unbind(qkv, 2)
+        assert not query.is_contiguous()
+
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+
+    if not op_bw.supports(fmha.Inputs(query, key, value, attn_bias)):
+        pytest.skip("inputs not supported")
+
+    out = fmha.memory_efficient_attention(
+        query, key, value, attn_bias, scale=scale, op=(op_fw, op_bw)
+    )
+
+    grad_out = torch.randn_like(out)
+    if grad_out_contiguous is False:
+        grad_out = torch.tensor([1.0], dtype=query.dtype, device=device)[
+            None, None, :
+        ].expand_as(out)
+
+    out.backward(grad_out)
+
+    if qkv is None and op_bw == fmha.cutlass.BwOp:
+        assert query.stride() == query.grad.stride()
+
+    grads = []
+    if qkv is None:
+        grads = [query.grad, key.grad, value.grad]
+        query.grad = None
+        key.grad = None
+        value.grad = None
+    else:
+        grads = [qkv.grad]
+        qkv.grad = None
+    if attn_bias_requires_grad:
+        attn_bias_grad = get_bias_grad(attn_bias, clear=True)
+        if attn_bias_grad is not None:
+            grads.append(attn_bias_grad)
+
+    if use_cpu_ref(device):
+        query = query.detach().cpu()
+        key = key.detach().cpu()
+        value = value.detach().cpu()
+        grad_out = grad_out.detach().cpu()
+
+        if qkv is not None:
+            qkv = torch.stack([query, key, value], 2)
+            qkv.requires_grad_(True)
+            query, key, value = unbind(qkv, 2)
+
+        query.requires_grad_(True)
+        key.requires_grad_(True)
+        value.requires_grad_(True)
+        grad_out.requires_grad_(True)
+
+        if isinstance(attn_bias, torch.Tensor):
+            attn_bias = attn_bias.cpu()
+
+    ref = ref_attention_for_test(query, key, value, attn_bias, scale=scale)
+    ref.backward(grad_out)
+
+    assert_allclose(
+        out.float().to(ref.device),
+        ref.float(),
+        "fw pass",
+        atol=op_fw.ERROR_ATOL[dtype],
+        rtol=op_fw.ERROR_RTOL[dtype],
+    )
+
+    del out
+    del grad_out
+    del ref
+
+    atol = op_bw.ERROR_ATOL[dtype]
+    rtol = op_bw.ERROR_RTOL[dtype]
+
+    # This is a special case without masks where the accumulated numbers become so big that
+    # we lose too much precision, especially on bfloat16. For this reason, the default bfloat16
+    # tolerance for the backward pass is set to 0.9, but in some cases on MTIA we get up to 1.3,
+    # probably due to the fact that the implementation doesn't use the fused kernels yet, which
+    # increases the precision loss caused by the accumulation.
+    if (
+        device.startswith("mtia")
+        and issubclass(bias_type, type(None))
+        and q_len >= 2**16
+    ):
+        atol *= 1.6
+
+    grads_ref = []
+    grads_name = []
+    if qkv is None:
+        assert isinstance(query.grad, torch.Tensor)
+        assert isinstance(key.grad, torch.Tensor)
+        assert isinstance(value.grad, torch.Tensor)
+        grads_ref = [query.grad, key.grad, value.grad]
+        grads_name = ["query", "key", "value"]
+    else:
+        assert isinstance(qkv.grad, torch.Tensor)
+        grads_ref = [qkv.grad]
+        grads_name = ["qkv"]
+
+    if attn_bias_requires_grad:
+        attn_bias_grad = get_bias_grad(attn_bias)
+        if attn_bias_grad is not None:
+            grads_ref.append(attn_bias.grad)
+            grads_name.append("bias")
+
+    del query
+    del key
+    del value
+    del qkv
+
+    assert len(grads_ref) == len(
+        grads
+    ), "Wrong number of gradients (maybe bias grad didn't backprop?)"
+    for name, calc_grad, ref_grad in zip(grads_name, grads, grads_ref):
+        assert_allclose(
+            calc_grad.to(ref_grad.device),
+            ref_grad,
+            msg=f"{op_fw.NAME}+{op_bw.NAME}:{name}",
+            atol=atol,
+            rtol=rtol,
+        )
+
+
+def _vec_binom_test(x, n, p):
+    """
+    vectorized implementation of scipy.stats.binom_test
+    this makes our tests much faster
+    reference: https://github.com/scipy/scipy/blob/v1.8.0/scipy/stats/_morestats.py#L2609-L2702
+    """
+    import numpy as np
+    from scipy.stats import distributions
+
+    x = np.atleast_1d(x)
+    d = distributions.binom.pmf(x, n, p)[:, None]
+    rerr = 1 + 1e-7
+    # x < p * n case
+    i = np.arange(np.ceil(p * n), n + 1)
+    y = np.sum(distributions.binom.pmf(i, n, p) <= d * rerr, axis=1)
+    pval1 = distributions.binom.cdf(x, n, p) + distributions.binom.sf(n - y, n, p)
+
+    # other case
+    i = np.arange(np.floor(p * n) + 1)
+    y = np.sum(distributions.binom.pmf(i, n, p) <= d * rerr, axis=1)
+    pval2 = distributions.binom.cdf(y - 1, n, p) + distributions.binom.sf(x - 1, n, p)
+
+    pval = np.where(x < p * n, pval1, pval2)
+    pval = np.minimum(1.0, pval)
+    return pval
+
+
+def _get_drop_mask(op, batch_size, q_len, kv_len, p, device):
+    assert op == fmha.ck.FwOp, f"Op {op.NAME} does not expose dropout mask"
+    mask = torch.empty((batch_size, 1, q_len, kv_len), device=device)
+    # rand_uniform is an int8_t tensor
+    rand_uniform = torch.ops.xformers._ck_rand_uniform(p, mask)
+    mask = (rand_uniform <= int((1.0 - p) * 255.0)).to(torch.float32)
+    mask = mask.reshape(batch_size, q_len, kv_len)
+
+    return mask
+
+
+@rocm_only
+@pytest.mark.parametrize("attn_bias", [None, fmha.attn_bias.LowerTriangularMask()])
+@pytest.mark.parametrize("seed", [42, 124])
+@pytest.mark.parametrize("p", [0.3, 0.7])
+@pytest.mark.parametrize("k_len", [32])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("kv_len", [3, 15, 32, 33, 65])
+@pytest.mark.parametrize("q_len", [2, 33])
+def test_dropout_ck(q_len, kv_len, batch_size, k_len, p, seed, attn_bias):
+    op = fmha.ck.FwOp
+    device = "cuda"
+    scale = 3
+
+    dtype = torch.float16
+
+    query = torch.randn((batch_size, q_len, k_len), device=device, dtype=dtype) * scale
+    key = torch.randn((batch_size, kv_len, k_len), device=device, dtype=dtype) * scale
+    value = torch.randn((batch_size, kv_len, k_len), device=device, dtype=dtype) * scale
+
+    inputs_for_support_check = fmha.Inputs(query, key, value, attn_bias, p, None)
+    if not op.supports(inputs_for_support_check):
+        del query, key, value, attn_bias
+        pytest.skip(f"{op.NAME}: unsupported input")
+
+    torch.manual_seed(seed)
+    out = fmha.memory_efficient_attention(
+        query, key, value, attn_bias, p, op=(op, None)
+    )
+
+    torch.manual_seed(seed)
+    out2 = fmha.memory_efficient_attention(
+        query, key, value, attn_bias, p, op=(op, None)
+    )
+
+    assert_allclose(out, out2, "dropout reproducibility")
+
+    torch.manual_seed(seed)
+    mask = _get_drop_mask(op, batch_size, q_len, kv_len, p, device)
+    ref = ref_attention_for_test(query, key, value, attn_bias, mask, p)
+
+    if dtype is torch.float:
+        assert_allclose(out, ref, atol=2e-4)
+    else:
+        assert_allclose(out.float(), ref, atol=2.8e-2)
+
+    num_trials = 1000
+    p_val_tol = 1e-6
+    keep_prob = 1 - p
+    masks = []
+    for _ in range(num_trials):
+        mask = _get_drop_mask(op, batch_size, q_len, kv_len, p, device)
+        masks.append(mask.clone().cpu())
+    masks = torch.stack(masks, dim=0)
+    p_value = binomtest(int(masks.sum()), masks.numel(), p=keep_prob).pvalue
+    assert p_value > p_val_tol, p_value
+    masks = masks.sum(0).flatten()
+    p_values = _vec_binom_test(masks, num_trials, p=keep_prob)
+    assert all(p_values > p_val_tol)
+
+
+@rocm_only
+@pytest.mark.parametrize("p", [0.000001, 0.3, 0.7])
+@pytest.mark.parametrize("k", [16, 64, 128])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("kv_len", [3, 248, 256])
+@pytest.mark.parametrize("q_len", [3, 248, 256])
+def test_dropout_backward_ck(q_len, kv_len, batch_size, k, p):
+    op = fmha.ck.FwOp
+    dtype = torch.float16
+    if not op.is_available():
+        pytest.skip()
+
+    scale = 3
+    device = "cuda"
+    query = torch.randn((batch_size, q_len, k), device=device, dtype=dtype) * scale
+    key = torch.randn((batch_size, kv_len, k), device=device, dtype=dtype) * scale
+    value = torch.randn((batch_size, kv_len, k), device=device, dtype=dtype) * scale
+
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+
+    grad_out = torch.ones_like(query)
+
+    assert op.supports(fmha.Inputs(query=query, key=key, value=value, p=p))
+
+    seed = 42
+    torch.manual_seed(seed)
+    out = fmha.memory_efficient_attention(query, key, value, p=p, op=(op, None))
+
+    out.backward(grad_out)
+
+    grad_q = query.grad
+    grad_k = key.grad
+    grad_v = value.grad
+
+    query.grad = None
+    key.grad = None
+    value.grad = None
+
+    torch.manual_seed(seed)
+    mask = _get_drop_mask(op, batch_size, q_len, kv_len, p, device)
+
+    ref = ref_attention_for_test(query, key, value, None, mask, p)
+    ref.backward(grad_out)
+
+    atol, rtol = (
+        fmha.AttentionBwOpBase.ERROR_ATOL[dtype],
+        fmha.AttentionBwOpBase.ERROR_RTOL[dtype],
+    )
+    assert_allclose(
+        grad_v,
+        value.grad,
+        "grad_v",
+        atol=atol,
+        rtol=rtol,
+    )
+    # TODO: Investigate why precision is worse
+    if dtype in [torch.float16, torch.bfloat16]:
+        atol = atol * 2 + 0.15
+        rtol = rtol * 2
+    assert_allclose(
+        grad_q,
+        query.grad,
+        "grad_q",
+        atol=atol,
+        rtol=rtol,
+    )
+    assert_allclose(
+        grad_k,
+        key.grad,
+        "grad_k",
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+@pytest.mark.parametrize("fmt", ["BMK", "BMHK"])
+@parametrize_opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs
+def test_lowlevel_api_shapes(opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, fmt):
+    query, key, value, attn_bias = create_tensors(
+        *opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, fmt=fmt
+    )
+    grad_out = torch.ones_like(query)
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+
+    inputs = fmha.Inputs(query=query, key=key, value=value, attn_bias=attn_bias)
+    op_bw = opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv[0]
+    op_fw = sample_random_supported_fw(
+        inputs, seed=f"{op_bw.NAME}{query.shape}", op_bw=op_bw
+    )
+    out, lse = fmha.memory_efficient_attention_forward_requires_grad(
+        query, key, value, attn_bias, op=op_fw
+    )
+    assert out.ndim == query.ndim
+    dq, dk, dv = fmha.memory_efficient_attention_backward(
+        grad_out, out, lse, query, key, value, attn_bias, op=op_bw
+    )
+    assert dq.shape == query.shape
+    assert dk.shape == key.shape
+    assert dv.shape == value.shape
+
+
+@parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs
+def test_cuda_streams(
+    opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+):
+    (
+        op,
+        device,
+        dtype,
+        bias_type,
+        batch_size,
+        q_len,
+        kv_len,
+        h,
+        k,
+        kv,
+    ) = opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+    if device != "cuda":
+        pytest.skip("Not CUDA")
+
+    bias_type = None
+    opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv = [
+        op,
+        device,
+        dtype,
+        bias_type,
+        batch_size,
+        q_len,
+        kv_len,
+        h,
+        k,
+        kv,
+    ]
+    s_hipri = torch.cuda.Stream(priority=-1)
+    s_lopri = torch.cuda.Stream(priority=0)
+    query, key, value, attn_bias = create_tensors(
+        *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, fmt="BMHK"
+    )
+    torch.cuda.synchronize()
+    with torch.cuda.stream(s_lopri):
+        torch.cuda._sleep(100_000_000)  # wait 100m cycles
+        query *= 2
+    s_hipri.wait_stream(s_lopri)
+    with torch.cuda.stream(s_hipri):
+        # If the kernel is scheduled in the main stream
+        # `query * 2` has not been executed yet
+        out = fmha.memory_efficient_attention(query, key, value, op=(op, None))
+    # Test that `s_lopri` is still sleeping
+    # and that `query *= 2` has not been executed yet
+    query2_main_stream = query * 2
+    torch.cuda.synchronize()
+    # TODO: Figure out why this is failing sometimes
+    # The sleep timer seems to be high enough already ...
+    # assert torch.allclose(query2_main_stream, query), "Need to increase sleep time"
+    del query2_main_stream
+
+    ref = ref_attention_for_test(query, key, value)
+    assert out.shape == ref.shape, out.shape
+
+    assert_allclose(
+        out.float(),
+        ref.float(),
+        atol=op.ERROR_ATOL[dtype],
+        rtol=op.ERROR_RTOL.get(dtype, 1e-5),
+    )
+
+
+@disable_tf32
+@parametrize_opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs
+def test_custom_scale(opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv):
+    p = 0.0
+    scale = 0.1
+
+    (
+        op_bw,
+        device,
+        dtype,
+        _,
+        B,
+        q_len,
+        kv_len,
+        H,
+        k,
+        Kv,
+    ) = opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+    torch.manual_seed(q_len + kv_len + k)
+    if device not in {"cuda", "mtia"}:
+        pytest.skip("Not CUDA or MTIA")
+
+    query, key, value, attn_bias = create_tensors(
+        *opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, fmt="BMK"
+    )
+    inputs = fmha.Inputs(
+        query=query, key=key, value=value, attn_bias=attn_bias, scale=scale
+    )
+    op_fw = sample_random_supported_fw(inputs, seed=q_len * k + kv_len * k, op_bw=op_bw)
+    grad_out = query.new_ones(B * H, q_len, Kv)
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+
+    reasons = op_fw.not_supported_reasons(inputs)
+    if reasons:
+        pytest.skip(f"{op_fw.NAME}: unsupported ({'/'.join(reasons)})")
+    reasons = op_bw.not_supported_reasons(inputs)
+    if reasons:
+        pytest.skip(f"{op_bw.NAME}: unsupported ({'/'.join(reasons)})")
+
+    # NOTE: we still need to scale the inputs to not blowup
+    # the pre-softmax values (numerical stability)
+    s = k**-0.5
+    out = fmha.memory_efficient_attention(
+        query * s, key, value, attn_bias, p, scale, op=(op_fw, op_bw)
+    )
+    out.backward(grad_out)
+    grad_q, grad_k, grad_v = query.grad, key.grad, value.grad
+    query.grad = key.grad = value.grad = None
+
+    ref = ref_attention_for_test(query * s, key, value, attn_bias, None, p, scale)
+    ref.backward(grad_out)
+    ref_grad_q, ref_grad_k, ref_grad_v = query.grad, key.grad, value.grad
+    query.grad = key.grad = value.grad = None
+
+    atol = op_fw.ERROR_ATOL[dtype]
+    rtol = op_fw.ERROR_RTOL[dtype]
+    assert_allclose(out.float(), ref.float(), "out", atol=atol, rtol=rtol)
+    atol = op_bw.ERROR_ATOL[dtype]
+    rtol = op_bw.ERROR_RTOL[dtype]
+    assert_allclose(grad_q, ref_grad_q, "grad_q", atol=atol, rtol=rtol)
+    assert_allclose(grad_k, ref_grad_k, "grad_k", atol=atol, rtol=rtol)
+    assert_allclose(grad_v, ref_grad_v, "grad_v", atol=atol, rtol=rtol)
+
+
+def apply_attention(query, key, value, attn_bias, op_fw, proj):
+    x = fmha.memory_efficient_attention(
+        query, key, value, attn_bias=attn_bias, op=(op_fw, None)
+    )
+    x = proj(x)
+    return x
+
+
+# TODO: Enable this for MTIA
+# MTIA doesn't support this yet
+@disable_on_mtia
+@pytest.mark.parametrize("use_reentrant", [False, True])
+@parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs
+def test_grad_checkpointing(
+    opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+    use_reentrant,
+):
+    fmt = "BMHK"
+    (
+        op,
+        device,
+        dtype,
+        bias_type,
+        batch_size,
+        q_len,
+        kv_len,
+        h,
+        k,
+        kv,
+    ) = opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+    if op is fmha.triton_splitk.FwOp:
+        pytest.skip("Triton Flash Decoding doesn't support backward pass yet")
+    if op is fmha.ck.FwOp:
+        pytest.skip("ck-tiled FMHA doesn't supported backward pass yet")
+
+    bias_type = None
+    opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv = (
+        op,
+        device,
+        dtype,
+        bias_type,
+        batch_size,
+        q_len,
+        kv_len,
+        h,
+        k,
+        kv,
+    )
+    query, key, value, attn_bias = create_tensors(
+        *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+        fmt=fmt,
+    )
+    qkv = None
+
+    if (
+        fmt == "BMHK"
+        and query.shape[3] == value.shape[3]
+        and query.shape[1] == value.shape[1]
+    ):
+        qkv = torch.stack([query, key, value], 2)
+        qkv.requires_grad_(True)
+        # bm3hk -> 3 x bmhk
+        query, key, value = unbind(qkv, 2)
+        assert not query.is_contiguous()
+
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+
+    proj = torch.nn.Linear(kv, k, device=device, dtype=dtype)
+
+    x = query
+    for _ in range(5):
+        x = checkpoint(
+            apply_attention,
+            x,
+            key,
+            value,
+            attn_bias,
+            op,
+            proj,
+            use_reentrant=use_reentrant,
+        )
+    x.mean().backward()
+
+
+@pytest.mark.parametrize("op", ALL_FW_OPS, ids=[op.NAME for op in ALL_FW_OPS])
+def test_unsupported_cpu(op: Type[fmha.AttentionFwOpBase]):
+    q = torch.empty([1, 1, 1, 32])
+    with pytest.raises(ValueError):
+        fmha.memory_efficient_attention(q, q, q, op=(op, None))
+
+
+@cuda_only
+@pytest.mark.parametrize("op", ALL_FW_OPS, ids=[op.NAME for op in ALL_FW_OPS])
+def test_unsupported_stride_lastdim(op: Type[fmha.AttentionFwOpBase]):
+    K = max(op.SUPPORTED_MIN_K, 32)
+    q = torch.empty([1, 1, K, 4], device="cuda", dtype=torch.float16).permute(
+        0, 3, 1, 2
+    )
+
+    try:
+        fmha.memory_efficient_attention(q, q, q, op=(op, None))
+    except ValueError as e:
+        if "Only work on pre-MLIR triton for now" in str(e):
+            pytest.skip("Only work on pre-MLIR triton for now")
+        q = q.contiguous()
+        fmha.memory_efficient_attention(q, q, q, op=(op, None))
+
+
+@cuda_only
+@pytest.mark.parametrize("op", ALL_FW_OPS, ids=[op.NAME for op in ALL_FW_OPS])
+def test_unsupported_stride_alignment(op: Type[fmha.AttentionFwOpBase]):
+    K = max(op.SUPPORTED_MIN_K, 32)
+    q = torch.empty([1, 2, 1, K + 1], device="cuda", dtype=torch.float16)[:, :, :, :K]
+
+    try:
+        fmha.memory_efficient_attention(q, q, q, op=(op, None))
+    except ValueError as e:
+        if "Only work on pre-MLIR triton for now" in str(e):
+            pytest.skip("Only work on pre-MLIR triton for now")
+        q = q.contiguous()
+        fmha.memory_efficient_attention(q, q, q, op=(op, None))
+
+
+@sm75_or_better_only
+def test_unsupported_dropout_combine_flash_cutlass() -> None:
+    q = torch.empty(
+        [1, 4, 1, 16], device="cuda", dtype=torch.float16, requires_grad=True
+    )
+    with pytest.raises(ValueError):
+        fmha.memory_efficient_attention(
+            q, q, q, p=0.1, op=(fmha.cutlass.FwOp, fmha.flash.BwOp)
+        )
+    with pytest.raises(ValueError):
+        fmha.memory_efficient_attention(
+            q, q, q, p=0.1, op=(fmha.flash.FwOp, fmha.cutlass.BwOp)
+        )
+
+
+def test_attn_bias_causal() -> None:
+    m = -math.inf
+    causal_mask = torch.tensor([[0, m], [0, 0], [0, 0]])
+    tensor_bias = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+
+    attn_bias = fmha.attn_bias.LowerTriangularMask()
+    assert_allclose(
+        attn_bias.materialize(tuple(causal_mask.shape)), causal_mask, "causal"
+    )
+    attn_bias = attn_bias.add_bias(tensor_bias)
+    assert_allclose(
+        attn_bias.materialize(tuple(causal_mask.shape)),
+        tensor_bias + causal_mask,
+        "causal+tensor_bias",
+    )
+
+
+def test_attn_bias_torch_tensor() -> None:
+    tensor_bias = torch.tensor([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0]])
+    attn_bias = fmha.attn_bias.LowerTriangularMaskWithTensorBias(tensor_bias)
+    m = -math.inf
+    causal_bias = torch.tensor([[0, m, m], [0, 0, m]])
+    assert_allclose(
+        attn_bias.materialize((2, 3)), causal_bias + tensor_bias, "tensor_bias+causal"
+    )
+
+
+def test_attn_bias_blockdiag() -> None:
+    queries = [
+        torch.randn([1, 3, 1, 8]),
+        torch.randn([1, 2, 1, 8]),
+        torch.randn([1, 5, 1, 8]),
+    ]
+    attn_bias, q = fmha.attn_bias.BlockDiagonalMask.from_tensor_list(queries)
+
+    # Verify mask
+    as_tensor = attn_bias.materialize((10, 10))
+    assert int((as_tensor != -math.inf).sum().item()) == 3 * 3 + 2 * 2 + 5 * 5
+    assert_allclose(as_tensor[0:3, 0:3], torch.zeros([3, 3]), "batch0")
+    assert_allclose(as_tensor[3:5, 3:5], torch.zeros([2, 2]), "batch1")
+    assert_allclose(as_tensor[5:, 5:], torch.zeros([5, 5]), "batch2")
+
+    # Verify we can split it back
+    queries2 = attn_bias.split(q)
+    assert len(queries) == len(queries2)
+    for q1, q2 in zip(queries, queries2):
+        assert_allclose(q1, q2)
+
+
+def test_attn_bias_blockdiag_batched() -> None:
+    queries = [
+        torch.randn([1, 3, 1, 8]),
+        torch.randn([3, 2, 1, 8]),
+        torch.randn([1, 5, 1, 8]),
+    ]
+    attn_bias, q = fmha.attn_bias.BlockDiagonalMask.from_tensor_list(queries)
+
+    # Verify mask
+    as_tensor = attn_bias.materialize((14, 14))
+    assert int((as_tensor != -math.inf).sum().item()) == 3 * 3 + 3 * 2 * 2 + 5 * 5
+    assert_allclose(as_tensor[0:3, 0:3], torch.zeros([3, 3]), "batch0")
+    assert_allclose(as_tensor[3:5, 3:5], torch.zeros([2, 2]), "batch1.0")
+    assert_allclose(as_tensor[5:7, 5:7], torch.zeros([2, 2]), "batch1.1")
+    assert_allclose(as_tensor[7:9, 7:9], torch.zeros([2, 2]), "batch1.2")
+    assert_allclose(as_tensor[9:, 9:], torch.zeros([5, 5]), "batch2")
+
+    # Verify we can split it back
+    queries2 = attn_bias.split(q)
+    assert len(queries) == len(queries2)
+    for q1, q2 in zip(queries, queries2):
+        assert_allclose(q1, q2)
+
+
+def test_attn_bias_blockdiag_crossattn_causal() -> None:
+    # Q / KV have different seqlen
+    list_q = [
+        torch.randn([1, 3, 1, 8]),
+        torch.randn([2, 1, 1, 8]),
+    ]
+    list_k = [
+        torch.randn([1, 2, 1, 8]),
+        torch.randn([2, 3, 1, 8]),
+    ]
+
+    attn_bias, q, k, _ = fmha.attn_bias.BlockDiagonalMask.from_tensor_lists_qkv(
+        list_q, list_k
+    )
+
+    # Verify mask
+    as_tensor = attn_bias.materialize((q.shape[1], k.shape[1]))
+    assert int((as_tensor != -math.inf).sum().item()) == 3 * 2 + 2 * 3 * 1
+    assert_allclose(as_tensor[0:3, 0:2], torch.zeros([3, 2]), "batch0")
+    assert_allclose(as_tensor[3:4, 2:5], torch.zeros([1, 3]), "batch1.0")
+    assert_allclose(as_tensor[4:, 5:], torch.zeros([1, 3]), "batch1.1")
+
+    # Also test causal version
+    as_tensor = attn_bias.make_causal().materialize((q.shape[1], k.shape[1]))
+    assert_allclose(
+        as_tensor[3:4, 2:5],
+        fmha.attn_bias.LowerTriangularMask().materialize((1, 3)),
+        "batch1.0[causal]",
+    )
+
+    # Verify we can split it back
+    list_q2 = attn_bias.split_queries(q)
+    assert len(list_q) == len(list_q2)
+    for q1, q2 in zip(list_q, list_q2):
+        assert_allclose(q1, q2)
+    with pytest.raises(ValueError):
+        attn_bias.split_queries(k)
+    list_k2 = attn_bias.split_kv(k)
+    assert len(list_k) == len(list_k2)
+    for k1, k2 in zip(list_k, list_k2):
+        assert_allclose(k1, k2)
+
+
+def test_attn_bias_blockdiag_crossattn_causal_with_prefix_qk_cond() -> None:
+    list_q = [
+        torch.randn([1, 3, 1, 8]),
+    ]
+    list_k = [
+        torch.randn([1, 2, 1, 8]),
+    ]
+    attn_bias, q, k, _ = fmha.attn_bias.BlockDiagonalMask.from_tensor_lists_qkv(
+        list_q, list_k
+    )
+    with pytest.raises(ValueError):
+        attn_bias.make_causal_from_bottomright()
+
+
+def test_attn_bias_blockdiag_crossattn_causal_with_prefix() -> None:
+    # Q / KV have different seqlen
+    list_q = [
+        torch.randn([1, 2, 1, 8]),
+        torch.randn([2, 2, 1, 8]),
+    ]
+    list_k = [
+        torch.randn([1, 2, 1, 8]),
+        torch.randn([2, 5, 1, 8]),
+    ]
+
+    attn_bias, q, k, _ = fmha.attn_bias.BlockDiagonalMask.from_tensor_lists_qkv(
+        list_q, list_k
+    )
+    as_tensor = attn_bias.make_causal_from_bottomright().materialize(
+        (q.shape[1], k.shape[1])
+    )
+    m = -math.inf
+    assert_allclose(
+        as_tensor[0:2, 0:2],
+        torch.tensor([[0, m], [0, 0]], dtype=torch.float32),
+        "batch1.1[causal_with_prefix]",
+    )
+    assert_allclose(
+        as_tensor[2:4, 2:7],
+        torch.tensor([[0, 0, 0, 0, m], [0, 0, 0, 0, 0]], dtype=torch.float32),
+        "batch2.1[causal_with_prefix]",
+    )
+    assert_allclose(
+        as_tensor[4:6, 7:12],
+        torch.tensor([[0, 0, 0, 0, m], [0, 0, 0, 0, 0]], dtype=torch.float32),
+        "batch2.2[causal_with_prefix]",
+    )
+
+
+@cuda_only
+def test_attn_bias_padded() -> None:
+    bsize, n_heads, d, padding = 8, 3, 8, 32
+    torch.manual_seed(0)
+
+    # Q / KV have different seqlen
+    k = torch.randn((bsize, padding, n_heads, d), device="cuda", dtype=torch.float16)
+    k_seqlen = [5, 8, 7, 1, 9, 3, 12, 32]
+    other = bsize - 1
+    v = torch.randn((bsize, padding, n_heads, d), device="cuda", dtype=torch.float16)
+    n_q_first = 4
+    q = [
+        torch.randn((1, n_q_first, n_heads, d), device="cuda", dtype=torch.float16),
+        torch.randn((1, other, n_heads, d), device="cuda", dtype=torch.float16),
+    ]
+    q_cat = torch.cat([x.view(1, -1, n_heads, d) for x in q], dim=1)
+    q_seqlen = [n_q_first] + [1] * other
+
+    attn_bias = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+        q_seqlen=q_seqlen,
+        kv_seqlen=k_seqlen,
+        kv_padding=padding,
+    )
+
+    v = v.view(1, -1, n_heads, d)
+    k = k.view(1, -1, n_heads, d)
+
+    scores = (q_cat.transpose(1, 2) @ k.transpose(1, 2).transpose(2, 3)).float()
+    assert not scores.isnan().any()
+    mask = torch.full_like(scores, -float("inf"))
+    for i, (slen, qlen) in enumerate(zip(k_seqlen, q_seqlen)):
+        kseq_start = i * padding
+        qstart = sum(q_seqlen[:i])
+        mask[:, :, qstart : qstart + qlen, kseq_start : kseq_start + slen] = torch.triu(
+            mask[:, :, qstart : qstart + qlen, kseq_start : kseq_start + slen].float(),
+            diagonal=1 + slen - qlen,
+        ).float()
+
+    scores += mask
+    assert not scores.isnan().any()
+    # 1,3,10,8 @ 1,3,8,256 -> 1,3,10,256
+    scores = torch.nn.functional.softmax(scores, -1).half()
+    # torch.Size([1, 3, 3, 32]) @ torch.Size([1, 3, 32, 8])
+    output = scores @ v.transpose(1, 2)  # 1,3,10,256 @ 1,3,256, 8 -> 1,3,10,8
+    output = output.transpose(1, 2).contiguous()
+
+    fmha_output = fmha.memory_efficient_attention_forward(
+        q_cat, k, v, attn_bias, scale=1.0
+    )
+
+    # assert torch.allclose(output, fmha_output)
+    assert_allclose(
+        output,
+        fmha_output,
+        atol=fmha.cutlass.FwOp.ERROR_ATOL[torch.float16],
+        rtol=fmha.cutlass.FwOp.ERROR_RTOL[torch.float16],
+    )
+
+
+def _kv_heads_label(kv_heads: Optional[int]) -> str:
+    if kv_heads is None:
+        return ""
+    if kv_heads == 1:
+        return "mq"
+    return f"gqa{kv_heads}"
+
+
+@sm70_or_better_only
+@pytest.mark.parametrize(
+    "op",
+    [
+        fmha.ck_decoder.FwOp,
+    ],
+)
+@pytest.mark.parametrize("kv_heads", [None, 1, 2], ids=_kv_heads_label)
+@pytest.mark.parametrize("bsz,n_heads", [(1, 1), (1, 16), (1, 32), (8, 1), (4, 8)])
+@pytest.mark.parametrize("padding", [32, 4096])
+@pytest.mark.parametrize("dtype", ["f16", "bf16", "f32"])
+def test_decoder(
+    op,
+    n_heads: int,
+    kv_heads: Optional[int],
+    padding: int,
+    bsz: int,
+    dtype: str,
+    dequant: bool = False,
+    num_queries: int = 1,
+    d: int = 128,
+) -> None:
+    if not op.is_available():
+        raise pytest.skip("not available")
+    # kv_heads = 1: multiquery
+    # kv_heads = None: neither MQA nor GQA
+    # kv_heads > 1: BMGHK
+    if dtype == "bf16" and torch.version.cuda and compute_capability < (8, 0):
+        raise pytest.skip("BF16 is only supported on SM80+")
+    import triton
+
+    if dequant and triton.__version__[:4] < "3.0.":
+        raise pytest.skip("dequant needs triton updates")
+    dtype_ = {"f16": torch.float16, "bf16": torch.bfloat16, "f32": torch.float32}[dtype]
+    torch.manual_seed(1)
+    if kv_heads is not None and kv_heads > 1:
+        # BMGHK
+        k_shape: Tuple[int, ...] = (1, bsz * padding, kv_heads, n_heads, d)
+        q_shape: Tuple[int, ...] = (
+            1,
+            bsz * num_queries,
+            kv_heads,
+            n_heads,
+            d,
+        )
+        k_shape_folded = [1, bsz * padding, kv_heads, 1, d]
+    else:
+        # BMHK
+        k_shape = (1, bsz * padding, n_heads, d)
+        q_shape = (1, bsz * num_queries, n_heads, d)
+        k_shape_folded = (
+            k_shape if kv_heads is None else (1, bsz * padding, kv_heads, d)
+        )
+
+    # for num_groups > 1, we need to make sure that the kv heads are the same in the same group.
+    k = torch.randn(
+        k_shape_folded, dtype=dtype_, device=torch.accelerator.current_accelerator()
+    )
+    k_seqlen = torch.randint(num_queries, padding + 1, (bsz,)).tolist()
+    v = torch.randn(
+        k_shape_folded, dtype=dtype_, device=torch.accelerator.current_accelerator()
+    )
+    q = torch.randn(q_shape, dtype=dtype_, device="cuda")
+
+    if dequant:
+        k_shape = k_shape[:-1] + (d // 8 + op.NUM_GROUPS,)
+        k = torch.zeros(k_shape, dtype=torch.int32, device="cuda")
+        k.random_()
+        k[..., : op.NUM_GROUPS].view(torch.float16).fill_(1.0)
+        v = torch.zeros(k_shape, dtype=torch.int32, device="cuda")
+        v.random_()
+        v[..., : op.NUM_GROUPS].view(torch.float16).fill_(1.0)
+
+    if kv_heads is not None:
+        k = k.expand(k_shape)
+        v = v.expand(k_shape)
+
+    if skip_reasons := op.not_supported_reasons(fmha.Inputs(q, k, v)):
+        pytest.skip("; ".join(skip_reasons))
+
+    attn_bias = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+        q_seqlen=[num_queries] * bsz,
+        kv_seqlen=k_seqlen,
+        kv_padding=padding,
+    )
+
+    decoder_output = fmha.memory_efficient_attention_forward(
+        q,
+        k,
+        v,
+        attn_bias,
+        op=op,
+    )
+
+    def dequant_cache(x):
+        x = x[..., op.NUM_GROUPS :, None].expand(k_shape[:-1] + (d // 8, 8))
+        x = x // (2 ** (4 * torch.arange(8, device="cuda")))
+        x = (x % 16).flatten(start_dim=-2)
+        return x.to(dtype_) + 1.0
+
+    if dequant:
+        k = dequant_cache(k)
+        v = dequant_cache(v)
+
+    ref_output = ref_attention_for_test(q, k, v, attn_bias)
+
+    assert_allclose(
+        decoder_output.to(ref_output.dtype),
+        ref_output,
+        atol=op.ERROR_ATOL[dtype_] * 4,
+        rtol=op.ERROR_RTOL[dtype_],
+    )
+
+
+@sm80_or_better_only
+@pytest.mark.parametrize(
+    "op,dequant,dtype",
+    [
+        (fmha.triton_splitk.FwOp_S1, False, "bf16"),
+        (fmha.triton_splitk.FwOp_S2, False, "f16"),
+        (fmha.triton_splitk.FwOp_S2, True, "bf16"),
+        (
+            type(
+                "S2_8", (fmha.triton_splitk.FwOp_S2,), {"NUM_GROUPS": 8, "NAME": "S2_8"}
+            ),
+            True,
+            "bf16",
+        ),
+    ],
+)
+@pytest.mark.parametrize("kv_heads", [None, 1, 2], ids=_kv_heads_label)
+@pytest.mark.parametrize("n_heads", [16])
+@pytest.mark.parametrize("padding, bsz", [(32, 8), (4096, 1)])
+def test_triton_splitk_decoder(
+    op,
+    dequant: bool,
+    kv_heads: Optional[int],
+    n_heads: int,
+    padding: int,
+    bsz: int,
+    dtype: str,
+) -> None:
+    # We omit dequant with f16: it needs a very high tol
+    test_decoder(
+        op,
+        kv_heads=kv_heads,
+        n_heads=n_heads,
+        padding=padding,
+        bsz=bsz,
+        dtype=dtype,
+        dequant=dequant,
+    )
+
+
+@sm100_or_better_only
+@pytest.mark.parametrize("kv_heads", [1, 2, 16], ids=_kv_heads_label)
+@pytest.mark.parametrize("n_heads", [1, 4, 16])
+@pytest.mark.parametrize("padding, bsz", [(4096, 1), (32, 8), (512, 1024)])
+@pytest.mark.parametrize("dtype", ["bf16"])
+def test_cutlass_blackwell_decoder(
+    kv_heads: Optional[int],
+    n_heads: int,
+    padding: int,
+    bsz: int,
+    dtype: str,
+) -> None:
+    """Test CUTLASS Blackwell decode kernel for single-query decode workloads."""
+    test_decoder(
+        fmha.cutlass_blackwell.FwOpDecode,
+        kv_heads=kv_heads,
+        n_heads=n_heads,  # qheads per kv head
+        padding=padding,
+        bsz=bsz,
+        dtype=dtype,
+        dequant=False,
+        d=128,  # Blackwell decode only supports d=128
+    )
+
+
+@rocm_only
+@pytest.mark.parametrize(
+    "op", [fmha.ck_splitk.FwOp_S1, fmha.ck_splitk.FwOp_S2, fmha.ck_splitk.FwOp_S4]
+)
+@pytest.mark.parametrize("dtype", ["f32"])
+@pytest.mark.parametrize("kv_heads", [None, 1, 2], ids=_kv_heads_label)
+@pytest.mark.parametrize("n_heads", [16])
+@pytest.mark.parametrize("d", [128, 256])
+@pytest.mark.parametrize("padding, bsz", [(32, 8), (4096, 1), (32, 1), (4096, 8)])
+def test_ck_splitk_decoder(
+    op,
+    kv_heads: Optional[int],
+    n_heads: int,
+    padding: int,
+    bsz: int,
+    dtype: str,
+    d: int,
+) -> None:
+    # no quantized impl compared to cuda
+    test_decoder(
+        op,
+        kv_heads=kv_heads,
+        n_heads=n_heads,
+        padding=padding,
+        bsz=bsz,
+        dtype=dtype,
+        d=d,
+    )
+
+
+@sm80_or_better_only
+@pytest.mark.parametrize(
+    "op",
+    [
+        fmha.triton_splitk.FwOp_S1,
+        fmha.triton_splitk.FwOp_S2,
+    ],
+    ids=lambda op: f"splitk{op.SPLIT_K}",
+)
+@pytest.mark.parametrize("multiquery", [True, False], ids=lambda x: "mq" if x else "")
+# n_heads=1 => it's ambiguous whether can count as multiquery
+@pytest.mark.parametrize("padding, bsz", [(32, 8), (44, 1)])
+@pytest.mark.parametrize("dtype", ["f16", "bf16"])
+@pytest.mark.parametrize("n_heads, num_queries", [(2, 4), (2, 5), (6, 7), (20, 3)])
+def test_triton_splitk_decoder_manyqueries(
+    op,
+    multiquery: bool,
+    n_heads: int,
+    padding: int,
+    bsz: int,
+    dtype: str,
+    num_queries: int,
+) -> None:
+    kv_heads = 1 if multiquery else None
+    test_decoder(
+        op,
+        kv_heads=kv_heads,
+        n_heads=n_heads,
+        padding=padding,
+        bsz=bsz,
+        dtype=dtype,
+        num_queries=num_queries,
+        dequant=False,
+    )
+
+
+def test_attn_bias_from_seqlens() -> None:
+    bias = fmha.attn_bias.BlockDiagonalMask.from_seqlens([3, 5, 1])
+    out = bias.split(torch.randn([1, 3 + 5 + 1, 16]))
+    assert len(out) == 3
+    assert tuple(out[0].shape) == (1, 3, 16)
+
+
+@cuda_only
+def test_attn_bias_blockdiag_doc() -> None:
+    """IMPORTANT:
+    This is the example in the doc for `BlockDiagonalMask`.
+    If this example needs to be updated, please also update the doc
+    """
+    import torch
+
+    from mslk.attention import fmha
+
+    if torch.version.hip:
+        pytest.skip("backward pass/gradience is not yet supported by ck-tiled fmha!")
+
+    K = 16
+    dtype = torch.float16
+    device = "cuda"
+    list_x = [
+        torch.randn([1, 3, 1, K], dtype=dtype, device=device),
+        torch.randn([1, 6, 1, K], dtype=dtype, device=device),
+        torch.randn([1, 2, 1, K], dtype=dtype, device=device),
+    ]
+    attn_bias, x = fmha.attn_bias.BlockDiagonalMask.from_tensor_list(list_x)
+
+    linear = torch.nn.Linear(K, K * 3).to(device=device, dtype=dtype)  # type: ignore
+
+    q, k, v = linear(x).reshape([1, -1, 1, 3, K]).unbind(-2)
+    out = fmha.memory_efficient_attention(q, k, v, attn_bias=attn_bias)
+    list_out = attn_bias.split(out)
+    assert tuple(list_out[0].shape) == (1, 3, 1, K)
+
+
+@cuda_only
+class TestAttnBias:
+    @staticmethod
+    def create_tensors(
+        dtype,
+        B: int = 2,
+        Mq: int = 32,
+        Mkv: int = 32,
+        H: int = 3,
+        K: int = 16,
+        Kv: int = 16,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        return (
+            torch.randn([B, Mq, H, K], device="cuda", dtype=dtype) * 3,
+            torch.randn([B, Mkv, H, K], device="cuda", dtype=dtype) * 3,
+            torch.randn([B, Mkv, H, Kv], device="cuda", dtype=dtype) * 3,
+            torch.randn([B, H, Mq, Mkv], device="cuda", dtype=dtype) * 3,
+        )
+
+    @staticmethod
+    def pad_bias(bias: torch.Tensor) -> torch.Tensor:
+        align_to = 16
+        if (bias.shape[-1] % align_to) == 0:
+            return bias
+        pad_count = align_to - (bias.shape[-1] % align_to)
+        return torch.nn.functional.pad(bias, [0, pad_count])[:, :, :, : bias.shape[-1]]
+
+    @skip_if_sm100_or_better
+    def test_f16_biasf32(self) -> None:
+        q, k, v, bias = self.create_tensors(torch.float16)
+        fmha.memory_efficient_attention(q, k, v, attn_bias=bias)
+        bias = bias.to(torch.float32)
+        with pytest.raises((ValueError, RuntimeError)):
+            fmha.memory_efficient_attention(q, k, v, attn_bias=bias)
+
+    @skip_if_sm100_or_better
+    @disable_on_rocm
+    def test_f32_biasf16(self) -> None:
+        q, k, v, bias = self.create_tensors(torch.float32)
+        fmha.memory_efficient_attention(q, k, v, attn_bias=bias)
+        bias = bias.to(torch.float16)
+        with pytest.raises((ValueError, RuntimeError)):
+            fmha.memory_efficient_attention(q, k, v, attn_bias=bias)
+
+    @skip_if_sm100_or_better
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_wrong_alignment(self, dtype) -> None:
+        op = fmha.cutlass.FwOp if torch.version.cuda else fmha.ck.FwOp
+        if dtype not in op.SUPPORTED_DTYPES:
+            pytest.skip(
+                f"{dtype=} is not supported by {op.__module__}.{op.__qualname__}"
+            )
+
+        q, k, v, bias = self.create_tensors(dtype, Mq=7, Mkv=5)
+        try:
+            fmha.memory_efficient_attention(q, k, v, attn_bias=bias, op=(op, None))
+            return
+        except (ValueError, RuntimeError):
+            pass
+        # This case is not supported, likely due to padding issues
+        # Let's make sure it works with padding
+        assert bias.ndim == 4, bias.shape
+        bias_padded = self.pad_bias(bias)
+        out = fmha.memory_efficient_attention(
+            q, k, v, attn_bias=bias_padded, op=(op, None)
+        ).float()
+        ref_out = ref_attention_bmhk_for_test(q, k, v, bias)
+        assert_allclose(
+            out, ref_out, atol=op.ERROR_ATOL[dtype], rtol=op.ERROR_RTOL[dtype]
+        )
+
+    def test_permuted_attn_bias(self) -> None:
+        op = fmha.cutlass.FwOp
+        dtype = torch.float16
+        q, k, v, bias = self.create_tensors(dtype, Mq=7, Mkv=7)
+        bias = bias.transpose(-1, -2)  # now `stride(-1) != 1`
+        # Either it works, or it raises an exception
+        # but we should never get a CUDA error
+        try:
+            out = fmha.memory_efficient_attention(
+                q, k, v, attn_bias=bias, op=(op, None)
+            ).float()
+            ref_out = ref_attention_bmhk_for_test(q, k, v, bias)
+            assert_allclose(
+                out, ref_out, atol=op.ERROR_ATOL[dtype], rtol=op.ERROR_RTOL[dtype]
+            )
+        except (ValueError, RuntimeError):
+            pass
+
+
+SM_AND_SHMEM_KBYTES = [
+    # https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications-technical-specifications-per-compute-capability
+    (50, 64),
+    (60, 64),
+    (70, 96),
+    (75, 64),
+    (80, 163),
+    (86, 99),
+    (89, 99),
+    # (90, 227),
+]
+
+
+def test_window_size_materialize() -> None:
+    seqlens = [4, 6]
+    attn_bias = fmha.attn_bias.BlockDiagonalMask.from_seqlens(
+        q_seqlen=seqlens,
+        kv_seqlen=seqlens,
+    ).make_local_attention(2)
+    mask = attn_bias.materialize(
+        (1, 1, sum(seqlens), sum(seqlens)),
+        device="cpu",
+        dtype=torch.float32,
+    )
+    true_mask = torch.log(
+        torch.Tensor(
+            [
+                [
+                    [
+                        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+                    ]
+                ]
+            ]
+        )
+    )
+    assert torch.all(mask == true_mask)
+
+
+@cuda_or_mtia_only
+@pytest.mark.parametrize("Mq", [1, 512])
+@pytest.mark.parametrize(
+    "opFW_biasT",
+    [
+        (op, biasT)
+        for op in ALL_FW_OPS
+        for biasT in get_supported_attn_bias_types(op)
+        if op.SUPPORTS_BMGHK
+    ],
+    ids=lambda o: f"{o[0].NAME}-{o[1].__name__}" if isinstance(o, tuple) else "",
+)
+def test_forward_gqa(opFW_biasT, Mq: int):
+    device = torch._C._get_accelerator().type
+
+    opFW, biasT = opFW_biasT
+    if Mq < 512 and (
+        issubclass(biasT, fmha.attn_bias.LowerTriangularMask)
+        or issubclass(biasT, fmha.attn_bias.BlockDiagonalCausalMask)
+    ):
+        pytest.skip("undefined upper left")
+    B_Mq_Mkv_H_K_Kv = (3, Mq, 512, 16, 128, 128)
+    test_forward(
+        (
+            opFW,
+            device,
+            torch.float16,
+            biasT,
+            *B_Mq_Mkv_H_K_Kv,
+        ),
+        packed=False,
+        fmt="BMGHK",
+        g=2,
+    )
+
+
+@cuda_or_mtia_only
+@pytest.mark.parametrize(
+    "opBW",
+    [
+        fmha.flash.BwOp,
+        fmha.ck.BwOp if torch.version.hip else fmha.cutlass.BwOp,
+        fmha.cutlass_blackwell.BwOp,
+    ],
+)
+def test_backward_gqa(opBW):
+    device = torch._C._get_accelerator().type
+
+    H = 8
+    B_Mq_Mkv_H_K_Kv = (3, 512, 512, H, 128, 128)
+    dtype = torch.float16
+    query, key, value, attn_bias = create_tensors(
+        *(opBW, device, dtype, type(None), *B_Mq_Mkv_H_K_Kv),
+        attn_bias_requires_grad=False,
+        fmt="BMHK",
+    )
+    op = (fmha.ck.FwOp if torch.version.hip else fmha.cutlass.FwOp, opBW)
+    key = key[:, :, :1].expand(-1, -1, H, -1)
+    value = value[:, :, :1].expand(-1, -1, H, -1)
+    key.requires_grad_(True)
+    out = fmha.memory_efficient_attention(query, key, value, attn_bias=attn_bias)
+    out.backward(query)
+    dk = key.grad
+    key.grad = None
+
+    if use_cpu_ref(device):
+        query = query.detach().cpu()
+        key = key.detach().cpu()
+        value = value.detach().cpu()
+        query.requires_grad_(True)
+        key.requires_grad_(True)
+        value.requires_grad_(True)
+
+    out_ref = ref_attention_bmhk_for_test(query, key, value, attn_bias=attn_bias)
+    out_ref.backward(query)
+
+    assert_allclose(
+        out.float().to(out_ref.device),
+        out_ref.float(),
+        atol=op[0].ERROR_ATOL[dtype],
+        rtol=op[0].ERROR_RTOL[dtype],
+    )
+    assert_allclose(
+        dk.float().to(key.grad.device),
+        key.grad.float(),
+        atol=op[1].ERROR_ATOL[dtype],
+        rtol=op[1].ERROR_RTOL[dtype],
+    )
+
+
+@cuda_or_mtia_only
+@pytest.mark.parametrize("opFW", [op for op in ALL_FW_OPS if op.SUPPORTS_BMGHK])
+def test_forward_gqa_one_group(opFW):
+    device = torch._C._get_accelerator().type
+
+    dtype = torch.float16
+    B, Mq, Mkv, H, K = 3, 13, 16, 5, 128
+    q = torch.randn([B, Mq, 1, H, K], dtype=dtype, device=device) * 3
+    k = torch.randn([B, Mkv, 1, H, K], dtype=dtype, device=device) * 3
+    v = torch.randn([B, Mkv, 1, H, K], dtype=dtype, device=device) * 3
+
+    supported = opFW.supports(fmha.Inputs(q, k, v))
+    if not supported:
+        supported_bmhk = opFW.supports(fmha.Inputs(q[:, :, 0], k[:, :, 0], v[:, :, 0]))
+        assert supported == supported_bmhk
+        pytest.skip("not supported")
+    out = fmha.memory_efficient_attention_forward(q, k, v, op=opFW)
+    ref = ref_attention_for_test(q, k, v)
+    assert_allclose(
+        out.float(),
+        ref,
+        atol=opFW.ERROR_ATOL[dtype],
+        rtol=opFW.ERROR_RTOL.get(dtype, 1e-5),
+    )
+
+
+@sm80_or_better_only
+@disable_on_rocm
+def test_flash_gqa_wrong_strides() -> None:
+    op = (fmha.flash.FwOp, None)
+
+    device = "cuda"
+    B, Mq, Mkv, G, H, K = 3, 1, 512, 2, 8, 128
+    q = torch.empty((B, Mq, G, H, K), dtype=torch.float16, device=device)
+    kv = torch.empty((B, Mkv, G, H, K), dtype=torch.float16, device=device)
+    fmha.memory_efficient_attention(q, kv, kv, op=op)
+
+    kv = torch.empty((B, Mkv, H, G, K), dtype=torch.float16, device=device).permute(
+        0, 1, 3, 2, 4
+    )
+    with pytest.raises(ValueError):
+        fmha.memory_efficient_attention(q, kv, kv, op=op)
+
+    kv = torch.empty((B, Mkv, G, 1, K), dtype=torch.float16, device=device)
+    with pytest.raises(ValueError):
+        fmha.memory_efficient_attention(q, kv, kv, op=op)
+    kv = kv.expand(-1, -1, -1, H, K)
+    fmha.memory_efficient_attention(q, kv, kv, op=op)
+
+    kv = torch.empty((B, Mkv, G, H, 2 * K), dtype=torch.float16, device=device)[
+        :, :, :, :, :K
+    ]
+    fmha.memory_efficient_attention(q, kv, kv, op=op)
+
+
+def _dispatches_to_splitK(q, kv):
+    return (
+        _dispatch_fw_priority_list(fmha.Inputs(q, kv, kv), False)[0]
+        is fmha.triton_splitk.FwOp
+    )
+
+
+def _dispatches_to_flash_decoding(q, kv):
+    flash = fmha.flash_mtia if torch.mtia.is_available() else fmha.flash
+    dispatched = _dispatch_fw_priority_list(fmha.Inputs(q, kv, kv), False)[0]
+    return dispatched is flash.FwOp
+
+
+@disable_on_rocm
+def test_dispatch_decoding_bmhk() -> None:
+    assert not _dispatches_to_splitK(
+        torch.empty([1, 8, 1, 128]), torch.empty([1, 2048, 1, 128])
+    ), "Should not use SplitK with 1 head (no tensorcores)"
+    assert _dispatches_to_flash_decoding(
+        torch.empty([1, 8, 32, 128]),
+        torch.empty([1, 2048, 1, 128]).expand(-1, -1, 32, -1),
+    ), "Should use Flash-Decoding with BMHK MQA"
+    assert not _dispatches_to_splitK(
+        torch.empty([1, 8, 32, 128]),
+        torch.empty([1, 2048, 32, 128]),
+    ), "Should not use SplitK when no TensorCores"
+    assert not _dispatches_to_splitK(
+        torch.empty([1, 128, 32, 128]),
+        torch.empty([1, 2048, 1, 128]).expand(-1, -1, 32, -1),
+    ), "Should not use SplitK if q seqlen is long"
+    assert not _dispatches_to_splitK(
+        torch.empty([128, 8, 32, 128]),
+        torch.empty([128, 2048, 1, 128]).expand(-1, -1, 32, -1),
+    ), "Should not use SplitK if B is big"
+
+
+@disable_on_rocm
+def test_dispatch_decoding_bmghk() -> None:
+    assert not _dispatches_to_splitK(
+        torch.empty([1, 8, 1, 1, 128]), torch.empty([1, 2048, 1, 1, 128])
+    ), "Should not use SplitK with 1 head (no tensorcores)"
+    assert _dispatches_to_flash_decoding(
+        torch.empty([1, 8, 1, 32, 128]),
+        torch.empty([1, 2048, 1, 1, 128]).expand(-1, -1, -1, 32, -1),
+    ), "Should use Flash-Decoding with MQA"
+    assert _dispatches_to_flash_decoding(
+        torch.empty([1, 8, 4, 32, 128]),
+        torch.empty([1, 2048, 4, 1, 128]).expand(-1, -1, -1, 32, -1),
+    ), "Should use Flash-Decoding with GQA"
+    assert not _dispatches_to_splitK(
+        torch.empty([1, 8, 1, 32, 128]),
+        torch.empty([1, 2048, 1, 32, 128]),
+    ), "Should not use SplitK when no TensorCores"
+    assert not _dispatches_to_splitK(
+        torch.empty([1, 128, 1, 32, 128]),
+        torch.empty([1, 2048, 1, 1, 128]).expand(-1, -1, -1, 32, -1),
+    ), "Should not use SplitK if q seqlen is long"
+    assert not _dispatches_to_splitK(
+        torch.empty([128, 8, 1, 32, 128]),
+        torch.empty([128, 2048, 1, 1, 128]).expand(-1, -1, -1, 32, -1),
+    ), "Should not use SplitK if B is big"
+
+
+shapes_triton_splitk = [
+    (1, 8, 2**16, 1, 128, 128),
+    (1, 4, 2**16, 1, 128, 128),
+    (1, 16, 2**16, 1, 128, 128),
+    (1, 16, 2**16, 1, 32, 32),
+    (1, 8, 1025, 1, 128, 128),
+    (2, 8, 4096, 1, 128, 128),
+    (10, 8, 2**16, 1, 128, 128),
+    (10, 15, 2**16, 1, 128, 128),
+    (1, 3, 2**16, 1, 128, 128),
+    (1, 3, 2**16 - 10, 1, 128, 128),
+    (2, 3, 73, 1, 128, 128),
+    (2, 7, 7328, 1, 128, 128),
+    (2, 7, 7328, 1, 120, 120),
+    (2, 7, 63, 1, 120, 120),
+]
+op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv_splitk = [
+    (fmha.triton_splitk.FwOp, "cuda", torch.float16, type(None), *s)
+    for s in shapes_triton_splitk
+] + [
+    (fmha.triton_splitk.FwOp, "cuda", torch.bfloat16, type(None), *s)
+    for s in shapes_triton_splitk
+]
+
+
+@pytest.mark.parametrize(
+    "opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv_splitk,
+    ids=[make_id(*c) for c in op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv_splitk],
+)
+@cuda_only
+def test_forward_splitk(
+    opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+    packed=False,
+    fmt="BMHK",
+):
+    test_forward(opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, packed=packed, fmt=fmt)
+
+
+@cuda_or_mtia_only
+@pytest.mark.parametrize(
+    "op",
+    [fmha.triton_splitk.FwOp, fmha.flash.FwOp, fmha.ck.FwOp, fmha.flash_mtia.FwOp],
+    ids=lambda op: op.NAME,
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=str)
+@pytest.mark.parametrize(
+    "B_Mkv_H_K",
+    [
+        (1, 2**16, 3, 128),
+        (5, 53, 4, 64),
+        (7, 51, 4, 256),
+        (3, 51, 2, 512),
+    ],
+)
+def test_mqa_decoding(op: Type[fmha.AttentionFwOpBase], dtype, B_Mkv_H_K):
+    device = torch._C._get_accelerator().type
+
+    B, Mkv, H, K = B_Mkv_H_K
+    q = torch.randn([B, 1, H, K], dtype=dtype, device=device) * 3
+    k = torch.randn([B, Mkv, 1, K], dtype=dtype, device=device) * 3
+    v = torch.randn([B, Mkv, 1, K], dtype=dtype, device=device) * 3
+    k = k.expand(-1, -1, H, -1)
+    v = v.expand(-1, -1, H, -1)
+
+    if skip_reasons := op.not_supported_reasons(fmha.Inputs(q, k, v)):
+        pytest.skip("; ".join(skip_reasons))
+    out = fmha.memory_efficient_attention_forward(q, k, v, op=op)
+    ref = ref_attention_for_test(q, k, v)
+    assert_allclose(
+        out.float(),
+        ref,
+        atol=op.ERROR_ATOL[dtype],
+        rtol=op.ERROR_RTOL.get(dtype, 1e-5),
+    )
+
+
+@parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs
+def test_empty_tensors_empty_query(
+    opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+):
+    query, key, value, attn_bias = create_tensors(
+        *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+        fmt="BMHK",
+    )
+    opFW = opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv[0]
+
+    if torch.version.hip:
+        pytest.skip("backward pass/gradience is not yet supported by ck-tiled fmha!")
+
+    query = query[:, :0]
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+    out = fmha.memory_efficient_attention(query, key, value, op=(opFW, None))
+    assert out.shape[1] == 0
+    out.backward(out)
+    # dK/dV should be all zeros
+    assert_allclose(key.grad, torch.zeros_like(key.grad), "key.grad")
+    assert_allclose(value.grad, torch.zeros_like(value.grad), "value.grad")
+
+
+@parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs
+def test_empty_tensors_empty_kv(
+    opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+):
+    query, key, value, attn_bias = create_tensors(
+        *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+        fmt="BMHK",
+    )
+    opFW = opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv[0]
+    if opFW == fmha.triton_splitk.FwOp:
+        pytest.skip("triton_splitk doesn't support empty kv")
+
+    if torch.version.hip:
+        pytest.skip("backward pass/gradience is not yet supported by ck-tiled fmha!")
+
+    key = key[:, :0]
+    value = value[:, :0]
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+    out = fmha.memory_efficient_attention(query, key, value, op=(opFW, None))
+    assert_allclose(out, torch.zeros_like(out), "out")
+    out.backward(out)
+    # dQ should be all zeros
+    assert_allclose(query.grad, torch.zeros_like(query.grad), "query.grad")
+
+
+@parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs
+def test_empty_tensors_empty_b(
+    opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+):
+    query, key, value, attn_bias = create_tensors(
+        *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+        fmt="BMHK",
+    )
+    opFW = opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv[0]
+
+    if torch.version.hip:
+        pytest.skip("backward pass/gradience is not yet supported by ck-tiled fmha!")
+
+    query, key, value = query[:0], key[:0], value[:0]
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+    out = fmha.memory_efficient_attention(query, key, value, op=(opFW, None))
+    out.backward(out)
+
+
+def test_local_attn_bias() -> None:
+    mask = (
+        fmha.attn_bias.LocalAttentionFromBottomRightMask(window_left=1, window_right=2)
+        .materialize(shape=(4, 4))
+        .exp()
+    )
+
+    expected = torch.tensor(
+        [[1, 1, 1, 0], [1, 1, 1, 1], [0, 1, 1, 1], [0, 0, 1, 1]], dtype=torch.float32
+    )
+    assert (mask == expected).all().item()
+
+
+@sm80_or_better_only
+@pytest.mark.parametrize("B", [1, 5, 128])
+@pytest.mark.parametrize("MAX_T", [64, 128, 2048, 4096, 8192])
+@pytest.mark.parametrize(
+    "op",
+    [
+        fmha.triton_splitk.FwOp,
+        fmha.triton_splitk.FwOp_S8,
+        fmha.triton_splitk.FwOp_Map[48],
+    ],
+    ids=lambda op: op.NAME,
+)
+@pytest.mark.parametrize("num_quant_groups", [0, 1, 8])
+@pytest.mark.parametrize("page_size", [64, 128, 256])
+@pytest.mark.parametrize("gappy", [False, True], ids=lambda x: "gappy" if x else "")
+def test_paged_attention(
+    B,
+    MAX_T: int,
+    num_quant_groups: int,
+    page_size: int,
+    op: Type[AttentionFwOpBase],
+    gappy: bool,
+):
+    msg = "Notional padding should be divisible by the page size"
+    if gappy and MAX_T % page_size:
+        context = pytest.raises(ValueError, match=msg)
+    else:
+        context = nullcontext()  # type: ignore[assignment]
+    with context:
+        paged_attention_run_inner(
+            B, MAX_T, num_quant_groups, page_size, op, bench=False, gappy=gappy
+        )
+
+
+@rocm_only
+@pytest.mark.parametrize("B", [1, 5, 128])
+@pytest.mark.parametrize("MAX_T", [64, 128, 2048, 4096, 8192])
+@pytest.mark.parametrize("page_size", [128, 256])
+@pytest.mark.parametrize("gappy", [False, True], ids=lambda x: "gappy" if x else "")
+def test_paged_attention_ck(B, MAX_T: int, page_size: int, gappy: bool):
+    op = fmha.ck.FwOp
+    num_quant_groups = 0
+    msg = "Notional padding should be divisible by the page size"
+    if gappy and MAX_T % page_size:
+        context = pytest.raises(ValueError, match=msg)
+    else:
+        context = nullcontext()  # type: ignore[assignment]
+    with context:
+        paged_attention_run_inner(
+            B, MAX_T, num_quant_groups, page_size, op, bench=False, gappy=gappy
+        )
+
+
+@sm80_or_better_only
+@disable_on_rocm
+@pytest.mark.parametrize("B", [1, 5, 128])
+@pytest.mark.parametrize("MAX_T", [64, 128, 2048, 4096, 8192])
+@pytest.mark.parametrize("page_size", [256])
+def test_paged_attention_flash(B, MAX_T: int, page_size: int):
+    # TODO: add smaller page sizes when https://github.com/Dao-AILab/flash-attention/pull/824 is merged
+    op = fmha.flash.FwOp
+    if (
+        fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask
+        not in get_supported_attn_bias_types(op)
+    ):
+        pytest.skip("Not supported bias")
+    num_quant_groups = 0
+    paged_attention_run_inner(B, MAX_T, num_quant_groups, page_size, op, bench=False)
+
+
+@skip_if_sm100_or_better
+@sm90_or_better_only
+@disable_on_rocm
+@pytest.mark.parametrize(
+    "op", _filter_unsupported_ops([fmha.flash3.FwOp, fmha.flash3.FwOp_KVSplit])
+)
+@pytest.mark.parametrize("B", [1, 5, 128])
+@pytest.mark.parametrize("MAX_T", [64, 128, 2048, 4096, 8192])
+@pytest.mark.parametrize("page_size", [256])
+def test_paged_attention_flash3(
+    op: Type[AttentionFwOpBase], B: int, MAX_T: int, page_size: int
+):
+    if (
+        fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask
+        not in get_supported_attn_bias_types(op)
+    ):
+        pytest.skip("Not supported bias")
+    num_quant_groups = 0
+    paged_attention_run_inner(B, MAX_T, num_quant_groups, page_size, op, bench=False)
+
+
+def paged_attention_run_inner(
+    B: int,
+    MAX_T: int,
+    num_quant_groups: int,
+    page_size: int,
+    op: Type[AttentionFwOpBase],
+    bench: bool,
+    gappy: bool = False,
+) -> None:
+    import triton
+
+    torch.manual_seed(10)
+    TEST_WARMUP_MS = 500
+    TEST_RUN_MS = 5000
+
+    N_H_L = 8
+    N_KVH_L = 1
+    D_H = 128
+    D_H_KV = D_H // 8 + num_quant_groups if num_quant_groups else D_H
+    kv_seqlens = torch.randint(low=1, high=MAX_T + 1, size=(B,)).tolist()
+    # Paged attention requires k.shape[1] and v.shape[1] to be divisible by page_size, so pad
+    padded_per_row_len = ((MAX_T + page_size - 1) // page_size) * page_size
+
+    if gappy:
+        make_paged_kwargs = {
+            "paged_type": fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+            "notional_padding": MAX_T,
+        }
+        attn_bias = fmha.attn_bias.BlockDiagonalGappyKeysMask.from_seqlens(
+            q_seqlen=[1] * B,
+            kv_seqstarts=list(range(0, MAX_T * (B + 1), MAX_T)),
+            kv_seqlen=kv_seqlens,
+        )
+    else:
+        make_paged_kwargs = {
+            "paged_type": fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+        }
+
+        block_type = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask
+        attn_bias = block_type.from_seqlens(  # type: ignore
+            q_seqlen=[1] * B,
+            kv_padding=MAX_T,
+            kv_seqlen=kv_seqlens,
+        )
+
+    q = torch.randn((B, 1, N_H_L, D_H), dtype=torch.bfloat16, device="cuda")
+    if num_quant_groups:
+        if triton.__version__[:4] < "3.0.":
+            raise pytest.skip("dequant needs triton updates")
+
+        # Using high=64 below, because with 256 both paged and non-paged paths
+        # will produce NaNs - probably some quantization coeffitions are NaNs
+        # after the bitwise cast.
+        cache_k = torch.randint(
+            0, 64, (B, MAX_T, N_KVH_L, D_H_KV * 4), dtype=torch.uint8, device="cuda"
+        )
+        cache_k = cache_k.view(dtype=torch.int32)
+        cache_v = torch.randint(
+            0, 64, (B, MAX_T, N_KVH_L, D_H_KV * 4), dtype=torch.uint8, device="cuda"
+        )
+        cache_v = cache_v.view(dtype=torch.int32)
+
+        op = type(
+            f"{op.__name__}_{num_quant_groups}",
+            (op,),
+            {"NUM_GROUPS": num_quant_groups},
+        )
+    else:
+        cache_k = torch.randn(
+            (B, MAX_T, N_KVH_L, D_H), dtype=torch.bfloat16, device="cuda"
+        )
+        cache_v = torch.randn_like(cache_k)
+
+    axq = q.view(1, B * 1, N_H_L, D_H)
+    axk = cache_k.view(1, B * MAX_T, N_KVH_L, D_H_KV).expand(
+        1, B * MAX_T, N_H_L, D_H_KV
+    )
+    axv = cache_v.view(1, B * MAX_T, N_KVH_L, D_H_KV).expand(
+        1, B * MAX_T, N_H_L, D_H_KV
+    )
+
+    k_cache_size_usual = axk.numel()
+
+    # First, create "wasteful" K/V cache, where every block in logical cache
+    # has a physical representation, even if there's nothing stored there
+
+    block_tables = torch.arange(
+        B * padded_per_row_len // page_size, device="cuda", dtype=torch.int32
+    ).reshape(B, -1)
+
+    shape_padded = (B, padded_per_row_len, N_KVH_L, D_H_KV)
+    axk_padded = torch.empty(shape_padded, device=axk.device, dtype=axk.dtype)
+    axv_padded = torch.empty(shape_padded, device=axv.device, dtype=axv.dtype)
+    axk_padded[:, :MAX_T] = axk.view(B, -1, N_H_L, D_H_KV)[:, :, :1, :]
+    axv_padded[:, :MAX_T] = axv.view(B, -1, N_H_L, D_H_KV)[:, :, :1, :]
+
+    axk_padded = axk_padded.view(1, B * padded_per_row_len, N_KVH_L, D_H_KV)
+    axv_padded = axv_padded.view(1, B * padded_per_row_len, N_KVH_L, D_H_KV)
+
+    axk_padded = axk_padded.expand(-1, -1, N_H_L, -1)
+    axv_padded = axv_padded.expand(-1, -1, N_H_L, -1)
+
+    attn_bias_paged = attn_bias.make_paged(
+        block_tables=block_tables,
+        page_size=page_size,
+        **make_paged_kwargs,  # type: ignore
+    )
+    if type(attn_bias_paged) not in op.SUPPORTED_ATTN_BIAS_TYPES:
+        pytest.skip(f"{type(attn_bias_paged)} not supported")
+    if type(attn_bias) not in op.SUPPORTED_ATTN_BIAS_TYPES:
+        pytest.skip(f"{type(attn_bias_paged)} not supported")
+    y_usual = fmha.memory_efficient_attention_forward(
+        axq,
+        axk,
+        axv,
+        attn_bias,
+        op=op,
+    )
+    if bench:
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            y_usual = fmha.memory_efficient_attention_forward(
+                axq,
+                axk,
+                axv,
+                attn_bias,
+                op=op,
+            )
+        t_ms = triton.testing.do_bench(
+            lambda g=g: g.replay(),
+            warmup=TEST_WARMUP_MS,
+            rep=TEST_RUN_MS,
+        )
+        logger.info(f"Non-paged attention took {t_ms * 1e3:.2f}us")
+
+    y_wasteful = fmha.memory_efficient_attention_forward(
+        axq,
+        axk_padded,
+        axv_padded,
+        attn_bias_paged,
+        op=op,
+    )
+    if bench:
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            y_wasteful = fmha.memory_efficient_attention_forward(
+                axq,
+                axk_padded,
+                axv_padded,
+                attn_bias_paged,
+                op=op,
+            )
+        t_ms = triton.testing.do_bench(
+            lambda g=g: g.replay(),
+            warmup=TEST_WARMUP_MS,
+            rep=TEST_RUN_MS,
+        )
+        logger.info(f"Paged attention with wasteful K/V-cache took {t_ms * 1e3:.2f}us")
+
+    torch.testing.assert_close(
+        y_wasteful,
+        y_usual,
+        atol=1.0e-2,
+        rtol=1.0e-2,
+    )
+
+    # Now let's create a "packed" K/V cache, where only meaniningful logical blocks are mapped to physical blocks
+    (block_tables, packed_cache_k, packed_cache_v) = pack_kv_cache(
+        cache_k,
+        cache_v,
+        kv_seqlens,
+        page_size,
+    )
+    attn_bias_paged = attn_bias.make_paged(
+        block_tables=block_tables,
+        page_size=page_size,
+        **make_paged_kwargs,  # type: ignore
+    )
+    axk = packed_cache_k.view(1, -1, N_KVH_L, D_H_KV).expand(1, -1, N_H_L, D_H_KV)
+    axv = packed_cache_v.view(1, -1, N_KVH_L, D_H_KV).expand(1, -1, N_H_L, D_H_KV)
+
+    k_cache_size_packed = axk.numel()
+
+    y_packed = fmha.memory_efficient_attention_forward(
+        axq,
+        axk,
+        axv,
+        attn_bias_paged,
+        op=op,
+    )
+
+    logger.info(
+        "KV-cache size reduced by "
+        f"{(100 * (1 - k_cache_size_packed / k_cache_size_usual)):.2f}%"
+    )
+
+    torch.testing.assert_close(y_wasteful, y_packed)
+
+    # Let's swap two blocks, and adjust two corresponding entries in the block table. The result shouldn't change
+    i, j = 0, axk.shape[1] // page_size - 1
+
+    axk = axk[:, :, :1, :]
+    axv = axv[:, :, :1, :]
+
+    vals_i = axk[:, i * page_size : (i + 1) * page_size, :, :].clone()
+    vals_j = axk[:, j * page_size : (j + 1) * page_size, :, :].clone()
+    axk[:, i * page_size : (i + 1) * page_size, :, :] = vals_j
+    axk[:, j * page_size : (j + 1) * page_size, :, :] = vals_i
+
+    vals_i = axv[:, i * page_size : (i + 1) * page_size, :, :].clone()
+    vals_j = axv[:, j * page_size : (j + 1) * page_size, :, :].clone()
+    axv[:, i * page_size : (i + 1) * page_size, :, :] = vals_j
+    axv[:, j * page_size : (j + 1) * page_size, :, :] = vals_i
+
+    axk = axk.expand(-1, -1, N_H_L, -1)
+    axv = axv.expand(-1, -1, N_H_L, -1)
+
+    where_i = block_tables == i
+    where_j = block_tables == j
+    block_tables.masked_fill_(where_i, j)
+    block_tables.masked_fill_(where_j, i)
+
+    y_swapped = fmha.memory_efficient_attention_forward(
+        axq,
+        axk,
+        axv,
+        attn_bias_paged,
+        op=op,
+    )
+    if bench:
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            y_swapped = fmha.memory_efficient_attention_forward(
+                axq,
+                axk,
+                axv,
+                attn_bias_paged,
+                op=op,
+            )
+        t_ms = triton.testing.do_bench(
+            lambda g=g: g.replay(),
+            warmup=TEST_WARMUP_MS,
+            rep=TEST_RUN_MS,
+        )
+        logger.info(f"Paged attention with packed K/V-cache took {t_ms * 1e3:.2f}us")
+
+    torch.testing.assert_close(y_swapped, y_packed)
+
+
+@sm80_or_better_only
+@pytest.mark.parametrize(
+    "bias_t",
+    [None, fmha.attn_bias.LowerTriangularMask, fmha.attn_bias.BlockDiagonalMask],
+)
+@pytest.mark.parametrize("create_bias_inside_compiled", [False, True])
+@pytest.mark.parametrize(
+    "op",
+    [
+        None,
+        (fmha.flash.FwOp, fmha.flash.BwOp),
+        (fmha.cutlass_blackwell.FwOp, fmha.cutlass_blackwell.BwOp),
+        (fmha.flash3.FwOp, fmha.flash3.BwOp),
+    ],
+)
+def test_memeff_compile(bias_t, create_bias_inside_compiled: bool, op) -> None:
+    torch.manual_seed(0)
+    if op is not None and not op[0].is_available():
+        pytest.skip("Op is not available")
+    torch._dynamo.reset_code_caches()  # avoids hitting recompilation limit
+    B, M, H, K = 1, 256, 2, 64
+    q, k, v, bias = create_tensors(
+        op if op is None else op[0],
+        "cuda",
+        torch.float16,
+        bias_t,
+        B,
+        M,
+        M,
+        H,
+        K,
+        K,
+        fmt="BMHK",
+    )
+    grad = torch.randn_like(q)
+    if create_bias_inside_compiled:
+        bias = None
+        if bias_t is not None:
+            pytest.skip("Can't create this mask inside compile")
+    if bias is not None:
+        bias.to(q.device)
+    q.requires_grad_(True)
+    k.requires_grad_(True)
+    v.requires_grad_(True)
+
+    def fmha_fn(q, k, v, bias):
+        if create_bias_inside_compiled and bias_t is not None:
+            bias = bias_t()
+        return fmha.memory_efficient_attention(q, k, v, attn_bias=bias, op=op)
+
+    # Eager reference
+    out_ref = fmha_fn(q, k, v, bias)
+    out_ref.backward(grad)
+    dq_ref, dk_ref, dv_ref = q.grad, k.grad, v.grad
+    q.grad, k.grad, v.grad = None, None, None
+
+    # Compiled version
+    fmha_c = torch.compile(fmha_fn, fullgraph=True, dynamic=False)
+    out = fmha_c(q, k, v, bias)
+    out.backward(grad)
+
+    assert_allclose(
+        out,
+        out_ref,
+        "out",
+        atol=fmha.flash.FwOp.ERROR_ATOL[q.dtype],
+        rtol=fmha.flash.FwOp.ERROR_RTOL[q.dtype],
+    )
+    atol, rtol = (
+        fmha.flash.BwOp.ERROR_ATOL[q.dtype],
+        fmha.flash.BwOp.ERROR_RTOL[q.dtype],
+    )
+    assert_allclose(q.grad, dq_ref, "dq", atol=atol, rtol=rtol)
+    assert_allclose(k.grad, dk_ref, "dk", atol=atol, rtol=rtol)
+    assert_allclose(v.grad, dv_ref, "dv", atol=atol, rtol=rtol)
+
+
+@sm90_or_better_only
+@pytest.mark.parametrize("B", [1, 16, 64])
+@pytest.mark.parametrize("Mkv", [2048, 8192])
+@pytest.mark.parametrize("Hkv", [1, 2])
+@pytest.mark.parametrize("G", [1, 8])
+@pytest.mark.parametrize("page_size", [64, 256])
+@torch.no_grad()
+def test_triton_splitk_rowwise_fp8(
+    B: int,
+    Mkv: int,
+    Hkv: int,
+    G: int,
+    page_size: int,
+    Mq: int = 1,
+    K: int = 128,
+) -> None:
+    torch.manual_seed(10)
+
+    Hq = Hkv * G
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    inp, inp_ref, inp_fp8_paged, inp_bf16_paged = construct_fp8_attention_inputs(
+        B, Mkv, Mq, Hkv, Hq, K, page_size, device, dtype
+    )
+
+    (
+        attn_output_fp8,
+        context_fp8,
+    ) = fmha._memory_efficient_attention_forward_requires_grad(
+        inp, op=fmha.triton_splitk.FwOp
+    )
+
+    (
+        attn_output_ref,
+        context_ref,
+    ) = fmha._memory_efficient_attention_forward_requires_grad(
+        inp_ref, op=fmha.triton_splitk.FwOp
+    )
+
+    torch.testing.assert_close(attn_output_fp8, attn_output_ref, atol=5e-3, rtol=5e-3)
+    assert context_fp8 is not None and context_ref is not None
+    torch.testing.assert_close(context_fp8.lse, context_ref.lse, atol=5e-4, rtol=5e-4)
+
+    # Paged K/V cache
+
+    paged_bias = fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetPaddedKeysMask
+    if paged_bias not in fmha.triton_splitk.FwOp.SUPPORTED_ATTN_BIAS_TYPES:
+        return
+
+    (
+        attn_output_fp8_paged,
+        context_fp8_paged,
+    ) = fmha._memory_efficient_attention_forward_requires_grad(
+        inp_fp8_paged, op=fmha.triton_splitk.FwOp
+    )
+    torch.testing.assert_close(
+        attn_output_fp8, attn_output_fp8_paged, atol=2e-3, rtol=2e-3
+    )
+    assert context_fp8_paged is not None
+    torch.testing.assert_close(
+        context_fp8.lse, context_fp8_paged.lse, atol=1e-4, rtol=1e-4
+    )
+
+
+def fp8_per_head_quantize(
+    x: torch.Tensor,
+    dtype_fp8: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    MAX_FP8 = torch.finfo(dtype_fp8).max
+    EPS = 1e-12
+    SCALE_UP = 1200.0
+    tensor_max = torch.amax(torch.abs(x), dim=(1, 3), keepdim=False).to(torch.float32)
+    clamp_max = torch.clamp(tensor_max, min=EPS, max=SCALE_UP)
+    scale: torch.Tensor = MAX_FP8 / clamp_max  # type: ignore  # Shape: [batch, num_heads]
+    x_quantized = (x * scale[:, None, :, None]).to(
+        dtype_fp8
+    )  # Shape: [B, seq_len, num_heads, head_dim]
+
+    return x_quantized, torch.reciprocal(scale)  # Shape: [batch, num_heads]
+
+
+def check_sqnr(a: torch.Tensor, b: torch.Tensor, threshold: int = 30) -> float:
+    def compute_sqnr(x: torch.Tensor, y: torch.Tensor, eps: float = 1e-30) -> float:
+        """Compute SQNR in dB.
+
+        Args:
+            x: The reference tensor.
+            y: The de-quantized tensor.
+            eps: A small value to avoid division by zero.
+
+        Returns:
+            SQNR in dB.
+        """
+        error = x - y
+        signal = x * x
+        error_power = error * error
+        ratio = signal.mean() / (error_power.mean() + eps)
+        sqnr_db = 10.0 * torch.log10(ratio).item()
+        return round(sqnr_db, 2)
+
+    sqnr = compute_sqnr(a, b)
+    assert sqnr >= threshold, f"SQNR should be ≥ {threshold}. Got: {sqnr}"
+    print(f"SQNR: {sqnr}")
+    return sqnr
+
+
+@sm90_or_better_only
+@pytest.mark.parametrize("B", [1, 16, 64])
+@pytest.mark.parametrize("Mkv", [2048, 8192])
+@pytest.mark.parametrize("Mq", [1])
+@pytest.mark.parametrize("Hkv", [1, 2])
+@pytest.mark.parametrize("Hq", [1, 8])
+@pytest.mark.parametrize("K", [128, 256])
+@torch.no_grad()
+def _test_triton_splitk_tokenwise_qkv_fp8(
+    B: int,  # Batch size
+    Mkv: int,  # Key/Value sequence length
+    Mq: int,  # Query sequence length (decode=1)
+    Hkv: int,  # Total number of KV heads
+    Hq: int,  # Total number of Query heads
+    K: int,  # Hidden dimension
+) -> None:
+    """
+    Tests _fwd_kernel_splitK with token-wise quantization.
+
+    Quantization combinations:
+    1. Baseline (KV quantization)
+    2. QK quantization only
+    3. PV quantization only
+    4. Both QK and PV quantization with FP32 scales
+    """
+    if Hkv > Hq:
+        # Each query head must have at least one KV head
+        return
+
+    PAGE_SIZE = 1  # This test doesn't cover paged KV
+    DEVICE = torch.accelerator.current_accelerator()
+    assert DEVICE is not None
+    DTYPE = torch.bfloat16
+
+    torch.manual_seed(10)
+    inp_fp8, inp_ref, _, _ = construct_fp8_attention_inputs(
+        B,
+        Mkv,
+        Mq,
+        Hkv,
+        Hq,
+        K,
+        PAGE_SIZE,
+        DEVICE,
+        DTYPE,
+        # use_fp32_scales=False,
+        use_symmetric=True,
+    )
+    # inp_fp8.quantize_pv_to_fp8 = False
+    # inp_fp8.use_fp32_scales = False
+
+    # 1. FP8 baseline
+    inp_baseline = inp_fp8
+    (
+        baseline_attn_output_fp8,
+        baseline_context_fp8,
+    ) = fmha._memory_efficient_attention_forward_requires_grad(
+        inp_baseline, op=fmha.triton_splitk.FwOp
+    )
+
+    # 2. PV quantization
+    inp_p_fp8 = inp_fp8
+    inp_p_fp8.quantize_pv_to_fp8 = True
+    (
+        attn_output_pv_fp8,
+        context_pv_fp8,
+    ) = fmha._memory_efficient_attention_forward_requires_grad(
+        inp_p_fp8, op=fmha.triton_splitk.FwOp
+    )
+    check_sqnr(baseline_attn_output_fp8, attn_output_pv_fp8)
+    # check_sqnr(baseline_context_fp8, context_pv_fp8)
+
+    # 3. QK quantization
+    inp_qk_fp8 = add_q_fp8_to_inputs(inp_fp8)
+    inp_qk_fp8.quantize_pv_to_fp8 = False
+    (
+        attn_output_qk_fp8,
+        context_qk_fp8,
+    ) = fmha._memory_efficient_attention_forward_requires_grad(
+        inp_qk_fp8, op=fmha.triton_splitk.FwOp
+    )
+    check_sqnr(baseline_attn_output_fp8, attn_output_qk_fp8)
+    # check_sqnr(baseline_context_fp8, context_qk_fp8, threshold=27)
+
+    # 4. PV quantization + QK quantization + FP32 scales
+    torch.manual_seed(10)
+    inp_fp8, inp_ref, _, _ = construct_fp8_attention_inputs(
+        B,
+        Mkv,
+        Mq,
+        Hkv,
+        Hq,
+        K,
+        PAGE_SIZE,
+        DEVICE,
+        DTYPE,
+        use_fp32_scales=True,
+        use_symmetric=True,
+    )
+    inp_qk_fp8_with_fp32_scales = add_q_fp8_to_inputs(inp_fp8)
+    inp_qk_fp8_with_fp32_scales.quantize_pv_to_fp8 = True
+    inp_qk_fp8_with_fp32_scales.use_fp32_scales = True
+    (
+        attn_output_qk_fp8_with_fp32_scales,
+        context_qk_fp8_with_fp32_scales,
+    ) = fmha._memory_efficient_attention_forward_requires_grad(
+        inp_qk_fp8_with_fp32_scales, op=fmha.triton_splitk.FwOp
+    )
+    check_sqnr(
+        baseline_attn_output_fp8, attn_output_qk_fp8_with_fp32_scales, threshold=27
+    )
+    # check_sqnr(baseline_context_fp8, context_qk_fp8_with_fp32_scales)
+    # torch.testing.assert_close(
+    #     baseline_attn_output_fp8, attn_output_qk_fp8_with_fp32, atol=0.125, rtol=1e-2
+    # )
+
+
+@disable_on_rocm
+@sm90_or_better_only
+@pytest.mark.parametrize("dtype_init", [torch.bfloat16])
+@pytest.mark.parametrize("deterministic", [True])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("B", [4, 8, 16])
+@pytest.mark.parametrize("nheads", [6, 16])
+@pytest.mark.parametrize("seq_len", [256, 512, 1024])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+def test_fp8_attention(dtype_init, deterministic, causal, B, nheads, seq_len, head_dim):
+    op = fmha.flash3.FwOp
+    if not op.is_available():
+        pytest.skip("FAv3 is not available")
+    dtype_fp8 = torch.float8_e4m3fn
+    if dtype_fp8 not in op.SUPPORTED_DTYPES:
+        pytest.skip("FP8 is not supported")
+
+    q = torch.randn(B, seq_len, nheads, head_dim, device="cuda", dtype=dtype_init)
+    k = torch.randn(B, seq_len, nheads, head_dim, device="cuda", dtype=dtype_init)
+    v = torch.randn(B, seq_len, nheads, head_dim, device="cuda", dtype=dtype_init)
+
+    q_fp8, descale_q = fp8_per_head_quantize(q, dtype_fp8)
+    k_fp8, descale_k = fp8_per_head_quantize(k, dtype_fp8)
+    v_fp8, descale_v = fp8_per_head_quantize(v, dtype_fp8)
+
+    q_fp8_packed = pack_fp8_tensorwise_per_head(q_fp8, descale_q, dtype_init)
+    k_fp8_packed = pack_fp8_tensorwise_per_head(k_fp8, descale_k, dtype_init)
+    v_fp8_packed = pack_fp8_tensorwise_per_head(v_fp8, descale_v, dtype_init)
+
+    q_fp8_fake = q_fp8_packed.dequantize()
+    k_fp8_fake = k_fp8_packed.dequantize()
+    v_fp8_fake = v_fp8_packed.dequantize()
+
+    out_ref = fmha.memory_efficient_attention_forward(
+        q_fp8_fake, k_fp8_fake, v_fp8_fake, None, op=op
+    )
+
+    out = fmha.memory_efficient_attention_forward(
+        q_fp8_packed,
+        k_fp8_packed,
+        v_fp8_packed,
+        None,
+        op=op,
+    )
+
+    # NOTE: output dtype of FP8 attention is hard-code to BF16 for now: https://fburl.com/jcfiqmg0
+    assert out.dtype == torch.bfloat16, "FP8 output is not BF16"
+    torch.testing.assert_close(out, out_ref, atol=3e-2, rtol=1e-4)
+
+
+def _pack_xformer_input(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cache_seqlens: List[int],
+    bias_type,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    fmha.attn_bias.BlockDiagonalPaddedKeysMask,
+]:
+    batch, seq_len_q, head_q, head_d = q.shape
+    _, max_len_kv, head_kv, _ = k.shape
+
+    attn_bias = bias_type.from_seqlens(
+        q_seqlen=[seq_len_q] * batch,
+        kv_seqlen=cache_seqlens,
+        kv_padding=max_len_kv,
+    )
+
+    q = q.view(1, -1, head_q, head_d)
+    k = k.expand(-1, -1, head_q, -1).view(1, -1, head_q, k.shape[-1])
+    v = v.expand(-1, -1, head_q, -1).view(1, -1, head_q, v.shape[-1])
+    return q, k, v, attn_bias
+
+
+@disable_on_rocm
+@sm90_or_better_only
+@pytest.mark.parametrize("dtype_init", [torch.bfloat16])
+@pytest.mark.parametrize("deterministic", [True])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("B", [4, 8, 16])
+@pytest.mark.parametrize("nheads_q", [8, 16])
+@pytest.mark.parametrize("seq_len_q", [1, 2, 4, 8])
+@pytest.mark.parametrize("seq_len_kv", [256, 512, 1024, 2048])
+@pytest.mark.parametrize("max_len_kv", [4096, 8192])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize(
+    "bias",
+    [
+        fmha.attn_bias.BlockDiagonalPaddedKeysMask,
+        fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    ],
+)
+def test_fav3_kvsplit_attn(
+    dtype_init,
+    deterministic,
+    causal,
+    B,
+    nheads_q,
+    seq_len_q,
+    seq_len_kv,
+    max_len_kv,
+    head_dim,
+    bias,
+):
+    op = fmha.flash3.FwOp_KVSplit
+    if not op.is_available():
+        pytest.skip("FAv3 KVSplit is not available")
+    nheads_kv = 1
+
+    q = torch.randn(B, seq_len_q, nheads_q, head_dim, device="cuda", dtype=dtype_init)
+    k = torch.randn(B, seq_len_kv, nheads_kv, head_dim, device="cuda", dtype=dtype_init)
+    v = torch.randn(B, seq_len_kv, nheads_kv, head_dim, device="cuda", dtype=dtype_init)
+
+    xq, xk, xv, attn_bias = _pack_xformer_input(q, k, v, [seq_len_kv] * B, bias)
+
+    out_ref, lse_ref = fmha.memory_efficient_attention_forward_requires_grad(
+        xq, xk, xv, attn_bias, op=fmha.flash3.FwOp
+    )
+
+    out, lse = fmha.memory_efficient_attention_forward_requires_grad(
+        xq,
+        xk,
+        xv,
+        attn_bias,
+        op=op,
+    )
+
+    torch.testing.assert_close(out, out_ref, atol=4e-3, rtol=1e-4)
+
+    torch.testing.assert_close(lse, lse_ref, atol=4e-3, rtol=1e-4)
+
+
+@sm90_or_better_only
+@pytest.mark.parametrize(
+    "op",
+    _filter_unsupported_ops(
+        (
+            [
+                fmha.flash.FwOp,
+                fmha.cutlass.FwOp,
+                fmha.flash3.FwOp,
+                fmha.flash3.FwOp_KVSplit,
+            ]
+            if not torch.version.hip
+            else [fmha.ck.FwOp]
+        )
+        + [fmha.triton_splitk.FwOp]
+    ),
+)
+def test_nans_in_padding(op):
+    """
+    Create a batch of sequences with variable lengths, stored in padded format,
+    and fill the unused positions in K/V with NaNs.
+    This shouldn't affect the result, but currently FA3 produces NaNs in the output.
+    The reason is probably that some sequences end in the middle of a K/V block,
+    and NaNs leak into quantities like per-block maximum of Q@K used in FA algorithm.
+    """
+
+    if "cuda" not in _devices:
+        pytest.skip("CUDA device is not available")
+
+    nheads_kv = 1
+    nheads_q = 8
+    B = 64
+    seq_len_q = 15
+    max_len_kv = 256
+    head_dim = 128
+    dtype = torch.bfloat16
+    page_size = 64
+
+    padded_per_row_len = ((max_len_kv + page_size - 1) // page_size) * page_size
+
+    assert padded_per_row_len == max_len_kv
+
+    q = torch.randn(B, seq_len_q, nheads_q, head_dim, device="cuda", dtype=dtype)
+    k = torch.randn(B, max_len_kv, nheads_kv, head_dim, device="cuda", dtype=dtype)
+    v = torch.randn(B, max_len_kv, nheads_kv, head_dim, device="cuda", dtype=dtype)
+
+    xq = q.view(1, -1, nheads_q, head_dim)
+    xk = k.view(1, -1, nheads_kv, head_dim).expand(1, -1, nheads_q, -1)
+    xv = v.view(1, -1, nheads_kv, head_dim).expand(1, -1, nheads_q, -1)
+
+    # For non-paged FA3, the seqlens need to be a multiple of tile_size (128) since TMA loading V uses fixed tile-size.
+    if op in [fmha.flash3.FwOp, fmha.flash3.FwOp_KVSplit]:
+        tile_sz = 128
+        seqlens = torch.randint(max_len_kv // tile_sz, size=(B,), device="cuda")
+        seqlens = seqlens * tile_sz
+    else:
+        seqlens = torch.randint(max_len_kv, size=(B,), device="cuda")
+
+    attn_bias = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+        q_seqlen=[seq_len_q] * B, kv_seqlen=seqlens.tolist(), kv_padding=max_len_kv
+    )
+    if type(attn_bias) not in op.SUPPORTED_ATTN_BIAS_TYPES:
+        pytest.skip(f"Op {op.NAME} doesn't support {type(attn_bias)}")
+
+    out_ref, lse_ref = fmha.memory_efficient_attention_forward_requires_grad(
+        xq, xk, xv, attn_bias, op=op
+    )
+
+    # Fill K/V with NaNs at padding positions.
+    mask_uninitialized = (
+        torch.arange(max_len_kv, device="cuda")[None, :].expand(B, max_len_kv)
+        >= seqlens[:, None]
+    )
+    mask_uninitialized = mask_uninitialized[:, :, None, None]
+    k.masked_fill_(mask_uninitialized, float("nan"))
+    v.masked_fill_(mask_uninitialized, float("nan"))
+
+    if op in [fmha.flash3.FwOp, fmha.flash3.FwOp_KVSplit]:
+        # NOTE: FA3 without paged attention uses TMA to load KV from global memory to shared memory based on a fixed length,
+        # which may load NaN elements for variable length cases.
+        # So the current FA3 implementation (TMA KV loading) cannot handle NaNs during V loading, which can propagate NaNs to the output.
+        # NaNs can occur in pre-allocated KV cache initialized with torch.empty()
+        # In these cases, FA3 paged attention should be used instead, which uses cp.async to load KV from global memory to shared memory
+        # based on the variable length (see: https://fburl.com/9q0rsyco)
+        make_paged_kwargs = {
+            "paged_type": fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+        }
+
+        block_tables = torch.arange(
+            B * padded_per_row_len // page_size, device="cuda", dtype=torch.int32
+        ).reshape(B, -1)
+
+        attn_bias_paged = attn_bias.make_paged(
+            block_tables=block_tables,
+            page_size=page_size,
+            **make_paged_kwargs,  # type: ignore
+        )
+        axq = q.view(1, -1, nheads_q, head_dim)
+        axk_padded = k.view(1, -1, nheads_kv, head_dim).expand(
+            1, -1, nheads_q, head_dim
+        )
+        axv_padded = v.view(1, -1, nheads_kv, head_dim).expand(
+            1, -1, nheads_q, head_dim
+        )
+
+        if type(attn_bias_paged) not in op.SUPPORTED_ATTN_BIAS_TYPES:
+            pytest.skip(f"Op {op.NAME} doesn't support {type(attn_bias)}")
+        out, lse = fmha.memory_efficient_attention_forward_requires_grad(
+            axq,
+            axk_padded,
+            axv_padded,
+            attn_bias_paged,
+            op=op,
+        )
+        torch.testing.assert_close(out, out_ref, atol=4e-3, rtol=1e-4)
+
+        torch.testing.assert_close(lse, lse_ref, atol=4e-3, rtol=1e-4)
+    out, lse = fmha.memory_efficient_attention_forward_requires_grad(
+        xq,
+        xk,
+        xv,
+        attn_bias,
+        op=op,
+    )
+
+    torch.testing.assert_close(out, out_ref, atol=4e-3, rtol=1e-4)
+
+    torch.testing.assert_close(lse, lse_ref, atol=4e-3, rtol=1e-4)
+
+
+# end of file
+# @fairinternal-below
+
+
+class SplitKAutotune(fmha.triton_splitk.FwOp):
+    AUTOTUNE = True
+
+
+@cuda_only
+def test_forward_triton_split_k_autotune():
+    """
+    Generally we disable autotuning in tests for performance reasons,
+    add just one test with autotuning.
+    """
+    opFW = SplitKAutotune
+    biasT = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask
+    B_Mq_Mkv_H_K_Kv = (1, 1, 2048, 8, 128, 128)
+    test_forward(
+        (
+            opFW,
+            "cuda",
+            torch.bfloat16,
+            biasT,
+            *B_Mq_Mkv_H_K_Kv,
+        ),
+        packed=False,
+        fmt="BMHK",
+    )
+
+
+@sm80_or_better_only
+def test_triton_splitk_numpy():
+    import numpy
+
+    q_seqlen = numpy.array([1])
+    kv_seqlen = [1]
+    options = {"device": "cuda", "dtype": torch.bfloat16}
+    q_shape = [1, 1, 8, 128]
+    kv_shape = [1, 4096, 1, 128]
+    q = torch.randn(q_shape, **options)
+    # force the mqa path to pick triton_splitk
+    k = torch.randn(kv_shape, **options).expand(-1, -1, 8, -1)
+    v = torch.randn(kv_shape, **options).expand(-1, -1, 8, -1)
+
+    bias = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+        q_seqlen=q_seqlen,
+        kv_padding=8192,
+        kv_seqlen=kv_seqlen,
+    )
+
+    for _ in range(3):
+        fmha.memory_efficient_attention_forward(
+            q,
+            k,
+            v,
+            attn_bias=bias,
+            op=fmha.triton_splitk.FwOp,
+        )
+    torch.cuda.synchronize()
+
+
+@sm80_or_better_only
+def test_block_diagonal_bias_nan():
+    xattn_q_seqlen = [3, 5, 3, 2]
+    xattn_kv_seqlen = [0, 1028, 0, 1028]
+    axq = torch.zeros(1, 13, 8, 1, 32).bfloat16().cuda()
+    axk = torch.zeros(1, 2056, 8, 1, 32).bfloat16().cuda()
+    axv = torch.zeros(1, 2056, 8, 1, 32).bfloat16().cuda()
+    xattn_bias = fmha.attn_bias.BlockDiagonalMask.from_seqlens(
+        q_seqlen=xattn_q_seqlen, kv_seqlen=xattn_kv_seqlen
+    )
+    y = fmha.memory_efficient_attention_forward(
+        axq,
+        axk,
+        axv,
+        attn_bias=xattn_bias,
+        op=None,
+    )
+    assert not torch.isnan(y).any()

--- a/test/attention/fmha/test_tree_attention.py
+++ b/test/attention/fmha/test_tree_attention.py
@@ -1,0 +1,559 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+from functools import reduce
+from itertools import accumulate
+from typing import List, Optional, Tuple, Type
+
+import pytest
+import torch
+
+from mslk.attention import fmha
+from mslk.attention.fmha.attn_bias import (
+    BlockDiagonalPaddedKeysMask,
+    PagedBlockDiagonalPaddedKeysMask,
+)
+from mslk.attention.fmha.common import AttentionFwOpBase
+from mslk.attention.fmha.tree_attention import (
+    construct_full_tree_choices,
+    construct_tree_choices,
+    tree_attention,
+    TreeAttnMetadata,
+    use_triton_splitk_for_prefix,
+)
+from mslk.attention.fmha.utils.bench import do_bench_cudagraph
+
+compute_capability = (0, 0)
+if torch.cuda.is_available():
+    compute_capability = torch.cuda.get_device_capability("cuda")
+sm80_or_better_only = pytest.mark.skipif(
+    compute_capability < (8, 0), reason="requires sm80+"
+)
+
+
+# fmt: off
+# Tree defintions - see doctring of
+# xformers.ops.tree_attention.TreeAttnMetadata.from_tree_choices
+# for the format description
+# from https://github.com/SafeAILab/EAGLE/blob/e98fc7c/model/choices.py
+eagle_mc_sim_7b_63 = [(0,),(1,),(2,),(3,),(0,0),(0,1),(0,2),(1,0),(1,1),(2,0),(2,1),(3,0)  # noqa
+                ,(0,0,0),(0,0,1),(0,0,2),(0,1,0),(0,1,1),(0,2,0),(0,2,1),(1,0,0),  # noqa
+                (0,0,0,0),(0,0,0,1),(0,0,0,2),(0,0,0,0,0),(0,0,0,0,1)]  # noqa
+
+# Medusa choices from
+# https://github.com/FasterDecoding/Medusa/blob/5e98053/medusa/model/medusa_choices.py
+mc_sim_7b_63 = [(0,), (0, 0), (1,), (0, 1), (2,), (0, 0, 0), (1, 0), (0, 2), (3,), (0, 3), (4,), (0, 4), (2, 0), (0, 5), (0, 0, 1), (5,), (0, 6), (6,), (0, 7), (0, 1, 0), (1, 1), (7,), (0, 8), (0, 0, 2), (3, 0), (0, 9), (8,), (9,), (1, 0, 0), (0, 2, 0), (1, 2), (0, 0, 3), (4, 0), (2, 1), (0, 0, 4), (0, 0, 5), (0, 0, 0, 0), (0, 1, 1), (0, 0, 6), (0, 3, 0), (5, 0), (1, 3), (0, 0, 7), (0, 0, 8), (0, 0, 9), (6, 0), (0, 4, 0), (1, 4), (7, 0), (0, 1, 2), (2, 0, 0), (3, 1), (2, 2), (8, 0), (0, 5, 0), (1, 5), (1, 0, 1), (0, 2, 1), (9, 0), (0, 6, 0), (0, 0, 0, 1), (1, 6), (0, 7, 0)]  # noqa
+vicuna_7b_stage2 = [(0,), (0, 0), (1,), (0, 1), (0, 0, 0), (1, 0), (2,), (0, 2), (0, 0, 1), (0, 3), (3,), (0, 1, 0), (2, 0), (4,), (0, 0, 2), (0, 4), (1, 1), (1, 0, 0), (0, 0, 0, 0), (5,), (0, 0, 3), (0, 5), (0, 2, 0), (3, 0), (0, 1, 1), (0, 6), (6,), (0, 7), (0, 0, 4), (4, 0), (1, 2), (0, 8), (7,), (0, 3, 0), (0, 0, 0, 1), (0, 0, 5), (2, 1), (0, 0, 6), (1, 0, 1), (0, 0, 1, 0), (2, 0, 0), (5, 0), (0, 9), (0, 1, 2), (8,), (0, 4, 0), (0, 2, 1), (1, 3), (0, 0, 7), (0, 0, 0, 2), (0, 0, 8), (1, 1, 0), (0, 1, 0, 0), (6, 0), (9,), (0, 1, 3), (0, 0, 0, 3), (1, 0, 2), (0, 5, 0), (3, 1), (0, 0, 2, 0), (7, 0), (1, 4)]  # noqa
+vicuna_7b_stage1_ablation = [(0,), (0, 0), (1,), (0, 0, 0), (0, 1), (1, 0), (2,), (0, 2), (0, 0, 1), (3,), (0, 3), (0, 1, 0), (2, 0), (0, 0, 2), (0, 4), (4,), (0, 0, 0, 0), (1, 0, 0), (1, 1), (0, 0, 3), (0, 2, 0), (0, 5), (5,), (3, 0), (0, 1, 1), (0, 6), (6,), (0, 0, 4), (1, 2), (0, 0, 0, 1), (4, 0), (0, 0, 5), (0, 7), (0, 8), (0, 3, 0), (0, 0, 1, 0), (1, 0, 1), (7,), (2, 0, 0), (0, 0, 6), (2, 1), (0, 1, 2), (5, 0), (0, 2, 1), (0, 9), (0, 0, 0, 2), (0, 4, 0), (8,), (1, 3), (0, 0, 7), (0, 1, 0, 0), (1, 1, 0), (6, 0), (9,), (0, 0, 8), (0, 0, 9), (0, 5, 0), (0, 0, 2, 0), (1, 0, 2), (0, 1, 3), (0, 0, 0, 3), (3, 0, 0), (3, 1)]  # noqa
+vicuna_7b_stage1 = [(0,), (0, 0), (1,), (2,), (0, 1), (1, 0), (3,), (0, 2), (4,), (0, 0, 0), (0, 3), (5,), (2, 0), (0, 4), (6,), (0, 5), (1, 1), (0, 0, 1), (7,), (3, 0), (0, 6), (8,), (9,), (0, 1, 0), (0, 7), (0, 8), (4, 0), (0, 0, 2), (1, 2), (0, 9), (2, 1), (5, 0), (1, 0, 0), (0, 0, 3), (1, 3), (0, 2, 0), (0, 1, 1), (0, 0, 4), (6, 0), (1, 4), (0, 0, 5), (2, 2), (0, 3, 0), (3, 1), (0, 0, 6), (7, 0), (1, 5), (1, 0, 1), (2, 0, 0), (0, 0, 7), (8, 0), (0, 0, 0, 0), (4, 1), (0, 1, 2), (0, 4, 0), (9, 0), (0, 2, 1), (2, 3), (1, 6), (0, 0, 8), (0, 5, 0), (3, 2), (5, 1)]  # noqa
+vicuna_13b_stage2 = [(0,), (0, 0), (1,), (0, 0, 0), (0, 1), (1, 0), (2,), (0, 2), (0, 0, 1), (0, 1, 0), (3,), (0, 3), (2, 0), (0, 0, 2), (0, 0, 0, 0), (0, 4), (1, 0, 0), (1, 1), (4,), (0, 0, 3), (0, 5), (0, 2, 0), (5,), (3, 0), (0, 1, 1), (0, 6), (0, 0, 4), (0, 0, 0, 1), (0, 7), (0, 0, 5), (1, 2), (0, 0, 1, 0), (0, 3, 0), (1, 0, 1), (4, 0), (0, 0, 6), (0, 8), (2, 0, 0), (0, 9), (6,), (7,), (2, 1), (5, 0), (0, 1, 2), (0, 0, 0, 2), (8,), (0, 4, 0), (0, 1, 0, 0), (0, 2, 1), (0, 0, 7), (1, 1, 0), (1, 3), (0, 0, 2, 0), (9,), (0, 0, 8), (0, 5, 0), (0, 0, 0, 3), (0, 0, 9), (0, 1, 3), (1, 0, 2), (0, 0, 1, 1), (3, 0, 0), (1, 0, 0, 0)]  # noqa
+vicuna_13b_stage1 = [(0,), (0, 0), (1,), (0, 1), (2,), (1, 0), (0, 0, 0), (0, 2), (3,), (0, 3), (4,), (2, 0), (0, 4), (0, 0, 1), (0, 5), (5,), (1, 1), (0, 1, 0), (6,), (0, 6), (0, 0, 2), (7,), (3, 0), (8,), (0, 7), (0, 8), (1, 0, 0), (0, 0, 3), (4, 0), (1, 2), (9,), (0, 9), (2, 1), (0, 2, 0), (0, 0, 4), (1, 3), (0, 1, 1), (0, 0, 5), (5, 0), (0, 3, 0), (0, 0, 0, 0), (0, 0, 6), (6, 0), (1, 4), (2, 0, 0), (0, 1, 2), (3, 1), (0, 4, 0), (1, 0, 1), (2, 2), (0, 0, 7), (1, 5), (7, 0), (0, 0, 8), (8, 0), (0, 5, 0), (0, 0, 9), (0, 2, 1), (1, 1, 0), (0, 1, 3), (4, 1), (2, 3), (1, 6)]  # noqa
+vicuna_33b_stage2 = [(0,), (0, 0), (1,), (0, 1), (0, 0, 0), (1, 0), (2,), (0, 2), (0, 0, 1), (0, 3), (3,), (0, 1, 0), (2, 0), (0, 4), (4,), (0, 0, 2), (1, 1), (1, 0, 0), (0, 5), (5,), (0, 0, 0, 0), (0, 0, 3), (3, 0), (0, 2, 0), (0, 6), (0, 1, 1), (6,), (0, 0, 4), (0, 7), (7,), (1, 2), (4, 0), (8,), (0, 3, 0), (0, 0, 5), (0, 0, 0, 1), (0, 8), (2, 1), (0, 9), (1, 0, 1), (2, 0, 0), (0, 0, 6), (5, 0), (0, 0, 1, 0), (1, 3), (0, 1, 2), (0, 4, 0), (0, 0, 7), (0, 2, 1), (9,), (1, 1, 0), (0, 0, 0, 2), (6, 0), (0, 0, 8), (0, 1, 0, 0), (7, 0), (0, 1, 3), (0, 5, 0), (1, 4), (0, 0, 9), (3, 1), (1, 0, 2), (2, 2)]  # noqa
+vicuna_33b_stage1 = [(0,), (1,), (0, 0), (2,), (0, 1), (3,), (1, 0), (4,), (0, 2), (5,), (0, 3), (0, 0, 0), (6,), (0, 4), (2, 0), (7,), (1, 1), (0, 5), (3, 0), (8,), (9,), (0, 6), (0, 7), (0, 0, 1), (1, 2), (4, 0), (0, 1, 0), (0, 8), (0, 9), (2, 1), (0, 0, 2), (5, 0), (1, 3), (0, 0, 3), (1, 0, 0), (1, 4), (6, 0), (0, 2, 0), (3, 1), (2, 2), (0, 0, 4), (7, 0), (0, 1, 1), (1, 5), (4, 1), (0, 0, 5), (0, 3, 0), (9, 0), (8, 0), (1, 6), (0, 0, 6), (2, 3), (0, 1, 2), (3, 2), (0, 4, 0), (2, 0, 0), (1, 7), (1, 0, 1), (0, 0, 7), (5, 1), (2, 4), (0, 0, 8), (0, 2, 1)]  # noqa
+zephyr_stage2 = [(0,), (0, 0), (1,), (0, 1), (2,), (0, 0, 0), (1, 0), (0, 2), (3,), (0, 3), (4,), (2, 0), (0, 0, 1), (0, 4), (5,), (0, 5), (0, 1, 0), (1, 1), (6,), (0, 0, 2), (3, 0), (0, 6), (7,), (0, 7), (0, 8), (0, 0, 3), (1, 0, 0), (0, 9), (0, 2, 0), (1, 2), (4, 0), (8,), (9,), (2, 1), (0, 1, 1), (0, 0, 4), (0, 0, 0, 0), (5, 0), (0, 3, 0), (1, 3), (0, 0, 5), (0, 0, 6), (6, 0), (2, 0, 0), (1, 0, 1), (0, 1, 2), (0, 4, 0), (1, 4), (3, 1), (2, 2), (0, 0, 7), (7, 0), (0, 2, 1), (0, 0, 8), (0, 1, 3), (0, 5, 0), (1, 5), (0, 0, 9), (1, 1, 0), (0, 0, 0, 1), (0, 0, 1, 0), (4, 1), (2, 3)]  # noqa
+
+medusa_choices = [
+    mc_sim_7b_63,
+    vicuna_7b_stage2,
+    vicuna_7b_stage1_ablation,
+    vicuna_7b_stage1,
+    vicuna_13b_stage2,
+    vicuna_13b_stage1,
+    vicuna_33b_stage2,
+    vicuna_33b_stage1,
+    zephyr_stage2,
+]
+
+# fmt: on
+
+
+@sm80_or_better_only
+@pytest.mark.parametrize(
+    "tree_choices",
+    [
+        eagle_mc_sim_7b_63,
+        *medusa_choices,
+        construct_full_tree_choices(1, 1),
+        construct_full_tree_choices(1, 4),
+        construct_full_tree_choices(4, 1),
+        construct_full_tree_choices(3, 2),
+        construct_full_tree_choices(2, 3),
+        construct_full_tree_choices(5, 3),
+        construct_full_tree_choices(10, 2),
+    ],
+)
+@pytest.mark.parametrize("B", [1, 16])
+@pytest.mark.parametrize("G", [1, 2])
+@pytest.mark.parametrize("square", [True, False])
+@pytest.mark.parametrize("paged", [True, False])
+@torch.no_grad()
+def test_tree_attention(
+    tree_choices: List[Tuple[int, ...]], B: int, G: int, square: bool, paged: bool
+) -> None:
+    H = 8
+    D = 128
+    Mk = 8192
+    dtype = torch.bfloat16
+    tree_size_q = len(tree_choices) + 1 if square else max(len(tree_choices) // 2, 1)
+    run_tree_attention_inner(
+        tree_choices, B, Mk, G, H, D, tree_size_q, dtype, paged=paged
+    )
+
+
+class SplitKAutotune(fmha.triton_splitk.FwOp):
+    AUTOTUNE = True
+
+
+def run_tree_attention_inner(
+    tree_choices: List[Tuple[int, ...]],
+    B: int,
+    Mk: int,
+    G: int,
+    H: int,
+    D: int,
+    tree_size_q: int,
+    dtype: torch.dtype,
+    benchmark: bool = False,
+    autotune: bool = False,
+    randomize_lengths: bool = True,
+    paged: bool = False,
+) -> None:
+    """
+    Test Medusa-style tree attention.
+    """
+    torch.manual_seed(0)
+    # + 1 comes from the root node
+    tree_size_kv = len(tree_choices) + 1
+
+    # Simulate output of speculative heads
+    q_full = torch.randn([B, tree_size_kv, G, H, D], device="cuda", dtype=dtype)
+    q = q_full[:, -tree_size_q:].clone()
+    spec_k = torch.randn([B, tree_size_kv, G, 1, D], device="cuda", dtype=dtype)
+    spec_v = torch.randn_like(spec_k)
+    spec_k = spec_k.expand(-1, -1, -1, H, -1)
+    spec_v = spec_v.expand(-1, -1, -1, H, -1)
+
+    # Create K/V cache before the speculative tokens
+    cache_k = torch.randn([B, Mk, G, 1, D], device="cuda", dtype=dtype)
+    cache_v = torch.randn_like(cache_k)
+    cache_k = cache_k.expand(-1, -1, -1, H, -1)
+    cache_v = cache_v.expand(-1, -1, -1, H, -1)
+
+    if randomize_lengths:
+        kv_lens_device = torch.randint(1, Mk + 1, size=(B,), device=q.device)
+    else:
+        kv_lens_device = torch.full(size=(B,), fill_value=Mk, device=q.device)
+    kv_lens = kv_lens_device.tolist()
+
+    triton_splitk_op = SplitKAutotune if autotune else fmha.triton_splitk.FwOp
+
+    # Compute attention on the full context using merge_attentions: it will use
+    # padded non-causal block-diagonal on the first part (before spec tokens) and
+    # explicit attn_bias mask on the second part (spec tokens)
+    attn = tree_attention_with_sync(
+        q,
+        spec_k,
+        spec_v,
+        cache_k,
+        cache_v,
+        tree_choices,
+        kv_lens,
+        prefix_op=triton_splitk_op,
+        suffix_op=triton_splitk_op,
+        paged=paged,
+    )
+
+    tree_attn_metadata = TreeAttnMetadata.from_tree_choices(
+        tree_choices, q.dtype, q.device
+    )
+
+    t_optimized_ms_fa = 0.0
+    t_optimized_ms_triton = 0.0
+    if benchmark:
+        # Construct attention bias for "left" part of the attention - the exising K/V context
+        prefix_attn_bias = fmha.attn_bias.BlockDiagonalPaddedKeysMask.from_seqlens(
+            q_seqlen=[tree_size_q for _ in range(B)], kv_seqlen=kv_lens, kv_padding=Mk
+        )
+        # Create an explit attention bias for the speculative part of the attention
+        spec_attn_bias = tree_attn_metadata.attention_bias
+
+        torch.cuda.synchronize()
+        bench_stream = torch.cuda.Stream()
+        with torch.cuda.stream(bench_stream):
+            t_optimized_ms_triton = do_bench_cudagraph(
+                lambda: tree_attention(
+                    q,
+                    spec_k,
+                    spec_v,
+                    cache_k,
+                    cache_v,
+                    spec_attn_bias,
+                    prefix_attn_bias,
+                    prefix_op=triton_splitk_op,
+                    suffix_op=triton_splitk_op,
+                )
+            )
+
+        torch.cuda.synchronize()
+        bench_stream = torch.cuda.Stream()
+        with torch.cuda.stream(bench_stream):
+            t_optimized_ms_fa = do_bench_cudagraph(
+                lambda: tree_attention(
+                    q,
+                    spec_k,
+                    spec_v,
+                    cache_k,
+                    cache_v,
+                    spec_attn_bias,
+                    prefix_attn_bias,
+                    prefix_op=fmha.flash.FwOp if torch.version.cuda else fmha.ck.FwOp,
+                    suffix_op=triton_splitk_op,
+                )
+            )
+
+    # Compute attention on the full context in a slow way, unrolling every path in the tree
+    paths_w_unpadded_indices = [
+        path.tolist()[:path_len]
+        for path, path_len in zip(
+            tree_attn_metadata.retrieval_indices, tree_attn_metadata.path_lengths
+        )
+    ]
+
+    # Reference implementation, which does path unrolling, will compute attention on the full query
+    # of length tree_size_kv > tree_size_q.
+    # Then we'll pick only relevant elements to compare with the optimized implementation.
+    paths_w_unpadded_indices_q = [
+        [x - tree_size_kv + tree_size_q for x in path]
+        for path in paths_w_unpadded_indices
+    ]
+    paths_w_unpadded_indices_q_mask = [
+        x >= 0 for path in paths_w_unpadded_indices_q for x in path
+    ]
+
+    paths_w_unpadded_indices_q = [
+        [x for x in path if x >= 0] for path in paths_w_unpadded_indices_q
+    ]
+    attn_unrolled = torch.cat(
+        [attn[:, path, :, :] for path in paths_w_unpadded_indices_q], dim=1
+    )
+    ref_attn_full = ref_tree_attention(
+        q_full, spec_k, spec_v, cache_k, cache_v, paths_w_unpadded_indices, kv_lens
+    )
+    ref_attn = ref_attn_full[:, paths_w_unpadded_indices_q_mask, :, :]
+
+    if benchmark:
+        # Here we compute vanilla attention with the the shapes similar to the tree attention we benchmarked above.
+        # The output of this vanilla attention will be different - we are just measuring the runtime to get
+        # some order of magnitude estimation of runtime.
+        torch.cuda.synchronize()
+        attn_bias_ref = (
+            fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+                q_seqlen=[tree_size_q for _ in range(B)],
+                kv_seqlen=kv_lens,
+                kv_padding=Mk,
+            )
+        )
+        bench_stream = torch.cuda.Stream()
+        with torch.cuda.stream(bench_stream):
+            t_ref_ms = do_bench_cudagraph(
+                lambda: fmha.memory_efficient_attention_forward(
+                    q.view(1, B * tree_size_q, G, H, D),
+                    cache_k.view(1, B * Mk, G, H, D),
+                    cache_v.view(1, B * Mk, G, H, D),
+                    attn_bias=attn_bias_ref,
+                )
+            )
+
+        gap = (1 - t_ref_ms / min(t_optimized_ms_fa, t_optimized_ms_triton)) * 100
+        triton_faster = t_optimized_ms_fa > t_optimized_ms_triton
+        triton_chosen = torch.version.hip is not None or use_triton_splitk_for_prefix(
+            B, G, tree_size_kv
+        )
+        print(
+            f"{B=}, {G=}, {Mk=}, {tree_size_q=}, {tree_size_kv=}: "
+            f"Tree attention with FA2/CK took {t_optimized_ms_fa * 1e3:.1f}us, "
+            f"with Triton Split-K took {t_optimized_ms_triton * 1e3:.1f}us, "
+            f"vanilla attention took {t_ref_ms * 1e3:.1f}us, gap {gap:.2f}%. "
+            f"Triton faster: {triton_faster}. "
+            f"Choice optimal: {triton_chosen == triton_faster}"
+        )
+
+    torch.testing.assert_close(attn_unrolled, ref_attn, atol=1e-2, rtol=3e-3)
+
+
+def ref_tree_attention(
+    q: torch.Tensor,
+    spec_k: torch.Tensor,
+    spec_v: torch.Tensor,
+    cache_k: torch.Tensor,
+    cache_v: torch.Tensor,
+    paths_w_unpadded_indices: List[List[int]],
+    kv_lens: List[int],
+) -> torch.Tensor:
+    attns = []
+
+    B, _, G, H, D = q.shape
+
+    # Compute attention for every path separately and then concatenate
+
+    for path in paths_w_unpadded_indices:
+        q_path = q[:, path, ...]
+
+        extra_k = torch.empty_like(spec_k[:, path, ...])
+        extra_v = torch.empty_like(extra_k)
+
+        full_k = torch.cat([cache_k, extra_k], dim=1)
+        full_v = torch.cat([cache_v, extra_v], dim=1)
+
+        tree_depth = len(path)
+
+        for b in range(B):
+            full_k[b, kv_lens[b] : kv_lens[b] + tree_depth] = spec_k[b, path]
+            full_v[b, kv_lens[b] : kv_lens[b] + tree_depth] = spec_v[b, path]
+
+        Mk = full_k.shape[1]
+        attn_bias = (
+            fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+                q_seqlen=[tree_depth for _ in range(B)],
+                kv_seqlen=[s + tree_depth for s in kv_lens],
+                kv_padding=Mk,
+            )
+        )
+        attn_path = fmha.memory_efficient_attention_forward(
+            q_path.view(1, B * tree_depth, G, H, D),
+            full_k.view(1, B * Mk, G, H, D),
+            full_v.view(1, B * Mk, G, H, D),
+            attn_bias=attn_bias,
+        )
+        attn_path = attn_path.reshape(B, tree_depth, G, H, D)
+
+        attns.append(attn_path)
+
+    attn = torch.cat(attns, dim=1)
+
+    return attn
+
+
+def tree_attention_with_sync(
+    q: torch.Tensor,
+    spec_k: torch.Tensor,
+    spec_v: torch.Tensor,
+    cache_k: torch.Tensor,
+    cache_v: torch.Tensor,
+    tree_choices: List[Tuple[int, ...]],
+    kv_lens: List[int],
+    prefix_op: Optional[Type[AttentionFwOpBase]] = None,
+    suffix_op: Optional[Type[AttentionFwOpBase]] = None,
+    paged: bool = False,
+) -> torch.Tensor:
+    """
+    A wrapper around tree_attention which constructs the biases.
+    Arguments are the same as in xformers.ops.tree_attention.tree_attention, but instead of
+    spec_attn_bias and prefix_attn_bias this function takes in tree definition in the form of tree_choices
+    and K/V sequence lengths kv_lens.
+    For the format of tree_choices see docstring of
+    xformers.ops.tree_attention.TreeAttnMetadata.from_tree_choices.
+    """
+    B, tree_size_q = q.shape[:2]
+    Mk = cache_k.shape[1]
+
+    # attn_prefix ~ (B, Mk, H, D)
+    prefix_attn_bias = BlockDiagonalPaddedKeysMask.from_seqlens(
+        q_seqlen=[tree_size_q for _ in range(B)], kv_seqlen=kv_lens, kv_padding=Mk
+    )
+
+    if paged:
+        # Create a paged K/V cache by randomly permuting blocks and storing the permutation in block_tables.
+        page_size = 256
+        assert Mk % page_size == 0
+        max_blocks_per_row = Mk // page_size
+
+        block_tables = torch.randperm(
+            B * max_blocks_per_row, device=q.device, dtype=torch.int32
+        ).view(B, max_blocks_per_row)
+
+        cache_v = cache_v.clone()
+        cache_k = cache_k.clone()
+
+        v_view = cache_v.view(1, -1, page_size, *cache_v.shape[2:])
+        k_view = cache_k.view(1, -1, page_size, *cache_k.shape[2:])
+
+        block_tables_expanded = (
+            block_tables.to(torch.int64)
+            .flatten()[None, :, None, None, None, None]
+            .expand(v_view.shape)
+        )
+        v_view.scatter_(1, block_tables_expanded, v_view.clone())
+        k_view.scatter_(1, block_tables_expanded, k_view.clone())
+
+        cache_k = k_view.view(1, -1, *cache_k.shape[2:])
+        cache_v = v_view.view(1, -1, *cache_k.shape[2:])
+
+        prefix_attn_bias = prefix_attn_bias.make_paged(  # type: ignore
+            block_tables,
+            page_size=page_size,
+            paged_type=PagedBlockDiagonalPaddedKeysMask,
+        )
+
+    # Create an explit attention bias for the speculative part of the attention
+    spec_attn_bias = TreeAttnMetadata.from_tree_choices(
+        tree_choices, q.dtype, q.device
+    ).attention_bias
+    return tree_attention(
+        q,
+        spec_k,
+        spec_v,
+        cache_k,
+        cache_v,
+        spec_attn_bias[-tree_size_q:],
+        prefix_attn_bias,
+        prefix_op,
+        suffix_op,
+    )
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3, 4])
+@pytest.mark.parametrize("branching", [1, 2, 3, 4])
+def test_tree_attention_metadata_full_tree(depth: int, branching: int) -> None:
+    """
+    Here we test that fields tree_seq_position_ids, tree_indices, and path_lengths
+    are constructed correctly; attention_bias and retrieval_indices are tested in test_tree_attention.
+    """
+    tree_choices = construct_full_tree_choices(depth, branching)
+    tree_attn_metadata = TreeAttnMetadata.from_tree_choices(tree_choices)
+
+    num_paths = branching**depth
+    assert len(tree_attn_metadata.path_lengths) == num_paths
+    assert all(length == depth + 1 for length in tree_attn_metadata.path_lengths)
+
+    seq_pos = []
+    for i in range(depth + 1):
+        seq_pos.extend([i] * branching**i)
+
+    assert seq_pos == tree_attn_metadata.tree_seq_position_ids.tolist()
+
+    tree_indices = []
+    for i in range(depth):
+        tree_indices.extend(
+            [i * branching + j + 1 for j in range(branching)] * branching**i
+        )
+
+    assert [0] + tree_indices == tree_attn_metadata.tree_indices.tolist()
+
+    tree_size = len(tree_choices) + 1
+    ref_child_node_indices = torch.arange(tree_size * branching).reshape(
+        tree_size, branching
+    )
+    ref_child_node_indices[ref_child_node_indices >= tree_size - 1] = 0
+    torch.testing.assert_allclose(
+        tree_attn_metadata.child_node_indices, ref_child_node_indices
+    )
+
+    ref_num_children_per_node = torch.full_like(
+        tree_attn_metadata.tree_indices, fill_value=branching
+    )
+    ref_num_children_per_node[-num_paths:] = 0
+    torch.testing.assert_close(
+        tree_attn_metadata.num_children_per_node, ref_num_children_per_node
+    )
+    ref_num_nodes_per_level = torch.tensor([branching**i for i in range(depth + 1)])
+    torch.testing.assert_close(
+        tree_attn_metadata.num_nodes_per_level, ref_num_nodes_per_level
+    )
+
+    ref_subtree_sizes = (
+        torch.tensor([branching**i for i in range(depth + 1)]).cumsum(dim=0).tolist()
+    )
+    assert all(
+        subtree_size == subtree_sizes_ref
+        for subtree_size, subtree_sizes_ref in zip(
+            tree_attn_metadata.subtree_sizes, ref_subtree_sizes
+        )
+    )
+
+    ref_num_children_per_node_at_level: List[torch.Tensor] = [
+        torch.tensor([branching if i < depth else 0] * (branching**i))
+        for i in range(0, depth + 1)
+    ]
+    assert all(
+        torch.allclose(num_children, ref_num_children)
+        for num_children, ref_num_children in zip(
+            tree_attn_metadata.num_children_per_node_at_level,
+            ref_num_children_per_node_at_level,
+        )
+    )
+
+
+@pytest.mark.parametrize("branching", [[2, 3], [2, 3, 2], [2] * 3, [4, 3, 2, 1]])
+def test_tree_attention_metadata_arbitrary_tree(branching: List[int]) -> None:
+    tree_choices = construct_tree_choices(branching)
+    tree_attn_metadata = TreeAttnMetadata.from_tree_choices(tree_choices)
+    assert all(
+        length == len(branching) + 1 for length in tree_attn_metadata.path_lengths
+    )
+
+    num_paths = reduce(lambda x, y: x * y, branching)
+    assert len(tree_attn_metadata.path_lengths) == num_paths
+
+    num_nodes_per_level = [*accumulate(branching, lambda x, y: x * y)]
+    seq_pos = []
+    for i in range(len(num_nodes_per_level)):
+        seq_pos.extend([i + 1] * num_nodes_per_level[i])
+    assert [0] + seq_pos == tree_attn_metadata.tree_seq_position_ids.tolist()
+
+    tree_indices = []
+    start_idx = 1
+    num_children_per_node_ref = []
+    num_children_per_node_at_level_ref: List[torch.Tensor] = []
+    subtree_sizes_ref: List[int] = []
+    total_num_nodes = 0
+    for i in range(len(branching)):
+        num_nodes_prev_level = 1 if i == 0 else num_nodes_per_level[i - 1]
+        tree_indices.extend(
+            [start_idx + j for j in range(branching[i])] * num_nodes_prev_level
+        )
+        start_idx += branching[i]
+        num_children_per_node_ref.extend([branching[i]] * num_nodes_prev_level)
+        num_children_per_node_at_level_ref.append(
+            torch.tensor([branching[i]] * num_nodes_prev_level)
+        )
+        total_num_nodes += num_nodes_prev_level
+        subtree_sizes_ref.append(total_num_nodes)
+    num_children_per_node_at_level_ref.append(
+        torch.tensor([0] * num_nodes_per_level[-1])
+    )
+    subtree_sizes_ref.append(len(tree_indices) + 1)
+    assert (
+        [0] + tree_indices == tree_attn_metadata.tree_indices.tolist()
+    ), f"{tree_indices=} {tree_attn_metadata.tree_indices.tolist()=}"
+
+    num_children_per_node_ref.extend([0] * num_paths)
+    num_children_per_node_ref_tensor = torch.tensor(num_children_per_node_ref)
+
+    assert all(
+        torch.allclose(num_children, num_children_ref)
+        for num_children, num_children_ref in zip(
+            tree_attn_metadata.num_children_per_node_at_level,
+            num_children_per_node_at_level_ref,
+        )
+    )
+    assert all(
+        subtree_size == subtree_sizes_ref
+        for subtree_size, subtree_sizes_ref in zip(
+            tree_attn_metadata.subtree_sizes, subtree_sizes_ref
+        )
+    )
+    torch.testing.assert_close(
+        num_children_per_node_ref_tensor, tree_attn_metadata.num_children_per_node
+    )
+    torch.testing.assert_close(
+        tree_attn_metadata.num_nodes_per_level,
+        torch.tensor([1] + num_nodes_per_level),
+    )
+    assert tree_attn_metadata.child_node_indices.shape == (
+        len(tree_indices) + 1,
+        max(branching),
+    )

--- a/test/attention/fmha/test_triton_varargs.py
+++ b/test/attention/fmha/test_triton_varargs.py
@@ -1,0 +1,139 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+import ast
+import logging
+
+import pytest
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    from mslk.attention.fmha._triton.vararg_kernel import (
+        _VisitorConditionalKernel,
+        unroll_varargs,
+        VarargMode,
+    )
+except ImportError as e:
+    logging.warning(
+        f"Triton is not available, some optimizations will not be tested.\n{e}"
+    )
+
+
+def test_triton_varargs_kernel():
+    @triton.jit
+    def sumN(output_ptr, scaling_ptr, *inputs, BLOCK_SIZE: tl.constexpr):
+        offset = tl.arange(0, BLOCK_SIZE)
+        output = tl.zeros([BLOCK_SIZE], tl.float32)
+        scaling: "VAR_ARGS_ARRAY"  # type: ignore # noqa: F821
+        for i in range(len(scaling)):
+            scaling[i] = tl.load(scaling_ptr + i)
+
+        for _ in range(2):
+            for j in range(len(inputs)):
+                output = output + tl.load(inputs[j] + offset) * scaling[j]
+        tl.store(output_ptr + offset, output)
+
+    BLOCK_SIZE = 32
+    NUM_INPUTS = 2
+    torch.manual_seed(0)
+    inputs = [
+        torch.randn([BLOCK_SIZE], dtype=torch.float32, device="cuda")
+        for _ in range(NUM_INPUTS)
+    ]
+    output = torch.randn([BLOCK_SIZE], dtype=torch.float32, device="cuda")
+    scaling = torch.randn([NUM_INPUTS, 1], dtype=torch.float32, device="cuda")
+    sumN_unrolled = unroll_varargs(sumN, N=NUM_INPUTS)
+    sumN_unrolled[(1,)](output, scaling, *inputs, BLOCK_SIZE=32)
+    assert torch.allclose((2 * torch.stack(inputs) * scaling).sum(0), output)
+
+
+@pytest.mark.parametrize("conditional", [True, False])
+def test_triton_multiple_varargs_kernel(conditional: bool):
+    @triton.jit
+    def weighted_sumN(
+        output_ptr,
+        a_ptr: "VAR_ARGS_ARRAY",  # type: ignore # noqa: F821
+        b: "VAR_ARGS_ARRAY",  # type: ignore # noqa: F821
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        # Weighted sum, where the weights are on CPU
+        offset = tl.arange(0, BLOCK_SIZE)
+        output = tl.zeros([BLOCK_SIZE], tl.float32)
+
+        for i in range(len(a_ptr)):
+            output = output + tl.load(a_ptr[i] + offset) * b[i]
+        tl.store(output_ptr + offset, output)
+
+    BLOCK_SIZE = 32
+    NUM_INPUTS = 2
+    torch.manual_seed(0)
+    a = [
+        torch.randn([BLOCK_SIZE], dtype=torch.float32, device="cuda")
+        for _ in range(NUM_INPUTS)
+    ]
+    b = [torch.randn([], dtype=torch.float32, device="cuda") for _ in range(NUM_INPUTS)]
+    b_list = [x.item() for x in b]
+    output = torch.randn([BLOCK_SIZE], dtype=torch.float32, device="cuda")
+    if conditional:
+        kernel = unroll_varargs(
+            weighted_sumN, N=NUM_INPUTS, mode=VarargMode.CONDITIONAL
+        )
+    else:
+        kernel = unroll_varargs(weighted_sumN, N=NUM_INPUTS)
+    kernel[(1,)](output, *a, *b_list, BLOCK_SIZE=32)
+    expected_output = (torch.stack(a) * torch.stack(b).unsqueeze(1)).sum(0)
+    assert torch.allclose(expected_output, output)
+
+
+def test_triton_varargs_conditional():
+    @triton.jit
+    def kernel(
+        x_ptrs: "VAR_ARGS_ARRAY",  # noqa: F821
+        y_ptrs: "VAR_ARGS_ARRAY",  # noqa: F821
+        numel,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        pid = tl.program_id(axis=0)
+        offsets = BLOCK_SIZE * pid + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < numel
+        for i in range(len(x_ptrs)):
+            x_ptr = x_ptrs[i]
+            y_ptr = y_ptrs[i]
+
+            data = tl.load(x_ptr + offsets, mask)
+            result = data * data
+            tl.store(y_ptr + offsets, result, mask)
+
+    k = triton.JITFunction(kernel.fn)
+    parsed = ast.parse(k.src)
+    visitor = _VisitorConditionalKernel(N=3)
+    parsed = visitor.visit(parsed)
+    parsed = ast.fix_missing_locations(parsed)
+    new_src = ast.unparse(parsed)  # type: ignore
+
+    assert "x_ptrs0, x_ptrs1, x_ptrs2" in new_src
+    assert "y_ptrs0, y_ptrs1, y_ptrs2", new_src
+    assert "for i in range(3):" in new_src
+    assert "x_ptr = x_ptrs0 if i == 0 else x_ptrs1 if i == 1 else x_ptrs2" in new_src
+    assert "y_ptr = y_ptrs0 if i == 0 else y_ptrs1 if i == 1 else y_ptrs2" in new_src
+
+
+def test_subscripting_call():
+    @triton.jit
+    def fused_group_contiguous_nan_clamp_copied_from_inductor(
+        _group_a_ptrs: "VAR_ARGS_ARRAY",  # type: ignore # noqa: F821
+        XBLOCK: tl.constexpr,
+    ):
+        xoffset = tl.program_id(0) * XBLOCK
+        xoffset + tl.arange(0, XBLOCK)[:]
+
+    unroll_varargs(
+        fused_group_contiguous_nan_clamp_copied_from_inductor,
+        N=2,
+        mode=VarargMode.CONDITIONAL,
+    )

--- a/test/attention/fmha/utils.py
+++ b/test/attention/fmha/utils.py
@@ -1,0 +1,450 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+from functools import wraps
+from typing import Optional, Tuple
+
+import numpy as np
+import pytest
+import torch
+from mslk.attention.fmha import Inputs
+from mslk.attention.fmha.attn_bias import (
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+)
+
+from mslk.attention.fmha.attn_bias_utils import (
+    pack_kv_cache,
+    ref_attention,
+    ref_attention_bmhk,
+)
+from mslk.attention.fmha.triton_splitk import InputsFp8
+
+cuda_or_mtia_only = pytest.mark.skipif(
+    not torch.cuda.is_available() and not torch.mtia.is_available(),
+    reason="requires CUDA or MTIA",
+)
+cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+rocm_only = pytest.mark.skipif(
+    not torch.cuda.is_available() or not torch.version.hip, reason="requires ROCM"
+)
+disable_on_rocm = pytest.mark.skipif(
+    not not torch.version.hip, reason="could not be done on ROCM"
+)
+disable_on_mtia = pytest.mark.skipif(
+    torch.mtia.is_available(), reason="Not supported yet on MTIA"
+)
+
+
+# We don't want to compare MTIA output against another MTIA output yet for 2 reasons:
+#   1. Some kernels may have bugs, and the reference implementation may share some of
+#      the same kernels as the mem_eff implementation. We would then end up comparing
+#      a faulty output against another faulty output, which could lead to tests passing
+#      when they shouldn't.
+#   2. We may run on some emulated devices that can be slower than the CPU implementation,
+#      and therefore increase the time it takes to run the tests by a lot.
+def use_cpu_ref(device: str):
+    return device.startswith("mtia")
+
+
+def maybe_use_cpu_ref(fn):
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        new_args = list(args)
+        new_kwargs = kwargs.copy()
+        original_device = None
+
+        for key in kwargs:
+            if isinstance(kwargs[key], torch.Tensor) and use_cpu_ref(
+                kwargs[key].device.type
+            ):
+                assert original_device is None or kwargs[key].device == original_device
+                original_device = kwargs[key].device
+                new_kwargs[key] = kwargs[key].cpu()
+
+        for index, arg in enumerate(new_args):
+            if isinstance(arg, torch.Tensor) and use_cpu_ref(arg.device.type):
+                assert original_device is None or arg.device == original_device
+                original_device = arg.device
+                new_args[index] = arg.cpu()
+
+        output = fn(*new_args, **new_kwargs)
+
+        if isinstance(output, torch.Tensor) and original_device is not None:
+            output = output.to(original_device)
+
+        return output
+
+    return wrapped
+
+
+def disable_tf32(fn):
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        cuda, cudnn = (
+            torch.backends.cuda.matmul.allow_tf32,
+            torch.backends.cudnn.allow_tf32,
+        )
+        torch.backends.cuda.matmul.allow_tf32, torch.backends.cudnn.allow_tf32 = (
+            False,
+            False,
+        )
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            torch.backends.cuda.matmul.allow_tf32, torch.backends.cudnn.allow_tf32 = (
+                cuda,
+                cudnn,
+            )
+
+    return wrapped
+
+
+ref_attention_for_test = disable_tf32(maybe_use_cpu_ref(ref_attention))
+ref_attention_bmhk_for_test = disable_tf32(maybe_use_cpu_ref(ref_attention_bmhk))
+
+
+def assert_allclose(
+    out: Optional[torch.Tensor],
+    ref: Optional[torch.Tensor],
+    msg: str = "failed",
+    atol: float = 1e-8,
+    rtol: float = 1e-5,
+) -> None:
+    assert out is not None, f"{msg}: output Tensor is None"
+    assert ref is not None, f"{msg}: reference Tensor is None"
+    assert out.shape == ref.shape, f"Shape: {out.shape} (expected: {ref.shape})"
+    if out.dtype != ref.dtype:
+        raise AssertionError(f"out dtype: {out.dtype}, ref dtype: {ref.dtype}")
+    if out.numel() == 0:
+        return
+    flatten_diff = ((out - ref).abs() - atol - ref.abs() * rtol).flatten()
+    max_pos = flatten_diff.argmax()
+    max_location = np.unravel_index(int(max_pos), out.shape)
+    max_diff = flatten_diff[max_pos]
+    num_different = flatten_diff.numel() - torch.count_nonzero(flatten_diff <= 0)
+    percentage = num_different / flatten_diff.numel()
+    del flatten_diff
+    assert torch.allclose(out, ref, rtol=rtol, atol=atol), (
+        f"{msg}: "
+        f"out={out.flatten()[max_pos]} and ref={ref.flatten()[max_pos]} (diff={max_diff} > 0)"
+        f" at {max_location} of shape {tuple(out.shape)} / atol={atol}, rtol={rtol}"
+        f"/ total failing elements: {num_different} ({percentage * 100:.3}%)"
+    )
+
+
+def construct_fp8_attention_inputs(
+    B: int,
+    Mkv: int,
+    Mq: int,
+    Hkv: int,
+    Hq: int,
+    K: int,
+    page_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    randomize_lengths: bool = True,
+    use_fp32_scales: bool = False,
+    use_symmetric: bool = False,
+) -> Tuple[InputsFp8, Inputs, InputsFp8, Inputs]:
+    """
+    Construct inputs for benchmarks and tests of Triton Split-k attention
+    with fused row-wise FP8 dequantization.
+    Quantization coefficients are packed as int32 tensors where each
+    element contains two fp16 numbers - scales and shifts.
+    """
+    G = Hq // Hkv
+    q = torch.randn(1, B * Mq, Hkv, G, K, dtype=dtype, device=device)
+    k = torch.randn(1, B * Mkv, Hkv, 1, K, dtype=dtype, device=device)
+    v = torch.randn(1, B * Mkv, Hkv, 1, K, dtype=dtype, device=device)
+
+    pt_fp8_dtype = (
+        torch.float8_e4m3fnuz if torch.version.hip is not None else torch.float8_e4m3fn
+    )
+
+    qfn = quantize_fp8_symmetric if use_symmetric else quantize_fp8_asymmetric
+
+    k_fp8, k_fp8_scales, k_fp8_shifts = qfn(k.view(-1, K), pt_fp8_dtype=pt_fp8_dtype)
+    v_fp8, v_fp8_scales, v_fp8_shifts = qfn(v.view(-1, K), pt_fp8_dtype=pt_fp8_dtype)
+
+    k_fp8, v_fp8 = k_fp8.view(torch.int32), v_fp8.view(torch.int32)
+
+    scale_dtype = torch.float32 if use_fp32_scales else torch.float16
+    k_fp8_scales = k_fp8_scales.to(scale_dtype)
+    v_fp8_scales = v_fp8_scales.to(scale_dtype)
+    k_fp8_shifts = k_fp8_shifts.to(scale_dtype)
+    v_fp8_shifts = v_fp8_shifts.to(scale_dtype)
+
+    def _to_expanded_shape(x):
+        return x.view(1, B * Mkv, Hkv, 1, -1).expand(1, B * Mkv, Hkv, G, -1)
+
+    k_fp8 = _to_expanded_shape(k_fp8)
+    v_fp8 = _to_expanded_shape(v_fp8)
+
+    k_fp8_scales_shifts = _combine_scale_shift(
+        k_fp8_scales, k_fp8_shifts, use_fp32_scales
+    )
+    v_fp8_scales_shifts = _combine_scale_shift(
+        v_fp8_scales, v_fp8_shifts, use_fp32_scales
+    )
+
+    k_fp8_scales_shifts = (
+        _to_expanded_shape(k_fp8_scales_shifts).squeeze(-1).contiguous()
+    )
+    v_fp8_scales_shifts = (
+        _to_expanded_shape(v_fp8_scales_shifts).squeeze(-1).contiguous()
+    )
+
+    k_fp8_scales = _to_expanded_shape(k_fp8_scales).squeeze(-1).to(scale_dtype)
+    v_fp8_scales = _to_expanded_shape(v_fp8_scales).squeeze(-1).to(scale_dtype)
+    k_fp8_shifts = _to_expanded_shape(k_fp8_shifts).squeeze(-1).to(scale_dtype)
+    v_fp8_shifts = _to_expanded_shape(v_fp8_shifts).squeeze(-1).to(scale_dtype)
+
+    kv_seqlens = (
+        torch.randint(0, Mkv, size=(B,)).tolist() if randomize_lengths else [Mkv] * B
+    )
+
+    k_deq = dequantize_fp8_asymmetric(
+        k_fp8.view(pt_fp8_dtype), k_fp8_scales, k_fp8_shifts
+    ).to(dtype)
+    v_deq = dequantize_fp8_asymmetric(
+        v_fp8.view(pt_fp8_dtype), v_fp8_scales, v_fp8_shifts
+    ).to(dtype)
+
+    k_deq = k_deq[:, :, :, :1, :].contiguous()
+    v_deq = v_deq[:, :, :, :1, :].contiguous()
+
+    attn_bias = BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
+        q_seqlen=[1 for _ in range(B)],
+        kv_seqlen=kv_seqlens,
+        kv_padding=Mkv,
+    )
+    inp = InputsFp8(
+        query=q,
+        key=k_fp8,
+        value=v_fp8,
+        k_fp8_scale_shift=k_fp8_scales_shifts,
+        v_fp8_scale_shift=v_fp8_scales_shifts,
+        attn_bias=attn_bias,
+    )
+    inp_ref = Inputs(
+        query=q,
+        key=_to_expanded_shape(k_deq),
+        value=_to_expanded_shape(v_deq),
+        attn_bias=attn_bias,
+    )
+
+    # Paged K/V cache
+    block_tables, packed_cache_k, packed_cache_v = pack_kv_cache(
+        k_deq.view(B, Mkv, Hkv, -1),
+        v_deq.view(B, Mkv, Hkv, -1),
+        kv_seqlens,
+        page_size,
+    )
+    block_tables_orig, packed_cache_k_orig, packed_cache_v_orig = pack_kv_cache(
+        k.view(B, Mkv, Hkv, -1),
+        v.view(B, Mkv, Hkv, -1),
+        kv_seqlens,
+        page_size,
+    )
+    assert (block_tables_orig == block_tables).all()
+
+    (
+        packed_cache_k_fp8,
+        packed_k_fp8_scales,
+        packed_k_fp8_shifts,
+    ) = quantize_fp8_asymmetric(
+        packed_cache_k_orig.view(-1, K), pt_fp8_dtype=pt_fp8_dtype
+    )
+    (
+        packed_cache_v_fp8,
+        packed_v_fp8_scales,
+        packed_v_fp8_shifts,
+    ) = quantize_fp8_asymmetric(
+        packed_cache_v_orig.view(-1, K), pt_fp8_dtype=pt_fp8_dtype
+    )
+
+    total_len_rounded = packed_cache_k_fp8.shape[0] // Hkv
+
+    packed_cache_k_fp8 = packed_cache_k_fp8.view(torch.int32).view(
+        1, total_len_rounded, Hkv, -1
+    )
+    packed_cache_v_fp8 = packed_cache_v_fp8.view(torch.int32).view(
+        1, total_len_rounded, Hkv, -1
+    )
+
+    packed_k_fp8_scales_shifts = _combine_scale_shift(
+        packed_k_fp8_scales, packed_k_fp8_shifts
+    )
+    packed_v_fp8_scales_shifts = _combine_scale_shift(
+        packed_v_fp8_scales, packed_v_fp8_shifts
+    )
+
+    def _to_packed_expanded_shape(x):
+        return x.reshape(1, total_len_rounded, Hkv, 1, -1).expand(
+            1, total_len_rounded, Hkv, Hq // Hkv, -1
+        )
+
+    packed_k_fp8_scales_shifts = (
+        _to_packed_expanded_shape(packed_k_fp8_scales_shifts).squeeze(-1).contiguous()
+    )
+    packed_v_fp8_scales_shifts = (
+        _to_packed_expanded_shape(packed_v_fp8_scales_shifts).squeeze(-1).contiguous()
+    )
+
+    attn_bias_paged = attn_bias.make_paged(
+        block_tables=block_tables,
+        page_size=page_size,
+        paged_type=PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+    )
+    inp_bf16_paged = Inputs(
+        query=q,
+        key=_to_packed_expanded_shape(packed_cache_k),
+        value=_to_packed_expanded_shape(packed_cache_v),
+        attn_bias=attn_bias_paged,
+        output_dtype=torch.bfloat16,
+    )
+    inp_fp8_paged = InputsFp8(
+        query=q,
+        key=_to_packed_expanded_shape(packed_cache_k_fp8),
+        value=_to_packed_expanded_shape(packed_cache_v_fp8),
+        attn_bias=attn_bias_paged,
+        k_fp8_scale_shift=packed_k_fp8_scales_shifts,
+        v_fp8_scale_shift=packed_v_fp8_scales_shifts,
+        output_dtype=torch.bfloat16,
+    )
+
+    return inp, inp_ref, inp_fp8_paged, inp_bf16_paged
+
+
+def _combine_scale_shift(
+    scale: torch.Tensor, shift: torch.Tensor, use_fp32_scales: bool = False
+) -> torch.Tensor:
+    scale_dtype = torch.float32 if use_fp32_scales else torch.float16
+    packed_dtype = torch.float32 if use_fp32_scales else torch.int32
+    if not use_fp32_scales:
+        return (
+            torch.concat([scale.unsqueeze(-1), shift.unsqueeze(-1)], dim=-1)
+            .flatten(-2)
+            .to(scale_dtype)
+            .view(packed_dtype)
+        )
+    else:
+        return scale.to(scale_dtype).view(packed_dtype)
+
+
+def quantize_fp8_asymmetric(
+    x: torch.Tensor,
+    pt_fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    max_fp8 = torch.finfo(pt_fp8_dtype).max
+
+    shift = x.mean(dim=1)
+    x_centered = x - shift[..., None]
+
+    row_max: torch.Tensor = x_centered.abs().max(dim=-1)[0]
+    scale = row_max.to(torch.float32) / max_fp8
+    scale = torch.nan_to_num(scale, posinf=1)
+
+    x_quant = (x_centered / scale[..., None]).to(pt_fp8_dtype)
+    return x_quant, scale, shift
+
+
+def quantize_fp8_symmetric(
+    x: torch.Tensor,
+    pt_fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Symmetrically quantize a tensor to FP8 format.
+
+    Args:
+        x: Input tensor to quantize
+        pt_fp8_dtype: PyTorch FP8 data type to use
+
+    Returns:
+        Tuple of (quantized tensor, scale)
+    """
+    max_fp8 = torch.finfo(pt_fp8_dtype).max
+
+    # Find the maximum absolute value per row
+    row_max: torch.Tensor = x.abs().max(dim=-1)[0]
+    # Calculate scale factor to map the max value to max_fp8
+    scale = row_max.to(torch.float32) / max_fp8
+    scale = torch.nan_to_num(scale, posinf=1)
+
+    # Quantize the tensor
+    x_quant = x / scale[..., None]
+    x_quant = x_quant.to(pt_fp8_dtype)  # .to(torch.bfloat16)
+
+    return x_quant, scale, torch.zeros_like(scale)
+
+
+def dequantize_fp8_asymmetric(
+    x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor
+) -> torch.Tensor:
+    return x.to(scale.dtype) * scale[..., None] + shift[..., None]
+
+
+def dequantize_fp8_symmetric(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """
+    Dequantize a symmetrically quantized FP8 tensor.
+
+    Args:
+        x: Quantized tensor
+        scale: Scale factor used during quantization
+
+    Returns:
+        Dequantized tensor
+    """
+    return x.to(scale.dtype) * scale[..., None]
+
+
+def add_q_fp8_to_inputs(
+    inp: InputsFp8,
+) -> InputsFp8:
+    """
+    Convert regular Inputs to InputsFp8 with query tensor quantized to FP8.
+
+    Args:
+        inp: Regular Inputs object
+        pt_fp8_dtype: PyTorch FP8 data type to use (defaults to platform-specific FP8 type)
+
+    Returns:
+        InputsFp8 object with quantized query tensor
+    """
+    inp.quantize_qk_to_fp8 = True
+    pt_fp8_dtype = (
+        torch.float8_e4m3fnuz if torch.version.hip is not None else torch.float8_e4m3fn
+    )
+    # Get original query tensor
+    q = inp.query
+
+    # Get shape information
+    orig_shape = q.shape
+    K = orig_shape[-1]
+
+    # Quantize query tensor
+    q_fp8, q_fp8_scales, _ = quantize_fp8_symmetric(
+        q.view(-1, K), pt_fp8_dtype=pt_fp8_dtype
+    )
+    # k_fp8, k_fp8_scales = quantize_fp8_symmetric(inp.key.view(-1, K), pt_fp8_dtype=pt_fp8_dtype)
+    # v_fp8, v_fp8_scales = quantize_fp8_symmetric(inp.value.view(-1, K)  , pt_fp8_dtype=pt_fp8_dtype)
+    # Reshape back to original dimensions
+    q_fp8 = q_fp8.view(orig_shape)
+    q_fp8_scales = q_fp8_scales.view(orig_shape[:-1]).contiguous()
+
+    # Create new InputsFp8 object
+    return InputsFp8(
+        query=q_fp8,
+        key=inp.key,
+        value=inp.value,
+        k_fp8_scale_shift=inp.k_fp8_scale_shift,
+        v_fp8_scale_shift=inp.v_fp8_scale_shift,
+        q_fp8_scale_shift=q_fp8_scales,
+        attn_bias=inp.attn_bias,
+        output_dtype=torch.bfloat16,
+        quantize_qk_to_fp8=True,
+    )


### PR DESCRIPTION
Summary:
Copy xformers/ops/fmha to a new location in mslk.

Yet to do
- doc refers to xformers
- migrate doc, benchmarks
- mtia CI
- build metadata / cpp_lib is a mess

see also D78783848 from cthi

Reviewed By: q10, cthi

Differential Revision: D87635236
