### PR TITLE
Validate group sizes padded to multiple of 16/32 for nvfp4/mxfp8 (#31)

### DIFF
--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_common.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_common.cuh
@@ -419,6 +419,7 @@ at::Tensor f4f4bf16_grouped_impl(
         wq_ptr,
         reinterpret_cast<ElementScale*>(x_scale.data_ptr()),
         x_scale_ptr,
+        x_scale.numel(),
         reinterpret_cast<ElementScale*>(w_scale.data_ptr()),
         w_scale_ptr,
         reinterpret_cast<ElementC*>(output.data_ptr()),

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_common.cuh
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_common.cuh
@@ -297,6 +297,7 @@ at::Tensor mx8mx8bf16_grouped_impl(
       wq_ptr,
       reinterpret_cast<ScaleDtype*>(x_scale.data_ptr()),
       x_scale_ptr,
+      x_scale.numel(),
       reinterpret_cast<ScaleDtype*>(w_scale.data_ptr()),
       w_scale_ptr,
       reinterpret_cast<ElementC*>(output.data_ptr()),

--- a/include/mslk/gemm/cutlass/grouped_common.cuh
+++ b/include/mslk/gemm/cutlass/grouped_common.cuh
@@ -44,6 +44,7 @@ __global__ void set_grouped_gemm_args_kernel(
     const ElementB** wq_ptr,
     ScaleDtype* x_scale,
     const ScaleDtype** x_scale_ptr,
+    int32_t x_scale_size,
     ScaleDtype* w_scale,
     const ScaleDtype** w_scale_ptr,
     ElementC* output,
@@ -109,10 +110,9 @@ __global__ void set_grouped_gemm_args_kernel(
             curr_group_end_offset - prev_group_end_offset;
 
         // Validate group offsets.
-        const int align = 128 / cutlass::sizeof_bits<ElementA>::value;
         CUDA_KERNEL_ASSERT(
-            K_group_size % align == 0 &&
-            "for 2d-2d grouped gemm, group sizes along K dim must be non-negative multiple of 16\n");
+            K_group_size % scale_factor_block_size == 0 &&
+            "for 2d-2d grouped gemm, group sizes along K dim must be non-negative multiple of 32 (mxfp8) or 16 (nvfp4)\n");
         CUDA_KERNEL_ASSERT(
             curr_group_end_offset <= K &&
             "for 2d-2d grouped gemm, group end offsets must be non-negative and must be <= K\n");
@@ -124,6 +124,9 @@ __global__ void set_grouped_gemm_args_kernel(
           xq_offset = prev_group_end_offset / 2;
         } else {
           xq_offset = prev_group_end_offset;
+          CUDA_KERNEL_ASSERT(
+              xq_offset + K_group_size <= (M * K) &&
+              "for 2d-2d grouped gemm, sum of group sizes along K dim must be <= M * K\n");
         }
 
         // WQ is shape (N,K) with strides (K, 1) and group offsets are along
@@ -152,6 +155,14 @@ __global__ void set_grouped_gemm_args_kernel(
           x_scale_offset += M_rounded * scale_cols_for_group_i_padded;
           w_scale_offset += N_rounded * scale_cols_for_group_i_padded;
         }
+
+        // Validate scale offsets are within bounds
+        int scale_cols_padded_curr_group =
+            round_up(K_group_size / scale_factor_block_size, 4);
+        CUDA_KERNEL_ASSERT(
+            x_scale_offset + M_rounded * scale_cols_padded_curr_group <=
+                x_scale_size &&
+            "for 2d-2d grouped gemm, sum of scale group sizes along K dim, each padded to nearest multiple of 4, must be <= x_scale_size\n");
 
         // Only write kernel args if this group is non-empty
         if (K_group_size > 0) {


### PR DESCRIPTION
Summary:

This lack of validation has led to user confusion when they attempt to the use the api improperly (i.e., group sizes not a valid multiple of scale factor granularity), resulting in garbage outputs.

Differential Revision: D88451341


