### PR TITLE
Fix BF16 Grouped GEMM wgrad allocation

### DIFF
--- a/csrc/gemm/cutlass/bf16bf16bf16_grouped_wgrad.cu
+++ b/csrc/gemm/cutlass/bf16bf16bf16_grouped_wgrad.cu
@@ -1067,7 +1067,15 @@ at::Tensor bf16bf16bf16_grouped_wgrad(
           "Output tensor must be BFloat16 when output_accum=False");
     }
   } else {
-    Y = at::empty(G * N * K, X.options().dtype(at::kBFloat16));
+    // When total_M is 0, we need to allocate zeros for the output since none
+    // will be written.
+    if (total_M == 0) {
+      Y = at::zeros({G, N, K}, X.options());
+      // Otherwise, using empty is more efficient since all N, K outputs are
+      // written.
+    } else {
+      Y = at::empty(G * N * K, X.options());
+    }
   }
 
   // Early exit for empty inputs.

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -1790,18 +1790,23 @@ class BF16Tests(unittest.TestCase):
         cls.device = torch.accelerator.current_accelerator()
 
     def generate_random_splits(G: int, M: int) -> torch.Tensor:
-        m_cumsums = torch.sort(
-            torch.randint(
-                0,
-                M,
-                (G + 1,),
-                dtype=torch.int32,
-                device=torch.accelerator.current_accelerator(),
+        if M > 0:
+            m_cumsums = torch.sort(
+                torch.randint(
+                    0,
+                    M,
+                    (G + 1,),
+                    dtype=torch.int32,
+                    device=torch.accelerator.current_accelerator(),
+                )
+            ).values
+            m_cumsums[0], m_cumsums[-1] = 0, M
+            m_sizes = m_cumsums[1:] - m_cumsums[:-1]
+            return m_sizes
+        else:
+            return torch.zeros(
+                (G,), dtype=torch.int32, device=torch.accelerator.current_accelerator()
             )
-        ).values
-        m_cumsums[0], m_cumsums[-1] = 0, M
-        m_sizes = m_cumsums[1:] - m_cumsums[:-1]
-        return m_sizes
 
     @unittest.skipIf(
         not torch.version.cuda,
@@ -1810,7 +1815,7 @@ class BF16Tests(unittest.TestCase):
     @settings(deadline=None)
     @given(
         G=st.sampled_from([2, 16]),
-        M=st.sampled_from([257, 2049]),
+        M=st.sampled_from([0, 257, 2049]),
         N=st.sampled_from([256, 2048]),
         K=st.sampled_from([128, 1024]),
         output_accum=st.booleans(),
@@ -1858,7 +1863,7 @@ class BF16Tests(unittest.TestCase):
         # Reference
         dy_fp32 = dy_bf16.to(torch.float32)
         x_fp32 = x_bf16.to(torch.float32)
-        ref_wgrad = torch.empty(
+        ref_wgrad = torch.zeros(
             (G, N, K),
             dtype=torch.float32,
             device=torch.accelerator.current_accelerator(),


### PR DESCRIPTION
Summary: This change fixes an issue in the bf16 grouped gemm wgrad kernel where outputs would be allocated with `torch.empty` even when `M=0`. For all `M!=0` cases, this is correct since the G*N*K outputs will be written and using empty is much more efficient than zeros. However, when M=0, we dont write any outputs, so we end up with uninitialized outputs. The best fix for this is to explicitly check total_M and use zero allocation for that case and empty for all others. I also extended the tests to make sure this behavior is tested and correct.

Differential Revision: D90558075


