### PR TITLE
Limit CK FMHA max head dimension to 256

### DIFF
--- a/mslk/attention/fmha/ck.py
+++ b/mslk/attention/fmha/ck.py
@@ -171,7 +171,7 @@ class FwOp(AttentionFwOpBase):
     OPERATOR = get_operator("xformers", "efficient_attention_forward_ck")
     SUPPORTED_DEVICES: Set[str] = {"cuda"}
     SUPPORTED_DTYPES: Set[torch.dtype] = {torch.half, torch.bfloat16}
-    SUPPORTED_MAX_K = 512
+    SUPPORTED_MAX_K = 256
 
     SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
         type(None),


### PR DESCRIPTION
Summary: Add -DFMHA_LIMIT_MAX_HEADDIM_TO_256=1 to hip_flags in both the fmha and _C_hip targets, and update SUPPORTED_MAX_K to 256 in the Python dispatch. This eliminates forward/infer kernel instantiations for head dimension 512, which are unused in practice.

Differential Revision: D93807513


