### PR TITLE
Use official flash attention packages instead of xformers C extensions

### DIFF
--- a/mslk/attention/fmha/attn_bias.py
+++ b/mslk/attention/fmha/attn_bias.py
@@ -141,6 +141,9 @@ class LowerTriangularMask(AttentionBias):
     of queries is not equal to the number of keys/values.
     """
 
+    def __init__(self, device: Union[torch.device, None] = None) -> None:
+        """not used, only here for backward compatibility"""
+
     def to(self, device: torch.device) -> "LowerTriangularMask":
         assert type(self) is LowerTriangularMask, "Please implement in subclass"
         return self

--- a/mslk/attention/fmha/cutlass_blackwell.py
+++ b/mslk/attention/fmha/cutlass_blackwell.py
@@ -38,6 +38,13 @@ def _get_operator(name: str):
             "- did you forget to build the library?"
         )
 
+    def no_cuda_environment(*args, **kwargs):
+        raise RuntimeError(
+            "The operator "
+            f"mslk.attention.cutlass_blackwell_fmha.{name} "
+            "cannot run in a non-cuda environment."
+        )
+
     try:
         # type: ignore  # pyre-ignore
         from mslk.attention.cutlass_blackwell_fmha import (
@@ -47,6 +54,10 @@ def _get_operator(name: str):
         return getattr(fmha, name)  # type: ignore  # pyre-ignore
     except (RuntimeError, ModuleNotFoundError):
         return no_such_operator
+    except OSError as e:
+        if torch.cuda.is_available() is False:
+            return no_cuda_environment
+        raise e
 
 
 def _convert_input_format(

--- a/mslk/attention/fmha/dispatch.py
+++ b/mslk/attention/fmha/dispatch.py
@@ -28,7 +28,14 @@ except (ImportError, OSError):
     _USE_MTIA_FLASH_ATTENTION = False
 
 
-_USE_FLASH_ATTENTION_3 = False
+try:
+    import ai_codesign.gen_ai.flash_attention_v2.hopper.flash_attn_interface  # noqa: F401,E501  # type: ignore
+
+    # fbcode: FA3 off by default
+    _USE_FLASH_ATTENTION_3 = False
+except ImportError:
+    # OSS: FA3 on by default
+    _USE_FLASH_ATTENTION_3 = True
 
 
 def _set_use_fa3(use_flash_attention3: bool) -> None:
@@ -41,9 +48,10 @@ def _get_use_fa3() -> bool:
 
 
 def fa3_available() -> bool:
+    has_cuda = torch.version.cuda is not None
+    is_supported = has_cuda and (8, 0) <= torch.cuda.get_device_capability() <= (9, 0)
     has_valid_flash3 = flash3._C_flashattention3 is not None  # pyre-ignore[16]
-    is_90a = torch.version.cuda and torch.cuda.get_device_capability() >= (9, 0)
-    return has_valid_flash3 and is_90a
+    return is_supported and has_valid_flash3
 
 
 def _format_inputs_description(inp: Inputs) -> str:
@@ -202,7 +210,9 @@ def _dispatch_bw(
                     (
                         op,
                         [
-                            f"LSE is in {'packed' if varlen_lse_packed else 'padded'} format"
+                            "LSE is in "
+                            f"{'packed' if varlen_lse_packed else 'padded'}"
+                            " format"
                         ],
                     )
                 )

--- a/mslk/attention/fmha/flash.py
+++ b/mslk/attention/fmha/flash.py
@@ -6,6 +6,7 @@
 # pyre-unsafe
 
 
+import importlib.util
 import os
 from itertools import zip_longest
 from typing import Any, Iterable, List, Optional, Set, Tuple, Union
@@ -45,58 +46,47 @@ from .common import (
     Gradients,
     Inputs,
 )
-from .torch_attention_compat import is_pt_flash_old
+from .torch_attention_compat import ensure_pt_flash_ok
 from .utils.op_common import get_operator, register_operator
 
 FLASH_VERSION = "0.0.0"
-VARLEN_LSE_PACKED = False
-pt_flash_is_old = False
-_TRY_PT_FLASH_ATTN = torch.version.hip is None
 _USE_PT_FLASH_ATTN = False
+_flash_attn_cuda = None
 
-try:  # noqa: C901
-    try:
-        from xformers import _C_flashattention  # type: ignore[attr-defined]
 
-        try:
-            from xformers._cpp_lib import _build_metadata  # type: ignore[attr-defined]
+if importlib.util.find_spec("flash_attn"):
+    # In fbcode this resolves to ai_codesign's flash_attn_2_cuda;
+    # in OSS this path is not expected to be used.
+    import flash_attn
+    import flash_attn.flash_attn_interface
 
-            if _build_metadata is not None:
-                FLASH_VERSION = _build_metadata.flash_version
-        except ImportError:
-            FLASH_VERSION = "unknown"
+    _iface = flash_attn.flash_attn_interface
+    if hasattr(_iface, "flash_attn_cuda"):
+        _flash_attn_cuda = _iface.flash_attn_cuda  # type: ignore
+    else:
+        _flash_attn_cuda = _iface.flash_attn_gpu  # type: ignore
 
-        VARLEN_LSE_PACKED = True
-    except ImportError:
-        try:
-            import flash_attn
-            import flash_attn.flash_attn_interface
+    FLASH_VERSION = flash_attn.__version__
+    FLASH_VER_MIN = (2, 6, 3)
+    FLASH_VER_LAST = (2, 8, 4)  # last supported, inclusive
+    flash_ver_parsed = tuple(int(s) for s in FLASH_VERSION.split(".")[:3])
+    if (
+        flash_ver_parsed < FLASH_VER_MIN or flash_ver_parsed > FLASH_VER_LAST
+    ) and os.environ.get("XFORMERS_IGNORE_FLASH_VERSION_CHECK", "0") != "1":
+        _min = ".".join([str(i) for i in FLASH_VER_MIN])
+        _max = ".".join([str(i) for i in FLASH_VER_LAST])
+        raise ImportError(
+            f"Requires Flash-Attention version >={_min},"
+            f"<={_max} but got {FLASH_VERSION}."
+        )
 
-            if hasattr(flash_attn.flash_attn_interface, "flash_attn_cuda"):
-                _C_flashattention = flash_attn.flash_attn_interface.flash_attn_cuda  # type: ignore[attr-defined]
-            else:
-                _C_flashattention = flash_attn.flash_attn_interface.flash_attn_gpu  # type: ignore[attr-defined]
+elif torch.version.hip is None and torch.backends.cuda.is_flash_attention_available():
+    ensure_pt_flash_ok()
+    FLASH_VERSION = torch.nn.attention._get_flash_version()  # type: ignore
+    _USE_PT_FLASH_ATTN = True
 
-            FLASH_VERSION = flash_attn.__version__
-            FLASH_VER_MIN = (2, 6, 3)
-            FLASH_VER_LAST = (2, 8, 3)  # last supported, inclusive
-            flash_ver_parsed = tuple(int(s) for s in FLASH_VERSION.split(".")[:3])
-            if (
-                flash_ver_parsed < FLASH_VER_MIN or flash_ver_parsed > FLASH_VER_LAST
-            ) and os.environ.get("XFORMERS_IGNORE_FLASH_VERSION_CHECK", "0") != "1":
-                raise ImportError(
-                    f"Requires Flash-Attention version >={'.'.join([str(i) for i in FLASH_VER_MIN])},"
-                    f"<={'.'.join([str(i) for i in FLASH_VER_LAST])} "
-                    f"but got {FLASH_VERSION}."
-                )
-            VARLEN_LSE_PACKED = True
-        except ImportError as e:
-            if not _TRY_PT_FLASH_ATTN:
-                raise e
-            pt_flash_is_old = is_pt_flash_old(force=True) is True
-            FLASH_VERSION = torch.nn.attention._get_flash_version()  # type: ignore
-            VARLEN_LSE_PACKED = not pt_flash_is_old
-            _USE_PT_FLASH_ATTN = True
+
+if FLASH_VERSION != "0.0.0":
 
     @torch.library.custom_op(
         "mslk_flash::flash_fwd",
@@ -139,23 +129,14 @@ try:  # noqa: C901
                 seqused_k=seqused_k,
                 alibi_slopes=None,  # alibi_slopes
             )
-            if pt_flash_is_old:
-                (
-                    attention,
-                    logsumexp,
-                    philox_seed,
-                    philox_offset,
-                    _,
-                ) = ret
-                rng_state = torch.stack([philox_seed, philox_offset])
-            else:
-                attention, logsumexp, rng_state, _, _ = ret
+            attention, logsumexp, rng_state, _, _ = ret
             return attention, logsumexp, rng_state
         else:
+            assert _flash_attn_cuda is not None
             if cu_seqlens_q is None:
                 assert cu_seqlens_k is None
                 assert seqused_k is None
-                out, softmax_lse, p, rng_state = _C_flashattention.fwd(
+                out, softmax_lse, p, rng_state = _flash_attn_cuda.fwd(
                     query,
                     key,
                     value,
@@ -171,7 +152,7 @@ try:  # noqa: C901
                     None,  # rng
                 )
             else:
-                out, softmax_lse, p, rng_state = _C_flashattention.varlen_fwd(
+                out, softmax_lse, p, rng_state = _flash_attn_cuda.varlen_fwd(
                     query,
                     key,
                     value,
@@ -217,14 +198,10 @@ try:  # noqa: C901
         out = torch.empty_like(query)
         if cu_seqlens_q is None:
             B, M, H, K = query.shape
-            lse_shape = [B, H, M]  # XXXX ?
+            lse_shape = [B, H, M]
         else:
             M, H, K = query.shape
-            B = cu_seqlens_q.shape[0] - 1
-            if VARLEN_LSE_PACKED:
-                lse_shape = [H, M]
-            else:
-                lse_shape = [B, H, max_seqlen_q]
+            lse_shape = [H, M]
         softmax_lse = torch.empty(lse_shape, device=query.device, dtype=torch.float32)
         rng_state = torch.empty([2], device=query.device, dtype=torch.int64)
         return out, softmax_lse, rng_state
@@ -256,11 +233,7 @@ try:  # noqa: C901
         softcap = 0.0
         if _USE_PT_FLASH_ATTN:
             assert softcap == 0.0
-            if rng_state is not None and pt_flash_is_old:
-                rng_state0 = rng_state[0]
-                rng_state1 = rng_state[1]
-            else:
-                rng_state0 = rng_state1 = rng_state
+            rng_state0 = rng_state1 = rng_state
             dq, dk, dv = torch.ops.aten._flash_attention_backward(
                 grad,
                 query,
@@ -281,10 +254,11 @@ try:  # noqa: C901
                 window_size_right=window_right,
             )
         else:
+            assert _flash_attn_cuda is not None
             dq, dk, dv = _create_dq_dk_dv(grads_share_storage, query, key, value)
             if cu_seqlens_k is None:
                 assert cu_seqlens_q is None
-                _C_flashattention.bwd(
+                _flash_attn_cuda.bwd(
                     grad,
                     query,
                     key,
@@ -306,7 +280,7 @@ try:  # noqa: C901
                     rng_state,
                 )
             else:
-                _C_flashattention.varlen_bwd(
+                _flash_attn_cuda.varlen_bwd(
                     grad,
                     query,
                     key,
@@ -360,9 +334,6 @@ try:  # noqa: C901
             )
             return chunk.select(-3, 0), chunk.select(-3, 1), chunk.select(-3, 2)
         return torch.empty_like(query), torch.empty_like(key), torch.empty_like(value)
-
-except ImportError:
-    pass
 
 
 def _convert_input_format(
@@ -517,6 +488,18 @@ def _window_size(
     return (win_left, win_right)
 
 
+def _is_paged_attention_supported(attn_bias_type) -> bool:
+    if issubclass(attn_bias_type, PagedBlockDiagonalPaddedKeysMask):
+        return not _USE_PT_FLASH_ATTN
+    if issubclass(
+        attn_bias_type,
+        (PagedBlockDiagonalGappyKeysMask, PagedBlockDiagonalPaddedKeysMask),
+    ):
+        return not torch.mtia.is_available()
+
+    return True
+
+
 def _check_needs_no_topleft(d: Inputs, reasons: List[str]) -> None:
     # Flash does not support TopLeft, so only allow causal masks with TopLeft
     # if each batch element has equal number of queries and keys.
@@ -536,7 +519,7 @@ def _check_needs_no_topleft(d: Inputs, reasons: List[str]) -> None:
     elif isinstance(attn_bias, LowerTriangularMask):
         if d.query.shape[1] != d.key.shape[1]:
             reasons.append(
-                "Only support LowerTriangularMask if equal number ofkeys and queries"
+                "Only support LowerTriangularMask if equal number of keys and queries"
             )
 
 
@@ -571,23 +554,11 @@ def _post_process_lse(
         return lse
 
     # Already packed: just bring back the batch dimension
-    if VARLEN_LSE_PACKED:
-        if len(original_query_shape) == 5:
-            # (1, G, H, total_q)
-            return lse.unflatten(0, original_query_shape[2:4]).unsqueeze(0)
-        # (1, H, total_q)
-        return lse.unsqueeze(0)
-
-    if not inp.is_partial:
-        # (B, H, M)
-        return lse
-
-    # reshape from (B, G*H, max_seqlen) to (1, G*H, B*max_seqlen)
-    # Unfortunately this flatten is not just a view.
-    lse_hkm = lse.permute(1, 0, 2).flatten(start_dim=1)[None]
     if len(original_query_shape) == 5:
-        return lse_hkm.unflatten(1, original_query_shape[2:4])
-    return lse_hkm
+        # (1, G, H, total_q)
+        return lse.unflatten(0, original_query_shape[2:4]).unsqueeze(0)
+    # (1, H, total_q)
+    return lse.unsqueeze(0)
 
 
 @register_operator
@@ -624,12 +595,15 @@ class FwOp(AttentionFwOpBase):
         PagedBlockDiagonalPaddedKeysMask,
     )
 
+    SUPPORTED_ATTN_BIAS_TYPES = tuple(
+        b for b in SUPPORTED_ATTN_BIAS_TYPES if _is_paged_attention_supported(b)
+    )
+
     SUPPORTS_DROPOUT = True
     SUPPORTS_CUSTOM_SCALE = True
     SUPPORTS_DIFFERENT_VALUE_EMBED = False
     SUPPORTS_BMGHK = True
     SUPPORTS_PARTIAL = True
-    VARLEN_LSE_PACKED = VARLEN_LSE_PACKED
     NAME = f"fa2F@{FLASH_VERSION}-pt" if _USE_PT_FLASH_ATTN else f"fa2F@{FLASH_VERSION}"
     VERSION = FLASH_VERSION
 
@@ -641,16 +615,6 @@ class FwOp(AttentionFwOpBase):
         _check_strides_for_bmghk(d.query, "query", reasons)
         _check_strides_for_bmghk(d.key, "key", reasons)
         _check_strides_for_bmghk(d.value, "value", reasons)
-
-        if (
-            d.is_partial
-            and not VARLEN_LSE_PACKED
-            and isinstance(d.attn_bias, VARLEN_BIASES)
-        ):
-            q_seqinfo = d.attn_bias.q_seqinfo
-            if q_seqinfo.min_seqlen != q_seqinfo.max_seqlen:
-                # Flash provides padded LSE which we don't handle.
-                reasons.append("partial attention with heterogeneous queries")
 
         if isinstance(
             d.attn_bias,
@@ -711,7 +675,7 @@ class FwOp(AttentionFwOpBase):
             rng_state = None
             lse_shape = (
                 [inp.query.shape[2], inp.query.shape[0] * inp.query.shape[1]]
-                if VARLEN_LSE_PACKED and isinstance(inp.attn_bias, VARLEN_BIASES)
+                if isinstance(inp.attn_bias, VARLEN_BIASES)
                 else [inp.query.shape[0], inp.query.shape[2], inp.query.shape[1]]
             )
             if inp.is_partial:
@@ -759,7 +723,9 @@ class BwOp(AttentionBwOpBase):
                 BlockDiagonalGappyKeysMask,
                 BlockDiagonalPaddedKeysMask,
                 PagedBlockDiagonalCausalLocalPaddedKeysMask,
+                PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
                 PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
+                PagedBlockDiagonalGappyKeysMask,
                 PagedBlockDiagonalPaddedKeysMask,
             }
         )
@@ -769,7 +735,6 @@ class BwOp(AttentionBwOpBase):
     SUPPORTS_DIFFERENT_VALUE_EMBED = FwOp.SUPPORTS_DIFFERENT_VALUE_EMBED
     IS_DETERMINISTIC = False
     SUPPORTS_BMGHK = False  # NOTE: Don't forget to update fmha doc when changing this!
-    VARLEN_LSE_PACKED = VARLEN_LSE_PACKED
     NAME = f"fa2B@{FLASH_VERSION}-pt" if _USE_PT_FLASH_ATTN else f"fa2B@{FLASH_VERSION}"
     VERSION = FLASH_VERSION
 
@@ -809,7 +774,7 @@ class BwOp(AttentionBwOpBase):
         # assert ctx.lse.is_contiguous()
         assert seqused_k is None
         ctx_lse = ctx.lse
-        if isinstance(inp.attn_bias, VARLEN_BIASES) and VARLEN_LSE_PACKED:
+        if isinstance(inp.attn_bias, VARLEN_BIASES):
             assert ctx_lse.shape[0] == 1
             ctx_lse = ctx_lse[0]
         else:

--- a/mslk/attention/fmha/flash3.py
+++ b/mslk/attention/fmha/flash3.py
@@ -6,8 +6,10 @@
 # pyre-unsafe
 
 
+import importlib.util
+import logging
 import os
-from typing import Any, Iterable, List, Optional, Sequence, Set, Tuple, TypeVar
+from typing import Any, Iterable, List, Optional, Sequence, Set, Tuple
 
 import torch
 from torch.utils.flop_counter import (
@@ -55,36 +57,62 @@ from .flash import (
     _post_process_lse,
     _window_size,
 )
+from .flash3_compatibility_check import (
+    _flash_attention3_incompatible_reason,
+    check_ai_codesign_compatibility,
+)
 from .utils.op_common import get_operator, register_operator
 
+
+def _check_different_value_headdim_ampere(d: Inputs, reasons: List[str]) -> None:
+    if (
+        d.query.device.type == "cuda"
+        and (torch.version.hip is None)
+        and d.query.shape[-1] != d.value.shape[-1]
+    ):
+        device_capability = torch.cuda.get_device_capability(d.device)
+        if device_capability < (9, 0):
+            reasons.append(
+                f"Q/K head-dim ({d.query.shape[-1]}) must be equal "
+                f"to V head-dim ({d.value.shape[-1]}) for Ampere GPUs"
+            )
+
+
 FLASH_VERSION = "0.0.0"
-
-T = TypeVar("T")
-
-
-def maybe_contiguous(x: T) -> T:
-    return x.contiguous() if x is not None and x.stride(-1) != 1 else x  # type: ignore[attr-defined]
+logger = logging.getLogger(__name__)
 
 
+def maybe_contiguous(x: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+    if x is not None and x.stride(-1) != 1:
+        return x.contiguous()
+    return x
+
+
+_FLASH3_HAS_ATTENTION_CHUNK = False
+_C_flashattention3 = None
 try:
-    from xformers import _C_flashattention3  # type: ignore[attr-defined]
+    # fbcode internal path - always fails in OSS
+    from ai_codesign.gen_ai.flash_attention_v2.hopper.flash_attn_interface import (  # type: ignore  # noqa: E501
+        flashattn_hopper_cuda as _C_flashattention3,
+    )
 
-    try:
-        from xformers._cpp_lib import _build_metadata  # type: ignore[attr-defined]
-
-        if _build_metadata is not None:
-            FLASH_VERSION = _build_metadata.flash_version
-    except ImportError:
-        FLASH_VERSION = "unknown"
+    check_ai_codesign_compatibility(_C_flashattention3)
 except ImportError:
-    try:
-        # type: ignore
-        from ai_codesign.gen_ai.flash_attention_v2.hopper.flash_attn_interface import (
-            flashattn_hopper_cuda as _C_flashattention3,
-        )
-    except ImportError:
-        # We end up here is arch is not 90a
-        _C_flashattention3 = None
+    # OSS: use the official flash_attn_3 package
+    if importlib.util.find_spec("flash_attn_3") and importlib.util.find_spec(
+        "flash_attn_3._C"
+    ):
+        import flash_attn_3._C  # type: ignore[attr-defined]  # noqa: F401
+
+        incompat_reason = _flash_attention3_incompatible_reason()
+        if incompat_reason is None:
+            _C_flashattention3 = torch.ops.flash_attn_3
+            FLASH_VERSION = "pip_pkg"
+            _FLASH3_HAS_ATTENTION_CHUNK = True
+        else:
+            logger.warning(
+                f"Flash-Attention 3 package can't be used: {incompat_reason}"
+            )
 
 
 def _heuristic_kvsplit(
@@ -94,13 +122,13 @@ def _heuristic_kvsplit(
     atten_bias = inp.attn_bias
 
     # make sure Q doesn't have varlen
-    # pyre-ignore Undefined attribute [16]
-    if atten_bias.q_seqinfo.min_seqlen != atten_bias.q_seqinfo.max_seqlen:  # type: ignore[union-attr]
+    q_info = atten_bias.q_seqinfo  # type: ignore[union-attr]
+    k_info = atten_bias.k_seqinfo  # type: ignore[union-attr]
+    if q_info.min_seqlen != q_info.max_seqlen:
         return False
 
     # filter out prefill case
-    # pyre-ignore Undefined attribute [16]
-    if atten_bias.q_seqinfo.max_seqlen == atten_bias.k_seqinfo.max_seqlen:  # type: ignore[union-attr]
+    if q_info.max_seqlen == k_info.max_seqlen:
         return False
 
     return enable_kvsplit_attn
@@ -116,7 +144,8 @@ def mask_non_zeros(s_q: int, s_k: int, window_left: int, window_right: int) -> i
 
     # NOTE: Flops calculations here assume `s_q == s_k`
     # otherwise the local attention computations are too involved
-    # See also https://docs.google.com/spreadsheets/d/1u1ItCZcHLArcqXLj7mwR4H1pI3lMKU1zlxCYi8JCYgk/edit?usp=sharing
+    # See also https://docs.google.com/spreadsheets/d/
+    #   1u1ItCZcHLArcqXLj7mwR4H1pI3lMKU1zlxCYi8JCYgk
     if window_left < 0:
         window_left = s_k
     if window_right < 0:
@@ -176,34 +205,6 @@ def sdpa_flop_count(
 
 
 if _C_flashattention3 is not None:  # noqa: C901
-    # Compatibility check for FAv3 APIs
-    EXPECTED_NUM_OF_ARGS = [
-        ("fwd", 33),
-        ("bwd", 22),
-    ]
-
-    import re
-
-    def count_args_from_doc(docstring) -> int:
-        # Use a regular expression to find the argument list inside parentheses
-        match = re.search(r"\((.*?)\)", docstring)
-        if match:
-            # Extract the argument list and split by commas
-            args_list = match.group(1).split(",")
-            # Count the number of arguments
-            return len(args_list)
-        else:
-            raise ValueError("No valid argument list found in the docstring.")
-
-    for name, num_of_args in EXPECTED_NUM_OF_ARGS:
-        num_of_args_from_doc = count_args_from_doc(
-            getattr(_C_flashattention3, name).__doc__
-        )
-        assert num_of_args_from_doc == num_of_args, (
-            f"Found func signature mismatch for {name}. Expected {num_of_args},"
-            f"actual: {num_of_args_from_doc} Please update the version of Flash Attention3."
-        )
-
     # returns: out, q_padded, k_padded, v_padded, out_padded, softmax_lse, p
     @torch.library.custom_op(
         "mslk_flash3::flash_fwd", mutates_args=(), device_types=["cuda"]
@@ -251,7 +252,8 @@ if _C_flashattention3 is not None:  # noqa: C901
 
         pack_gqa = None
         if use_kvsplit:
-            # For KV split, we need to make sure query in shape [batch, seqlen, num_heads, head_dim_q]
+            # For KV split, query must be
+            # [batch, seqlen, num_heads, head_dim_q]
             # to be compatible with `pack_gqa` feature
             query = query.view(bs, -1, query.shape[-2], query.shape[-1])
             cu_seqlens_q = None
@@ -289,6 +291,9 @@ if _C_flashattention3 is not None:  # noqa: C901
             is_causal,
             window_left,
             window_right,
+            *(
+                [0] if _FLASH3_HAS_ATTENTION_CHUNK else []
+            ),  # attention_chunk (flash_attn_3 pip pkg only)
             0.0,  # softcap
             not use_kvsplit,  # rotary_interleaved
             None,  # scheduler_metadata
@@ -385,7 +390,8 @@ if _C_flashattention3 is not None:  # noqa: C901
         # all ranks always use the "worst case" FLOP estimate. Ranks are in
         # lockstep anyways and will be going as fast as the slowest one.
         if os.environ.get("XFORMERS_FLOP_FORMULA_WORST_CASE", "0") == "1":
-            cu_seqlens_q = cu_seqlens_k = max_seqlen_q = max_seqlen_k = None  # type: ignore[assignment]
+            cu_seqlens_q = cu_seqlens_k = None  # type: ignore[assignment]
+            max_seqlen_q = max_seqlen_k = None  # type: ignore[assignment]
             query = query.unsqueeze(0) if query.ndim == 3 else query
             key = key.unsqueeze(0) if key.ndim == 3 else key
             value = value.unsqueeze(0) if value.ndim == 3 else value
@@ -448,12 +454,13 @@ if _C_flashattention3 is not None:  # noqa: C901
         window_right: int,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         dq, dk, dv = _create_dq_dk_dv(grads_share_storage, query, key, value)
-        is_deterministic = False
+        is_deterministic = torch.are_deterministic_algorithms_enabled()
         if cu_seqlens_q is None:
             assert cu_seqlens_k is None
 
         assert _C_flashattention3 is not None
-        dq, dk, dv, softmax_d, *rest = _C_flashattention3.bwd(
+        # bwd writes dq/dk/dv in-place; return values are other tensors.
+        _C_flashattention3.bwd(
             dout,
             query,
             key,
@@ -556,7 +563,7 @@ class FwOp(AttentionFwOpBase):
 
     OPERATOR = get_operator("mslk_flash3", "flash_fwd")
     SUPPORTED_DEVICES: Set[str] = {"cuda"}
-    CUDA_MINIMUM_COMPUTE_CAPABILITY = (9, 0)
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (8, 0)
     CUDA_MAXIMUM_COMPUTE_CAPABILITY = (9, 0)
     SUPPORTED_DTYPES: Set[torch.dtype] = {
         torch.half,
@@ -592,7 +599,7 @@ class FwOp(AttentionFwOpBase):
 
     SUPPORTS_DROPOUT = False
     SUPPORTS_CUSTOM_SCALE = True
-    SUPPORTS_DIFFERENT_VALUE_EMBED = False
+    SUPPORTS_DIFFERENT_VALUE_EMBED = True
     SUPPORTS_BMGHK = True
     SUPPORTS_PARTIAL = True
     UNPADDED_LSE = True
@@ -607,6 +614,7 @@ class FwOp(AttentionFwOpBase):
             reasons.append("only head-dim 64, 128, 192 or 256 is supported")
 
         _check_needs_no_topleft(d, reasons)
+        _check_different_value_headdim_ampere(d, reasons)
 
         return reasons
 
@@ -747,7 +755,6 @@ class BwOp(AttentionBwOpBase):
     SUPPORTS_DROPOUT = FwOp.SUPPORTS_DROPOUT
     SUPPORTS_CUSTOM_SCALE = FwOp.SUPPORTS_CUSTOM_SCALE
     SUPPORTS_DIFFERENT_VALUE_EMBED = FwOp.SUPPORTS_DIFFERENT_VALUE_EMBED
-    IS_DETERMINISTIC = False
     SUPPORTS_BMGHK = False
     SUPPORTS_LSE_FORMATS: Sequence[str] = ["", "varlen_flat"]
     NAME = f"fa3B@{FLASH_VERSION}"
@@ -757,11 +764,11 @@ class BwOp(AttentionBwOpBase):
     def not_supported_reasons(cls, d: Inputs) -> List[str]:
         reasons = super(BwOp, cls).not_supported_reasons(d)
         check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
-        _check_needs_no_topleft(d, reasons)
         if d.query.shape[-1] not in [64, 128, 192, 256]:
             reasons.append("only head-dim 64, 128, 192 or 256 is supported")
 
         _check_needs_no_topleft(d, reasons)
+        _check_different_value_headdim_ampere(d, reasons)
         return reasons
 
     @classmethod
@@ -800,7 +807,7 @@ class BwOp(AttentionBwOpBase):
                 inp.key,
                 inp.value,
                 ctx.out.reshape(kernel_out_shape),
-                ctx.lse,
+                ctx_lse,
                 cu_seqlens_q,
                 cu_seqlens_k,
                 max_seqlen_q,
@@ -826,9 +833,10 @@ class BwOp(AttentionBwOpBase):
 
 @register_operator
 class FwOp_KVSplit(FwOp):
-    """Operator that computes memory-efficient attention using \
-        `Flash-Attention3 <https://github.com/Dao-AILab/flash-attention/tree/main/hopper>`_ \
-        implementation with heuristic rules to dispatch decoding shapes to KVSplit Attention \
+    """Flash-Attention3 with heuristic KVSplit dispatch.
+
+    Uses heuristic rules to dispatch decoding shapes
+    to KVSplit Attention.
     """
 
     NAME = f"fa3F_splitKV@{FLASH_VERSION}"
