### PR TITLE
Add FP8 fnuz support for gfx950 (MI350) GPUs

### DIFF
--- a/mslk/gemm/triton/fp8_gemm.py
+++ b/mslk/gemm/triton/fp8_gemm.py
@@ -1172,7 +1172,9 @@ def matmul_fp8_row(
     if torch.version.cuda:
         assert a.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     elif torch.version.hip:
-        if torch.cuda.get_device_capability() < (9, 5):
+        # gfx942 (MI300) reports (9, 4), gfx950 (MI350) reports (9, 5)
+        # Both use fnuz format
+        if torch.cuda.get_device_capability() >= (9, 4):
             assert a.dtype in (
                 torch.float8_e4m3fnuz,
                 torch.float8_e5m2fnuz,

--- a/mslk/utils/triton/fp8_utils.py
+++ b/mslk/utils/triton/fp8_utils.py
@@ -32,7 +32,9 @@ def supports_float8_fnuz(throw_on_hip_incompatibility: bool = True) -> bool:
                 logging.error(msg)
                 return False
 
-        elif device_capability == (9, 4):
+        elif device_capability >= (9, 4):
+            # gfx942 (MI300) reports (9, 4), gfx950 (MI350) reports (9, 5)
+            # Both use fnuz format
             return True
 
     return False


### PR DESCRIPTION
Summary:
Running the below cmd:
```
TRITON_PRINT_AUTOTUNING=1 buck2 run mode/opt-amd-gpu -m rocm70 \
    -c fbcode.enable_gpu_sections=true \
    //pytorch/tritonbench:run -- \
    --op fp8_gemm_rowwise \
    --no_use_tma \
    --no_use_persistent \
    --m 1024 --n 6144 --k 105728 \
    --bias
```

generated the error:
```
WARNING:tritonbench.utils.triton_op:Caught exception on backend _cutlass_or_ck, terminating early with partial results
Traceback (most recent call last):
  File "/data/users/ligeng/fbsource/buck-out/v2/art/fbcode/23e470adb1b21a64/pytorch/tritonbench/__run__/run-inplace#link-tree/tritonbench/utils/triton_op.py", line 1199, in run
    y_vals: Dict[str, BenchmarkOperatorMetrics] = functools.reduce(
                                                  ^^^^^^^^^^^^^^^^^
  File "/data/users/ligeng/fbsource/buck-out/v2/art/fbcode/23e470adb1b21a64/pytorch/tritonbench/__run__/run-inplace#link-tree/tritonbench/utils/triton_op.py", line 1177, in _reduce_benchmarks
    acc[bm_name] = self._do_bench(
                   ^^^^^^^^^^^^^^^
  File "/data/users/ligeng/fbsource/buck-out/v2/art/fbcode/23e470adb1b21a64/pytorch/tritonbench/__run__/run-inplace#link-tree/tritonbench/utils/triton_op.py", line 1804, in _do_bench
    metrics.latency = do_bench_wrapper(
                      ^^^^^^^^^^^^^^^^^
  File "/data/users/ligeng/fbsource/buck-out/v2/art/fbcode/23e470adb1b21a64/pytorch/tritonbench/__run__/run-inplace#link-tree/tritonbench/components/do_bench/run.py", line 743, in do_bench_wrapper
    raise e
  File "/data/users/ligeng/fbsource/buck-out/v2/art/fbcode/23e470adb1b21a64/pytorch/tritonbench/__run__/run-inplace#link-tree/tritonbench/components/do_bench/run.py", line 688, in do_bench_wrapper
    times=bench_fn(
          ^^^^^^^^^
  File "/data/users/ligeng/fbsource/buck-out/v2/art/fbcode/23e470adb1b21a64/pytorch/tritonbench/__run__/run-inplace#link-tree/tritonbench/components/do_bench/run.py", line 195, in _do_bench_cudagraph_with_cache_clear
    fn()
  File "/data/users/ligeng/fbsource/buck-out/v2/art/fbcode/23e470adb1b21a64/pytorch/tritonbench/__run__/run-inplace#link-tree/tritonbench/operators/fp8_gemm_rowwise/operator.py", line 232, in <lambda>
    lambda: cutlass_or_ck_fp8_row(
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/ligeng/fbsource/buck-out/v2/art/fbcode/23e470adb1b21a64/pytorch/tritonbench/__run__/run-inplace#link-tree/torch/_ops.py", line 1269, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Inputs must be type float8_e4m3fnuz.
WARNING:tritonbench.utils.triton_op:Failing input: --input-id 0 --num-inputs 1 --input-sample-mode first-k
  (M, N, K)
```

Reviewed By: RandySheriff

Differential Revision: D94412667


