### PR TITLE
remove some references to xformers

### DIFF
--- a/mslk/attention/cutlass_blackwell_fmha/cutlass_blackwell_fmha_interface.py
+++ b/mslk/attention/cutlass_blackwell_fmha/cutlass_blackwell_fmha_interface.py
@@ -276,7 +276,7 @@ def cutlass_blackwell_fmha_decode_forward(
     This is a wrapper to use the gen kernel which is optimized
     for decode (query length = 1).
 
-    This function is called externally by xformers ops.
+    This function is called externally by fmha ops.
 
     Accepts inputs in two formats:
     - Varlen format: [total_queries, num_heads, head_dim] (3D)

--- a/mslk/attention/fmha/_triton/available.py
+++ b/mslk/attention/fmha/_triton/available.py
@@ -11,7 +11,7 @@ import os
 import torch
 
 
-logger = logging.getLogger("xformers")
+logger = logging.getLogger(__file__)
 
 
 def compute_once(func):

--- a/mslk/attention/fmha/attn_bias.py
+++ b/mslk/attention/fmha/attn_bias.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 """
 This file contains biases that can be used as the `attn_bias` argument in
-:attr:`xformers.ops.memory_efficient_attention`.
+`memory_efficient_attention`.
 Essentially, a bias is a Tensor which will be added to the ``Q @ K.t`` before
 computing the ``softmax``.
 
@@ -56,8 +56,7 @@ def _to_device_tensor(seq: Sequence[int], dtype: torch.dtype, device: torch.devi
 
 class AttentionBias:
     """Base class for a custom bias that can be applied \
-        as the attn_bias argument in
-    :attr:`xformers.ops.memory_efficient_attention`.
+        as the attn_bias argument in memory_efficient_attention.
 
     That function has the ability to add a tensor, the
     attention bias, to the QK^T matrix before it is used
@@ -73,19 +72,9 @@ class AttentionBias:
     be used as the attn_bias input to define an attention bias which
     forms such a mask, for some common cases.
 
-    When using an :attr:`xformers.ops.AttentionBias`
-    instead of a :attr:`torch.Tensor`, the mask matrix does
+    When using an AttentionBias torch.Tensor, the mask matrix does
     not need to be materialized, and can be
     hardcoded into some kernels for better performance.
-
-    See:
-
-    - :attr:`xformers.ops.fmha.attn_bias.LowerTriangularMask`
-    - :attr:`xformers.ops.fmha.attn_bias.LowerTriangularFromBottomRightMask`
-    - :attr:`xformers.ops.fmha.attn_bias.LowerTriangularMaskWithTensorBias`
-    - :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`
-    - :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`
-
     """
 
     def materialize(
@@ -186,7 +175,7 @@ class LocalAttentionFromBottomRightMask(AttentionBias):
     .. code-block:: python
 
         import torch
-        from xformers.ops import fmha
+        from mslk.attention import fmha
 
         bias = fmha.attn_bias.LocalAttentionFromBottomRightMask(window_left=1, window_right=2)
         print(bias.materialize(shape=(4, 4)).exp())
@@ -748,7 +737,7 @@ class _GappySeqInfo(_SeqLenInfo):
 class BlockDiagonalMask(AttentionBias):
     """
     A block-diagonal mask that can be passed as ``attn_bias``
-    argument to :attr:`xformers.ops.memory_efficient_attention`.
+    argument to memory_efficient_attention.
 
     Queries and Keys are each divided into the same number of blocks.
     Queries in block i only attend to keys in block i.
@@ -763,7 +752,7 @@ class BlockDiagonalMask(AttentionBias):
     .. code-block:: python
 
         import torch
-        from xformers.ops import fmha
+        from mslk.attention import fmha
 
         K = 16
         dtype = torch.float16
@@ -984,7 +973,7 @@ class BlockDiagonalMask(AttentionBias):
 @dataclass
 class BlockDiagonalCausalMask(BlockDiagonalMask):
     """
-    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`, except that each block is causal.
+    Same as BlockDiagonalMask, except that each block is causal.
 
     Queries and Keys are each divided into the same number of blocks.
     A query Q in block i cannot attend to a key which is not in block i,
@@ -1016,7 +1005,7 @@ class BlockDiagonalCausalMask(BlockDiagonalMask):
 @dataclass
 class BlockDiagonalCausalFromBottomRightMask(BlockDiagonalMask):
     """
-    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`, except that each block is causal.
+    Same as BlockDiagonalMask, except that each block is causal.
     This mask allows for a non-causal prefix
     NOTE: Each block should have `num_keys >= num_queries` otherwise the forward pass is not
     defined (softmax of vector of `-inf` in the attention)
@@ -1066,7 +1055,7 @@ class BlockDiagonalCausalFromBottomRightMask(BlockDiagonalMask):
 @dataclass
 class BlockDiagonalPaddedKeysMask(AttentionBias):
     """
-    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`,
+    Same as BlockDiagonalMask,
     except we support padding for k/v
 
     The keys and values are divided into blocks which are padded out to
@@ -1193,7 +1182,7 @@ class BlockDiagonalPaddedKeysMask(AttentionBias):
 @dataclass
 class BlockDiagonalCausalWithOffsetPaddedKeysMask(BlockDiagonalPaddedKeysMask):
     """
-    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`,
+    Same as BlockDiagonalCausalMask,
     except an offset on causality is allowed for each block and we support padding for k/v
 
     The keys and values are divided into blocks which are padded out to
@@ -1267,7 +1256,7 @@ class BlockDiagonalCausalWithOffsetPaddedKeysMask(BlockDiagonalPaddedKeysMask):
 @dataclass
 class BlockDiagonalLocalAttentionPaddedKeysMask(BlockDiagonalPaddedKeysMask):
     """
-    Like :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalLocalAttentionPaddedKeysMask`,
+    Like BlockDiagonalCausalLocalAttentionPaddedKeysMask,
     except that this is non-causal.
 
     A query Q in block i cannot attend to a key which is not in block i,
@@ -1333,8 +1322,7 @@ class BlockDiagonalLocalAttentionPaddedKeysMask(BlockDiagonalPaddedKeysMask):
 @dataclass
 class BlockDiagonalCausalLocalAttentionPaddedKeysMask(BlockDiagonalPaddedKeysMask):
     """
-    Like :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask`,
-    except with a window size.
+    Like BlockDiagonalCausalWithOffsetPaddedKeysMask except with a window size.
 
     A query Q in block i cannot attend to a key which is not in block i,
     nor one which is not in use (i.e. in the padded area),
@@ -1656,8 +1644,7 @@ class PagedBlockDiagonalCausalLocalPaddedKeysMask(PagedBlockDiagonalPaddedKeysMa
 @dataclass
 class BlockDiagonalGappyKeysMask(AttentionBias):
     """
-    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`,
-    except k/v is gappy.
+    Same as BlockDiagonalMask, except k/v is gappy.
 
     A query Q in block i only attends to a key which is in block i.
     """
@@ -1781,8 +1768,7 @@ class BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask(
     BlockDiagonalGappyKeysMask
 ):
     """
-    Like :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalGappyKeysMask`,
-    except that this has local attention.
+    Like BlockDiagonalGappyKeysMask except that this has local attention.
 
     A query Q in block i cannot attend to a key which is not in block i,
     nor one which is not in use (i.e. in the padded area),
@@ -1862,7 +1848,7 @@ class BlockDiagonalLocalAttentionFromBottomRightGappyKeysMask(
 @dataclass
 class BlockDiagonalCausalWithOffsetGappyKeysMask(BlockDiagonalGappyKeysMask):
     """
-    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`,
+    Same as BlockDiagonalCausalMask,
     except k/v is gappy.
 
     A query Q in block i cannot attend to a key which is not in block i,
@@ -2056,7 +2042,7 @@ class PagedBlockDiagonalCausalWithOffsetGappyKeysMask(PagedBlockDiagonalGappyKey
 class BlockDiagonalCausalLocalAttentionMask(BlockDiagonalCausalMask):
     """
     (Experimental feature)
-    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`.
+    Same as BlockDiagonalCausalMask.
     This makes the mask "local" and the attention pattern banded.
 
     The ith query in a block only attends to keys in its block with index
@@ -2121,7 +2107,7 @@ class BlockDiagonalCausalLocalAttentionFromBottomRightMask(
 ):
     """
     (Experimental feature)
-    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`.
+    Same as BlockDiagonalCausalMask.
     This makes the mask "local" and the attention pattern banded.
 
     A query with distance j from the last query in its block only attends to

--- a/mslk/attention/fmha/ck.py
+++ b/mslk/attention/fmha/ck.py
@@ -166,7 +166,7 @@ def _custom_mask_type(bias: Optional[Union[torch.Tensor, AttentionBias]]) -> int
 
 @register_operator
 class FwOp(AttentionFwOpBase):
-    """xFormers' MHA kernel based on Composable Kernel."""
+    """MHA kernel based on Composable Kernel."""
 
     OPERATOR = get_operator("xformers", "efficient_attention_forward_ck")
     SUPPORTED_DEVICES: Set[str] = {"cuda"}

--- a/mslk/attention/fmha/common.py
+++ b/mslk/attention/fmha/common.py
@@ -458,17 +458,7 @@ class Gradients:
 
 
 class AttentionOpBase(BaseOperator):
-    """Base class for any attention operator in xFormers
-
-    See:
-
-    - :attr:`xformers.ops.fmha.cutlass.FwOp`
-    - :attr:`xformers.ops.fmha.cutlass.BwOp`
-    - :attr:`xformers.ops.fmha.flash.FwOp`
-    - :attr:`xformers.ops.fmha.flash.BwOp`
-    - :attr:`xformers.ops.fmha.triton.FwOp`
-    - :attr:`xformers.ops.fmha.triton.BwOp`
-    """
+    """Base class for any attention operator"""
 
     OPERATOR: Any  # pyre-ignore[13]
     SUPPORTED_DEVICES: Set[str]  # pyre-ignore[13]
@@ -539,7 +529,7 @@ class AttentionOpBase(BaseOperator):
             and not _built_with_cuda
             and (torch.version.hip is None)
         ):
-            reasons.append("xFormers wasn't build with CUDA support")
+            reasons.append("Library not built with CUDA support")
         if device_type == "cuda" and (torch.version.hip is None):
             device_capability = torch.cuda.get_device_capability(d.device)
             if device_capability < cls.CUDA_MINIMUM_COMPUTE_CAPABILITY:

--- a/mslk/attention/fmha/cutlass.py
+++ b/mslk/attention/fmha/cutlass.py
@@ -158,7 +158,7 @@ def _custom_mask_type(bias: Optional[Union[torch.Tensor, AttentionBias]]) -> int
 
 @register_operator
 class FwOp(AttentionFwOpBase):
-    """xFormers' MHA kernel based on CUTLASS.
+    """MHA kernel based on CUTLASS.
     Supports a large number of settings (including without TensorCores, f32 ...)
     and GPUs as old as P100 (Sm60)
     """

--- a/mslk/attention/fmha/cutlass_blackwell.py
+++ b/mslk/attention/fmha/cutlass_blackwell.py
@@ -35,7 +35,7 @@ def _get_operator(name: str):
         raise RuntimeError(
             "No such operator "
             f"mslk.attention.cutlass_blackwell_fmha.{name} "
-            "- did you forget to build xformers with `python setup.py develop`?"
+            "- did you forget to build the library?"
         )
 
     try:

--- a/mslk/attention/fmha/tree_attention.py
+++ b/mslk/attention/fmha/tree_attention.py
@@ -507,7 +507,7 @@ def select_prefix_op(
     elif use_triton_splitk_for_prefix(B, G, tree_size):
         return triton_splitk_op
     else:
-        # use default heuristics from xformers
+        # use default heuristics
         return None
 
 
@@ -693,8 +693,7 @@ def construct_full_tree_choices(
     Construct a full tree of a given depth where each node (except for leaves) has a given number of children.
     The format is compatible with that used by Medusa and EAGLE:
     https://github.com/FasterDecoding/Medusa/blob/5e98053/medusa/model/medusa_choices.py
-    For detailed description, see docstring of
-    xformers.ops.tree_attention.TreeAttnMetadata.from_tree_choices .
+    For detailed description, see docstring of TreeAttnMetadata.from_tree_choices .
     """
     return construct_tree_choices(branching=[branching] * tree_depth)
 

--- a/mslk/attention/fmha/utils/op_common.py
+++ b/mslk/attention/fmha/utils/op_common.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 # pyre-unsafe
 
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, List, Type, TypeVar
 
 import torch
 
@@ -13,17 +13,13 @@ import torch
 def get_operator(library: str, name: str):
     def no_such_operator(*args, **kwargs):
         raise RuntimeError(
-            f"No such operator {library}::{name} - did you forget to build xformers with `python setup.py develop`?"
+            f"No such operator {library}::{name} - did you forget to build the library?"
         )
 
     try:
         return getattr(getattr(torch.ops, library), name)
     except (RuntimeError, AttributeError):
         return no_such_operator
-
-
-def get_xformers_operator(name: str):
-    return get_operator("xformers", name)
 
 
 class BaseOperator:
@@ -43,14 +39,12 @@ class BaseOperator:
 
 
 OPERATORS_REGISTRY: List[Type[BaseOperator]] = []
-FUNC_TO_XFORMERS_OPERATOR: Dict[Any, Type[BaseOperator]] = {}
 
 ClsT = TypeVar("ClsT")
 
 
 def register_operator(cls: ClsT) -> ClsT:
     OPERATORS_REGISTRY.append(cls)  # type: ignore
-    FUNC_TO_XFORMERS_OPERATOR[cls.OPERATOR] = cls  # type: ignore
     return cls
 
 

--- a/test/attention/fmha/case_generation.py
+++ b/test/attention/fmha/case_generation.py
@@ -18,8 +18,6 @@ from mslk.attention.fmha.common import AttentionOpBase
 
 from .utils import _devices
 
-logger = logging.getLogger("xformers")
-
 
 def sample_random_supported_fw(
     inp: fmha.Inputs,

--- a/test/attention/fmha/test_backward.py
+++ b/test/attention/fmha/test_backward.py
@@ -41,7 +41,7 @@ from .utils import (
     use_cpu_ref,
 )
 
-logger = logging.getLogger("xformers")
+logger = logging.getLogger(__file__)
 
 ALL_FW_OPS = _filter_unsupported_ops(ALL_FW_OPS)
 ALL_BW_OPS = _filter_unsupported_ops(ALL_BW_OPS)
@@ -116,7 +116,7 @@ def test_backward(  # noqa: C901
         op_fw = fmha.ck.FwOp
         if dtype == torch.bfloat16:
             # bfloat16 testing can be enabled by export ENABLE_HIP_FMHA_RTN_BF16_CONVERT=1 when
-            # building xformers and get accurate results
+            # building and get accurate results
             pytest.skip(
                 "CK Fmha backward for bfloat16 currently is not very accurate for some cases!"
             )

--- a/test/attention/fmha/test_forward.py
+++ b/test/attention/fmha/test_forward.py
@@ -40,7 +40,7 @@ from .utils import (
     UNSUPPORTED_OP_PASSES,
 )
 
-logger = logging.getLogger("xformers")
+logger = logging.getLogger(__file__)
 
 ALL_FW_OPS = _filter_unsupported_ops(ALL_FW_OPS)
 ALL_BW_OPS = _filter_unsupported_ops(ALL_BW_OPS)

--- a/test/attention/fmha/test_mem_eff_attention.py
+++ b/test/attention/fmha/test_mem_eff_attention.py
@@ -60,7 +60,7 @@ from .utils import (
     UNSUPPORTED_OP_PASSES,
 )
 
-logger = logging.getLogger("xformers")
+logger = logging.getLogger(__file__)
 
 ALL_FW_OPS = _filter_unsupported_ops(ALL_FW_OPS)
 ALL_BW_OPS = _filter_unsupported_ops(ALL_BW_OPS)
@@ -2234,7 +2234,7 @@ def test_fp8_attention(dtype_init, deterministic, causal, B, nheads, seq_len, he
     torch.testing.assert_close(out, out_ref, atol=3e-2, rtol=1e-4)
 
 
-def _pack_xformer_input(
+def _pack_input(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -2302,7 +2302,7 @@ def test_fav3_kvsplit_attn(
     k = torch.randn(B, seq_len_kv, nheads_kv, head_dim, device="cuda", dtype=dtype_init)
     v = torch.randn(B, seq_len_kv, nheads_kv, head_dim, device="cuda", dtype=dtype_init)
 
-    xq, xk, xv, attn_bias = _pack_xformer_input(q, k, v, [seq_len_kv] * B, bias)
+    xq, xk, xv, attn_bias = _pack_input(q, k, v, [seq_len_kv] * B, bias)
 
     out_ref, lse_ref = fmha.memory_efficient_attention_forward_requires_grad(
         xq, xk, xv, attn_bias, op=fmha.flash3.FwOp

--- a/test/attention/fmha/test_tree_attention.py
+++ b/test/attention/fmha/test_tree_attention.py
@@ -36,7 +36,7 @@ sm80_or_better_only = pytest.mark.skipif(
 
 # fmt: off
 # Tree defintions - see doctring of
-# xformers.ops.tree_attention.TreeAttnMetadata.from_tree_choices
+# TreeAttnMetadata.from_tree_choices
 # for the format description
 # from https://github.com/SafeAILab/EAGLE/blob/e98fc7c/model/choices.py
 eagle_mc_sim_7b_63 = [(0,),(1,),(2,),(3,),(0,0),(0,1),(0,2),(1,0),(1,1),(2,0),(2,1),(3,0)  # noqa
@@ -351,11 +351,11 @@ def tree_attention_with_sync(
 ) -> torch.Tensor:
     """
     A wrapper around tree_attention which constructs the biases.
-    Arguments are the same as in xformers.ops.tree_attention.tree_attention, but instead of
+    Arguments are the same as in tree_attention, but instead of
     spec_attn_bias and prefix_attn_bias this function takes in tree definition in the form of tree_choices
     and K/V sequence lengths kv_lens.
     For the format of tree_choices see docstring of
-    xformers.ops.tree_attention.TreeAttnMetadata.from_tree_choices.
+    TreeAttnMetadata.from_tree_choices.
     """
     B, tree_size_q = q.shape[:2]
     Mk = cache_k.shape[1]


### PR DESCRIPTION
Summary: Removing the string "xformers" where no longer relevant. These are easy places - doc, loggers etc. Not touching op names or env var names.

Differential Revision: D94527948