@@ -841,6 +849,7 @@ class FwOp_KVSplit(FwOp):
         BlockDiagonalCausalWithOffsetGappyKeysMask,
         BlockDiagonalGappyKeysMask,
         BlockDiagonalLocalAttentionPaddedKeysMask,
+        BlockDiagonalCausalLocalAttentionPaddedKeysMask,
         PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
         PagedBlockDiagonalGappyKeysMask,
         PagedBlockDiagonalPaddedKeysMask,

--- a/mslk/attention/fmha/flash3_compatibility_check.py
+++ b/mslk/attention/fmha/flash3_compatibility_check.py
@@ -1,0 +1,139 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+# pyre-unsafe
+
+import re
+from typing import Optional
+
+import torch
+from torch._C import parse_schema
+
+
+def _flash_attention3_incompatible_reason() -> Optional[str]:
+    if not hasattr(torch.ops.flash_attn_3, "fwd") or not hasattr(
+        torch.ops.flash_attn_3, "bwd"
+    ):
+        return (
+            "PyTorch has no `flash_attn_3` "
+            "- is your Flash-Attention version recent enough?"
+        )
+    _fwd_schema = torch.ops.flash_attn_3.fwd.default._schema  # type: ignore
+    if not _fwd_schema.is_backward_compatible_with(
+        parse_schema(
+            "flash_attn_3::fwd("
+            "Tensor q, Tensor k, Tensor v, "
+            "Tensor(k_new!)? k_new=None, "
+            "Tensor(v_new!)? v_new=None, "
+            "Tensor? q_v=None, Tensor(out!)? out=None, "
+            "Tensor? cu_seqlens_q=None, "
+            "Tensor? cu_seqlens_k=None, "
+            "Tensor? cu_seqlens_k_new=None, "
+            "Tensor? seqused_q=None, "
+            "Tensor? seqused_k=None, "
+            "int? max_seqlen_q=None, "
+            "int? max_seqlen_k=None, "
+            "Tensor? page_table=None, "
+            "Tensor? kv_batch_idx=None, "
+            "Tensor? leftpad_k=None, "
+            "Tensor? rotary_cos=None, "
+            "Tensor? rotary_sin=None, "
+            "Tensor? seqlens_rotary=None, "
+            "Tensor? q_descale=None, "
+            "Tensor? k_descale=None, "
+            "Tensor? v_descale=None, "
+            "float? softmax_scale=None, "
+            "bool is_causal=False, "
+            "int window_size_left=-1, "
+            "int window_size_right=-1, "
+            "int attention_chunk=0, "
+            "float softcap=0., "
+            "bool is_rotary_interleaved=False, "
+            "Tensor? scheduler_metadata=None, "
+            "int num_splits=0, "
+            "bool? pack_gqa=None, "
+            "int sm_margin=0) "
+            "-> (Tensor(out!), Tensor, Tensor, Tensor)"
+        )
+    ):
+        return "flash_attn_3::fwd operator is not compatible"
+
+    _bwd_schema = torch.ops.flash_attn_3.bwd.default._schema  # type: ignore
+    _bwd_expected = parse_schema(
+        "flash_attn_3::bwd("
+        "Tensor dout, Tensor q, Tensor k, Tensor v, "
+        "Tensor out, Tensor softmax_lse, "
+        "Tensor(dq!)? dq=None, "
+        "Tensor(dk!)? dk=None, "
+        "Tensor(dv!)? dv=None, "
+        "Tensor? cu_seqlens_q=None, "
+        "Tensor? cu_seqlens_k=None, "
+        "Tensor? seqused_q=None, "
+        "Tensor? seqused_k=None, "
+        "int? max_seqlen_q=None, "
+        "int? max_seqlen_k=None, "
+        "float? softmax_scale=None, "
+        "bool is_causal=False, "
+        "int window_size_left=-1, "
+        "int window_size_right=-1, "
+        "float softcap=0., "
+        "bool deterministic=False, "
+        "int sm_margin=0) "
+        "-> (Tensor(dq!), Tensor(dk!), Tensor(dv!), "
+        "Tensor, Tensor, Tensor, Tensor, Tensor)"
+    )
+    _bwd_expected_alt = parse_schema(
+        "flash_attn_3::bwd("
+        "Tensor dout, Tensor q, Tensor k, Tensor v, "
+        "Tensor out, Tensor softmax_lse, "
+        "Tensor(dq!)? dq=None, "
+        "Tensor(dk!)? dk=None, "
+        "Tensor(dv!)? dv=None, "
+        "Tensor? cu_seqlens_q=None, "
+        "Tensor? cu_seqlens_k=None, "
+        "Tensor? seqused_q=None, "
+        "Tensor? seqused_k=None, "
+        "int? max_seqlen_q=None, "
+        "int? max_seqlen_k=None, "
+        "float? softmax_scale=None, "
+        "bool is_causal=False, "
+        "int window_size_left=-1, "
+        "int window_size_right=-1, "
+        "float softcap=0., "
+        "bool deterministic=False, "
+        "int sm_margin=0) "
+        "-> (Tensor, Tensor, Tensor, Tensor, Tensor)"
+    )
+    if not _bwd_schema.is_backward_compatible_with(
+        _bwd_expected
+    ) and not _bwd_schema.is_backward_compatible_with(_bwd_expected_alt):
+        return "flash_attn_3::bwd operator is not compatible"
+    return None
+
+
+def _count_args_from_doc(docstring: str) -> int:
+    """Count the number of arguments from a pybind docstring."""
+    match = re.search(r"\((.*?)\)", docstring)
+    if match:
+        args_list = match.group(1).split(",")
+        return len(args_list)
+    else:
+        raise ValueError("No valid argument list found in the docstring.")
+
+
+def check_ai_codesign_compatibility(c_module: object) -> None:
+    """Compatibility check for ai_codesign FAv3 APIs."""
+    expected_num_of_args = [
+        ("fwd", 33),
+        ("bwd", 22),
+    ]
+    for name, num_of_args in expected_num_of_args:
+        num_of_args_from_doc = _count_args_from_doc(getattr(c_module, name).__doc__)
+        assert num_of_args_from_doc == num_of_args, (
+            f"Found func signature mismatch for {name}. "
+            f"Expected {num_of_args}, "
+            f"actual: {num_of_args_from_doc} "
+            "Please update the version of Flash Attention3."
+        )

