### PR TITLE
Don't read C matrix in f4f4bf16 gemm

### DIFF
--- a/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_common.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16/f4f4bf16_common.cuh
@@ -106,9 +106,9 @@ at::Tensor _f4f4bf16(
           cutlass::epilogue::collective::EpilogueTileAuto,
           ElementAccumulator,
           ElementAccumulator,
-          ElementOutput,
-          LayoutOutputTag_Transpose,
-          AlignmentOutput,
+          void, // No C input - we are doing C = A @ B, not C = A @ B + beta*C
+          void,
+          0,
           ElementOutput,
           LayoutOutputTag_Transpose,
           AlignmentOutput,


### PR DESCRIPTION
Summary:
This change removes unnecessary reads of the C matrix in the f4f4bf16 GEMM kernel.
Since we are computing C = A @ B (not C = A @ B + beta*C), there is no reason to
load the C matrix before writing to it. This should improve performance by reducing
memory bandwidth usage.
 (placeholder)

Differential Revision: D94178092


