### PR TITLE
Fix AMD FP16 UVM performance regression by using vectorized stores

### DIFF
--- a/include/mslk/utils/float.cuh
+++ b/include/mslk/utils/float.cuh
@@ -51,9 +51,17 @@ struct Half4 {
 
   __device__ inline void store(at::Half* p) {
 #ifdef USE_ROCM
-    *reinterpret_cast<unsigned int*>(p) = *reinterpret_cast<unsigned int*>(&a);
-    *reinterpret_cast<unsigned int*>(p + 2) =
-        *reinterpret_cast<unsigned int*>(&b);
+    // CRITICAL PERFORMANCE FIX: Use single 64-bit store instead of two 32-bit
+    // stores. With UVM (managed memory), each separate store can trigger a
+    // page fault, causing significant slowdown. A single 64-bit store (uint2)
+    // reduces this to at most one page fault.
+    union {
+      half2 h[2];
+      uint2 ui;
+    } tmp;
+    tmp.h[0] = a;
+    tmp.h[1] = b;
+    *reinterpret_cast<uint2*>(p) = tmp.ui;
 #elif CUDA_VERSION >= 9000
 
 #ifndef __HALF2_TO_UI


### PR DESCRIPTION
Summary:
Apply the same Half4::store() fix from fbgemm_gpu to mslk. Use single 64-bit store (uint2) instead of two 32-bit stores for AMD ROCm.

With UVM (managed memory), each separate store can trigger a page fault, causing significant slowdown. A single 64-bit store reduces this to at most one page fault.

Reviewed By: henrylhtsang

Differential Revision: D96156750