--- a/mslk/attention/fmha/torch_attention_compat.py
+++ b/mslk/attention/fmha/torch_attention_compat.py
@@ -5,8 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 # pyre-strict
 
-from typing import Optional
-
 import torch
 from torch._C import parse_schema
 
@@ -63,92 +61,72 @@ def is_pt_cutlass_compatible(force: bool = False) -> bool:
     return compatible
 
 
-def is_pt_flash_old(force: bool) -> Optional[bool]:
-    """
-    Returns True if the current PyTorch version has the old Flash-Attention
-    ops instead of the new ones.
-    If it has none at all, raises an ImportError or returns None.
-    """
+def ensure_pt_flash_ok() -> None:
+    """Raises an ImportError if the current PyTorch version
+    has an unexpected Flash-Attention."""
     if not torch.backends.cuda.is_flash_attention_available():
-        if force:
-            raise ImportError("Flash SDP backend is disabled")
-        return None
+        raise ImportError("Flash SDP backend is disabled")
 
     if not hasattr(torch.nn, "attention") or not hasattr(
         torch.nn.attention, "_get_flash_version"
     ):
-        if force:
-            raise ImportError(
-                f"Current Torch {torch.__version__} doesnt implement "
-                "torch.nn.attention._get_flash_version()"
-            )
-        return None
+        raise ImportError(
+            f"Current Torch {torch.__version__} doesnt implement "
+            "torch.nn.attention._get_flash_version()"
+        )
 
     FLASH_VERSION = torch.nn.attention._get_flash_version()
 
