### PR TITLE
Don't read C matrix in f8f8bf16_rowwise_batched gemm

### DIFF
--- a/csrc/gemm/cutlass/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_common.cuh
+++ b/csrc/gemm/cutlass/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_common.cuh
@@ -192,9 +192,9 @@ at::Tensor f8f8bf16_rowwise_batched_impl(
           cutlass::epilogue::collective::EpilogueTileAuto,
           ElementAccumulator,
           ElementComputeEpilogue,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
+          void, // No C input - we are doing C = A @ B, not C = A @ B + beta*C
+          void,
+          0,
           ElementOutput,
           LayoutOutput,
           AlignmentOutput,


### PR DESCRIPTION
Summary:
This change removes unnecessary reads of the C matrix in the f8f8bf16_rowwise_batched GEMM kernel.
Since we are computing C = A @ B (not C = A @ B + beta*C), there is no reason to
load the C matrix before writing to it. This should improve performance by reducing
memory bandwidth usage.
 (placeholder)

Differential Revision: D94178093


