### PR TITLE
split mem_eff tests

### DIFF
--- a/test/attention/fmha/case_generation.py
+++ b/test/attention/fmha/case_generation.py
@@ -1,0 +1,368 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+# pyre-ignore-all-errors[29]
+
+import logging
+import random
+from typing import Any, Iterable, List, Optional, Sequence, Tuple, Type, Union
+
+import pytest
+import torch
+from mslk.attention import fmha
+from mslk.attention.fmha.attn_bias_utils import create_attn_bias
+from mslk.attention.fmha.common import AttentionOpBase
+
+from .utils import _devices
+
+logger = logging.getLogger("xformers")
+
+
+def sample_random_supported_fw(
+    inp: fmha.Inputs,
+    fw_ops: Sequence[Type[fmha.common.AttentionFwOpBase]],
+    seed: Union[int, str],
+    op_bw: Type[fmha.common.AttentionBwOpBase],
+) -> Type[fmha.common.AttentionFwOpBase]:
+    r = random.Random(seed)
+    fw_ops = list(fw_ops)
+    if op_bw == fmha.cutlass_blackwell.BwOp:
+        fw_ops = [fmha.cutlass_blackwell.FwOp, fmha.flash.FwOp]
+    if (
+        isinstance(inp.attn_bias, fmha.attn_bias.VARLEN_BIASES)
+        and inp.attn_bias.q_seqinfo.seqstart.shape[0] > 2
+    ):
+        fw_ops = [
+            op for op in fw_ops if op.VARLEN_LSE_PACKED == op_bw.VARLEN_LSE_PACKED
+        ]
+    r.shuffle(fw_ops)
+    for op in fw_ops:
+        if op.supports(inp):
+            return op
+    raise NotImplementedError(f"Could not find a FW operator for: {inp}")
+
+
+def generate_test_shapes_B_Mq_Mkv_H_K_Kv(
+    op: Type[fmha.AttentionOpBase],
+) -> List[Tuple[int, ...]]:  # noqa: C901
+    shapes: List[Tuple[int, ...]] = []
+    for B in op._TEST_BATCH_SIZES:
+        for Mq in [32, 256]:
+            for Mkv in [32, 64, 256, 1024]:
+                for K in op._TEST_K:
+                    shapes.append((B, Mq, Mkv, 1, K, K))
+        Mq = 256
+        Mkv = 128
+        K = 32
+        H = 1
+        # Weird values of parameters
+        for M in [2, 3, 15, 31, 32, 34, 68, 72, 90, 132, 136]:
+            shapes.append((B, M, Mkv, H, K, K))
+            shapes.append((B, Mq, M, H, K, K))
+        Ks = [1, 2, 3, 31, 34, 36, 38, 40, 64, 80, 160, 256 + 2, 256 + 8, 512]
+        for _K in Ks:
+            if op.SUPPORTED_MIN_K <= _K <= op.SUPPORTED_MAX_K:
+                shapes.append((B, Mq, Mkv, H, _K, _K))
+        # Different value for K / Kv
+        if op.SUPPORTS_DIFFERENT_VALUE_EMBED:
+            for _K in [32, 36, 64, 256 + 8]:
+                shapes.append((B, Mq, Mkv, H, K, _K))
+                shapes.append((B, Mq, Mkv, H, _K, K))
+        # Exotic sizes
+        for K in op._TEST_K:
+            shapes.append((B, 16, 1024, H, K, K))
+            shapes.append((B, 1024, 16, H, K, K))
+        # Some number of heads
+        for H in [3, 5, 12]:
+            shapes.append((max(1, B // H), Mq, Mkv, H, K, K))
+    # Filter-out not supported shapes
+    shapes = [
+        shape
+        for shape in shapes
+        if len(
+            op.shape_not_supported_reasons(
+                Mq=shape[1], Mkv=shape[2], K=shape[4], Kv=shape[5]
+            )
+        )
+        == 0
+    ]
+    # Add some random shapes
+    if op in [
+        fmha.cutlass.FwOp,
+        fmha.cutlass.BwOp,
+        fmha.cutlass_blackwell.FwOp,
+        fmha.cutlass_blackwell.BwOp,
+        fmha.flash.BwOp,
+        fmha.ck.FwOp,
+    ]:
+        K_CHOICES = [8 * i for i in range(1, 256 // 8)]
+        r = random.Random(0)
+        found_count = 0
+        while found_count < 200:
+            B = r.randint(1, 400)
+            Mq = r.randint(1, 500)
+            Mkv = r.randint(1, 500)
+            H = r.randint(2, 11)
+            B = max(B // H, 1)
+            K = r.choice(K_CHOICES)
+            Kv = r.choice(K_CHOICES)
+            if not op.SUPPORTS_DIFFERENT_VALUE_EMBED:
+                Kv = K
+            if len(op.shape_not_supported_reasons(Mq, Mkv, K, Kv)):
+                continue
+            found_count += 1
+            shapes.append((B, Mq, Mkv, H, K, Kv))
+    return shapes
+
+
+def make_id(
+    op: Type[fmha.AttentionOpBase],
+    device: torch.device,
+    dtype: torch.dtype,
+    bias_type: Type[fmha.attn_bias.AttentionBias],
+    *shape: int,
+) -> str:
+    return (
+        f"{op.NAME}-{device}-{str(dtype)}-{bias_type.__name__}"
+        f"-{'-'.join([str(s) for s in shape])}"
+    )
+
+
+# This temporary working is necessary because the MTIA test collection might not happen
+# on the same device as the device the tests are actually executed on. If test collection
+# is done on a device without MTIA, the supported masks will contain masks that MTIA support
+# and the corresponding tests will get collected. But when it comes time to actually run the
+# tests, the mask won't be supported because it is run on an actual MTIA device.
+def get_supported_attn_bias_types(op: Type[fmha.AttentionOpBase]) -> Iterable[Any]:
+    supported_attn_bias_types = op.SUPPORTED_ATTN_BIAS_TYPES
+
+    try:
+        import mtia.host_runtime.torch_mtia.dynamic_library  # noqa  # type: ignore
+
+        supported_attn_bias_types = [
+            b
+            for b in supported_attn_bias_types
+            if not issubclass(
+                b,
+                (
+                    fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+                    fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                ),
+            )
+        ]
+    except (ImportError, OSError):
+        pass
+
+    return supported_attn_bias_types
+
+
+def _generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(  # noqa: C901
+    ops_list: Sequence[Type[fmha.AttentionOpBase]], max_shapes_per_op: int = 65000
+):
+    r = random.Random(0)
+    combination = []
+    for op in ops_list:
+        op_count = 0
+        # Sort list of masks, so it's deterministic across runs
+        LIST_MASKS = sorted(get_supported_attn_bias_types(op), key=str)
+        for shape in generate_test_shapes_B_Mq_Mkv_H_K_Kv(op):
+            has_one = False
+            for device in _devices:
+                if device not in op.SUPPORTED_DEVICES:
+                    continue
+                # Sort set of dtypes to make it deterministic across runs
+                for dtype in sorted(op.SUPPORTED_DTYPES, key=str):
+                    # "normal_kernel_cuda" not implemented for 'Float8_e4m3fn'
+                    if dtype in [torch.float8_e4m3fn]:
+                        continue
+                    bias_type = r.choice(LIST_MASKS)
+                    # Avoid using too much memory
+                    B, Mq, Mkv, H, K, Kv = shape
+                    if bias_type not in [
+                        type(None),
+                        fmha.attn_bias.LowerTriangularMask,
+                    ]:
+                        B = min(B, 12)
+
+                        if bias_type in {
+                            fmha.attn_bias.BlockDiagonalCausalFromBottomRightMask,
+                            fmha.attn_bias.BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+                        }:
+                            Mq, Mkv = min(Mkv, Mq), max(Mkv, Mq) + 2
+                        elif bias_type in {
+                            fmha.attn_bias.BlockDiagonalCausalLocalAttentionPaddedKeysMask,
+                            fmha.attn_bias.BlockDiagonalLocalAttentionPaddedKeysMask,
+                            fmha.attn_bias.BlockDiagonalCausalWithOffsetGappyKeysMask,
+                            fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask,
+                            fmha.attn_bias.BlockDiagonalPaddedKeysMask,
+                            fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+                            fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                            fmha.attn_bias.PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
+                            fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+                        }:
+                            Mq, Mkv = min(Mkv, Mq), max(Mkv, Mq)
+                    new_shape = (B, Mq, Mkv, H, K, Kv)
+                    combination.append((op, device, dtype, bias_type, *new_shape))
+                    has_one = True
+            if has_one:
+                op_count += 1
+            if op_count > max_shapes_per_op:
+                break
+        # Some specific shapes for which we want to run without any mask
+        bias_type = type(None)
+        for shape in (
+            # Some strides/dims don't fit on an uint16
+            (1, 128, 128, 300, 128, 128),
+            (13, 1, 67, 200, 8, 8),
+            (1, 1 + 2**16, 4, 1, 8, 8),
+            (1, 4, 1 + 2**16, 1, 8, 8),
+            # TODO: Some strides don't fit on an uint32
+            # Crashes on Flash, Errors on Cutlass
+            # (1, 1, 64000, 300, 128, 128)
+        ):
+            for device in _devices:
+                if device not in op.SUPPORTED_DEVICES:
+                    continue
+                # Sort set of dtypes to make it deterministic across runs
+                for dtype in sorted(op.SUPPORTED_DTYPES, key=str):
+                    # "normal_kernel_cuda" not implemented for 'Float8_e4m3fn'
+                    if dtype in [torch.float8_e4m3fn]:
+                        continue
+                    combination.append((op, device, dtype, bias_type, *shape))
+    return {
+        "argvalues": combination,
+        "ids": [make_id(*c) for c in combination],
+    }
+
+
+def get_bias_grad(attn_bias: Any, clear: bool = False) -> Optional[torch.Tensor]:
+    tensor_with_grad: Optional[torch.Tensor] = None
+    if isinstance(attn_bias, torch.Tensor):
+        tensor_with_grad = attn_bias
+    if tensor_with_grad is not None:
+        grad = tensor_with_grad.grad
+        if clear:
+            tensor_with_grad.grad = None
+        return grad
+    return None
+
+
+def create_tensors(  # noqa: C901
+    op: Optional[Type[AttentionOpBase]],
+    device: Union[str, torch.device],
+    dtype: torch.dtype,
+    attn_bias_type: Optional[Type[fmha.attn_bias.AttentionBias]],
+    B: int,
+    q_len: int,
+    kv_len: int,
+    h: int,
+    k: int,
+    kv: int,
+    *,
+    attn_bias_requires_grad: bool = False,
+    fmt: str = "BMK",
+    g: int = 1,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Any]:
+    torch.manual_seed(B * q_len + kv_len * k + kv)
+
+    mask_is_bottom_right = attn_bias_type is not None and issubclass(
+        attn_bias_type,
+        (
+            fmha.attn_bias.LowerTriangularFromBottomRightMask,
+            fmha.attn_bias.LowerTriangularFromBottomRightLocalAttentionMask,
+            fmha.attn_bias.BlockDiagonalCausalFromBottomRightMask,
+            fmha.attn_bias.BlockDiagonalCausalLocalAttentionFromBottomRightMask,
+            fmha.attn_bias.BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask,
+            fmha.attn_bias.BlockDiagonalCausalLocalAttentionMask,
+            fmha.attn_bias.LocalAttentionFromBottomRightMask,
+            fmha.attn_bias.PagedBlockDiagonalCausalLocalPaddedKeysMask,
+        ),
+    )
+    if mask_is_bottom_right and q_len > kv_len:
+        # Bottom-right attention and local-attention masks require q_len <= kv_len
+        kv_len = q_len
+
+    if attn_bias_type is not None and issubclass(
+        attn_bias_type,
+        (
+            fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+            fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+        ),
+    ):
+        page_size_choices = [256, 512]
+        if op is not None and issubclass(op, fmha.triton_splitk.FwOp):
+            # TODO: enable small pages for flash attention when that's implemented
+            page_size_choices.extend([64, 128])
+        page_size = random.choice(page_size_choices)
+        kv_len_paged = (kv_len + page_size - 1) // page_size * page_size
+    else:
+        kv_len_paged = kv_len
+        page_size = None
+
+    scale = 3
+    if fmt == "BMK":
+        query = torch.randn((B * h, q_len, k), device=device, dtype=dtype)
+        key = torch.randn((B * h, kv_len_paged, k), device=device, dtype=dtype)
+        value = torch.randn((B * h, kv_len_paged, kv), device=device, dtype=dtype)
+    elif fmt == "BMHK":
+        query = torch.randn((B, q_len, h, k), device=device, dtype=dtype)
+        key = torch.randn((B, kv_len_paged, h, k), device=device, dtype=dtype)
+        value = torch.randn((B, kv_len_paged, h, kv), device=device, dtype=dtype)
+    else:
+        assert fmt == "BMGHK"
+        query = torch.randn((B, q_len, g, h, k), device=device, dtype=dtype)
+        key = torch.randn((B, kv_len_paged, g, 1, k), device=device, dtype=dtype)
+        value = torch.randn((B, kv_len_paged, g, 1, kv), device=device, dtype=dtype)
+
+    for x in [query, key, value]:
+        x.mul_(scale)
+
+    if fmt == "BMGHK":
+        # Expand - after the in-place mul
+        key = key.expand((B, kv_len_paged, g, h, k))
+        value = value.expand((B, kv_len_paged, g, h, k))
+
+    if fmt == "BMK" and not fmha.common._is_bias_type_supported_in_BMK(attn_bias_type):
+        attn_bias_type = None
+    attn_bias = None
+    if attn_bias_type is not None:
+        attn_bias = create_attn_bias(
+            attn_bias_type,
+            batch_size=B,
+            num_heads=h,
+            num_heads_groups=g,
+            q_len=q_len,
+            kv_len=kv_len,
+            dtype=dtype,
+            device=device,
+            requires_grad=attn_bias_requires_grad,
+            fmt=fmt,
+            op=op,
+            page_size=page_size,
+        )
+        if isinstance(
+            attn_bias,
+            (
+                fmha.attn_bias.BlockDiagonalMask,
+                fmha.attn_bias.BlockDiagonalGappyKeysMask,
+                fmha.attn_bias.BlockDiagonalPaddedKeysMask,
+                fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+                fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+            ),
+        ):
+            query, key, value = [
+                x.reshape([1, -1, *x.shape[2:]]) for x in [query, key, value]
+            ]
+
+    inputs = fmha.Inputs(query=query, key=key, value=value, attn_bias=attn_bias)
+    if op is not None:
+        reasons = op.not_supported_reasons(inputs)
+        if reasons:
+            err_msg = f"{op.NAME}: unsupported ({'/'.join(reasons)})"
+            # Ensure we free memory to avoid OOMs
+            del query, key, value, attn_bias, inputs
+            pytest.skip(err_msg)
+    return query, key, value, attn_bias

--- a/test/attention/fmha/test_backward.py
+++ b/test/attention/fmha/test_backward.py
@@ -1,0 +1,309 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+# pyre-ignore-all-errors[29]
+
+import logging
+import random
+
+import pytest
+import torch
+
+try:
+    from mtia.re.re_unittest_lib import init_mtia_device  # type: ignore
+
+    init_mtia_device()
+except ImportError:
+    # Failed to load MTIA libraries, so just keep going without MTIA devices
+    pass
+
+from mslk.attention import fmha
+from mslk.attention.fmha import ALL_BW_OPS, ALL_FW_OPS
+from mslk.attention.fmha.unbind import unbind
+
+from .case_generation import (
+    _generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+    create_tensors,
+    get_bias_grad,
+    sample_random_supported_fw,
+)
+from .utils import (
+    _filter_unsupported_ops,
+    assert_allclose,
+    cuda_or_mtia_only,
+    disable_tf32,
+    ref_attention_bmhk_for_test,
+    ref_attention_for_test,
+    use_cpu_ref,
+)
+
+logger = logging.getLogger("xformers")
+
+ALL_FW_OPS = _filter_unsupported_ops(ALL_FW_OPS)
+ALL_BW_OPS = _filter_unsupported_ops(ALL_BW_OPS)
+
+parametrize_opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv = pytest.mark.parametrize(
+    "opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    **_generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(ALL_BW_OPS),
+)
+
+
+@disable_tf32
+@pytest.mark.parametrize("fmt", ["BMK", "BMHK"])
+@pytest.mark.parametrize("grad_out_contiguous", [False, True])
+@parametrize_opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+def test_backward(  # noqa: C901
+    opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+    grad_out_contiguous,
+    fmt,
+):
+    (
+        op_bw,
+        device,
+        dtype,
+        bias_type,
+        batch_size,
+        q_len,
+        kv_len,
+        h,
+        k,
+        kv,
+    ) = opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+
+    # Big batch sizes can be slow on MTIA, especially older devices because
+    # it doesn't have attention fast paths. Testing on very big batch sizes
+    # doesn't meaningfully increase our test coverage here, as long as most
+    # permutations of parameters are tested on lower batch sizes.
+    if device.startswith("mtia") and batch_size >= 11:
+        pytest.skip("Skipping big batch test cases on MTIA")
+
+    attn_bias_requires_grad = (
+        random.Random(q_len + kv_len * batch_size).randint(0, 1) > 0
+    )
+    query, key, value, attn_bias = create_tensors(
+        *opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+        attn_bias_requires_grad=attn_bias_requires_grad,
+        fmt=fmt,
+    )
+
+    # To understand why we do this, check the comment on the
+    # `AttentionBwOpBase` class
+    scale = None
+    if op_bw.SUPPORTS_CUSTOM_SCALE and query.shape[-1] < 32:
+        scale = (1 / 32) ** 0.5
+    op_fw = (
+        sample_random_supported_fw(
+            fmha.Inputs(query=query, key=key, value=value, attn_bias=attn_bias),
+            ALL_FW_OPS,
+            seed=q_len * kv + kv_len * k,
+            op_bw=op_bw,
+        )
+        if op_bw != fmha.cutlass.BwOp
+        else fmha.cutlass.FwOp
+    )
+
+    if op_bw == fmha.ck.BwOp:
+        op_fw = fmha.ck.FwOp
+        if dtype == torch.bfloat16:
+            # bfloat16 testing can be enabled by export ENABLE_HIP_FMHA_RTN_BF16_CONVERT=1 when
+            # building xformers and get accurate results
+            pytest.skip(
+                "CK Fmha backward for bfloat16 currently is not very accurate for some cases!"
+            )
+        if not grad_out_contiguous:
+            pytest.skip("CK Fmha does not support non-contiguous layout for grad_out!")
+        if k % 2 != 0:
+            pytest.skip(
+                "CK Fmha currently requires the headdim size of query input be an even value!"
+            )
+
+    qkv = None
+
+    if (
+        fmt == "BMHK"
+        and query.shape[3] == value.shape[3]
+        and query.shape[1] == value.shape[1]
+    ):
+        qkv = torch.stack([query, key, value], 2)
+        qkv.requires_grad_(True)
+        # bm3hk -> 3 x bmhk
+        query, key, value = unbind(qkv, 2)
+        assert not query.is_contiguous()
+
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+
+    if not op_bw.supports(fmha.Inputs(query, key, value, attn_bias)):
+        pytest.skip("inputs not supported")
+
+    out = fmha.memory_efficient_attention(
+        query, key, value, attn_bias, scale=scale, op=(op_fw, op_bw)
+    )
+
+    grad_out = torch.randn_like(out)
+    if grad_out_contiguous is False:
+        grad_out = torch.tensor([1.0], dtype=query.dtype, device=device)[
+            None, None, :
+        ].expand_as(out)
+
+    out.backward(grad_out)
+
+    if qkv is None and op_bw == fmha.cutlass.BwOp:
+        assert query.stride() == query.grad.stride()
+
+    grads = []
+    if qkv is None:
+        grads = [query.grad, key.grad, value.grad]
+        query.grad = None
+        key.grad = None
+        value.grad = None
+    else:
+        grads = [qkv.grad]
+        qkv.grad = None
+    if attn_bias_requires_grad:
+        attn_bias_grad = get_bias_grad(attn_bias, clear=True)
+        if attn_bias_grad is not None:
+            grads.append(attn_bias_grad)
+
+    if use_cpu_ref(device):
+        query = query.detach().cpu()
+        key = key.detach().cpu()
+        value = value.detach().cpu()
+        grad_out = grad_out.detach().cpu()
+
+        if qkv is not None:
+            qkv = torch.stack([query, key, value], 2)
+            qkv.requires_grad_(True)
+            query, key, value = unbind(qkv, 2)
+
+        query.requires_grad_(True)
+        key.requires_grad_(True)
+        value.requires_grad_(True)
+        grad_out.requires_grad_(True)
+
+        if isinstance(attn_bias, torch.Tensor):
+            attn_bias = attn_bias.cpu()
+
+    ref = ref_attention_for_test(query, key, value, attn_bias, scale=scale)
+    ref.backward(grad_out)
+
+    assert_allclose(
+        out.float().to(ref.device),
+        ref.float(),
+        "fw pass",
+        atol=op_fw.ERROR_ATOL[dtype],
+        rtol=op_fw.ERROR_RTOL[dtype],
+    )
+
+    del out
+    del grad_out
+    del ref
+
+    atol = op_bw.ERROR_ATOL[dtype]
+    rtol = op_bw.ERROR_RTOL[dtype]
+
+    # This is a special case without masks where the accumulated numbers become so big that
+    # we lose too much precision, especially on bfloat16. For this reason, the default bfloat16
+    # tolerance for the backward pass is set to 0.9, but in some cases on MTIA we get up to 1.3,
+    # probably due to the fact that the implementation doesn't use the fused kernels yet, which
+    # increases the precision loss caused by the accumulation.
+    if (
+        device.startswith("mtia")
+        and issubclass(bias_type, type(None))
+        and q_len >= 2**16
+    ):
+        atol *= 1.6
+
+    grads_ref = []
+    grads_name = []
+    if qkv is None:
+        assert isinstance(query.grad, torch.Tensor)
+        assert isinstance(key.grad, torch.Tensor)
+        assert isinstance(value.grad, torch.Tensor)
+        grads_ref = [query.grad, key.grad, value.grad]
+        grads_name = ["query", "key", "value"]
+    else:
+        assert isinstance(qkv.grad, torch.Tensor)
+        grads_ref = [qkv.grad]
+        grads_name = ["qkv"]
+
+    if attn_bias_requires_grad:
+        attn_bias_grad = get_bias_grad(attn_bias)
+        if attn_bias_grad is not None:
+            grads_ref.append(attn_bias.grad)
+            grads_name.append("bias")
+
+    del query
+    del key
+    del value
+    del qkv
+
+    assert len(grads_ref) == len(
+        grads
+    ), "Wrong number of gradients (maybe bias grad didn't backprop?)"
+    for name, calc_grad, ref_grad in zip(grads_name, grads, grads_ref):
+        assert_allclose(
+            calc_grad.to(ref_grad.device),
+            ref_grad,
+            msg=f"{op_fw.NAME}+{op_bw.NAME}:{name}",
+            atol=atol,
+            rtol=rtol,
+        )
+
+
+@cuda_or_mtia_only
+@pytest.mark.parametrize(
+    "opBW",
+    [
+        fmha.flash.BwOp,
+        fmha.ck.BwOp if torch.version.hip else fmha.cutlass.BwOp,
+        fmha.cutlass_blackwell.BwOp,
+    ],
+)
+def test_backward_gqa(opBW):
+    device = torch._C._get_accelerator().type
+
+    H = 8
+    B_Mq_Mkv_H_K_Kv = (3, 512, 512, H, 128, 128)
+    dtype = torch.float16
+    query, key, value, attn_bias = create_tensors(
+        *(opBW, device, dtype, type(None), *B_Mq_Mkv_H_K_Kv),
+        attn_bias_requires_grad=False,
+        fmt="BMHK",
+    )
+    op = (fmha.ck.FwOp if torch.version.hip else fmha.cutlass.FwOp, opBW)
+    key = key[:, :, :1].expand(-1, -1, H, -1)
+    value = value[:, :, :1].expand(-1, -1, H, -1)
+    key.requires_grad_(True)
+    out = fmha.memory_efficient_attention(query, key, value, attn_bias=attn_bias)
+    out.backward(query)
+    dk = key.grad
+    key.grad = None
+
+    if use_cpu_ref(device):
+        query = query.detach().cpu()
+        key = key.detach().cpu()
+        value = value.detach().cpu()
+        query.requires_grad_(True)
+        key.requires_grad_(True)
+        value.requires_grad_(True)
+
+    out_ref = ref_attention_bmhk_for_test(query, key, value, attn_bias=attn_bias)
+    out_ref.backward(query)
+
+    assert_allclose(
+        out.float().to(out_ref.device),
+        out_ref.float(),
+        atol=op[0].ERROR_ATOL[dtype],
+        rtol=op[0].ERROR_RTOL[dtype],
+    )
+    assert_allclose(
+        dk.float().to(key.grad.device),
+        key.grad.float(),
+        atol=op[1].ERROR_ATOL[dtype],
+        rtol=op[1].ERROR_RTOL[dtype],
+    )

--- a/test/attention/fmha/test_forward.py
+++ b/test/attention/fmha/test_forward.py
@@ -1,0 +1,262 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+# pyre-ignore-all-errors[29]
+
+import logging
+
+import pytest
+import torch
+
+try:
+    from mtia.re.re_unittest_lib import init_mtia_device  # type: ignore
+
+    init_mtia_device()
+except ImportError:
+    # Failed to load MTIA libraries, so just keep going without MTIA devices
+    pass
+
+from mslk.attention import fmha
+from mslk.attention.fmha import ALL_BW_OPS, ALL_FW_OPS
+from mslk.attention.fmha.attn_bias_utils import create_attn_bias
+from mslk.attention.fmha.unbind import unbind
+
+from .case_generation import (
+    _generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+    create_tensors,
+    get_supported_attn_bias_types,
+    make_id,
+)
+from .utils import (
+    _filter_unsupported_ops,
+    assert_allclose,
+    cuda_only,
+    cuda_or_mtia_only,
+    nanify_oob_seqlen,
+    ref_attention_for_test,
+)
+
+logger = logging.getLogger("xformers")
+
+ALL_FW_OPS = _filter_unsupported_ops(ALL_FW_OPS)
+ALL_BW_OPS = _filter_unsupported_ops(ALL_BW_OPS)
+
+parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv = pytest.mark.parametrize(
+    "opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    **_generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(ALL_FW_OPS),
+)
+parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs = pytest.mark.parametrize(
+    "opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    **_generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(ALL_FW_OPS, max_shapes_per_op=1),
+)
+parametrize_opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv__xs = pytest.mark.parametrize(
+    "opBW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    **_generate_op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv(ALL_BW_OPS, max_shapes_per_op=1),
+)
+
+
+@pytest.mark.parametrize("fmt", ["BMK", "BMHK"])
+@pytest.mark.parametrize("packed", [False, True])
+@parametrize_opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+def test_forward(opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, packed, fmt, **kwargs):
+    (
+        op,
+        device,
+        dtype,
+        bias_type,
+        batch_size,
+        q_len,
+        kv_len,
+        h,
+        k,
+        kv,
+    ) = opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+    if packed and issubclass(
+        bias_type,
+        (
+            fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+            fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+        ),
+    ):
+        pytest.skip(
+            "packed doesn't make sense with paged attention, since q has different shape than k/v"
+        )
+    if packed and not (k == kv and q_len == kv_len):
+        pytest.skip(
+            f"packed incompatible with `k ({k}) != kv ({kv})` or `q_len ({q_len}) != kv_len ({kv_len})`"
+        )
+    if fmt == "BMK" and not fmha.common._is_bias_type_supported_in_BMK(bias_type):
+        pytest.skip("BMK incompatible with this bias")
+
+    if op is fmha.ck.FwOp:
+        if (k > 256 or kv > 256) and issubclass(
+            bias_type,
+            (
+                fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+            ),
+        ):
+            pytest.skip("ck.FwOp hdim-512 is not supported when Paged-KVCache is used!")
+
+    query, key, value, attn_bias = create_tensors(
+        *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+        fmt="BMHK" if packed else fmt,
+        **kwargs,
+    )
+    if attn_bias is not None:
+        assert type(attn_bias.to(query.device)) is type(attn_bias)
+
+    if packed:
+        c = torch.stack([query, key, value], 2)
+        if fmt == "BMK":
+            # bm3hk -> 3bhmk -> 3Bmk
+            c = c.permute(2, 0, 3, 1, 4).view([3, -1, q_len, k])
+            query, key, value = c[0], c[1], c[2]
+            # Re-create bias in the right format
+            attn_bias = create_attn_bias(
+                bias_type=bias_type,
+                batch_size=batch_size,
+                num_heads=h,
+                num_heads_groups=1,
+                q_len=q_len,
+                kv_len=kv_len,
+                device=device,
+                dtype=dtype,
+                requires_grad=False,
+                fmt=fmt,
+                op=op,
+            )
+        elif fmt == "BMHK":
+            # bm3hk -> 3 x bmhk
+            query, key, value = unbind(c, 2)
+        else:
+            raise AssertionError(f"Unsupport fmt {fmt} with packing")
+        assert not query.is_contiguous()
+
+    out = fmha.memory_efficient_attention_forward(query, key, value, attn_bias, op=op)
+    assert not out.isnan().any(), ("Output has NaNs", attn_bias)
+    out2 = fmha.memory_efficient_attention_forward(
+        nanify_oob_seqlen(query),
+        nanify_oob_seqlen(key),
+        nanify_oob_seqlen(value),
+        attn_bias,
+        op=op,
+    )
+    assert not out2.isnan().any(), "Output has NaNs - most likely reading out-of-bounds"
+    assert torch.allclose(out, out2, atol=0.0, rtol=0.0), (
+        "Non-deterministic behavior",
+        attn_bias,
+    )
+
+    ref = ref_attention_for_test(query, key, value, attn_bias)
+    assert out.shape == ref.shape, out.shape
+    assert_allclose(
+        out.float(),
+        ref,
+        atol=op.ERROR_ATOL[dtype],
+        rtol=op.ERROR_RTOL.get(dtype, 1e-5),
+    )
+
+
+@cuda_or_mtia_only
+@pytest.mark.parametrize("Mq", [1, 512])
+@pytest.mark.parametrize(
+    "opFW_biasT",
+    [
+        (op, biasT)
+        for op in ALL_FW_OPS
+        for biasT in get_supported_attn_bias_types(op)
+        if op.SUPPORTS_BMGHK
+    ],
+    ids=lambda o: f"{o[0].NAME}-{o[1].__name__}" if isinstance(o, tuple) else "",
+)
+def test_forward_gqa(opFW_biasT, Mq: int):
+    device = torch._C._get_accelerator().type
+
+    opFW, biasT = opFW_biasT
+    if Mq < 512 and (
+        issubclass(biasT, fmha.attn_bias.LowerTriangularMask)
+        or issubclass(biasT, fmha.attn_bias.BlockDiagonalCausalMask)
+    ):
+        pytest.skip("undefined upper left")
+    B_Mq_Mkv_H_K_Kv = (3, Mq, 512, 16, 128, 128)
+    test_forward(
+        (
+            opFW,
+            device,
+            torch.float16,
+            biasT,
+            *B_Mq_Mkv_H_K_Kv,
+        ),
+        packed=False,
+        fmt="BMGHK",
+        g=2,
+    )
+
+
+shapes_triton_splitk = [
+    (1, 8, 2**16, 1, 128, 128),
+    (1, 4, 2**16, 1, 128, 128),
+    (1, 16, 2**16, 1, 128, 128),
+    (1, 16, 2**16, 1, 32, 32),
+    (1, 8, 1025, 1, 128, 128),
+    (2, 8, 4096, 1, 128, 128),
+    (10, 8, 2**16, 1, 128, 128),
+    (10, 15, 2**16, 1, 128, 128),
+    (1, 3, 2**16, 1, 128, 128),
+    (1, 3, 2**16 - 10, 1, 128, 128),
+    (2, 3, 73, 1, 128, 128),
+    (2, 7, 7328, 1, 128, 128),
+    (2, 7, 7328, 1, 120, 120),
+    (2, 7, 63, 1, 120, 120),
+]
+op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv_splitk = [
+    (fmha.triton_splitk.FwOp, "cuda", torch.float16, type(None), *s)
+    for s in shapes_triton_splitk
+] + [
+    (fmha.triton_splitk.FwOp, "cuda", torch.bfloat16, type(None), *s)
+    for s in shapes_triton_splitk
+]
+
+
+@pytest.mark.parametrize(
+    "opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv",
+    op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv_splitk,
+    ids=[make_id(*c) for c in op_device_dtype_biasT_B_Mq_Mkv_H_K_Kv_splitk],
+)
+@cuda_only
+def test_forward_splitk(
+    opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
+    packed=False,
+    fmt="BMHK",
+):
+    test_forward(opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, packed=packed, fmt=fmt)
+
+
+@cuda_only
+def test_forward_triton_split_k_autotune():
+    """
+    Generally we disable autotuning in tests for performance reasons,
+    add just one test with autotuning.
+    """
+
+    class SplitKAutotune(fmha.triton_splitk.FwOp):
+        AUTOTUNE = True
+
+    opFW = SplitKAutotune
+    biasT = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask
+    B_Mq_Mkv_H_K_Kv = (1, 1, 2048, 8, 128, 128)
+    test_forward(
+        (
+            opFW,
+            "cuda",
+            torch.bfloat16,
+            biasT,
+            *B_Mq_Mkv_H_K_Kv,
+        ),
+        packed=False,
+        fmt="BMHK",
+    )


### PR DESCRIPTION
Summary:
Break test_mem_eff_attention into 3 files (which are about equal work) and break all the files into separate targets.

Should make it a bit easier to get other diffs landed.

Reviewed By: danthe3rd

Differential Revision: D89404296