-    compatible = True
-
-    # old = before 25/2/2025
-    # https://github.com/pytorch/pytorch/commit/3ecfe6be256c585bcadf4c845d7119545444a222
-    old_fwd_schema_str = (
-        "aten::_flash_attention_forward(Tensor query, Tensor key, Tensor value, "
-        "Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, float dropout_p, "
-        "bool is_causal, bool return_debug_mask, *, float? scale=None, "
-        "SymInt? window_size_left=None, SymInt? window_size_right=None, "
-        "Tensor? seqused_k=None, Tensor? alibi_slopes=None) -> (Tensor output, Tensor softmax_logsumexp, "
-        "Tensor philox_seed, Tensor philox_offset, Tensor debug_attn_mask)"
-    )
     fwd_schema_str = (
-        "aten::_flash_attention_forward(Tensor query, Tensor key, Tensor value, "
-        "Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, float dropout_p, "
-        "bool is_causal, bool return_debug_mask, *, float? scale=None, "
-        "SymInt? window_size_left=None, SymInt? window_size_right=None, "
-        "Tensor? seqused_k=None, Tensor? alibi_slopes=None) -> (Tensor output, Tensor softmax_logsumexp, "
-        "Tensor rng_state, Tensor unused, Tensor debug_attn_mask)"
+        "aten::_flash_attention_forward("
+        "Tensor query, Tensor key, Tensor value, "
+        "Tensor? cum_seq_q, Tensor? cum_seq_k, "
+        "SymInt max_q, SymInt max_k, "
+        "float dropout_p, "
+        "bool is_causal, bool return_debug_mask, *, "
+        "float? scale=None, "
+        "SymInt? window_size_left=None, "
+        "SymInt? window_size_right=None, "
+        "Tensor? seqused_k=None, "
+        "Tensor? alibi_slopes=None) -> "
+        "(Tensor output, Tensor softmax_logsumexp, "
+        "Tensor rng_state, Tensor unused, "
+        "Tensor debug_attn_mask)"
     )
     expected_fwd_schema = parse_schema(fwd_schema_str)
