### PR TITLE
make .flake8 line length match fbcode

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+max-line-length = 88
 exclude =
     .git,
     __pycache__,


### PR DESCRIPTION
Summary:
Now we have our own .flake8, it can complain about long lines, because the default is 80 not 88.
(An alternative would be to disable B950 completely like in fbsource)

Differential Revision: D89671886


