### PR TITLE
Remove unused AVX flags from cmake

### DIFF
--- a/cmake/CxxCompilerSetup.cmake
+++ b/cmake/CxxCompilerSetup.cmake
@@ -46,33 +46,3 @@ endif()
 
 # Enable compile commands to compile_commands.json for debugging
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-################################################################################
-# Setup AVX2 and AVX512 Flags (for MSLK builds)
-################################################################################
-
-# Set flags for AVX2
-set(AVX2_FLAGS "-mavx2;-mf16c;-mfma;-fopenmp")
-if(NOT MSLK_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU AND WSL_MODE)
-  # NVCC in WSL complains about unknown -mavx options
-  # https://github.com/pytorch/fbgemm/issues/2135
-  set(AVX2_FLAGS "-Xcompiler;-mavx;-Xcompiler;-mavx2;-Xcompiler;-mf16c;-Xcompiler;-mfma;-fopenmp")
-endif()
-
-# Set flags for AVX512
-set(AVX512_FLAGS "-mavx2;-mf16c;-mfma;-mavx512f;-mavx512bw;-mavx512dq;-mavx512vl;-fopenmp")
-if(NOT MSLK_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU AND WSL_MODE)
-  set(AVX512_FLAGS "-Xcompiler;-mavx2;-Xcompiler;-mf16c;-Xcompiler;-mfma;-Xcompiler;-mavx512f;-Xcompiler;-mavx512bw;-Xcompiler;-mavx512dq;-Xcompiler;-mavx512vl;-fopenmp")
-endif()
-
-BLOCK_PRINT(
-  "AVX2_FLAGS:"
-  ""
-  "${AVX2_FLAGS}"
-)
-
-BLOCK_PRINT(
-  "AVX512_FLAGS:"
-  ""
-  "${AVX512_FLAGS}"
-)


### PR DESCRIPTION
Summary:
See fbgemm diff D90277087

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D90289749


