### PR TITLE
Improve fp8_quantize_correctness_test

### DIFF
--- a/test/quantize/fp8_quantize_correctness_test.py
+++ b/test/quantize/fp8_quantize_correctness_test.py
@@ -5,33 +5,29 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-# pyre-ignore-all-errors[56]
 
 import unittest
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Tuple
 
 import mslk.quantize  # noqa: F401
 import torch
-from hypothesis import given, settings, strategies as st
 from mslk.quantize.triton.fp8_quantize import (
     quantize_fp8_block,
     quantize_fp8_row,
     quantize_fp8_tensor,
 )
+from parameterized import parameterized
 
 
 def undo_tensorwise_quant(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    # Undo FP8 tensorwise quantization.
     return x.to(torch.float) * scale
 
 
 def undo_rowwise_quant(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    # Undo FP8 rowwise quantization.
     return x.to(torch.float) * scale.unsqueeze(1)
 
 
 def undo_colwise_quant(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    # Undo FP8 colwise quantization.
     return x.to(torch.float) * scale.unsqueeze(0)
 
 
@@ -41,53 +37,101 @@ def undo_blockwise_quant(
     block_m: int = 256,
     block_k: int = 256,
 ) -> torch.Tensor:
-    orig_shape = x.shape
-    # View input in blocks:
-    # We limit block size to x's shape as a way to skip padding.
-    block_m = min(block_m, x.shape[-2])
-    block_k = min(block_k, x.shape[-1])
-    x = x.to(torch.float).view(-1, block_m, block_k)
-    # Apply scaling.
-    x = x * scale
-    return x.view(orig_shape)
+    M, K = x.shape[-2], x.shape[-1]
+    block_m = min(block_m, M)
+    block_k = min(block_k, K)
+
+    # Pad to be divisible by block sizes
+    pad_m = (block_m - M % block_m) % block_m
+    pad_k = (block_k - K % block_k) % block_k
+
+    x = x.to(torch.float)
+    if pad_m > 0 or pad_k > 0:
+        x = torch.nn.functional.pad(x, (0, pad_k, 0, pad_m))
+
+    M_padded, K_padded = x.shape[-2], x.shape[-1]
+    grid_m = M_padded // block_m
+    grid_k = K_padded // block_k
+
+    # Reshape into blocks and apply per-block scale
+    x = x.reshape(grid_m, block_m, grid_k, block_k)
+    x = x * scale[:, None, :, None]
+    x = x.reshape(M_padded, K_padded)
+
+    # Remove padding
+    return x[:M, :K]
+
+
+INPUT_SHAPES: List[List[int]] = [
+    # Small shape
+    [16, 16],
+    # Non-square shape
+    [32, 64],
+    # Medium shape
+    [1024, 1024],
+    # Large shape
+    [8192, 4096],
+    # Non-power-of-2 shapes
+    [333, 777],
+    # Small dimensions
+    [1, 128],
+    [128, 1],
+]
+
+TRITON_QUANTIZE_OPS: List[Tuple[Callable[..., Any], Callable[..., Any]]] = [
+    (quantize_fp8_row, undo_rowwise_quant),
+    (quantize_fp8_block, undo_blockwise_quant),
+    (quantize_fp8_tensor, undo_tensorwise_quant),
+]
+
+MSLK_QUANTIZE_OPS: List[Tuple[Callable[..., Any], Callable[..., Any]]] = [
+    (torch.ops.mslk.quantize_fp8_per_row, undo_rowwise_quant),
+    (torch.ops.mslk.quantize_fp8_per_col, undo_colwise_quant),
+    (torch.ops.mslk.quantize_fp8_per_tensor, undo_tensorwise_quant),
+]
+
+ALL_QUANTIZE_OPS: List[Tuple[Callable[..., Any], Callable[..., Any]]] = (
+    TRITON_QUANTIZE_OPS + MSLK_QUANTIZE_OPS
+)
+
+
+def _generate_test_cases() -> List[
+    Tuple[str, List[int], Callable[..., Any], Callable[..., Any]]
+]:
+    """Generate test cases for parameterized tests."""
+    test_cases = []
+    for shape in INPUT_SHAPES:
+        for quantize_op, dequantize_op in ALL_QUANTIZE_OPS:
+            name = f"{quantize_op}_{shape[0]}x{shape[1]}"
+            test_cases.append((name, shape, quantize_op, dequantize_op))
+    return test_cases
 
 
 @unittest.skipIf(
     not torch.cuda.is_available(),
     "Operators are only available on CUDA enabled machines",
 )
+@unittest.skipIf(
+    torch.version.cuda is None or torch.cuda.get_device_capability("cuda") < (9, 0),
+    "Only support sm90+",
+)
 class FP8CorrectnessTest(unittest.TestCase):
     """Check that FP8 ops produce correct results."""
 
-    @unittest.skipIf(
-        torch.version.cuda is None or torch.cuda.get_device_capability("cuda") < (9, 0),
-        "Only support sm90+",
-    )
-    @given(
-        input_shape=st.sampled_from([[32, 32]]),
-        quantize_op_pair=st.sampled_from(
-            [
-                [quantize_fp8_row, undo_rowwise_quant],
-                [quantize_fp8_block, undo_blockwise_quant],
-                [quantize_fp8_tensor, undo_tensorwise_quant],
-                [torch.ops.mslk.quantize_fp8_per_row, undo_rowwise_quant],
-                [torch.ops.mslk.quantize_fp8_per_col, undo_colwise_quant],
-                [torch.ops.mslk.quantize_fp8_per_tensor, undo_tensorwise_quant],
-            ]
-        ),
-    )
-    @settings(deadline=None)
-    def test_correctness(
+    # pyre-ignore[56]: Pyre can't track decorator-modified signatures.
+    @parameterized.expand(_generate_test_cases())
+    def test_quantize(
         self,
-        quantize_op_pair: List[Callable[..., Any]],
+        _name: str,
         input_shape: List[int],
+        quantize_op: Callable[..., Any],
+        dequantize_op: Callable[..., Any],
     ) -> None:
-        quantize_op, dequantize_op = quantize_op_pair
         test_input = torch.randn(input_shape, device="cuda", dtype=torch.bfloat16)
         quant_out = quantize_op(test_input)
         reconstructed_input = dequantize_op(*quant_out).to(torch.bfloat16)
         torch.testing.assert_close(
-            test_input, reconstructed_input, atol=2e-1, rtol=1e-3
+            test_input, reconstructed_input, atol=2.5e-1, rtol=1e-3
         )
 
 


### PR DESCRIPTION
Summary:
- Switch hypothesis for parameterized
- Add more shapes, need adjust atol slightly
- Remove `pyre-ignore-all-errors[56]`
- Make blockwise work for padded MK

Differential Revision: D93912419


