### PR TITLE
Adding support for bias addition + rescaling with token weights to MSLK's grouped gemm

### DIFF
--- a/bench/gemm/grouped_gemm_bias_scale_benchmark.py
+++ b/bench/gemm/grouped_gemm_bias_scale_benchmark.py
@@ -1,0 +1,177 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Callable, Dict, List
+
+import click
+import pandas as pd
+import torch
+import triton  # @manual
+from mslk.gemm.triton.grouped_gemm import grouped_gemm
+
+
+def triton_fused_bench(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    m_sizes: torch.Tensor,
+    bias: torch.Tensor,
+    token_weights: torch.Tensor,
+) -> Callable[[], torch.Tensor]:
+    """Factory for Triton fused grouped_gemm + bias + token_weights."""
+
+    def run() -> torch.Tensor:
+        return grouped_gemm(x, w, m_sizes, bias=bias, token_weights=token_weights)
+
+    return run
+
+
+@torch.compile(mode="reduce-overhead")
+def _torch_bmm_bias_scale(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    bias: torch.Tensor,
+    token_weights: torch.Tensor,
+    G: int,
+    M_per_group: int,
+) -> torch.Tensor:
+    """Compiled torch baseline: bmm + bias + scale."""
+    N = w.shape[0] // G
+    K = w.shape[1]
+    x_3d = x.view(G, M_per_group, K)
+    w_3d = w.view(G, N, K)
+    out = torch.bmm(x_3d, w_3d.transpose(-1, -2))
+    out = out + bias.unsqueeze(1)
+    out = out * token_weights.view(G, M_per_group, 1)
+    return out.view(-1, N)
+
+
+def torch_baseline_bench(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    bias: torch.Tensor,
+    token_weights: torch.Tensor,
+    G: int,
+    M_per_group: int,
+) -> Callable[[], torch.Tensor]:
+    """Factory for torch.compile'd batched matmul baseline."""
+
+    def run() -> torch.Tensor:
+        return _torch_bmm_bias_scale(x, w, bias, token_weights, G, M_per_group)
+
+    return run
+
+
+def triton_gemm_torch_bias_scale_bench(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    m_sizes: torch.Tensor,
+    bias: torch.Tensor,
+    token_weights: torch.Tensor,
+    G: int,
+    M_per_group: int,
+) -> Callable[[], torch.Tensor]:
+    """Factory for Triton grouped_gemm + torch bias + torch token_weights."""
+
+    def run() -> torch.Tensor:
+        out = grouped_gemm(x, w, m_sizes)
+        out_3d = out.view(G, M_per_group, -1)
+        out_3d = out_3d + bias.unsqueeze(1)
+        out_3d = out_3d * token_weights.view(G, M_per_group, 1)
+        return out_3d.view(-1, out.shape[-1])
+
+    return run
+
+
+@click.command()
+@click.option("--warmup", type=int, default=25, help="Warmup iterations")
+@click.option("--rep", type=int, default=25, help="Benchmark repetitions")
+def bench(warmup: int, rep: int) -> None:
+    """Benchmark grouped_gemm_bias_scale vs torch baseline."""
+    device = torch.accelerator.current_accelerator()
+    dtype = torch.bfloat16
+
+    # G: Number of experts/groups in the MoE layer
+    # M: Total number of tokens across all groups
+    # N: Output dimension (hidden size of expert output)
+    # K: Input dimension (hidden size of expert input)
+    configs = [
+        {"G": 4, "M": 512, "N": 256, "K": 256, "name": "Small"},
+        {"G": 16, "M": 4096, "N": 512, "K": 512, "name": "Medium"},
+        {"G": 64, "M": 16384, "N": 512, "K": 512, "name": "Large"},
+    ]
+
+    # Print configuration table
+    config_df = pd.DataFrame(configs).rename(
+        columns={
+            "name": "Config",
+            "G": "G (experts)",
+            "M": "M (tokens)",
+            "N": "N (out_dim)",
+            "K": "K (in_dim)",
+        }
+    )[["Config", "G (experts)", "M (tokens)", "N (out_dim)", "K (in_dim)"]]
+    print("\nBenchmark Configurations:")
+    print(config_df.to_string(index=False))
+    print()
+
+    results: List[Dict[str, str]] = []
+
+    for idx, cfg in enumerate(configs):
+        G: int = cfg["G"]  # pyre-ignore[9]
+        M: int = cfg["M"]  # pyre-ignore[9]
+        N: int = cfg["N"]  # pyre-ignore[9]
+        K: int = cfg["K"]  # pyre-ignore[9]
+        name: str = cfg["name"]  # pyre-ignore[9]
+        M_per_group = M // G
+
+        print(f"Processing config {idx + 1}/{len(configs)}: {name}...")
+
+        # Create tensors
+        x = torch.randn(M, K, dtype=dtype, device=device)
+        w = torch.randn(G * N, K, dtype=dtype, device=device)
+        bias = torch.randn(G, N, dtype=dtype, device=device)
+        token_weights = torch.rand(M, dtype=dtype, device=device) + 0.5
+        m_sizes = torch.full((G,), M_per_group, dtype=torch.int32, device=device)
+
+        # Create benchmark functions
+        triton_fn = triton_fused_bench(x, w, m_sizes, bias, token_weights)
+        triton_torch_fn = triton_gemm_torch_bias_scale_bench(
+            x, w, m_sizes, bias, token_weights, G, M_per_group
+        )
+        torch_fn = torch_baseline_bench(x, w, bias, token_weights, G, M_per_group)
+
+        # Warmup torch.compile
+        for _ in range(3):
+            torch_fn()
+        torch.cuda.synchronize()
+
+        # Benchmark
+        fused_ms = triton.testing.do_bench(triton_fn, warmup=warmup, rep=rep)
+        triton_torch_ms = triton.testing.do_bench(
+            triton_torch_fn, warmup=warmup, rep=rep
+        )
+        torch_ms = triton.testing.do_bench(torch_fn, warmup=warmup, rep=rep)
+
+        results.append(
+            {
+                "Config": name,
+                "fused (ms)": f"{fused_ms:.3f}",
+                "triton+torch (ms)": f"{triton_torch_ms:.3f}",
+                "torch (ms)": f"{torch_ms:.3f}",
+                "Speedup vs torch": f"{torch_ms / fused_ms:.2f}x",
+                "Speedup vs triton+torch": f"{triton_torch_ms / fused_ms:.2f}x",
+            }
+        )
+
+    print("\nBenchmark Results:")
+    print(pd.DataFrame(results).to_string(index=False))
+    print()
+
+
+if __name__ == "__main__":
+    bench()

