### PR TITLE
Sync cutlass blackwell FMHA to v4.4

### DIFF
--- a/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_fmha.cu
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_fmha.cu
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1045,14 +1045,18 @@ int main_single(int argc, char const **args) {
     return -1;
   }
 
-  if (__CUDACC_VER_MAJOR__ < 12 || props.major != 10) {
-    std::cout
-      << "This example requires a GPU of NVIDIA's Blackwell Architecture "
-      << "(compute capability major 10) and CUDA 12.8 or greater.\n";
+  if (__CUDACC_VER_MAJOR__ < 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8)) {
+    std::cerr << "This example requires CUDA 12.8 or newer." << std::endl;
+    // Returning zero so this test passes on older Toolkits. Its actions are no-op.
     return 0;
   }
 
-  //
+  if (props.major != 10) {
+    std::cerr
+      << "This example requires a GPU of NVIDIA's Blackwell Architecture "
+      << "(compute capability 100a)." << std::endl;
+    return 0;
+  }  //
   // Parse options
   //
 

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_fmha_bwd.cu
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_fmha_bwd.cu
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2025 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -942,13 +942,18 @@ int main_single(int argc, char const **args) {
     return -1;
   }
 
-  if (__CUDACC_VER_MAJOR__ < 12 || props.major != 10) {
-    std::cout
-      << "This example requires a GPU of NVIDIA's Blackwell Architecture "
-      << "(compute capability 100a) and CUDA 12.8 or greater.\n";
+  if (__CUDACC_VER_MAJOR__ < 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8)) {
+    std::cerr << "This example requires CUDA 12.8 or newer." << std::endl;
+    // Returning zero so this test passes on older Toolkits. Its actions are no-op.
     return 0;
   }
-  
+
+  if (props.major != 10) {
+    std::cerr
+      << "This example requires a GPU of NVIDIA's Blackwell Architecture "
+      << "(compute capability 100a)." << std::endl;
+    return 0;
+  }  
   //
   // Parse options
   //

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_fmha_gen.cu
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_fmha_gen.cu
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -499,7 +499,7 @@ struct ExampleRunner {
       initialize_block(block_new_v, seed + 2021, options.init_style_new_v);
     }
 
-    initialize_block(block_cache_k, seed + 2024 - 2025, options.init_style_cache_k);
+    initialize_block(block_cache_k, seed + 2024 - 2026, options.init_style_cache_k);
     initialize_block(block_cache_v, seed + 2025, options.init_style_cache_v);
 
     block_ref_cache_k.copy_from_device(block_cache_k.get(), block_cache_k.size());
@@ -723,12 +723,20 @@ int main_single(int argc, char const **args) {
     return -1;
   }
 
-  if (__CUDACC_VER_MAJOR__ < 12 || props.major < 10) {
-    std::cout
-      << "This example requires a GPU of NVIDIA's Blackwell Architecture or "
-      << "later (compute capability 90 or greater) and CUDA 12.0 or greater.\n";
+  if (__CUDACC_VER_MAJOR__ < 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8)) {
+    std::cerr << "This example requires CUDA 12.8 or newer." << std::endl;
+    // Returning zero so this test passes on older Toolkits. Its actions are no-op.
     return 0;
   }
