### PR TITLE
Install specific CUDA components instead of full metapackage

### DIFF
--- a/ci/scripts/utils_cuda.bash
+++ b/ci/scripts/utils_cuda.bash
@@ -208,8 +208,20 @@ install_cuda () {
       cuda) || return 1
   else
     # shellcheck disable=SC2086
-    (exec_with_retries 3 conda install --force-reinstall ${env_prefix} -c conda-forge --override-channels -y \
-      cuda=${cuda_version}) || return 1
+    (exec_with_retries 3 conda install ${env_prefix} -c conda-forge --override-channels -y \
+      "cuda-version=${cuda_version%.*}" \
+      cuda-compiler \
+      cuda-libraries-dev \
+      cuda-cudart-dev \
+      cuda-cudart-static \
+      cuda-driver-dev \
+      cuda-nvtx \
+      cuda-nvml-dev \
+      cuda-nvrtc-dev \
+      cuda-cupti-dev \
+      cuda-profiler-api \
+      cuda-opencl-dev \
+      nsight-compute) || return 1
   fi
 
   # Set the symlinks and environment variables not covered by conda install


### PR DESCRIPTION
Summary:
The conda-forge `cuda` metapackage pulls in ~500 MB of unneeded tools
(gdb, nsight, nvvp, gds-tools) and force-reinstalls gcc/gxx compilers
that were already set up by install_cxx_compiler. The gdb post-link
script then crashes on an unset CONDA_BACKUP_CXX variable, corrupting
the conda environment and failing the entire CI job.

Replace `conda install --force-reinstall cuda=X.Y.Z` with an explicit
list of only the packages needed for building, and drop --force-reinstall.

Differential Revision: D94536031


