### PR TITLE
remove caffe2 from hipify

### DIFF
--- a/csrc/attention/ck/fmha/hip_decoder/attention_forward_decoder.hip
+++ b/csrc/attention/ck/fmha/hip_decoder/attention_forward_decoder.hip
@@ -100,7 +100,7 @@ at::Tensor& efficient_attention_forward_decoder_ck_out_impl(
   int32_t smem_output = K_MAX * sizeof(float) *
       threads.y; // 4 * threadsPerBlock * sizeof(float) == sizeof(O[b][0][h][:])
   const size_t lds_bytes = max(smem_softmax, smem_output);
-  auto stream = at::hip::getCurrentHIPStream().stream();
+  auto stream = at::cuda::getCurrentHIPStream().stream();
 
   AT_DISPATCH_SWITCH_3(
       at::ScalarType::Half,

--- a/csrc/attention/ck/fmha/hip_decoder/attention_forward_splitk.hip
+++ b/csrc/attention/ck/fmha/hip_decoder/attention_forward_splitk.hip
@@ -143,7 +143,7 @@ at::Tensor& efficient_attention_forward_decoder_splitk_ck_out_impl(
       WavefrontsPerBlock; // 4 * threadsPerBlock * sizeof(float) ==
                           // sizeof(O[b][0][h][:])
   const size_t attn_lds_bytes = max(smem_softmax, smem_output);
-  auto stream = at::hip::getCurrentHIPStream().stream();
+  auto stream = at::cuda::getCurrentHIPStream().stream();
 
   AT_DISPATCH_SWITCH_3(
       at::ScalarType::Half,

--- a/csrc/attention/ck/fmha/hip_fmha/attention_backward_generic_ck_tiled.hip
+++ b/csrc/attention/ck/fmha/hip_fmha/attention_backward_generic_ck_tiled.hip
@@ -115,7 +115,7 @@ efficient_attention_backward_ck(
     TORCH_CHECK(max_seqlen_k_.has_value());
   }
 
-  hipStream_t stream = at::hip::getCurrentHIPStream().stream();
+  hipStream_t stream = at::cuda::getCurrentHIPStream().stream();
 
   int64_t B = query.size(0);
   int64_t M = query.size(1);

--- a/csrc/attention/ck/fmha/hip_fmha/attention_ck_rand_uniform.hip
+++ b/csrc/attention/ck/fmha/hip_fmha/attention_ck_rand_uniform.hip
@@ -37,7 +37,7 @@ at::Tensor rand_uniform_int(
   int M = out_pattern.size(2);
   int N = out_pattern.size(3);
 
-  hipStream_t stream = at::hip::getCurrentHIPStream().stream();
+  hipStream_t stream = at::cuda::getCurrentHIPStream().stream();
 
   at::CUDAGeneratorImpl* gen =
       at::get_generator_or_default<at::CUDAGeneratorImpl>(

--- a/csrc/attention/ck/fmha/hip_fmha/attention_forward_generic_ck_tiled.hip
+++ b/csrc/attention/ck/fmha/hip_fmha/attention_forward_generic_ck_tiled.hip
@@ -120,7 +120,7 @@ efficient_attention_forward_ck(
   CHECK_NOSPARSE_LASTCONTIGUOUS_CUDA(key);
   CHECK_NOSPARSE_LASTCONTIGUOUS_CUDA(value);
 
-  hipStream_t stream = at::hip::getCurrentHIPStream().stream();
+  hipStream_t stream = at::cuda::getCurrentHIPStream().stream();
 
   int64_t B = query.size(0);
   int64_t M = query.size(1);


### PR DESCRIPTION
Summary:
Reland of https://github.com/pytorch/pytorch/issues/172796.  Which replaced https://github.com/pytorch/pytorch/issues/151845 due to infra issue with pytorchbot PAT and ROCm fork where PR branch was originally hosted.  Which was a reland of https://github.com/pytorch/pytorch/issues/137157.

- "MasqueradingAsCUDA" files and classes thinly wrap their corresponding CUDA classes.
- Do not rename "CUDA" classes to "HIP".

cc sunway513 jithunnair-amd pruthvistony ROCmSupport jataylo hongxiayang naromero77amd pragupta jerrymannil xinyazhang voznesenskym penguinwu EikanWang jgong5 Guobing-Chen XiaobingSuper zhuhaozhe blzheng wenzhe-nrv jiayisunx ipiszy kadeng muchulee8 amjames chauhang aakhundov coconutruben

X-link: https://github.com/pytorch/pytorch/pull/174087

Reviewed By: malfet

Differential Revision: D92063294

Pulled By: atalman


