### PR TITLE
Fix workflow to extract pytorch channel first before passing to build_fbgemm_gpu_package

### DIFF
--- a/.github/workflows/_mslk_cuda_build.yml
+++ b/.github/workflows/_mslk_cuda_build.yml
@@ -121,7 +121,14 @@ jobs:
       run: . $PRELUDE; prepare_mslk_build $BUILD_ENV
 
     - name: Build MSLK Wheel
-      run: . $PRELUDE; build_mslk_package $BUILD_ENV ${{ inputs.pytorch-channel-version }} ${{ matrix.build-target }}/cuda
+      run: |
+        . $PRELUDE
+
+        # Extract channel from channel/version string
+        PYTORCH_CHANNEL_VERSION="${{ inputs.pytorch-channel-version }}"
+        PYTORCH_CHANNEL_ONLY="${PYTORCH_CHANNEL_VERSION%%/*}"
+
+        build_mslk_package $BUILD_ENV "$PYTORCH_CHANNEL_ONLY" ${{ matrix.build-target }}/cuda
 
     - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/_mslk_rocm_build.yml
+++ b/.github/workflows/_mslk_rocm_build.yml
@@ -123,7 +123,14 @@ jobs:
       run: . $PRELUDE; prepare_mslk_build $BUILD_ENV
 
     - name: Build MSLK Wheel
-      run: . $PRELUDE; build_mslk_package $BUILD_ENV nightly ${{ matrix.build-target }}/rocm
+      run: |
+        . $PRELUDE
+
+        # Extract channel from channel/version string
+        PYTORCH_CHANNEL_VERSION="${{ inputs.pytorch-channel-version }}"
+        PYTORCH_CHANNEL_ONLY="${PYTORCH_CHANNEL_VERSION%%/*}"
+
+        build_mslk_package $BUILD_ENV "$PYTORCH_CHANNEL_ONLY" ${{ matrix.build-target }}/rocm
 
     - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Summary: - Fix workflow to extract pytorch channel first before passing to build_fbgemm_gpu_package

Differential Revision: D92442795


