### PR TITLE
Replace C-style asserts with TORCH_CHECK

### DIFF
--- a/csrc/kv_cache/kv_cache.cu
+++ b/csrc/kv_cache/kv_cache.cu
@@ -263,7 +263,8 @@ __global__ void rope_xpos_qkv_varseq_prefill_kernel(
   if (update_kv) {
     N_KVH = XK.size(1);
   } else {
-    assert(!write_k_back);
+    CUDA_KERNEL_ASSERT_MSG(
+        !write_k_back, "write_k_back must be false when update_kv is false");
   }
   auto N_H = XQ.size(1);
   auto D_H = XQ.size(2);
@@ -1053,7 +1054,9 @@ at::Tensor nope_qkv_varseq_prefill(
 
   at::Tensor XK, XV;
   if (!update_kv) {
-    assert(XK_.has_value() == false);
+    TORCH_CHECK(
+        XK_.has_value() == false,
+        "XK_ must not have a value when update_kv is false");
     XK = at::empty_like(XQ);
     // at::zeros({0, 0, 0}, at::BFloat16); // at::zeros(0);
     XV = at::empty_like(XQ);
@@ -1258,7 +1261,9 @@ at::Tensor nope_qkv_decoding(
   auto N_KVH = 0;
   at::Tensor XK, XV;
   if (!update_kv) {
-    assert(XK_.has_value() == false);
+    TORCH_CHECK(
+        XK_.has_value() == false,
+        "XK_ must not have a value when update_kv is false");
     XK = at::empty_like(XQ);
     // at::zeros({0, 0, 0}, at::BFloat16); // at::zeros(0);
     XV = at::empty_like(XQ);
@@ -1461,7 +1466,9 @@ at::Tensor rope_qkv_varseq_prefill(
 
   at::Tensor XK, XV;
   if (!update_kv) {
-    assert(XK_.has_value() == false);
+    TORCH_CHECK(
+        XK_.has_value() == false,
+        "XK_ must not have a value when update_kv is false");
     XK = at::empty_like(XQ);
     // at::zeros({0, 0, 0}, at::BFloat16); // at::zeros(0);
     XV = at::empty_like(XQ);
@@ -1844,7 +1851,9 @@ at::Tensor rope_qkv_decoding(
   auto N_KVH = 0;
   at::Tensor XK, XV;
   if (!update_kv) {
-    assert(XK_.has_value() == false);
+    TORCH_CHECK(
+        XK_.has_value() == false,
+        "XK_ must not have a value when update_kv is false");
     XK = at::empty_like(XQ);
     // at::zeros({0, 0, 0}, at::BFloat16); // at::zeros(0);
     XV = at::empty_like(XQ);

--- a/csrc/moe/gather_scatter.cu
+++ b/csrc/moe/gather_scatter.cu
@@ -212,9 +212,13 @@ void gather_or_scatter_along_first_dim(
     at::Tensor src,
     at::Tensor index,
     at::Tensor dst) {
-  assert(src.dtype() == TorchDTypeTrait<DataType>::dtype());
-  assert(dst.dtype() == TorchDTypeTrait<DataType>::dtype());
-  assert(index.dtype() == TorchDTypeTrait<IndexType>::dtype());
+  TORCH_CHECK(
+      src.dtype() == TorchDTypeTrait<DataType>::dtype(), "src dtype mismatch");
+  TORCH_CHECK(
+      dst.dtype() == TorchDTypeTrait<DataType>::dtype(), "dst dtype mismatch");
+  TORCH_CHECK(
+      index.dtype() == TorchDTypeTrait<IndexType>::dtype(),
+      "index dtype mismatch");
 
   constexpr int L = kL;
   const int M = src.size(0);
@@ -313,14 +317,14 @@ void scatter_add_along_first_dim(
   const int K = src.size(1);
   const int N = index.size(0);
   if (N == 0 || M == 0) {
-    assert(M == 0);
+    TORCH_CHECK(M == 0, "M must be 0 when N == 0 || M == 0");
     return;
   }
   if (dst.is_contiguous() && dst.dim() == 2 && src.is_contiguous() &&
       src.dim() == 2 && index.is_contiguous() && index.dim() == 1) {
     using T = cutlass::bfloat16_t;
 
-    assert(dst.size(1) == K);
+    TORCH_CHECK(dst.size(1) == K, "dst.size(1) must equal K");
     // TODO(shikaili): Make it supports more configurations.
     if (dst.dtype() == at::kBFloat16 && src.dtype() == at::kBFloat16 &&
         (K * sizeof(T) % kTmaGmemAlignment == 0) && (K % kL == 0)) {

--- a/csrc/quantize/quantize.cu
+++ b/csrc/quantize/quantize.cu
@@ -495,7 +495,7 @@ __inline__ __device__ T blockReduceMax(T val) {
 }
 
 __device__ float atomicMaxExtd(float* address, float val) {
-  assert(val >= 0);
+  CUDA_KERNEL_ASSERT(val >= 0);
   unsigned int* address_as_u = reinterpret_cast<unsigned int*>(address);
   unsigned int old = atomicMax(address_as_u, __float_as_uint(val));
   return __uint_as_float(old);

--- a/include/mslk/utils/cuda_prelude.cuh
+++ b/include/mslk/utils/cuda_prelude.cuh
@@ -34,10 +34,10 @@ namespace mslk {
   at::cuda::OptionalCUDAGuard device_guard; \
   device_guard.set_index(TENSOR.get_device())
 
-#define MSLK_CUDA_CHECK(X)                 \
-  do {                                     \
-    cudaError_t err = X;                   \
-    assert(err == cudaError::cudaSuccess); \
+#define MSLK_CUDA_CHECK(X)                                           \
+  do {                                                               \
+    cudaError_t err = X;                                             \
+    TORCH_CHECK(err == cudaError::cudaSuccess, "CUDA error: ", err); \
   } while (0)
 
 // Warp size


### PR DESCRIPTION
Summary: - Replace C-style asserts with TORCH_CHECK, since assert() can be no-op if -DNDEBUG is defined

Differential Revision: D95505866


