### PR TITLE
Fix Pyre type error in CutlassBlackwellFmhaFunc.backward

### DIFF
--- a/mslk/attention/cutlass_blackwell_fmha/cutlass_blackwell_fmha_interface.py
+++ b/mslk/attention/cutlass_blackwell_fmha/cutlass_blackwell_fmha_interface.py
@@ -433,9 +433,10 @@ class CutlassBlackwellFmhaFunc(torch.autograd.Function):
         return out
 
     @staticmethod
+    # pyre-ignore[14]: Signature matches PyTorch autograd convention
     def backward(
-        ctx, dout: torch.Tensor, *args: Any
-    ) -> tuple[  # type: ignore
+        ctx: Any, *grad_outputs: Any
+    ) -> tuple[
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
@@ -452,6 +453,7 @@ class CutlassBlackwellFmhaFunc(torch.autograd.Function):
         None,
         None,
     ]:
+        dout: torch.Tensor = grad_outputs[0]
         if ctx.is_gen:
             # For gen case, no backward pass is needed (generation is inference only)
             raise RuntimeError(


### PR DESCRIPTION
Summary: The backward method signature was inconsistent with PyTorch's _SingleLevelFunction.backward parent class. Changed the signature from `backward(ctx, dout: torch.Tensor, *args)` to `backward(ctx: Any, *grad_outputs: Any)` and extract dout from grad_outputs[0]. Added pyre-ignore comment since this is the standard PyTorch autograd convention.

Reviewed By: cthi

Differential Revision: D92659906


