### PR TITLE
Fix 'enviroment' -> 'environment' in comments, docs, and display strings

### DIFF
--- a/ci/integration/mslk_oss_build.bash
+++ b/ci/integration/mslk_oss_build.bash
@@ -49,7 +49,7 @@ elif [[ "$BUILD_VARIANT" == "cuda" ]]; then
 echo "BUILD_CUDA_VERSION        : $BUILD_CUDA_VERSION"
 fi
 echo ""
-echo "Target Conda Enviroment   : $BUILD_ENV"
+echo "Target Conda Environment   : $BUILD_ENV"
 echo ""
 echo "################################################################################"
 
@@ -67,7 +67,7 @@ else
   setup_miniconda "$HOME/miniconda" || exit 1
 fi
 
-# Set up the Conda enviroment for building the package
+# Set up the Conda environment for building the package
 echo "[MSLK CI] Setting up the conda environment ..."
 integration_setup_conda_environment "$BUILD_ENV" gcc "$PYTHON_VERSION" "$PYTORCH_VERSION" "$BUILD_VARIANT/$BUILD_VARIANT_VERSION" || exit 1
 


### PR DESCRIPTION
Summary:
Fix misspelling of "environment" in comments, documentation, JSDoc comments, help text, echo strings, log messages, and description strings across fbcode/ and xplat/. All changes are limited to non-functional text — no identifiers or API-facing strings are affected.

Skipped: generated code (generated), third-party code (TVM, WebRTC, Boost, VS Code extensions), GraphQL schema identifiers, exported type/context names (CosplayEnviromentContext), public method names, Manifold paths, URL paths, icon glyph names, and spelling dictionary entries.

Differential Revision: D92873933