-    expected_old_fwd_schema = parse_schema(old_fwd_schema_str)
 
-    current_schema = torch.ops.aten._flash_attention_forward.default._schema
-    old = current_schema.is_backward_compatible_with(expected_old_fwd_schema)
-    if not old and not current_schema.is_backward_compatible_with(expected_fwd_schema):
-        compatible = False
+    current_schema = torch.ops.aten._flash_attention_forward.default._schema  # noqa: E501
+    if not current_schema.is_backward_compatible_with(expected_fwd_schema):
+        raise ImportError(
+            "Current Torch with Flash-Attention "
+            f"{FLASH_VERSION} doesnt have a compatible "
+            "aten::_flash_attention_forward schema\n"
+            f"EXPECTED:\n{expected_fwd_schema}\n"
+            f"but GOT:\n{current_schema}"
+        )
 
-        if force:
-            raise ImportError(
-                f"Current Torch with Flash-Attention {FLASH_VERSION} doesnt have "
-                "a compatible aten::_flash_attention_forward schema\n"
-                f"EXPECTED:\n{expected_old_fwd_schema}\n"
-                f"or:\n{expected_fwd_schema}\n"
-                f"but GOT:\n{current_schema}"
-            )
-
-    bwd_schema_old_str = (
-        "aten::_flash_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, "
-        "Tensor out, Tensor logsumexp, Tensor cum_seq_q, Tensor cum_seq_k, SymInt max_q, SymInt max_k, "
-        "float dropout_p, bool is_causal, Tensor philox_seed, Tensor philox_offset, *, float? scale=None, "
-        "SymInt? window_size_left=None, SymInt? window_size_right=None) -> (Tensor, Tensor, Tensor)"
-    )
     bwd_schema_str = (
-        "aten::_flash_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, "
-        "Tensor out, Tensor logsumexp, Tensor cum_seq_q, Tensor cum_seq_k, SymInt max_q, SymInt max_k, "
-        "float dropout_p, bool is_causal, Tensor rng_state, Tensor unused, *, float? scale=None, "
-        "SymInt? window_size_left=None, SymInt? window_size_right=None) -> (Tensor, Tensor, Tensor)"
+        "aten::_flash_attention_backward("
+        "Tensor grad_out, Tensor query, "
+        "Tensor key, Tensor value, "
+        "Tensor out, Tensor logsumexp, "
+        "Tensor cum_seq_q, Tensor cum_seq_k, "
+        "SymInt max_q, SymInt max_k, "
+        "float dropout_p, bool is_causal, "
+        "Tensor rng_state, Tensor unused, *, "
+        "float? scale=None, "
+        "SymInt? window_size_left=None, "
+        "SymInt? window_size_right=None) -> "
+        "(Tensor, Tensor, Tensor)"
     )
