### PR TITLE
Fix rotating buffer function

### DIFF
--- a/bench/common/utils.py
+++ b/bench/common/utils.py
@@ -100,9 +100,8 @@ def do_bench(
     # We benchmark on a different stream, so a sync is required.
     torch.cuda.synchronize()
 
-    def rotating_buffer_fn() -> None:
-        for a in args_list:
-            fn(*a)
+    def rotating_buffer_fn() -> list[Any]:
+        return [fn(*args) for args in args_list]
 
     return _do_bench(rotating_buffer_fn, opts) / len(args_list)
 

--- a/bench/quantize/quantize_ops.py
+++ b/bench/quantize/quantize_ops.py
@@ -96,6 +96,28 @@ def get_ops() -> list[QuantizeOpBase]:
 
 
 @register_op
+class Copy(QuantizeOpBase):
+    """Copies input to output.
+
+    Useful for measuring achievable DRAM bandwidth.
+    """
+
+    def quantize(self, input: torch.Tensor) -> Any:
+        return (input.clone(),)
+
+    def dequantize(self, *args: Any) -> torch.Tensor:
+        return args[0]
+
+    @property
+    def hip(self) -> bool:
+        return True
+
+    @property
+    def cuda(self) -> bool:
+        return True
+
+
+@register_op
 class TritonFP8Rowwise(QuantizeOpBase):
     def quantize(self, input: torch.Tensor) -> Any:
         return triton_quantize_fp8_row(input)


### PR DESCRIPTION
Summary: This fixes a long-standing issue I noticed where some small shapes could exceed the theoretical roofline. The root cause is that we were not properly capturing output references in cuda graph, which could cause the output addresses to be reused during graph replay, and this would evade the purpose of the buffer rotation.

Differential Revision: D93867183


