### PR TITLE
build hip_fmha on github (#104)

### DIFF
--- a/.github/scripts/nova_dir.bash
+++ b/.github/scripts/nova_dir.bash
@@ -14,6 +14,9 @@ if [[ "$working_dir" == "$MSLK_REPO" ]]; then cd MSLK || echo "Failed to cd MSLK
 ## Build clean/wheel will be done in pre-script. Set flag such that setup.py will skip these steps in Nova workflow
 export BUILD_FROM_NOVA=1
 
+# Disable HIP FMHA build in the manywheel CI (the runner is too small)
+export MSLK_BUILD_HIP_FMHA=0
+
 if [[ "$CU_VERSION" == "cu"* ]]; then
     echo "Current TORCH_CUDA_ARCH_LIST value: ${TORCH_CUDA_ARCH_LIST}"
 elif [[ "$CU_VERSION" == "rocm"* ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ include(${CMAKEMODULES}/GpuCppLibrary.cmake)
 set(mslk_include_directories
   # MSLK
   ${MSLK}/include
+  ${MSLK}/csrc/attention/ck/fmha/hip_fmha
   # PyTorch
   ${TORCH_INCLUDE_DIRS}
   # Third-party

--- a/cmake/RocmSetup.cmake
+++ b/cmake/RocmSetup.cmake
@@ -16,6 +16,14 @@ if(MSLK_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
   include(Hip)
   include(Hipify)
 
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_link_options(-fuse-ld=/opt/rocm/llvm/bin/ld.lld)
+  else()
+    # GCC doesn't support -fuse-ld= with full paths. Use -B to add the
+    # ROCm LLVM directory to GCC's tool search path.
+    add_link_options(-B/opt/rocm/llvm/bin/ -fuse-ld=lld)
+  endif()
+
   # Configure compiler for HIP
   list(APPEND HIP_HCC_FLAGS
     " \"-Wno-#pragma-messages\" "


### PR DESCRIPTION
Summary:

Add CK FMHA (hip_fmha) to the CMake-based ROCm CI build on GitHub.

- Glob the hip_fmha sources and build them as a separate static library
  (`mslk_hip_fmha`) targeting only gfx942, gated on ROCm 7.x+ and the
  `MSLK_BUILD_HIP_FMHA` env var.
- Set `MSLK_BUILD_HIP_FMHA=0` in the Nova manywheel CI to skip the build
  there (the runner is too resource-constrained).
- Add `-DFMHA_LIMIT_MAX_HEADDIM_TO_256=1` to match the fbcode build (D93807513),
  eliminating unused head-dim-512 kernel instantiations.
- Use the ROCm LLD linker to avoid link failures with the default system linker.
- Auto-detect the build variant (cuda/rocm/cpu) from the installed PyTorch
  instead of defaulting to cuda.
- Fall back to `torch.version.hip` when `BUILD_ROCM_VERSION` is not set.

Differential Revision: D90669881