-    expected_bwd_schema = parse_schema(bwd_schema_old_str if old else bwd_schema_str)
+    expected_bwd_schema = parse_schema(bwd_schema_str)
 
-    current_schema = torch.ops.aten._flash_attention_backward.default._schema
+    current_schema = torch.ops.aten._flash_attention_backward.default._schema  # noqa: E501
     if not current_schema.is_backward_compatible_with(expected_bwd_schema):
-        compatible = False
-
-        if force:
-            raise ImportError(
-                f"Current Torch with Flash-Attention {FLASH_VERSION} doesnt have "
-                "a compatible aten::_flash_attention_backward schema\n"
-                f"EXPECTED:\n{expected_bwd_schema}\n"
-                f"but GOT:\n{current_schema}"
-            )
-
-    if not compatible:
-        return None
-    return old
+        raise ImportError(
+            "Current Torch with Flash-Attention "
+            f"{FLASH_VERSION} doesnt have a compatible "
+            "aten::_flash_attention_backward schema\n"
+            f"EXPECTED:\n{expected_bwd_schema}\n"
+            f"but GOT:\n{current_schema}"
+        )

--- a/setup.py
+++ b/setup.py
@@ -628,6 +628,18 @@ def main(argv: List[str]) -> None:
             "cmdclass": {"install": MSLKInstall},
         }
 
