### PR TITLE
Don't read C matrix in f8i4bf16_rowwise gemm

### DIFF
--- a/csrc/gemm/cutlass/f8i4bf16_rowwise.cu
+++ b/csrc/gemm/cutlass/f8i4bf16_rowwise.cu
@@ -143,9 +143,9 @@ at::Tensor f8i4bf16_rowwise_impl(
           EpilogueTileType,
           ElementAccumulator,
           ElementAccumulator,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
+          void, // No C input - we are doing C = A @ B, not C = A @ B + beta*C
+          void,
+          0,
           ElementOutput,
           LayoutOutput,
           AlignmentOutput,


### PR DESCRIPTION
Summary:
This change removes unnecessary reads of the C matrix in the f8i4bf16_rowwise GEMM kernel.
Since we are computing C = A @ B (not C = A @ B + beta*C), there is no reason to
load the C matrix before writing to it. This should improve performance by reducing
memory bandwidth usage.

Reviewed By: henrylhtsang

Differential Revision: D94455232


