### PR TITLE
Add actual_num_tokens hint and smaller tile sizes to CUTLASS grouped GEMM kernel selection

### DIFF
--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped.cu
@@ -33,7 +33,8 @@ Kernel_mx8mx8bf16_grouped get_kernel_via_tuning(
     at::Tensor offsets) {
   static TuningCache cache("mx8mx8bf16_grouped");
 
-  M = nextPowerOf2OrRoundUp(M, 1024, 1024);
+  // Don't round M — fine-grained M values matter for hint path kernel
+  // selection. N and K are model-specific and already in 1024 increments.
   N = nextPowerOf2OrRoundUp(N, 1024, 1024);
   K = nextPowerOf2OrRoundUp(K, 1024, 1024);
   const std::string shape_key =
@@ -48,17 +49,637 @@ Kernel_mx8mx8bf16_grouped get_kernel_via_tuning(
 
 Kernel_mx8mx8bf16_grouped
 get_kernel_via_heuristics(int M, int N, int K, int G) {
-  if (M <= 64) {
+  if (M <= 1) {
     return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
-  } else if (M <= 128) {
+  } else if (M <= 2) {
+    if (N <= 2048) {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    } else if (N <= 3072) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    }
+  } else if (M <= 4) {
     if (N <= 1024) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    }
+  } else if (M <= 8) {
+    if (N <= 2048) {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    } else if (N <= 3072) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 7168) {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    } else {
       if (K <= 5120) {
         return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    }
+  } else if (M <= 16) {
+    if (N <= 2048) {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    } else if (N <= 3072) {
+      if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    }
+  } else if (M <= 32) {
+    if (N <= 1024) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 3072) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      }
+    } else if (N <= 4096) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 5120) {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    } else if (N <= 6144) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 7168) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else {
+      if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    }
+  } else if (M <= 48) {
+    if (N <= 1024) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      }
+    } else if (N <= 3072) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 5120) {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    } else if (N <= 7168) {
+      if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      }
+    } else {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    }
+  } else if (M <= 64) {
+    if (N <= 1024) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    } else if (N <= 3072) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 4096) {
+      if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 5120) {
+      return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+    } else if (N <= 6144) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else if (N <= 7168) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    } else {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_128_64_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_64_256_2_1_1_ba;
+      }
+    }
+  } else if (M <= 96) {
+    if (N <= 2048) {
+      return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+    } else if (N <= 3072) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_128_128_256_1_1_1_ba;
       } else {
         return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
       }
