### PR TITLE
Add vendored quack to internal build

### DIFF
--- a/MslkDefault.cmake
+++ b/MslkDefault.cmake
@@ -177,4 +177,7 @@ if(BUILD_FB_CODE)
   install(
     DIRECTORY fb/mslk/attention/flash_attn
     DESTINATION mslk/fb/mslk/attention)
+  install(
+    DIRECTORY fb/external/quack
+    DESTINATION mslk/fb/external)
 endif()


### PR DESCRIPTION
Summary:
Install fb/external/quack/ into the package when BUILD_FB_CODE is
enabled, so the vendored quack is available in pip-installed MSLK
builds. Excludes the BUCK file which is fbsource-only.

Differential Revision: D95144843


