### PR TITLE
Fix import error blocking MTIA startup

### DIFF
--- a/mslk/attention/fmha/cute_blackwell.py
+++ b/mslk/attention/fmha/cute_blackwell.py
@@ -74,7 +74,7 @@ def _get_operator(name: str):
         import mslk.attention.flash_attn.interface as flash_attn
 
         return getattr(flash_attn, name)  # type: ignore  # pyre-ignore
-    except (RuntimeError, ModuleNotFoundError):
+    except (RuntimeError, ModuleNotFoundError, AttributeError):
         return no_such_operator
 
 


### PR DESCRIPTION
Summary:
Fix an import-time crash that prevents the MTIA vLLM binary from
starting:

**cute_blackwell.py**: Add `AttributeError` to the exception handler
in `_get_operator()`. The existing handler catches `RuntimeError` and
`ModuleNotFoundError`, but a CUTLASS DSL version mismatch in
`flash_fwd_sm100.py` raises `AttributeError` (for
`PipelineClcFetchAsync`), which propagated uncaught and killed the
process at startup.

Before:
```
AttributeError: module 'cutlass.pipeline' has no attribute 'PipelineClcFetchAsync'
```
After: Import failure is caught gracefully; `no_such_operator` fallback used.

Differential Revision: D95647194


