### PR TITLE
Fix CUTLASS grouped GEMM wgrad NaN for zero-token experts

### DIFF
--- a/csrc/gemm/cutlass/bf16bf16bf16_grouped_wgrad.cu
+++ b/csrc/gemm/cutlass/bf16bf16bf16_grouped_wgrad.cu
@@ -1080,15 +1080,7 @@ at::Tensor bf16bf16bf16_grouped_wgrad(
           "Output tensor must be BFloat16 or Float16 when output_accum=False");
     }
   } else {
-    // When total_M is 0, we need to allocate zeros for the output since none
-    // will be written.
-    if (total_M == 0) {
-      Y = at::zeros({G, N, K}, X.options());
-      // Otherwise, using empty is more efficient since all N, K outputs are
-      // written.
-    } else {
-      Y = at::empty(G * N * K, X.options());
-    }
+    Y = at::zeros({G, N, K}, X.options());
   }
 
   // Early exit for empty inputs.

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -2064,6 +2064,132 @@ class BF16Tests(unittest.TestCase):
             y_half_Y_preallocated, ref_y_half, atol=1e-3, rtol=1.6e-2
         )
 
+    @unittest.skipIf(
+        not torch.version.cuda,
+        "Skip on AMD: test not yet supported.",
+    )
+    @settings(deadline=None)
+    @given(
+        N=st.sampled_from([256, 2048]),
+        K=st.sampled_from([128, 1024]),
+        dtype=st.sampled_from([torch.bfloat16, torch.float16]),
+        output_accum=st.booleans(),
+        all_zero=st.booleans(),
+    )
+    def test_grouped_gemm_wgrad_zero_token_experts(
+        self,
+        N: int,
+        K: int,
+        dtype: torch.dtype,
+        output_accum: bool,
+        all_zero: bool,
+    ) -> None:
+        """Test wgrad produces zeros (not NaN) for experts with zero tokens.
+
+        Covers two cases:
+        - all_zero=True:  total_M == 0, all experts receive zero tokens.
+        - all_zero=False: total_M > 0, some experts receive tokens, others don't.
+        """
+        G = 8
+        if all_zero:
+            M = 0
+            m_sizes = torch.zeros(
+                G, dtype=torch.int32, device=torch.accelerator.current_accelerator()
+            )
+            zero_experts = list(range(G))
+        else:
+            M = 100
+            m_sizes = torch.zeros(
+                G, dtype=torch.int32, device=torch.accelerator.current_accelerator()
+            )
+            # Experts 0, 3, 5 get tokens; others get zero
+            m_sizes[0] = 40
+            m_sizes[3] = 30
+            m_sizes[5] = 30
+            zero_experts = [1, 2, 4, 6, 7]
+
+        torch.manual_seed(hash((G, M, N, K)))
+        dy_bf16 = torch.randn(
+            (M, N), dtype=dtype, device=torch.accelerator.current_accelerator()
+        )
+        x_bf16 = torch.randn(
+            (M, K), dtype=dtype, device=torch.accelerator.current_accelerator()
+        )
+
+        if output_accum:
+            wgrad_accum = torch.randn(
+                (G, N, K),
+                dtype=torch.float32,
+                device=torch.accelerator.current_accelerator(),
+            )
+        else:
+            wgrad_accum = None
+
+        sm_margin = 0
+        num_sms = (
+            torch.cuda.get_device_properties("cuda").multi_processor_count - sm_margin
+        )
+
+        # Poison the CUDA caching allocator by running the same kernel with all
+        # experts having tokens, producing a non-zero output buffer of exactly
+        # G*N*K elements. When freed, the caching allocator will reuse this
+        # dirty block for the next at::empty(G*N*K, ...) call inside the kernel.
+        # Zero-token experts then retain stale non-zero values.
+        warmup_M = G * 10
+        warmup_dy = torch.randn(
+            (warmup_M, N),
+            dtype=dtype,
+            device=torch.accelerator.current_accelerator(),
+        )
+        warmup_x = torch.randn(
+            (warmup_M, K),
+            dtype=dtype,
+            device=torch.accelerator.current_accelerator(),
+        )
+        warmup_m_sizes = torch.full(
+            (G,), 10, dtype=torch.int64, device=torch.accelerator.current_accelerator()
+        )
+        warmup_result = torch.ops.mslk.bf16bf16bf16_grouped_wgrad(
+            warmup_dy,
+            warmup_x,
+            warmup_m_sizes,
+            output_accum=False,
+            num_sms=num_sms,
+        )
+        assert warmup_result.abs().sum() > 0, "Warmup should produce non-zero output"
+        del warmup_result, warmup_dy, warmup_x, warmup_m_sizes
+
+        test_wgrad = torch.ops.mslk.bf16bf16bf16_grouped_wgrad(
+            dy_bf16,
+            x_bf16,
+            m_sizes.to(torch.int64),
+            output=wgrad_accum.clone() if output_accum else None,
+            output_accum=output_accum,
+            num_sms=num_sms,
+        )
+
+        self.assertFalse(
+            torch.isnan(test_wgrad).any().item(),
+            f"NaN found in wgrad (all_zero={all_zero})",
+        )
+
+        for idx in zero_experts:
+            if output_accum:
+                expected = wgrad_accum[idx].to(test_wgrad.dtype)
+            else:
+                expected = torch.zeros(
+                    (N, K),
+                    dtype=test_wgrad.dtype,
+                    device=torch.accelerator.current_accelerator(),
+                )
+            torch.testing.assert_close(
+                test_wgrad[idx],
+                expected,
+                atol=1e-4,
+                rtol=1e-3,
+                msg=f"Expert {idx} (zero tokens, all_zero={all_zero}) has unexpected gradient values",
+            )
+
 
 @unittest.skipIf(
     not SUPPORTS_NVFP4, "Skip if NVFP4Tests is not supported on this device."


### PR DESCRIPTION
Summary:
When using CUTLASS grouped GEMM for wgrad, experts that receive zero tokens produce NaN weight gradients. The root cause is in bf16bf16bf16_grouped_wgrad.cu: when total_M > 0 (at least one expert has tokens), the output buffer was allocated with at::empty (uninitialized memory). The kernel's set_stacked_kernel_args_kernel skips experts where M_sizes[i] == 0, so those experts never write to their portion of the output, leaving NaN/garbage values. This is triggered consistently in RL training with 256 experts and small microbatches, where many experts receive zero tokens per microbatch.

The fix changes at::empty to at::zeros so that zero-token experts get zero gradients instead of uninitialized memory. The cost of zeroing vs not is negligible relative to the GEMM computation.

Also adds dedicated tests for wgrad with zero-token experts across FBGEMM, MSLK, and MSL test suites. The tests use a warmup-based cache poisoning technique — running the kernel once with all experts having tokens to fill the CUDA caching allocator with a non-zero G*N*K buffer, then freeing it so the allocator reuses that dirty block for the next at::empty call. This makes uninitialized-memory bugs deterministic and reproducible in tests, rather than relying on non-deterministic allocator behavior. Tests cover both total_M == 0 (all experts zero tokens) and total_M > 0 with partial zero-token experts.

Differential Revision: D93777683


