### PR TITLE
Don't read C in MXFP8 grouped GEMM

### DIFF
--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_common.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_common.cuh
@@ -419,6 +419,7 @@ at::Tensor f4f4bf16_grouped_impl(
         wq_ptr,
         reinterpret_cast<ElementScale*>(x_scale.data_ptr()),
         x_scale_ptr,
+        x_scale.numel(),
         reinterpret_cast<ElementScale*>(w_scale.data_ptr()),
         w_scale_ptr,
         reinterpret_cast<ElementC*>(output.data_ptr()),

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_common.cuh
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_common.cuh
@@ -297,6 +297,7 @@ at::Tensor mx8mx8bf16_grouped_impl(
       wq_ptr,
       reinterpret_cast<ScaleDtype*>(x_scale.data_ptr()),
       x_scale_ptr,
+      x_scale.numel(),
       reinterpret_cast<ScaleDtype*>(w_scale.data_ptr()),
       w_scale_ptr,
       reinterpret_cast<ElementC*>(output.data_ptr()),

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_common.cuh
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_common.cuh
@@ -120,10 +120,8 @@ at::Tensor mx8mx8bf16_grouped_impl(
           cutlass::epilogue::collective::EpilogueTileAuto,
           ElementAccumulator,
           ElementAccumulator,
-          //   void, // Indicate there is no beta scaling to save register
-          //   space.
-          ElementC,
-          typename cutlass::layout::LayoutTranspose<LayoutC>::type*,
+          void, // no beta for C
+          void, // don't read C
           128 / cutlass::sizeof_bits<ElementC>::value,
           ElementC,
           typename cutlass::layout::LayoutTranspose<LayoutC>::type*,

--- a/include/mslk/gemm/cutlass/grouped_common.cuh
+++ b/include/mslk/gemm/cutlass/grouped_common.cuh
@@ -44,6 +44,7 @@ __global__ void set_grouped_gemm_args_kernel(
     const ElementB** wq_ptr,
     ScaleDtype* x_scale,
     const ScaleDtype** x_scale_ptr,
+    int32_t x_scale_size,
     ScaleDtype* w_scale,
     const ScaleDtype** w_scale_ptr,
     ElementC* output,
@@ -109,10 +110,9 @@ __global__ void set_grouped_gemm_args_kernel(
             curr_group_end_offset - prev_group_end_offset;
 
         // Validate group offsets.
-        const int align = 128 / cutlass::sizeof_bits<ElementA>::value;
         CUDA_KERNEL_ASSERT(
-            K_group_size % align == 0 &&
-            "for 2d-2d grouped gemm, group sizes along K dim must be non-negative multiple of 16\n");
+            K_group_size % scale_factor_block_size == 0 &&
+            "for 2d-2d grouped gemm, group sizes along K dim must be non-negative multiple of 32 (mxfp8) or 16 (nvfp4)\n");
         CUDA_KERNEL_ASSERT(
             curr_group_end_offset <= K &&
             "for 2d-2d grouped gemm, group end offsets must be non-negative and must be <= K\n");
@@ -124,6 +124,9 @@ __global__ void set_grouped_gemm_args_kernel(
           xq_offset = prev_group_end_offset / 2;
         } else {
           xq_offset = prev_group_end_offset;
+          CUDA_KERNEL_ASSERT(
+              xq_offset + K_group_size <= (M * K) &&
+              "for 2d-2d grouped gemm, sum of group sizes along K dim must be <= M * K\n");
         }
 
         // WQ is shape (N,K) with strides (K, 1) and group offsets are along
@@ -152,6 +155,14 @@ __global__ void set_grouped_gemm_args_kernel(
           x_scale_offset += M_rounded * scale_cols_for_group_i_padded;
           w_scale_offset += N_rounded * scale_cols_for_group_i_padded;
         }
+
+        // Validate scale offsets are within bounds
+        int scale_cols_padded_curr_group =
+            round_up(K_group_size / scale_factor_block_size, 4);
+        CUDA_KERNEL_ASSERT(
+            x_scale_offset + M_rounded * scale_cols_padded_curr_group <=
+                x_scale_size &&
+            "for 2d-2d grouped gemm, sum of scale group sizes along K dim, each padded to nearest multiple of 4, must be <= x_scale_size\n");
 
         // Only write kernel args if this group is non-empty
         if (K_group_size > 0) {


### PR DESCRIPTION
Summary:
Tip from ngimel: we can boost perf a bit by not reading C.

This is because we are not adding each dot product result to beta*C[i,j], we can just write the result directly to C without reading it, there is no reason to load it.

Benchmarks before and after the change, looks to be around 20-60 extra tflops/sec for the shape I tested: https://www.internalfb.com/phabricator/paste/view/P2088325237

Up to 1950 tflops/sec on dsv3 shapes which is the highest i've seen it: https://www.internalfb.com/phabricator/paste/view/P2088341372

Reviewed By: cthi

Differential Revision: D89500065


