### PR TITLE
Add MXFP4 GEMM with 1x16 block size (mxfp4_16)

### DIFF
--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_1_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_1_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_128_1_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 128, 1, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 128, 1, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 128, 1, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_1_2_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_1_2_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_128_1_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 128, 1, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 128, 1, 2, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 128, 1, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_1_4_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_1_4_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_128_1_4_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 128, 1, 4, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 128, 1, 4, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 128, 1, 4, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_2_2_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_2_2_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_128_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 128, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 128, 2, 2, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 128, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_4_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_4_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_128_4_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 128, 4, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 128, 4, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 128, 4, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_4_2_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_128_4_2_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_128_4_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 128, 4, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 128, 4, 2, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 128, 4, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_192_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_192_2_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_192_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 192, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 192, 2, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 192, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_192_2_2_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_192_2_2_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_192_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 192, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 192, 2, 2, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 192, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_192_4_2_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_192_4_2_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_192_4_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 192, 4, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 192, 4, 2, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 192, 4, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_128_256_2_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_128_256_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 128, 256, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 128, 256, 2, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 128, 256, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_128_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_128_2_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_128_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 128, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 128, 2, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 128, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_128_2_2_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_128_2_2_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_128_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 128, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 128, 2, 2, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 128, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_128_2_4_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_128_2_4_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_128_2_4_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 128, 2, 4, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 128, 2, 4, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 128, 2, 4, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_128_4_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_128_4_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_128_4_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 128, 4, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 128, 4, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 128, 4, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_192_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_192_2_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_192_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 192, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 192, 2, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 192, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_192_2_2_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_192_2_2_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_192_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 192, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 192, 2, 2, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 192, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_192_2_4_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_192_2_4_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_192_2_4_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 192, 2, 4, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 192, 2, 4, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 192, 2, 4, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_192_4_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_192_4_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_192_4_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 192, 4, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 192, 4, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 192, 4, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_256_2_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_256_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 256, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 256, 2, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 256, 2, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_256_2_2_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_256_2_2_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_256_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 256, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 256, 2, 2, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 256, 2, 2, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_256_2_4_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_256_2_4_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_256_2_4_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 256, 2, 4, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 256, 2, 4, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 256, 2, 4, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_256_4_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_256_256_4_1_1.cu
@@ -18,11 +18,18 @@ at::Tensor f4f4bf16_256_256_4_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale) {
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size) {
   if (global_scale) {
+    // NVFP4: uses global_scale, block_size parameter ignored
     return _f4f4bf16<NVFP4, 256, 256, 4, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
+  } else if (mxfp4_block_size == 16) {
+    // MXFP4_16: 1x16 block size with E8M0 scales
+    return _f4f4bf16<MXFP4_16, 256, 256, 4, 1, 1>(
+        XQ, WQ, x_scale, w_scale, output, global_scale);
   } else {
+    // MXFP4: standard 1x32 block size (default)
     return _f4f4bf16<MXFP4, 256, 256, 4, 1, 1>(
         XQ, WQ, x_scale, w_scale, output, global_scale);
   }

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_common.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_common.cuh
@@ -28,6 +28,8 @@ namespace cutlass = cutlass_mslk;
 
 using MXFP4 = cutlass::mx_float4_t<cutlass::float_e2m1_t>;
 using NVFP4 = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
+// MXFP4 with 1x16 block size
+using MXFP4_16 = cutlass::mx_float4_16_t<cutlass::float_e2m1_t>;
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 

--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_manifest.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_manifest.cuh
@@ -18,7 +18,8 @@ at::Tensor f4f4bf16_128_128_1_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_128_128_1_2_1(
     at::Tensor XQ, // FP4
@@ -26,7 +27,8 @@ at::Tensor f4f4bf16_128_128_1_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_128_128_1_4_1(
     at::Tensor XQ, // FP4
@@ -34,7 +36,8 @@ at::Tensor f4f4bf16_128_128_1_4_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_128_128_2_2_1(
     at::Tensor XQ, // FP4
@@ -42,7 +45,8 @@ at::Tensor f4f4bf16_128_128_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_128_128_4_1_1(
     at::Tensor XQ, // FP4
@@ -50,7 +54,8 @@ at::Tensor f4f4bf16_128_128_4_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_128_128_4_2_1(
     at::Tensor XQ, // FP4
@@ -58,7 +63,8 @@ at::Tensor f4f4bf16_128_128_4_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_128_192_2_1_1(
     at::Tensor XQ, // FP4
@@ -66,7 +72,8 @@ at::Tensor f4f4bf16_128_192_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_128_192_2_2_1(
     at::Tensor XQ, // FP4
@@ -74,7 +81,8 @@ at::Tensor f4f4bf16_128_192_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_128_192_4_2_1(
     at::Tensor XQ, // FP4
@@ -82,7 +90,8 @@ at::Tensor f4f4bf16_128_192_4_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_128_256_2_1_1(
     at::Tensor XQ, // FP4
@@ -90,7 +99,8 @@ at::Tensor f4f4bf16_128_256_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_128_2_1_1(
     at::Tensor XQ, // FP4
@@ -98,7 +108,8 @@ at::Tensor f4f4bf16_256_128_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_128_2_2_1(
     at::Tensor XQ, // FP4
@@ -106,7 +117,8 @@ at::Tensor f4f4bf16_256_128_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_128_2_4_1(
     at::Tensor XQ, // FP4
@@ -114,7 +126,8 @@ at::Tensor f4f4bf16_256_128_2_4_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_128_4_1_1(
     at::Tensor XQ, // FP4
@@ -122,7 +135,8 @@ at::Tensor f4f4bf16_256_128_4_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_192_2_1_1(
     at::Tensor XQ, // FP4
@@ -130,7 +144,8 @@ at::Tensor f4f4bf16_256_192_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_192_2_2_1(
     at::Tensor XQ, // FP4
@@ -138,7 +153,8 @@ at::Tensor f4f4bf16_256_192_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_192_2_4_1(
     at::Tensor XQ, // FP4
@@ -146,7 +162,8 @@ at::Tensor f4f4bf16_256_192_2_4_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_192_4_1_1(
     at::Tensor XQ, // FP4
@@ -154,7 +171,8 @@ at::Tensor f4f4bf16_256_192_4_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_256_2_1_1(
     at::Tensor XQ, // FP4
@@ -162,7 +180,8 @@ at::Tensor f4f4bf16_256_256_2_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_256_2_2_1(
     at::Tensor XQ, // FP4
@@ -170,7 +189,8 @@ at::Tensor f4f4bf16_256_256_2_2_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_256_2_4_1(
     at::Tensor XQ, // FP4
@@ -178,7 +198,8 @@ at::Tensor f4f4bf16_256_256_2_4_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
 at::Tensor f4f4bf16_256_256_4_1_1(
     at::Tensor XQ, // FP4
@@ -186,15 +207,20 @@ at::Tensor f4f4bf16_256_256_4_1_1(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> global_scale);
+    std::optional<at::Tensor> global_scale,
+    int64_t mxfp4_block_size);
 
+// Kernel function pointer type
+// mxfp4_block_size: 32 for standard MXFP4 (1x32 block), 16 for MXFP4_16 (1x16
+// block)
 using Kernel_f4f4bf16 = at::Tensor (*)(
     at::Tensor,
     at::Tensor,
     at::Tensor,
     at::Tensor,
     at::Tensor,
-    std::optional<at::Tensor>);
+    std::optional<at::Tensor>,
+    int64_t);
 
 #endif
 } // namespace mslk::gemm

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -52,7 +52,7 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
 #else
   m.def("i8i8bf16(Tensor XQ, Tensor WQ, float scale, int split_k=1) -> Tensor");
   m.def(
-      "f4f4bf16(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? output=None, Tensor? global_scale=None) -> Tensor");
+      "f4f4bf16(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? output=None, Tensor? global_scale=None, int mxfp4_block_size=32) -> Tensor");
   m.def(
       "f4f4bf16_grouped_stacked(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes, Tensor? global_scale=None, Tensor? starting_row_after_padding=None, bool use_mx=True) -> Tensor");
   m.def(
@@ -198,7 +198,8 @@ at::Tensor f4f4bf16_meta(
     at::Tensor /* x_scale */,
     at::Tensor /* w_scale */,
     std::optional<at::Tensor> /* output = std::nullopt */,
-    std::optional<at::Tensor> /* global_scale = std::nullopt */) {
+    std::optional<at::Tensor> /* global_scale = std::nullopt */,
+    int64_t /* mxfp4_block_size = 32 */) {
   const at::SymInt M = XQ.sym_size(0);
   const at::SymInt N = WQ.sym_size(0);
   auto Y = at::empty_symint({M, N}, XQ.options().dtype(at::kBFloat16));

--- a/include/mslk/gemm/gemm_torch.h
+++ b/include/mslk/gemm/gemm_torch.h
@@ -44,13 +44,23 @@ at::Tensor f4f4bf16_grouped_mm(
     std::optional<at::Tensor> output = std::nullopt,
     std::optional<at::Tensor> global_scale = std::nullopt);
 
+// FP4 GEMM supporting NVFP4, MXFP4 (1x32 block), and MXFP4_16 (1x16 block)
+//
+// Format selection:
+// - NVFP4: Provide global_scale (mxfp4_block_size is ignored)
+// - MXFP4 (1x32): No global_scale, mxfp4_block_size = 32 (default)
+// - MXFP4_16 (1x16): No global_scale, mxfp4_block_size = 16
+//
+// MXFP4_16 is a hybrid format that uses MXFP4's E8M0 scale factors with
+// NVFP4's 16-element block size, enabling finer-grained quantization.
 at::Tensor f4f4bf16(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
     std::optional<at::Tensor> output = std::nullopt,
-    std::optional<at::Tensor> global_scale = std::nullopt);
+    std::optional<at::Tensor> global_scale = std::nullopt,
+    int64_t mxfp4_block_size = 32);
 
 #endif
 

--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -5576,6 +5576,8 @@ def triton_quantize_nvfp4_kernel(
     USE_E8M0_SCALE: tl.constexpr,
 ):
     E4M3_EPS = 1.5258789e-05
+    FP4_E2M1_MAX = 6.0
+    FP8_E4M3_MAX = 448.0
 
     NUM_ELEM_PER_LAYOUT = 128 * 4
     NUM_N_BLOCKS = tl.cdiv(N, 64)


### PR DESCRIPTION
Summary:
We submitted a paper to improve the representation fidelity of the MXFP4 format with Software algorithms [here](https://fb.workplace.com/groups/831302610278251/permalink/33525534057095017/)
There are multiple startegies in the paper. The two most straight forward algorithms are
1. Reduce the block size from 1x32 to 1x16
2. Use th OAS rounding for the E8M0 scaling factor. The OAS rounding algorithm is called "Even" rounding in the MSLK stack.

This diff tries to enable the 1x16 GEMM so we can leverage these two new ideas in real MXFP4 use cases.

Add support for MXFP4_16 format - a hybrid MXFP4 variant that combines:
- E8M0 scale factors (same as standard MXFP4)
- 16-element block size (same as NVFP4)

This enables finer-grained quantization compared to standard MXFP4's 32-element
blocks, potentially improving model accuracy for certain workloads.

The MXFP4_16 format is integrated into the existing f4f4bf16 function via a new
'mxfp4_block_size' parameter (default=32 for backward compatibility):
- mxfp4_block_size=32: Standard MXFP4 with 1x32 block size
- mxfp4_block_size=16: MXFP4_16 with 1x16 block size (same granularity as NVFP4)

Changes:
- Add blockscaled_type type definition in cutlass sm1xx_common.inl
- Add mx_float4_16_t type definition in cutlass float_subbyte.h
- Add MXFP4_16 type alias in f4f4bf16_common.cuh
- Update all 21 kernel files to support MXFP4_16 via the mxfp4_block_size parameter
- Update f4f4bf16_manifest.cuh with unified function signatures
- Update f4f4bf16.cu entry point and heuristics
- Update PyTorch operator bindings in gemm_ops.cpp
- Update function declaration in gemm_torch.h
- Added unit tests to test the new MXFP4-16 GEMMs

Reviewed By: cthi

Differential Revision: D91929697