--- a/mslk/gemm/triton/grouped_gemm.py
+++ b/mslk/gemm/triton/grouped_gemm.py
@@ -256,6 +256,8 @@ def _mslk_grouped_gemm(
     c_ptr,
     scatter_add_indices,
     m_sizes,
+    bias_ptr,
+    token_weights_ptr,
     # problem sizes
     G: tl.constexpr,
     M_BUCKET,
@@ -266,6 +268,8 @@ def _mslk_grouped_gemm(
     USE_TMA_LOAD: tl.constexpr,
     USE_TMA_STORE: tl.constexpr,
     USE_FAST_ACCUM: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    HAS_TOKEN_WEIGHTS: tl.constexpr,
     # tile sizes
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -356,6 +360,22 @@ def _mslk_grouped_gemm(
                         a_ptrs += BLOCK_SIZE_K
                         b_ptrs += BLOCK_SIZE_K
 
+                if HAS_BIAS:
+                    offs_bn = tile_n_idx * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+                    bias_ptrs = bias_ptr + g.to(tl.int64) * N + offs_bn
+                    bias = tl.load(bias_ptrs, mask=(offs_bn < n_size), other=0.0).to(
+                        accumulator.dtype
+                    )
+                    accumulator = accumulator + bias[None, :]
+
+                if HAS_TOKEN_WEIGHTS:
+                    offs_am = tile_m_idx * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+                    tw_ptrs = token_weights_ptr + M_start_offset + offs_am
+                    tw = tl.load(tw_ptrs, mask=(offs_am < m_size), other=1.0).to(
+                        accumulator.dtype
+                    )
+                    accumulator = accumulator * tw[:, None]
+
                 if USE_TMA_STORE:
                     m_offset = (tile_m_idx * BLOCK_SIZE_M).to(tl.int32)
                     n_offset = (tile_n_idx * BLOCK_SIZE_N).to(tl.int32)
@@ -409,6 +429,8 @@ def _mslk_grouped_gemm_ws(
     c_ptr,
     scatter_add_indices,
     m_sizes,
+    bias_ptr,
+    token_weights_ptr,
     # problem sizes
     G: tl.constexpr,
     M_BUCKET: tl.constexpr,
@@ -418,6 +440,8 @@ def _mslk_grouped_gemm_ws(
     FUSE_SCATTER_ADD: tl.constexpr,
     USE_TMA_LOAD: tl.constexpr,
     USE_FAST_ACCUM: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    HAS_TOKEN_WEIGHTS: tl.constexpr,
     # tile sizes
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -481,6 +505,20 @@ def _mslk_grouped_gemm_ws(
                             accumulator = tl.dot(a, b.T, accumulator)
                         else:
                             accumulator += tl.dot(a, b.T)
+
+                    if HAS_BIAS:
+                        offs_bn = tile_n_idx * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+                        bias_ptrs = bias_ptr + g.to(tl.int64) * N + offs_bn
+                        bias = tl.load(bias_ptrs).to(accumulator.dtype)
+                        accumulator = accumulator + bias[None, :]
+
+                    if HAS_TOKEN_WEIGHTS:
+                        offs_am = tile_m_idx * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+                        tw_ptrs = token_weights_ptr + M_start_offset + offs_am
+                        tw = tl.load(tw_ptrs, mask=(offs_am < m_size), other=1.0).to(
+                            accumulator.dtype
+                        )
+                        accumulator = accumulator * tw[:, None]
 
                     if USE_TMA_STORE:
                         m_offset = (tile_m_idx * BLOCK_SIZE_M).to(tl.int32)
@@ -836,6 +874,8 @@ def _grouped_gemm(
     m_sizes: torch.Tensor,
     x_scale: Optional[torch.Tensor],
     w_scale: Optional[torch.Tensor],
+    bias: Optional[torch.Tensor],
+    token_weights: Optional[torch.Tensor],
     use_fast_accum: bool,
     use_warp_specialization: bool,
     output_tensor: Optional[torch.Tensor],
@@ -880,6 +920,25 @@ def _grouped_gemm(
 
         assert output_tensor is None, (
             f"Fused scatter add has large rounding error when K or N is not a multiple of 8: {K=}, {N=}."
+        )
+
+    HAS_BIAS = bias is not None
+    if HAS_BIAS:
+        assert bias is not None  # for type checker
+        assert bias.is_contiguous(), "Bias must be contiguous"
+        assert len(bias.shape) == 2, f"Bias must be 2D, got shape {bias.shape}"
+        assert bias.shape[0] == G, f"Bias dim 0 must match G={G}, got {bias.shape[0]}"
+        assert bias.shape[1] == N, f"Bias dim 1 must match N={N}, got {bias.shape[1]}"
+
+    HAS_TOKEN_WEIGHTS = token_weights is not None
+    if HAS_TOKEN_WEIGHTS:
+        assert token_weights is not None  # for type checker
+        assert token_weights.is_contiguous(), "token_weights must be contiguous"
+        assert len(token_weights.shape) == 1, (
+            f"token_weights must be 1D, got shape {token_weights.shape}"
+        )
+        assert token_weights.shape[0] == M, (
+            f"token_weights dim 0 must match M={M}, got {token_weights.shape[0]}"
         )
 
     if output_tensor is None:
@@ -980,6 +1039,8 @@ def _grouped_gemm(
             y,
             scatter_add_indices,
             m_sizes,
+            bias if HAS_BIAS else None,
+            token_weights if HAS_TOKEN_WEIGHTS else None,
             G,
             M_BUCKET,
             N,
@@ -989,9 +1050,9 @@ def _grouped_gemm(
             USE_TMA_LOAD,
         )
         if use_warp_specialization:
-            args += (use_fast_accum,)
+            args += (use_fast_accum, HAS_BIAS, HAS_TOKEN_WEIGHTS)
         else:
-            args += (USE_TMA_STORE, use_fast_accum)
+            args += (USE_TMA_STORE, use_fast_accum, HAS_BIAS, HAS_TOKEN_WEIGHTS)
         fn[grid](*args)
 
     return y
@@ -1001,18 +1062,42 @@ def grouped_gemm(
     x: torch.Tensor,
     w: torch.Tensor,
     m_sizes: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    token_weights: Optional[torch.Tensor] = None,
     use_fast_accum: bool = True,
     *,
     _use_warp_specialization: bool = True,
     _output_tensor: Optional[torch.Tensor] = None,
     _scatter_add_indices: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    """
+    Grouped GEMM with optional bias addition and per-token weight scaling.
+
+    Performs: output = (x @ w.T + bias) * token_weights
+    where operations are grouped by experts.
+
+    Args:
+        x: Input tensor [M, K] where M is total tokens across all experts
+        w: Weight tensor [G * N, K] where G is number of experts
+        m_sizes: Tensor [G] indicating number of tokens per expert
+        bias: Optional bias tensor [G, N], one bias vector per expert
+        token_weights: Optional per-token scaling weights [M] (e.g., router weights)
+        use_fast_accum: Enable fast accumulation for better performance
+        _use_warp_specialization: Flag for warp specialization
+        _output_tensor: Optional pre-allocated output tensor for scatter-add
+        _scatter_add_indices: Optional indices for scatter-add operation
+
+    Returns:
+        Output tensor [M, N]
+    """
     return _grouped_gemm(
         x=x,
         w=w,
         m_sizes=m_sizes,
         x_scale=None,
         w_scale=None,
+        bias=bias,
+        token_weights=token_weights,
         use_fast_accum=use_fast_accum,
         use_warp_specialization=_use_warp_specialization,
         output_tensor=_output_tensor,
@@ -1038,6 +1123,8 @@ def grouped_gemm_fp8_rowwise(
         m_sizes=m_sizes,
         x_scale=x_scale,
         w_scale=w_scale,
+        bias=None,
+        token_weights=None,
         use_fast_accum=use_fast_accum,
         use_warp_specialization=_use_warp_specialization,
         output_tensor=_output_tensor,

--- a/test/gemm/triton/grouped_gemm_test.py
+++ b/test/gemm/triton/grouped_gemm_test.py
@@ -240,3 +240,206 @@ class TestGroupedGEMM(unittest.TestCase):
         torch.testing.assert_close(
             result, expected_result, atol=1e-5, rtol=1.6e-2, msg=msg
         )
+
+    @given(
+        G=st.sampled_from([1, 4, 16, 128]),
+        M=st.sampled_from([0, 128, 2048, 16384]),
+        N=st.sampled_from([256, 451]),
+        K=st.sampled_from([100, 256, 257]),
+        warp_specialization=st.sampled_from([False]),
+        has_bias=st.sampled_from([True, False]),
+        has_token_weights=st.sampled_from([True, False]),
+    )
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=_MAX_SAMPLES,
+        deadline=None,
+    )
+    @unittest.skipIf(  # pyre-ignore [56]
+        (not torch.cuda.is_available())
+        or (torch.version.hip is None)
+        and (torch.cuda.get_device_properties(0).major < 9),
+        "Skip BF16 test on architectures before SM90.",
+    )
+    def test_grouped_gemm_bias_scale(
+        self,
+        G: int,
+        M: int,
+        N: int,
+        K: int,
+        warp_specialization: bool,
+        has_bias: bool,
+        has_token_weights: bool,
+    ) -> None:
+        torch.manual_seed(0)
+
+        device = torch.accelerator.current_accelerator()
+
+        a = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+        b = torch.randn(N * G, K, dtype=torch.bfloat16, device=device)
+
+        m_ends, _ = torch.sort(
+            torch.randint(low=0, high=M, size=[G - 1], device=device, dtype=torch.int32)
+            if M > 0
+            else torch.zeros([G - 1], device=device, dtype=torch.int32)
+        )
+        m_ends = m_ends.tolist()
+        m_starts = [0] + m_ends
+        m_ends = m_ends + [M]
+        m_sizes = torch.tensor(
+            [m_ends[i] - m_starts[i] for i in range(G)],
+            device=device,
+            dtype=torch.int32,
+        )
+
+        # Generate optional bias and token_weights
+        # Use uniform distribution with values away from 0
+        bias = (
+            (torch.rand(G, N, dtype=torch.bfloat16, device=device) * 2 - 1)
+            if has_bias
+            else None
+        )
+        # Token weights typically represent router scores
+        token_weights = (
+            (torch.rand(M, dtype=torch.bfloat16, device=device) + 0.5)
+            if has_token_weights
+            else None
+        )
+
+        result = grouped_gemm(
+            a,
+            b,
+            m_sizes,
+            bias=bias,
+            token_weights=token_weights,
+            _use_warp_specialization=warp_specialization,
+        )
+        self.assertEqual(result.shape, (M, N))
+
+        if M == 0:
+            return
+
+        # Compute expected result: (a @ b.T + bias) * token_weights
+        # Use float32 accumulator to match kernel's accumulator precision
+        expected_result = torch.zeros(M, N, dtype=torch.float32, device=device)
+        for g in range(G):
+            m_start = m_starts[g]
+            m_end = m_ends[g]
+            expected_result[m_start:m_end, :] = (
+                a[m_start:m_end, :].float() @ b[g * N : (g + 1) * N, :].float().T
+            )
+            if bias is not None:
+                expected_result[m_start:m_end, :] += bias[g, :].unsqueeze(0)
+            if token_weights is not None:
+                expected_result[m_start:m_end, :] *= token_weights[
+                    m_start:m_end
+                ].unsqueeze(1)
+
+        expected_result = expected_result.to(torch.bfloat16)
+
+        def msg(s: str) -> str:
+            return (
+                f"{G=}, {M=}, {N=}, {K=}, {warp_specialization=}, "
+                f"{has_bias=}, {has_token_weights=}, {s}"
+            )
+
+        torch.testing.assert_close(
+            result, expected_result, atol=1e-5, rtol=1.6e-2, msg=msg
+        )
+
+    @given(
+        G=st.sampled_from([1, 4, 16, 128]),
+        M=st.sampled_from([0, 128, 2048, 16384]),
+        K=st.sampled_from([100, 256, 257]),
+        warp_specialization=st.sampled_from([False]),
+        has_bias=st.sampled_from([True, False]),
+        has_token_weights=st.sampled_from([True, False]),
+    )
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=_MAX_SAMPLES,
+        deadline=None,
+    )
+    @unittest.skipIf(  # pyre-ignore [56]
+        (not torch.cuda.is_available())
+        or (torch.version.hip is None)
+        and (torch.cuda.get_device_properties(0).major < 9),
+        "Skip BF16 test on architectures before SM90.",
+    )
+    def test_grouped_gemm_bias_scale_identity_weights(
+        self,
+        G: int,
+        M: int,
+        K: int,
+        warp_specialization: bool,
+        has_bias: bool,
+        has_token_weights: bool,
+    ) -> None:
+        """Test bias and token_weights application using identity matrix weights.
+
+        With identity matrix weights, x @ I.T = x, we expect bit-exact matching.
+        """
+        torch.manual_seed(0)
+        device = torch.accelerator.current_accelerator()
+
+        N = K
+        a = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+        identity = torch.eye(N, K, dtype=torch.bfloat16, device=device)
+        b = identity.repeat(G, 1)
+
+        m_ends, _ = torch.sort(
+            torch.randint(low=0, high=M, size=[G - 1], device=device, dtype=torch.int32)
+            if M > 0
+            else torch.zeros([G - 1], device=device, dtype=torch.int32)
+        )
+        m_ends = m_ends.tolist()
+        m_starts = [0] + m_ends
+        m_ends = m_ends + [M]
+        m_sizes = torch.tensor(
+            [m_ends[i] - m_starts[i] for i in range(G)],
+            device=device,
+            dtype=torch.int32,
+        )
+
+        bias = (
+            (torch.rand(G, N, dtype=torch.bfloat16, device=device) * 2 - 1)
+            if has_bias
+            else None
+        )
+        token_weights = (
+            (torch.rand(M, dtype=torch.bfloat16, device=device) + 0.5)
+            if has_token_weights
+            else None
+        )
+
+        result = grouped_gemm(
+            a,
+            b,
+            m_sizes,
+            bias=bias,
+            token_weights=token_weights,
+            _use_warp_specialization=warp_specialization,
+        )
+        self.assertEqual(result.shape, (M, N))
+
+        # Expected: (a @ I.T + bias) * token_weights = (a + bias) * token_weights
+        # Use float32 accumulator to match kernel precision
+        expected_result = torch.zeros(M, N, dtype=torch.float32, device=device)
+        for g in range(G):
+            m_start = m_starts[g]
+            m_end = m_ends[g]
+            # x @ I.T = x, load directly into float32 accumulator (auto-promoted)
+            expected_result[m_start:m_end, :] = a[m_start:m_end, :]
+            if bias is not None:
+                expected_result[m_start:m_end, :] += bias[g, :].unsqueeze(0)
+            if token_weights is not None:
+                expected_result[m_start:m_end, :] *= token_weights[
+                    m_start:m_end
+                ].unsqueeze(1)
+        expected_result = expected_result.to(torch.bfloat16)
+
+        self.assertTrue(
+            torch.equal(result, expected_result),
+            f"Bit-exact match failed for {G=}, {M=}, {K=}, {warp_specialization=}, "
+            f"{has_bias=}, {has_token_weights=}",
+        )


### PR DESCRIPTION
Summary:
Adds support for providing bias and token weights as optional arguments to MSLK's triton grouped gemm. The changes were added to the _grouped_gemm protected kernel implementation, and exposed through a new public function `grouped_gemm_bias_scale` --- the original `grouped_gemm` signature remains functionally untouched.

For internal testing use,
```
buck test -c fbcode.nvcc_arch=h100a -c fbcode.enable_gpu_sections=true fbcode//mslk/test/gemm:grouped_gemm -- test_grouped_gemm_bias_scale
```

For basic benchmarking on H100 nodes use,
```
buck run -c fbcode.nvcc_arch=h100a -c fbcode.enable_gpu_sections=true fbcode//mslk/bench/gemm:grouped_gemm_bias_scale_benchmark 2>/dev/null
```

```
Benchmark Results:
Config fused (ms) triton+torch (ms) torch (ms) Speedup vs torch Speedup vs triton+torch
 Small      0.009             0.017      0.026            2.97x                   1.92x
Medium      0.018             0.034      0.045            2.53x                   1.90x
 Large      0.050             0.093      0.136            2.70x                   1.85x
```

Differential Revision: D90047821


