### PR TITLE
Add missing cute_hopper import to fmha __init__.py (#217)

### DIFF
--- a/mslk/attention/fmha/__init__.py
+++ b/mslk/attention/fmha/__init__.py
@@ -9,12 +9,13 @@ from typing import Any, cast, List, Optional, Sequence, Tuple, Type, Union
 
 import torch
 
-from . import (
+from . import (  # noqa: F401
     attn_bias,
     ck,
     ck_decoder,
     ck_splitk,
     cute_blackwell,
+    cute_hopper,
     cutlass,
     cutlass_blackwell,
     flash,
@@ -986,4 +987,5 @@ __all__ = [
     "_get_use_fa3",
     "_set_use_fa3",
     "BlockDiagonalMask",
+    "cute_hopper",
 ]


### PR DESCRIPTION
Summary:

The `cute_hopper` module exists in `mslk/attention/fmha/` but was not
imported in `__init__.py`, causing `AttributeError: module
'mslk.attention.fmha' has no attribute 'cute_hopper'` when tests
reference `fmha.cute_hopper.FwOp`.

**Context:** test_mem_eff_attention uses it.

Reviewed By: cthi

Differential Revision: D96362702
