### PR TITLE
Enable MXFP8 grouped non-tranpose AB and retune.

### DIFF
--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_common.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_common.cuh
@@ -431,6 +431,7 @@ at::Tensor f4f4bf16_grouped_impl(
         layout_SFA,
         layout_SFB,
         gemm_type,
+        true, // is_transposeAB
         is_nvfp4 ? reinterpret_cast<ElementGlobalScale*>(
                        global_scale.value().data_ptr())
                  : nullptr,

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped.cu
@@ -49,28 +49,394 @@ Kernel_mx8mx8bf16_grouped get_kernel_via_tuning(
 Kernel_mx8mx8bf16_grouped
 get_kernel_via_heuristics(int M, int N, int K, int G) {
   if (M <= 64) {
-    return mx8mx8bf16_grouped_256_64_256_2_1_1;
+    return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
   } else if (M <= 128) {
     if (N <= 1024) {
-      return mx8mx8bf16_grouped_256_64_256_2_1_1;
+      if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      }
     } else {
-      return mx8mx8bf16_grouped_256_128_256_2_1_1;
+      return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
     }
-  } else if (M <= 512) {
-    if (N <= 512) {
-      return mx8mx8bf16_grouped_256_128_256_2_1_1;
+  } else if (M <= 1024) {
+    if (N <= 1024) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 4096) {
+      if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 5120) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 6144) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 7168) {
+      if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 8192) {
+      if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
     } else {
-      return mx8mx8bf16_grouped_256_256_256_2_1_1;
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
     }
-  } else if (M < 16384) {
-    return mx8mx8bf16_grouped_256_256_256_2_1_1;
+  } else if (M <= 2048) {
+    if (N <= 1024) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+    } else if (N <= 4096) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 6144) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 7168) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 8192) {
+      if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    }
+  } else if (M <= 4096) {
+    if (N <= 1024) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 4096) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 5120) {
+      if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 6144) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 7168) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 8192) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    }
+  } else if (M <= 5120) {
+    if (N <= 1024) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+    } else if (N <= 4096) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 5120) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 6144) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 7168) {
+      if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 8192) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    }
+  } else if (M <= 6144) {
+    if (N <= 1024) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+    } else if (N <= 2048) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 4096) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+    } else if (N <= 5120) {
+      if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 6144) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+    } else if (N <= 7168) {
+      if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 8192) {
+      if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    }
+  } else if (M <= 7168) {
+    if (N <= 2048) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 4096) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 6144) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+    } else if (N <= 7168) {
+      if (K <= 8192) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 8192) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    }
+  } else if (M <= 8192) {
+    if (N <= 1024) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+    } else if (N <= 2048) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 8192) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+    } else {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    }
   } else {
-    if (K <= 4096) {
-      return mx8mx8bf16_grouped_256_256_256_2_1_1;
-    } else if (K <= 7168) {
-      return mx8mx8bf16_grouped_256_128_256_2_1_1;
+    if (N <= 1024) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
     } else {
-      return mx8mx8bf16_grouped_256_256_256_2_1_1;
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
     }
   }
 }

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_128_256_2_1_1_ba.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_128_256_2_1_1_ba.cu
@@ -12,7 +12,7 @@ namespace mslk::gemm {
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
-at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1(
+at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1_ba(
     at::Tensor XQ, // FP8
     at::Tensor WQ, // FP8
     at::Tensor x_scale,
@@ -20,7 +20,7 @@ at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1(
     at::Tensor output,
     int64_t G,
     at::Tensor offsets) {
-  return mx8mx8bf16_grouped_impl<at::Tensor, 256, 256, 256, 2, 1, 1>(
+  return mx8mx8bf16_grouped_impl<at::Tensor, 256, 128, 256, 2, 1, 1, true>(
       XQ, WQ, x_scale, w_scale, output, G, offsets);
 }
 

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_256_256_2_1_1_ab.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_256_256_2_1_1_ab.cu
@@ -12,7 +12,7 @@ namespace mslk::gemm {
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
-at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1(
+at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1_ab(
     at::Tensor XQ, // FP8
     at::Tensor WQ, // FP8
     at::Tensor x_scale,
@@ -20,7 +20,7 @@ at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1(
     at::Tensor output,
     int64_t G,
     at::Tensor offsets) {
-  return mx8mx8bf16_grouped_impl<at::Tensor, 256, 128, 256, 2, 1, 1>(
+  return mx8mx8bf16_grouped_impl<at::Tensor, 256, 256, 256, 2, 1, 1, false>(
       XQ, WQ, x_scale, w_scale, output, G, offsets);
 }
 

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_256_256_2_1_1_ba.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_256_256_2_1_1_ba.cu
@@ -12,7 +12,7 @@ namespace mslk::gemm {
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
-at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1(
+at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1_ba(
     at::Tensor XQ, // FP8
     at::Tensor WQ, // FP8
     at::Tensor x_scale,
@@ -20,7 +20,7 @@ at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1(
     at::Tensor output,
     int64_t G,
     at::Tensor offsets) {
-  return mx8mx8bf16_grouped_impl<at::Tensor, 256, 64, 256, 2, 1, 1>(
+  return mx8mx8bf16_grouped_impl<at::Tensor, 256, 256, 256, 2, 1, 1, true>(
       XQ, WQ, x_scale, w_scale, output, G, offsets);
 }
 

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_64_256_2_1_1_ba.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_64_256_2_1_1_ba.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx8bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1_ba(
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx8bf16_grouped_impl<at::Tensor, 256, 64, 256, 2, 1, 1, true>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_manifest.cuh
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_manifest.cuh
@@ -12,7 +12,7 @@ namespace mslk::gemm {
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
-at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1(
+at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1_ba(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
@@ -21,7 +21,7 @@ at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1(
     int64_t G,
     at::Tensor offsets);
 
-at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1(
+at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1_ba(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
@@ -30,7 +30,16 @@ at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1(
     int64_t G,
     at::Tensor offsets);
 
-at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1(
+at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1_ab(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1_ba(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
@@ -52,12 +61,14 @@ const std::unordered_map<std::string, Kernel_mx8mx8bf16_grouped>&
 get_mx8mx8bf16_grouped_kernels() {
   static const std::unordered_map<std::string, Kernel_mx8mx8bf16_grouped>
       kernels = {
-          {"mx8mx8bf16_grouped_256_64_256_2_1_1",
-           mx8mx8bf16_grouped_256_64_256_2_1_1},
-          {"mx8mx8bf16_grouped_256_128_256_2_1_1",
-           mx8mx8bf16_grouped_256_128_256_2_1_1},
-          {"mx8mx8bf16_grouped_256_256_256_2_1_1",
-           mx8mx8bf16_grouped_256_256_256_2_1_1},
+          {"mx8mx8bf16_grouped_256_256_256_2_1_1_ab",
+           mx8mx8bf16_grouped_256_256_256_2_1_1_ab},
+          {"mx8mx8bf16_grouped_256_64_256_2_1_1_ba",
+           mx8mx8bf16_grouped_256_64_256_2_1_1_ba},
+          {"mx8mx8bf16_grouped_256_128_256_2_1_1_ba",
+           mx8mx8bf16_grouped_256_128_256_2_1_1_ba},
+          {"mx8mx8bf16_grouped_256_256_256_2_1_1_ba",
+           mx8mx8bf16_grouped_256_256_256_2_1_1_ba},
       };
   return kernels;
 }


### PR DESCRIPTION
Summary:
Non tranpose AB can give better performance in some cases enabling us to reach cublas non-grouped MXFP8 gemm performance.

The code is a bit ugly, it could be cleaned up a bit with some structs, but the `set_grouped_gemm_args` should be called with the actual A and B (not transposed) and it needs to know we are computing transpose instead. So for now I think this is fine.

Differential Revision: D89548806