+    # Flash Attention 3 package is optional, only for CUDA.
+    # Install with: pip install mslk[flash3]
+    # flash-attn-3 (v3): Hopper (SM90) and newer
+    # NOTE: flash-attn-3 may require:
+    #   --extra-index-url https://download.pytorch.org/whl/cu126
+    # Flash Attention v2 uses PyTorch's built-in implementation.
+    extras_require = {}
+    if build.variant() == "cuda":
+        extras_require["flash3"] = [
+            "flash-attn-3",
+        ]
+
     _setup_fn(
         name=package_name,
         version=package_version,
@@ -652,6 +664,7 @@ def main(argv: List[str]) -> None:
             # nightly and test packages
             "numpy",
         ],
+        extras_require=extras_require,
         # PyPI package information
         classifiers=[
             "Development Status :: 4 - Beta",


### PR DESCRIPTION
Summary:
Replace xformers C extension imports with official flash attention packages
for OSS builds:

flash3.py (Flash Attention v3):
- Try ai_codesign (fbcode internal) first, then flash_attn_3 pip package
- Add schema-based compatibility checking for the pip package path
- Handle attention_chunk arg difference (pip has 34 fwd args, ai_codesign has 33)
- Extract compatibility checks to flash3_compatibility_check.py

flash.py (Flash Attention v2):
- Try flash_attn pip package first (resolves to ai_codesign in fbcode), then
  fall back to PyTorch built-in flash attention
- Drop old PT flash support (pt_flash_is_old), use ensure_pt_flash_ok()
- Remove VARLEN_LSE_PACKED from flash.py (always True, inherited from base class)
- Simplify _post_process_lse and _flash_fwd_abstract accordingly

torch_attention_compat.py:
- Add ensure_pt_flash_ok() that rejects old PT flash entirely

setup.py:
- Add optional extras for flash attention packages (Linux + CUDA only):
  pip install mslk[flash] for v2 (Ampere+), mslk[flash3] for v3 (Hopper+)

Differential Revision: D95059444


