### PR TITLE
Use int64 M_sizes in bf16i4bf16 and f8i4bf16 shuffled grouped kernels

### DIFF
--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -1846,7 +1846,7 @@ class CutlassFP8Int4GroupwiseGroupedPreshuffle(GemmOpBase):
         )
         m_values = [i.shape[0] for i in x]
         # Convert m_values into offsets into grouped tensor.
-        m_sizes = torch.tensor(m_values).to(dtype=torch.int32, device=x[0].device)
+        m_sizes = torch.tensor(m_values).to(dtype=torch.int64, device=x[0].device)
         # Quantize weights.
         wq, scales = zip(*[quantize_int4_preshuffle(i) for i in w])
         group_scale, row_scale = zip(*scales)
@@ -1906,7 +1906,7 @@ class CutlassBF16Int4GroupwiseGroupedPreshuffle(GemmOpBase):
         )
         m_values = [i.shape[0] for i in x]
         # Convert m_values into offsets into grouped tensor.
-        m_sizes = torch.tensor(m_values).to(dtype=torch.int32, device=x[0].device)
+        m_sizes = torch.tensor(m_values).to(dtype=torch.int64, device=x[0].device)
         # Quantize weights.
         wq, scales = zip(
             *[quantize_int4_preshuffle(i, dtype="bf16", use_zp=False) for i in w]

--- a/csrc/gemm/cutlass/bf16i4bf16_shuffled_grouped.cu
+++ b/csrc/gemm/cutlass/bf16i4bf16_shuffled_grouped.cu
@@ -56,7 +56,7 @@ __global__ void set_kernel_args(
     int N,
     int K,
     int num_scale_groups,
-    int32_t* M_sizes,
+    int64_t* M_sizes,
     ProblemShape* problem_shape_ptr,
     ElementA* xq,
     const ElementA** xq_ptr,
@@ -363,7 +363,7 @@ void _bf16i4bf16_shuffled_grouped(
       N,
       K,
       num_scale_groups,
-      reinterpret_cast<int32_t*>(M_sizes.data_ptr()),
+      reinterpret_cast<int64_t*>(M_sizes.data_ptr()),
       problem_shape_ptr,
       reinterpret_cast<ElementA*>(X.data_ptr()),
       xq_ptr,
@@ -434,10 +434,14 @@ at::Tensor bf16i4bf16_shuffled_grouped_dispatch(
   int total_M = X.size(0);
   int K = X.size(1);
   int N = WQ.size(1);
-  int group_count = M_sizes.size(0);
   TORCH_CHECK(
-      M_sizes.device() == X.device() && M_sizes.dtype() == at::kInt,
-      "M_sizes must be int32 and on the same device as inputs.");
+      M_sizes.device() == X.device(),
+      "M_sizes must be on the same device as inputs.");
+  TORCH_CHECK(
+      M_sizes.dtype() == at::kLong || M_sizes.dtype() == at::kInt,
+      "M_sizes must be int32 or int64.");
+  M_sizes = M_sizes.to(at::kLong);
+  int group_count = M_sizes.size(0);
   TORCH_CHECK(
       WQ.dim() == 3 && WQ.size(0) == group_count && WQ.size(2) == K / 2,
       "Weights should be shape [G, N, K / 2]");

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -1326,7 +1326,7 @@ class BF16Int4Tests(unittest.TestCase):
         else:
             ms = torch.zeros((G,), dtype=torch.int)
 
-        M_sizes = ms.to(device=self.device, dtype=torch.int32)
+        M_sizes = ms.to(device=self.device, dtype=torch.int64)
         ns = [N] * G
         ks = [K] * G
 
@@ -1507,7 +1507,7 @@ class FP8Int4Tests(unittest.TestCase):
         else:
             ms = torch.zeros((G,), dtype=torch.int)
 
-        M_sizes = ms.to(device=self.device, dtype=torch.int32)
+        M_sizes = ms.to(device=self.device, dtype=torch.int64)
         ns = [N] * G
         ks = [K] * G
 


### PR DESCRIPTION
Summary:
Make `bf16i4bf16_shuffled_grouped` and `f8i4bf16_shuffled_grouped` compatible with int64 `M_sizes`, matching the convention used by all other grouped GEMM kernels in MSLK.

The `M_sizes` pointer type changes from `int32_t*` to `int64_t*` in both GPU kernels, the dtype check changes from `at::kInt` to `at::kLong`, and the `reinterpret_cast` is updated accordingly. All fbcode call sites are migrated to pass int64 M_sizes.

Differential Revision: D94549082


