### PR TITLE
Don't read C matrix in f8f8bf16_tensorwise gemm

### DIFF
--- a/csrc/gemm/cutlass/f8f8bf16_tensorwise.cu
+++ b/csrc/gemm/cutlass/f8f8bf16_tensorwise.cu
@@ -146,9 +146,9 @@ at::Tensor f8f8bf16_tensorwise_impl(
           cutlass::epilogue::collective::EpilogueTileAuto,
           ElementAccumulator,
           ElementComputeEpilogue,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
+          void, // No C input - we are doing C = A @ B, not C = A @ B + beta*C
+          void,
+          0,
           ElementOutput,
           LayoutOutput,
           AlignmentOutput,


### PR DESCRIPTION
Summary:
This change removes unnecessary reads of the C matrix in the f8f8bf16_tensorwise GEMM kernel.
Since we are computing C = A @ B (not C = A @ B + beta*C), there is no reason to
load the C matrix before writing to it. This should improve performance by reducing
memory bandwidth usage.

Differential Revision: D94454929