-    } else {
+    } else if (N <= 4096) {
+      if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_128_128_256_1_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_128_128_256_1_1_1_ba;
+      }
+    } else if (N <= 5120) {
+      if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_128_128_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      }
+    } else if (N <= 6144) {
       return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+    } else if (N <= 7168) {
+      if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_128_128_256_1_1_1_ba;
+      }
+    } else {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_128_128_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      }
+    }
+  } else if (M <= 128) {
+    if (N <= 1024) {
+      if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_128_128_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      }
+    } else if (N <= 4096) {
+      return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+    } else if (N <= 5120) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_128_128_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      }
+    } else if (N <= 7168) {
+      return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+    } else {
+      if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_128_256_256_1_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      }
+    }
+  } else if (M <= 160) {
+    if (N <= 1024) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 3072) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 4096) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 5120) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 6144) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 7168) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+    } else {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    }
+  } else if (M <= 192) {
+    if (N <= 1024) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 3072) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 4096) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 5120) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 6144) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 7168) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+    } else {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    }
+  } else if (M <= 256) {
+    if (N <= 1024) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 2048) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 3072) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else if (N <= 4096) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 5120) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+    } else if (N <= 6144) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 7168) {
+      if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      }
+    } else {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    }
+  } else if (M <= 384) {
+    if (N <= 1024) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_128_256_256_1_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_128_128_256_1_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      }
+    } else if (N <= 2048) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      }
+    } else if (N <= 3072) {
+      return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+    } else if (N <= 4096) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      }
+    } else if (N <= 5120) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_128_256_256_1_1_1_ab;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_128_256_256_1_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 6144) {
+      if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 7168) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_128_256_256_1_1_1_ab;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else {
+      if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_128_256_2_1_1_ba;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else {
+        return mx8mx8bf16_grouped_128_256_256_1_1_1_ab;
+      }
+    }
+  } else if (M <= 512) {
+    if (N <= 1024) {
+      if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 2048) {
+      if (K <= 5120) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 6144) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 7168) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 3072) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+    } else if (N <= 4096) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 5120) {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 6144) {
+      if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 4096) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
+    } else if (N <= 7168) {
+      return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+    } else {
+      if (K <= 1024) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else if (K <= 2048) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      } else if (K <= 3072) {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ba;
+      } else {
+        return mx8mx8bf16_grouped_256_256_256_2_1_1_ab;
+      }
     }
   } else if (M <= 1024) {
     if (N <= 1024) {
@@ -471,7 +1092,8 @@ at::Tensor mx8mx8bf16_grouped_mm(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor offsets,
-    std::optional<at::Tensor> output) {
+    std::optional<at::Tensor> output,
+    std::optional<int64_t> actual_num_tokens) {
   TORCH_CHECK(offsets.dtype() == at::kInt, "offsets must be int32.");
   TORCH_CHECK(offsets.dim() == 1, "offsets must be 1D tensor.");
   TORCH_CHECK(XQ.is_contiguous(), "XQ must be row major.");
@@ -505,10 +1127,24 @@ at::Tensor mx8mx8bf16_grouped_mm(
             output_actual.size(1) == N,
         "for 2d-3d grouped GEMM, output shape must be (total_M, N).");
 
-    // Normalized jagged dim for heuristics
-    M /= G;
+    // Normalized jagged dim for heuristics.
+    // If Matrix is padded in the M dimension, the offsets may be for a
+    // prefix of M. This could lead to a larger tile size picked than necessary.
+    // Callers can pass actual_num_tokens to override the heuristic.
+    if (actual_num_tokens.has_value()) {
+      auto ant = actual_num_tokens.value();
+      TORCH_CHECK(ant > 0, "actual_num_tokens must be > 0, got ", ant);
+      M = ant / G;
+    } else {
+      M /= G;
+    }
     // 2d-2d case.
   } else if (XQ.dim() == 2 && WQ.dim() == 2) {
+    // actual_num_tokens is only used for 2d-3d forward (M-dimension padding).
+    TORCH_CHECK(
+        !actual_num_tokens.has_value(),
+        "actual_num_tokens is not supported for 2d-2d grouped GEMM.");
+
     // Alias for clarity that groups are along K dimension for 2d-2d case.
     int64_t total_K = K;
 
@@ -550,7 +1186,8 @@ at::Tensor mx8mx8bf16_grouped_mm(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor offsets,
-    std::optional<at::Tensor> output) {
+    std::optional<at::Tensor> output,
+    std::optional<int64_t> actual_num_tokens) {
   throw std::runtime_error(
       "CUDA version is older than 12.8"); // requires CUDA>=12.8
 }

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_128_256_1_1_1_ba.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_128_256_1_1_1_ba.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx8bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx8bf16_grouped_128_128_256_1_1_1_ba(
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx8bf16_grouped_impl<128, 128, 256, 1, 1, 1, true>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_256_256_1_1_1_ab.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_256_256_1_1_1_ab.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx8bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx8bf16_grouped_128_256_256_1_1_1_ab(
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx8bf16_grouped_impl<128, 256, 256, 1, 1, 1, false>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_256_256_1_1_1_ba.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_256_256_1_1_1_ba.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx8bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx8bf16_grouped_128_256_256_1_1_1_ba(
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx8bf16_grouped_impl<128, 256, 256, 1, 1, 1, true>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_64_256_1_1_1_ba.cu
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_64_256_1_1_1_ba.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx8bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx8bf16_grouped_128_64_256_1_1_1_ba(
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx8bf16_grouped_impl<128, 64, 256, 1, 1, 1, true>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_manifest.cuh
+++ b/csrc/gemm/cutlass/mx8mx8bf16_grouped/mx8mx8bf16_grouped_manifest.cuh
@@ -12,6 +12,44 @@ namespace mslk::gemm {
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
+// TB_M=128, TBS_M=1 (1-SM schedule)
+at::Tensor mx8mx8bf16_grouped_128_64_256_1_1_1_ba(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx8bf16_grouped_128_128_256_1_1_1_ba(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx8bf16_grouped_128_256_256_1_1_1_ba(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx8bf16_grouped_128_256_256_1_1_1_ab(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+// TB_M=256, TBS_M=2 (2-SM cooperative schedule)
 at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1_ba(
     at::Tensor XQ,
     at::Tensor WQ,
@@ -61,12 +99,22 @@ const std::unordered_map<std::string, Kernel_mx8mx8bf16_grouped>&
 get_mx8mx8bf16_grouped_kernels() {
   static const std::unordered_map<std::string, Kernel_mx8mx8bf16_grouped>
       kernels = {
-          {"mx8mx8bf16_grouped_256_256_256_2_1_1_ab",
-           mx8mx8bf16_grouped_256_256_256_2_1_1_ab},
+          // TB_M=128 (1-SM)
+          {"mx8mx8bf16_grouped_128_64_256_1_1_1_ba",
+           mx8mx8bf16_grouped_128_64_256_1_1_1_ba},
+          {"mx8mx8bf16_grouped_128_128_256_1_1_1_ba",
+           mx8mx8bf16_grouped_128_128_256_1_1_1_ba},
+          {"mx8mx8bf16_grouped_128_256_256_1_1_1_ba",
+           mx8mx8bf16_grouped_128_256_256_1_1_1_ba},
+          {"mx8mx8bf16_grouped_128_256_256_1_1_1_ab",
+           mx8mx8bf16_grouped_128_256_256_1_1_1_ab},
+          // TB_M=256 (2-SM cooperative)
           {"mx8mx8bf16_grouped_256_64_256_2_1_1_ba",
            mx8mx8bf16_grouped_256_64_256_2_1_1_ba},
           {"mx8mx8bf16_grouped_256_128_256_2_1_1_ba",
            mx8mx8bf16_grouped_256_128_256_2_1_1_ba},
+          {"mx8mx8bf16_grouped_256_256_256_2_1_1_ab",
+           mx8mx8bf16_grouped_256_256_256_2_1_1_ab},
           {"mx8mx8bf16_grouped_256_256_256_2_1_1_ba",
            mx8mx8bf16_grouped_256_256_256_2_1_1_ba},
       };

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -56,7 +56,7 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   m.def(
       "f4f4bf16_grouped_stacked(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes, Tensor? global_scale=None, Tensor? starting_row_after_padding=None, bool use_mx=True) -> Tensor");
   m.def(
-      "mx8mx8bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None) -> Tensor");
+      "mx8mx8bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None, int? actual_num_tokens=None) -> Tensor");
   m.def(
       "f4f4bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None, Tensor(a!)? global_scale=None) -> Tensor");
   m.def(

--- a/include/mslk/gemm/gemm_torch.h
+++ b/include/mslk/gemm/gemm_torch.h
@@ -32,7 +32,8 @@ at::Tensor mx8mx8bf16_grouped_mm(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor offsets,
-    std::optional<at::Tensor> output = std::nullopt);
+    std::optional<at::Tensor> output = std::nullopt,
+    std::optional<int64_t> actual_num_tokens = std::nullopt);
 
 // Torch compliant FP4 grouped GEMM.
 at::Tensor f4f4bf16_grouped_mm(

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -1780,6 +1780,138 @@ class MXFP8Tests(unittest.TestCase):
         # Assert outputs are close.
         torch.testing.assert_close(y_mxfp8, y_bf16, atol=8.0e-2, rtol=8.0e-2)
 
+    @settings(deadline=None)
+    @given(
+        G=st.sampled_from([4, 16, 32]),
+        M_per_group=st.sampled_from([16, 32, 64]),
+        pad_factor=st.sampled_from([2, 4, 8]),
+        N=st.sampled_from([1024, 2048]),
+        K=st.sampled_from([512, 3072]),
+    )
+    def test_grouped_gemm_2d_3d_actual_num_tokens(
+        self,
+        G: int,
+        M_per_group: int,
+        pad_factor: int,
+        N: int,
+        K: int,
+    ) -> None:
+        """Test that actual_num_tokens hint produces correct results.
+
+        XQ is padded to pad_factor * actual_total_M, but offsets only cover the
+        actual tokens. Verifies that:
+        1. Output with hint matches output without hint (same GEMM, different tile)
+        2. Output matches bf16 reference
+        """
+        from mslk.gemm.triton.fp8_gemm import to_mxfp8
+
+        block_size = 32
+        actual_total_M = M_per_group * G
+        padded_total_M = actual_total_M * pad_factor
+
+        # Create actual data
+        X = (
+            torch.randn((actual_total_M, K), dtype=torch.bfloat16, device=self.device)
+            * 0.1
+        )
+        W = torch.randn((G, N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+
+        # Uniform offsets for actual tokens
+        offsets = torch.arange(
+            M_per_group,
+            actual_total_M + 1,
+            M_per_group,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        # Quantize weights
+        wq_list = []
+        w_scale_list = []
+        for i in range(G):
+            w_scale, wq = to_mxfp8(W[i])
+            w_scale = _to_blocked(w_scale)
+            wq_list.append(wq)
+            w_scale_list.append(w_scale)
+        wq = torch.stack(wq_list, dim=0).contiguous()
+        w_scale = torch.stack(w_scale_list, dim=0).contiguous()
+
+        # Quantize input per group
+        xq_list = []
+        x_scale_list = []
+        for i in range(G):
+            x_slice = X[i * M_per_group : (i + 1) * M_per_group]
+            xs, xq = to_mxfp8(x_slice)
+            xs = _to_blocked(xs)
+            xq_list.append(xq)
+            x_scale_list.append(xs)
+        xq_actual = torch.cat(xq_list, dim=0).contiguous()
+        x_scale_actual = torch.cat(x_scale_list, dim=0).contiguous()
+        x_scale_actual = x_scale_actual.reshape(-1, K // block_size)
+
+        # Pad XQ and x_scale to simulate static-shape padding
+        xq_padded = torch.zeros(
+            (padded_total_M, K), dtype=torch.float8_e4m3fn, device=self.device
+        )
+        xq_padded[:actual_total_M] = xq_actual
+
+        actual_scale_rows = x_scale_actual.shape[0]
+        padded_scale_rows = max(
+            ((padded_total_M + 127) // 128) * 128, actual_scale_rows
+        )
+        x_scale_padded = torch.zeros(
+            (padded_scale_rows, x_scale_actual.shape[1]),
+            dtype=x_scale_actual.dtype,
+            device=self.device,
+        )
+        x_scale_padded[:actual_scale_rows] = x_scale_actual
+
+        # Run without hint (actual_num_tokens=None)
+        out_no_hint = torch.empty(
+            (padded_total_M, N), dtype=torch.bfloat16, device=self.device
+        )
+        y_no_hint = torch.ops.mslk.mx8mx8bf16_grouped_mm(
+            xq_padded,
+            wq.transpose(-2, -1),
+            x_scale_padded,
+            w_scale,
+            offsets,
+            out_no_hint,
+        )
+
+        # Run with hint (actual_num_tokens=actual_total_M)
+        out_with_hint = torch.empty(
+            (padded_total_M, N), dtype=torch.bfloat16, device=self.device
+        )
+        y_with_hint = torch.ops.mslk.mx8mx8bf16_grouped_mm(
+            xq_padded,
+            wq.transpose(-2, -1),
+            x_scale_padded,
+            w_scale,
+            offsets,
+            out_with_hint,
+            actual_total_M,
+        )
+
+        # Outputs should be identical (only tile selection differs)
+        torch.testing.assert_close(
+            y_no_hint[:actual_total_M],
+            y_with_hint[:actual_total_M],
+            atol=0.0,
+            rtol=0.0,
+        )
+
+        # Compare with bf16 reference
+        y_bf16 = torch._grouped_mm(
+            X,
+            W.transpose(-2, -1),
+            offs=offsets,
+            out_dtype=torch.bfloat16,
+        )
+        torch.testing.assert_close(
+            y_with_hint[:actual_total_M], y_bf16, atol=8.0e-2, rtol=8.0e-2
+        )
+
 
 @unittest.skipIf(
     not SUPPORTS_BF16, "Skip if BF16Tests is not supported on this device."


### PR DESCRIPTION
Summary:
When Matrix A is padded in the M-dimension (=dimension of number of tokens, e.g., T*topk padding), the grouped GEMM heuristic uses PaddedTensor.size(0)/G to select tile sizes. This leads to oversized tiles because PaddedTensor.size(0) includes padding beyond the actual token count.

This diffs adds an `actual_num_tokens` parameter (as optional, for backward compatible) that callers can use to override the heuristic with the true token count, enabling appropriately sized tile selection. Actual number of tokens should represent "expected" total number of tokens to be received to the local experts (in the grouped gemm function, it will be further divided by the number of local experts, representing expected number of tokens per expert).

Reviewed By: cthi

Differential Revision: D95738860


