### PR TITLE
clean up pytorch_infra Nova CI scripts

### DIFF
--- a/.github/scripts/nova_dir.bash
+++ b/.github/scripts/nova_dir.bash
@@ -5,14 +5,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-## Workaround for Nova Workflow to look for setup.py in MSLK rather than root repo
+## Set MSLK_REPO path for other scripts to use
 MSLK_DIR="/__w/MSLK/MSLK"
 export MSLK_REPO="${MSLK_DIR}/${REPOSITORY}"
-working_dir=$(pwd)
-if [[ "$working_dir" == "$MSLK_REPO" ]]; then cd MSLK || echo "Failed to cd MSLK from $(pwd)"; fi
 
-## Build clean/wheel will be done in pre-script. Set flag such that setup.py will skip these steps in Nova workflow
-export BUILD_FROM_NOVA=1
+export BUILD_FROM_NOVA=0
 
 # Disable HIP FMHA build in the manywheel CI (the runner is too small)
 export MSLK_BUILD_HIP_FMHA=0

--- a/.github/scripts/nova_prescript.bash
+++ b/.github/scripts/nova_prescript.bash
@@ -136,9 +136,7 @@ if [[ ${CHANNEL} == "" ]]; then
   export CHANNEL="nightly"
 fi
 
-# Build the wheel
-build_mslk_package "${BUILD_ENV_NAME}" "${CHANNEL}" "${mslk_build_target}/${mslk_build_variant}"
 end_time=$(date +%s)
 runtime=$((end_time-start_time))
 start_time=${end_time}
-echo "[NOVA] Time taken to build the package: ${runtime} seconds / $(display_time ${runtime})"
+echo "[NOVA] Time taken to prepare to build the package: ${runtime} seconds / $(display_time ${runtime})"


### PR DESCRIPTION
Summary:
Clean up the Nova CI scripts for the pytorch_infra manywheel builds:
- Remove the cd MSLK workaround and set BUILD_FROM_NOVA=0 directly
- Move the wheel build out of the prescript (it will run in the main step)
- Simplify ROCm arch handling to a single gfx942 target for all ROCm versions

Reviewed By: q10

Differential Revision: D93869885


