### PR TITLE
Add option to relax triton_quantize_nvfp4 scale calc math

### DIFF
--- a/test/quantize/triton/fp4_quantize_test.py
+++ b/test/quantize/triton/fp4_quantize_test.py
@@ -300,8 +300,8 @@ class TestNVFp4Quantize:
         x_scales_ref = _to_blocked(x_scales_ref).view(x_scales.shape)
 
         torch.testing.assert_close(x_global_scale, x_global_scale_ref.reciprocal())
-        torch.testing.assert_close(x_scales, x_scales_ref)
-        torch.testing.assert_close(x_fp4, x_fp4_ref)
+        assert torch.equal(x_scales, x_scales_ref)
+        assert torch.equal(x_fp4, x_fp4_ref)
 
     @pytest.mark.parametrize(
         "test_case",


### PR DESCRIPTION
Summary:
These kernels are pretty bound on fp32 div. We can cheat a little by relaxing this when computing the scales in FP32. The reason is that the scales are FP8 E4M3, ~1-2 ULP difference have minimal impact for most FP32 values when casting from FP32 to FP8. We still pass all existing unit tests with bitwise accuracy, but there are cases where it would fail (e.g. construct a boundary case that changes the resulting FP8 scale due to 1 ULP difference). As such we can guard it with `use_precise_math`, and users can decide what to do (although in practice I feel this is likely fine for 99% of use-cases).

`use_precise_math=False` 
- some shapes (e.g. (2048, 8192)) get a nice boost of ~7%, achieving ~68% of theoretical memory BW.
- smaller benefit on larger shapes.
```
Quantize Bench
-----------------------------------------------------------------------------------
OpName               Problem Shape   Sim        Us         GB/s       Mem BW Util %
-----------------------------------------------------------------------------------
TritonNVFP4          (1, 4096)       0.009      1.949      22.07      0.28
TritonNVFP4          (1, 6144)       0.009      2.015      32.03      0.40
TritonNVFP4          (1, 8192)       0.008      2.050      41.95      0.53
TritonNVFP4          (2048, 4096)    0.009      5.186      4144.99    52.28
TritonNVFP4          (2048, 6144)    0.009      6.985      4616.17    58.23
TritonNVFP4          (2048, 8192)    0.009      7.945      5411.49    68.26
TritonNVFP4          (4096, 4096)    0.009      7.903      5440.25    68.62
TritonNVFP4          (4096, 6144)    0.009      13.270     4859.69    61.30
TritonNVFP4          (4096, 8192)    0.009      16.856     5101.10    64.34
TritonNVFP4          (8192, 4096)    0.009      16.723     5141.58    64.85
TritonNVFP4          (8192, 6144)    0.009      24.301     5307.39    66.94
TritonNVFP4          (8192, 8192)    0.009      31.966     5379.61    67.86
```

`use_precise_math=True` (default)
```
Quantize Bench
-----------------------------------------------------------------------------------
OpName               Problem Shape   Sim        Us         GB/s       Mem BW Util %
-----------------------------------------------------------------------------------
TritonNVFP4          (1, 4096)       0.009      2.009      21.41      0.27
TritonNVFP4          (1, 6144)       0.009      2.065      31.25      0.39
TritonNVFP4          (1, 8192)       0.009      2.098      41.00      0.52
TritonNVFP4          (2048, 4096)    0.009      5.803      3704.26    46.72
TritonNVFP4          (2048, 6144)    0.009      7.729      4171.64    52.62
TritonNVFP4          (2048, 8192)    0.009      8.816      4876.46    61.51
TritonNVFP4          (4096, 4096)    0.009      8.653      4968.23    62.67
TritonNVFP4          (4096, 6144)    0.009      14.039     4593.42    57.94
TritonNVFP4          (4096, 8192)    0.009      17.967     4785.49    60.36
TritonNVFP4          (8192, 4096)    0.009      17.869     4811.96    60.70
TritonNVFP4          (8192, 6144)    0.009      25.692     5019.97    63.32
TritonNVFP4          (8192, 8192)    0.009      33.832     5082.88    64.11
```

Differential Revision: D93776349