+
+  if (props.major != 10 || (props.minor != 0 && props.minor != 3)) {
+    std::cout
+      << "This example requires a GPU of NVIDIA's Blackwell Datacenter-class Architecture "
+      << "(compute capability 100 or 103) and CUDA 12.0 or greater.\n";
+    return 0;
+  }
+
+
   //
   // Parse options
   //

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_mla.cu
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_mla.cu
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -76,7 +76,11 @@ struct Options {
   int split_kv = -1; // number of split along k dim.
   bool is_var_split_kv = false;
   int max_split_kv = 16;
+#ifdef CPASYNC
+  int page = 1;
+#else
   int page = -1;
+#endif
   float spread = 0.2f;
   int iterations = 3;
   bool verify = false;
@@ -261,7 +265,7 @@ struct ExampleResult {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+#if (defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM103_SUPPORTED))
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -752,7 +756,7 @@ void run_mla(Options const & options, cutlass::KernelHardwareInfo const& hw_info
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#endif // defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+#endif // defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM103_SUPPORTED)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -767,13 +771,18 @@ int main_single(int argc, char const **args) {
     return -1;
   }
 
-  if (__CUDACC_VER_MAJOR__ < 12 || props.major != 10) {
-    std::cout
-      << "This example requires a GPU of NVIDIA's Blackwell Architecture "
-      << "(compute capability major 10) and CUDA 12.8 or greater.\n";
+  if (__CUDACC_VER_MAJOR__ < 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8)) {
+    std::cerr << "This example requires CUDA 12.8 or newer." << std::endl;
+    // Returning zero so this test passes on older Toolkits. Its actions are no-op.
     return 0;
   }
 
+  if (props.major != 10) {
+    std::cerr
+      << "This example requires a GPU of NVIDIA's Blackwell Architecture "
+      << "(compute capability 100a)." << std::endl;
+    return 0;
+  }
   //
   // Parse options
   //
@@ -792,7 +801,7 @@ int main_single(int argc, char const **args) {
     return -1;
   }
 
-#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+#if (defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM103_SUPPORTED))
 
   //
   // Run examples

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_mla_fwd.cu
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/77_blackwell_mla_fwd.cu
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -973,10 +973,16 @@ int main_single(int argc, char const **args) {
     return -1;
   }
 
-  if (__CUDACC_VER_MAJOR__ < 12 || props.major != 10) {
-    std::cout
+  if (__CUDACC_VER_MAJOR__ < 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8)) {
+    std::cerr << "This example requires CUDA 12.8 or newer." << std::endl;
+    // Returning zero so this test passes on older Toolkits. Its actions are no-op.
+    return 0;
+  }
+
+  if (props.major != 10) {
+    std::cerr
       << "This example requires a GPU of NVIDIA's Blackwell Architecture "
-      << "(compute capability major 10) and CUDA 12.8 or greater.\n";
+      << "(compute capability 100a)." << std::endl;
     return 0;
   }
 

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/CMakeLists.txt
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2014 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # Redistribution and use in source and binary forms, with or without
@@ -112,7 +112,7 @@ set(TEST_MLA_FUSE_REDUCTION --b=1 --k=4096 --split_kv=8 --page=128 --fuse_reduct
 
 set(TEST_MLA_LARGE_SPLIT_KV --verify --split_kv=20 --page=128)
 
-if(NOT WIN32 AND (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) AND (CUTLASS_NVCC_ARCHS MATCHES 100a))
+if(NOT WIN32 AND (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) AND (CUTLASS_NVCC_ARCHS MATCHES 100a OR CUTLASS_NVCC_ARCHS MATCHES 103a))
 
   foreach(PREC fp8 fp16)
     string(TOUPPER "${PREC}" PREC_MACRO)

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/README.md
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/README.md
@@ -69,9 +69,11 @@ For detailed information on how to invoke them, check out either the tests in `C
 
 * 4.3.0: For variable sequence length, the code requires a batch of valid (but never used) padding memory ahead of the first output batch. No padding is needed for the input tensor, but it requires that the input tensor contain no NaN or Inf values. Note that users should set `total_length` to the `problem_shape`.
 
+* 4.4.0: Added support for Blackwell Ultra (Sm103).
+
 # Copyright
 
-Copyright (c) 2017 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 
 ```

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/fmha_common.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/fmha_common.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/fmha_fusion.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/fmha_fusion.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_fwd_epilogue_tma_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_fwd_epilogue_tma_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_fwd_mainloop_tma_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_fwd_mainloop_tma_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_gen_epilogue_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_gen_epilogue_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_gen_mainloop_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_gen_mainloop_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_load_cpasync_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_load_cpasync_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_load_tma_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_load_tma_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_mla_fwd_mainloop_tma_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_mla_fwd_mainloop_tma_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_mla_load_tma_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_mla_load_tma_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/common/pipeline_mla.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/common/pipeline_mla.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/common/pow_2.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/common/pow_2.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2023 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/device/fmha.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/device/fmha.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/device/fmha_device_bwd.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/device/fmha_device_bwd.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2025 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/device/sm100_mla.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/device/sm100_mla.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_causal_tile_scheduler.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_causal_tile_scheduler.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_kernel_bwd_convert.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_kernel_bwd_convert.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2025 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -70,7 +70,7 @@ struct FmhaKernelBwdConvert {
 
   static const int MinBlocksPerMultiprocessor = 1;
   static const int MaxThreadsPerBlock = 128;
-  using ArchTag = cutlass::arch::Sm90;
+  using ArchTag = cutlass::arch::Sm100;
 
   static const int kBlockSeq = 128;
 

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_kernel_bwd_sum_OdO.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_kernel_bwd_sum_OdO.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2025 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_options.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_options.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_tile_scheduler.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/fmha_tile_scheduler.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_bwd_kernel_tma_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_bwd_kernel_tma_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2025  - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025  - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1657,8 +1657,8 @@ struct Sm100FmhaBwdKernelTmaWarpSpecialized {
 
 
   CUTLASS_DEVICE void operator()(Params const& params, char* smem) {
-#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && \
-     ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED))
+#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else
     int warp_idx = cutlass::canonical_warp_idx_sync();

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_bwd_mla_kernel_tma_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_bwd_mla_kernel_tma_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2025  - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025  - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1481,8 +1481,8 @@ struct Sm100FmhaBwdMlaKernelTmaWarpSpecialized {
 
 
   CUTLASS_DEVICE void operator()(Params const& params, char* smem) {
-#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && \
-     ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED))
+#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else
     int warp_idx = cutlass::canonical_warp_idx_sync();

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_fwd_kernel_tma_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_fwd_kernel_tma_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -265,8 +265,8 @@ struct Sm100FmhaFwdKernelTmaWarpspecialized {
   }
 
   CUTLASS_DEVICE void operator()(const Params &params, char* smem) {
-#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && \
-     ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED))
+#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else
 

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_gen_kernel_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_gen_kernel_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -316,8 +316,8 @@ struct Sm100FmhaGenKernelWarpspecialized {
   }
 
   CUTLASS_DEVICE void operator()(const Params &params, char* smem) {
-#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && \
-     ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED))
+#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else
 

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_mla_reduction.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_mla_reduction.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_mla_tma_warpspecialized.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_mla_tma_warpspecialized.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -508,8 +508,8 @@ struct Sm100FmhaMlaKernelTmaWarpspecialized {
 
 
   CUTLASS_DEVICE void operator()(Params const& params, char* smem_raw) {
-#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && \
-     ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED))
+#if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else
 

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_mla_tile_scheduler.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_mla_tile_scheduler.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/reference/fmha_bwd_reference.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/reference/fmha_bwd_reference.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2025 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/reference/fmha_fwd_gen_reference.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/reference/fmha_fwd_gen_reference.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/reference/fmha_fwd_reference.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/reference/fmha_fwd_reference.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/reference/fmha_mla_reference.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/reference/fmha_mla_reference.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/reference/reference_abs_error.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/reference/reference_abs_error.hpp
@@ -1,6 +1,6 @@
 // @nolint
 /***************************************************************************************************
- * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Summary:
Sync Example 77 Blackwell FMHA in mslk with upstream cutlass v4.4.

https://github.com/NVIDIA/cutlass/commit/8dbce014737cd2aa2e7ec58a204703645d8139a0

Differential Revision: D93149670
