### PR TITLE
[ROCm] hipify v2 fixes

### DIFF
--- a/cmake/RocmSetup.cmake
+++ b/cmake/RocmSetup.cmake
@@ -34,6 +34,24 @@ if(MSLK_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
     -mllvm -greedy-reverse-local-assignment=1
     -fhip-new-launch-api)
 
+  # is this hipify v2?
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c
+            "from torch.utils.hipify import __version__; print(__version__)"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE _tempvar
+    RESULT_VARIABLE _resvar
+    ERROR_VARIABLE _errvar)
+  if(NOT "${_resvar}" EQUAL "0")
+    message(WARNING "Failed to execute Python (${Python_EXECUTABLE})\n"
+      "Result: ${_resvar}\n"
+      "Error: ${_errvar}\n")
+  endif()
+  string(FIND "${_tempvar}" "2" found_pos)
+  if(found_pos GREATER_EQUAL 0)
+    list(APPEND HIP_HCC_FLAGS -DHIPIFY_V2)
+  endif()
+
   BLOCK_PRINT(
     "HIP found: ${HIP_FOUND}"
     "HIPCC compiler flags:"

--- a/csrc/attention/ck/fmha/hip_decoder/attention_forward_decoder.hip
+++ b/csrc/attention/ck/fmha/hip_decoder/attention_forward_decoder.hip
@@ -13,6 +13,10 @@
 
 #include "ck_attention_forward_decoder.h"
 
+#ifdef HIPIFY_V2
+#define getCurrentHIPStream getCurrentCUDAStream
+#endif
+
 namespace {
 constexpr int32_t kThreadsPerWavefront = 64;
 constexpr int32_t kWavefrontsPerBlock = 16;

--- a/csrc/attention/ck/fmha/hip_decoder/attention_forward_splitk.hip
+++ b/csrc/attention/ck/fmha/hip_decoder/attention_forward_splitk.hip
@@ -10,6 +10,10 @@
 
 #include "ck_tile_attention_forward_decoder_splitk.h"
 
+#ifdef HIPIFY_V2
+#define getCurrentHIPStream getCurrentCUDAStream
+#endif
+
 namespace {
 constexpr int32_t kThreadsPerWavefront = 64;
 constexpr int32_t kWavefrontsPerBlock = 4;

--- a/csrc/attention/ck/fmha/hip_fmha/attention_backward_generic_ck_tiled.hip
+++ b/csrc/attention/ck/fmha/hip_fmha/attention_backward_generic_ck_tiled.hip
@@ -17,6 +17,10 @@
 #include "ck_fmha_util.h"
 #include "ck_tiled_fmha_params.h"
 
+#ifdef HIPIFY_V2
+#define getCurrentHIPStream getCurrentCUDAStream
+#endif
+
 extern void batched_backward_fp16(
     BatchedBackwardParams& param,
     hipStream_t stream);

--- a/csrc/attention/ck/fmha/hip_fmha/attention_ck_rand_uniform.hip
+++ b/csrc/attention/ck/fmha/hip_fmha/attention_ck_rand_uniform.hip
@@ -18,6 +18,10 @@
 
 #include "ck_tiled_rand_uniform_kernel.h"
 
+#ifdef HIPIFY_V2
+#define getCurrentHIPStream getCurrentCUDAStream
+#endif
+
 namespace {
 
 /**

--- a/csrc/attention/ck/fmha/hip_fmha/attention_forward_generic_ck_tiled.hip
+++ b/csrc/attention/ck/fmha/hip_fmha/attention_forward_generic_ck_tiled.hip
@@ -23,6 +23,10 @@
 #include "ck_tiled_fmha_fwd_splitkv_selector.h"
 #include "ck_tiled_fmha_params.h"
 
+#ifdef HIPIFY_V2
+#define getCurrentHIPStream getCurrentCUDAStream
+#endif
+
 extern void batched_forward_fp16(
     BatchedForwardParams& param,
     hipStream_t stream);

--- a/csrc/quantize/ck/ck_utility.hip
+++ b/csrc/quantize/ck/ck_utility.hip
@@ -24,6 +24,10 @@
 #include "ck/host_utility/hip_check_error.hpp"
 #include "ck/utility/flush_icache.hpp"
 
+#ifdef HIPIFY_V2
+#define getCurrentHIPStream getCurrentCUDAStream
+#endif
+
 namespace mslk::quantize {
 
 void flush_icache_ck()


### PR DESCRIPTION
Prior to landing the pytorch hipify v2 PR, fixes are needed. Similar changes were made to FBGEMM in https://github.com/pytorch/FBGEMM/pull/4854. Since MSLK derives from FBGEMM, similar changes are needed here.

The fbgemm_gpu *.hip sources do not undergo additional hipify steps and they were written to assume pytorch's hipify v1 interfaces. Some small changes are necessary to make the sources more flexible to either hipify v1 or v2 torch APIs.