### PR TITLE
Simplify cpp_lib.py: remove xformers dead code and rename to mslk (#220)

### DIFF
--- a/mslk/attention/fmha/common.py
+++ b/mslk/attention/fmha/common.py
@@ -33,7 +33,6 @@ from .attn_bias import (
     PagedBlockDiagonalGappyKeysMask,
     PagedBlockDiagonalPaddedKeysMask,
 )
-from .utils.cpp_lib import _built_with_cuda
 from .utils.op_common import BaseOperator
 
 
@@ -538,12 +537,6 @@ class AttentionOpBase(BaseOperator):
         dtype = d.query.dtype
         if device_type not in cls.SUPPORTED_DEVICES:
             reasons.append(f"device={device_type} (supported: {cls.SUPPORTED_DEVICES})")
-        if (
-            device_type == "cuda"
-            and not _built_with_cuda
-            and (torch.version.hip is None)
-        ):
-            reasons.append("Library not built with CUDA support")
         if device_type == "cuda" and (torch.version.hip is None):
             device_capability = torch.cuda.get_device_capability(d.device)
             if device_capability < cls.CUDA_MINIMUM_COMPUTE_CAPABILITY:
@@ -582,9 +575,7 @@ class AttentionOpBase(BaseOperator):
         if dtype is torch.bfloat16 and not supports_bf16:
             reasons.append("bf16 is only supported on A100+ GPUs and MTIA")
         if not cls.is_available():
-            reasons.append(
-                "operator wasn't built - see `python -m xformers.info` for more info"
-            )
+            reasons.append("operator wasn't built")
         if not cls.IS_DETERMINISTIC and torch.are_deterministic_algorithms_enabled():
             reasons.append(
                 "operator is non-deterministic, but `torch.use_deterministic_algorithms` is set"

--- a/mslk/attention/fmha/dispatch.py
+++ b/mslk/attention/fmha/dispatch.py
@@ -176,10 +176,6 @@ def _dispatch_fw(inp: Inputs, needs_gradient: bool) -> Type[AttentionFwOpBase]:
     )
 
 
-def _is_cutlassB_faster_than_flash(inp: Inputs) -> bool:
-    return False
-
-
 def _dispatch_bw(
     inp: Inputs, varlen_lse_packed: Optional[bool]
 ) -> Type[AttentionBwOpBase]:
@@ -219,10 +215,6 @@ def _dispatch_bw(
         priority_list_ops = [
             op for op in priority_list_ops if op.VARLEN_LSE_PACKED == varlen_lse_packed
         ]
-    if torch.version.cuda and _is_cutlassB_faster_than_flash(inp):
-        priority_list_ops.remove(cutlass.BwOp)
-        priority_list_ops.insert(0, cutlass.BwOp)
-
     # torch.mtia.is_available() cannot be called here because it isn't supported
     # when tracing with PT2, so we simply add flash_mtia to the end if the MTIA
     # dynamic library can be loaded

--- a/mslk/attention/fmha/triton_splitk.py
+++ b/mslk/attention/fmha/triton_splitk.py
@@ -135,8 +135,10 @@ class FwOp(AttentionFwOpBase):
     ...
 
     For fp8 only row-wise quantization is supported. To use it, provide input of type
-    xformers.ops.fmha.triton_splitk.InputsFp8 (instead of the usual xformers.ops.fmha.Inputs) to
-    xformers.ops.fmha.triton_splitk.FwOp.apply or xformers.ops.fmha._memory_efficient_attention_forward.
+    mslk.attention.fmha.triton_splitk.InputsFp8
+    (instead of the usual mslk.attention.fmha.Inputs) to
+    mslk.attention.fmha.triton_splitk.FwOp.apply
+    or mslk.attention.fmha._memory_efficient_attention_forward.
 
     This op uses Paged Attention when bias is one of the Paged* classes.
     In this case bias has additional fields:

--- a/mslk/attention/fmha/utils/cpp_lib.py
+++ b/mslk/attention/fmha/utils/cpp_lib.py
@@ -5,148 +5,59 @@
 # LICENSE file in the root directory of this source tree.
 # pyre-unsafe
 
-import dataclasses
 import logging
 import os
-import platform
 from pathlib import Path
-from typing import Any, Dict, Optional
 
-import torch
 
 logger = logging.getLogger("mslk_fmha")
 
 UNAVAILABLE_FEATURES_MSG = "  Memory-efficient attention won't be available."
 
 
-@dataclasses.dataclass
-class _BuildInfo:
-    metadata: Dict[str, Any]
-
-    @property
-    def cuda_version(self) -> Optional[int]:
-        return self.metadata["version"]["cuda"]
-
-    @property
-    def hip_version(self) -> Optional[int]:
-        return self.metadata["version"]["hip"]
-
-    @property
-    def torch_version(self) -> str:
-        return self.metadata["version"]["torch"]
-
-    @property
-    def python_version(self) -> str:
-        return self.metadata["version"]["python"]
-
-    @property
-    def flash_version(self) -> str:
-        return self.metadata["version"].get("flash", "0.0.0")
-
-    @property
-    def use_torch_flash(self) -> bool:
-        return self.metadata["version"].get("use_torch_flash", False)
-
-    @property
-    def build_env(self) -> Dict[str, Any]:
-        return self.metadata["env"]
-
-
-class xFormersWasNotBuiltException(Exception):
+class MslkWasNotBuiltException(Exception):
     def __str__(self) -> str:
         return (
             "Need to compile C++ extensions to use all fmha features.\n"
-            "    Please install xformers properly "
-            "(see https://github.com/facebookresearch/xformers#installing-xformers)\n"
-            + UNAVAILABLE_FEATURES_MSG
+            "    Please install mslk properly.\n" + UNAVAILABLE_FEATURES_MSG
         )
 
 
-class xFormersInvalidLibException(Exception):
-    def __init__(self, build_info: Optional[_BuildInfo]) -> None:
-        self.build_info = build_info
-
+class MslkInvalidLibException(Exception):
     def __str__(self) -> str:
-        if self.build_info is None:
-            msg = "fmha was built for a different version of PyTorch or Python."
-        else:
-            msg = f"""fmha was built for:
-    PyTorch {self.build_info.torch_version} with CUDA {self.build_info.cuda_version} (you have {torch.__version__})
-    Python  {self.build_info.python_version} (you have {platform.python_version()})"""
         return (
             "fmha can't load C++/CUDA extensions. "
-            + msg
-            + "\n  Please reinstall mslk "
-            + UNAVAILABLE_FEATURES_MSG
+            "fmha was built for a different version of PyTorch or Python."
+            "\n  Please reinstall mslk " + UNAVAILABLE_FEATURES_MSG
         )
 
 
 def _register_extensions():
     import importlib
-    import os
 
     import torch
 
-    # load the custom_op_library from the mslk directory
-    # and register the custom ops
+    # Only AMD builds ship a binary extension that needs explicit loading
+    if not (torch.version.hip and not hasattr(torch.version, "git_version")):
+        return
+
     lib_dir = str(Path(__file__).parent.parent.parent.parent)
-    if os.name == "nt":
-        # Register the main torchvision library location on the default DLL path
-        import ctypes
-        import sys
-
-        kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
-        with_load_library_flags = hasattr(kernel32, "AddDllDirectory")
-        prev_error_mode = kernel32.SetErrorMode(0x0001)
-
-        if with_load_library_flags:
-            kernel32.AddDllDirectory.restype = ctypes.c_void_p
-
-        if sys.version_info >= (3, 8):
-            os.add_dll_directory(lib_dir)
-        elif with_load_library_flags:
-            res = kernel32.AddDllDirectory(lib_dir)
-            if res is None:
-                err = ctypes.WinError(ctypes.get_last_error())
-                err.strerror += f' Error adding "{lib_dir}" to the DLL directories.'
-                raise err
-
-        kernel32.SetErrorMode(prev_error_mode)
-
     loader_details = (
         importlib.machinery.ExtensionFileLoader,
         importlib.machinery.EXTENSION_SUFFIXES,
     )
-
     extfinder = importlib.machinery.FileFinder(lib_dir, loader_details)
-    if torch.version.hip and not hasattr(torch.version, "git_version"):
-        ext_specs = extfinder.find_spec("_C_hip")
-    else:
-        ext_specs = extfinder.find_spec("_C")
+    ext_specs = extfinder.find_spec("_C_hip")
     if ext_specs is None:
-        raise xFormersWasNotBuiltException()
+        raise MslkWasNotBuiltException()
     try:
         torch.ops.load_library(ext_specs.origin)
     except OSError as exc:
-        raise xFormersInvalidLibException(None) from exc
+        raise MslkInvalidLibException() from exc
 
 
-_cpp_library_load_exception = None
-
-if os.environ.get("MSLK_PYTHON_ONLY", "0") == "1":
-    _cpp_library_load_exception = xFormersWasNotBuiltException()
-else:
+if os.environ.get("MSLK_PYTHON_ONLY", "0") != "1":
     try:
         _register_extensions()
-    except (xFormersInvalidLibException, xFormersWasNotBuiltException) as e:
-        ENV_VAR_FOR_DETAILS = "XFORMERS_MORE_DETAILS"
-        if os.environ.get(ENV_VAR_FOR_DETAILS, False):
-            logger.warning(f"WARNING[XFORMERS]: {e}", exc_info=e)
-        else:
-            logger.warning(
-                f"WARNING[XFORMERS]: {e}\n"
-                f"  Set {ENV_VAR_FOR_DETAILS}=1 for more details"
-            )
-        _cpp_library_load_exception = e
-
-_built_with_cuda = True  # XXXXX
+    except (MslkInvalidLibException, MslkWasNotBuiltException) as e:
+        logger.warning(f"WARNING[MSLK]: {e}", exc_info=e)


### PR DESCRIPTION
Summary:

cpp_lib.py was copied from xformers and had dead code and xformers-specific
naming. This removes the unused _BuildInfo class, _cpp_library_load_exception
variable, and hardcoded _built_with_cuda flag. Renames exceptions from
xFormers* to Mslk*, simplifies MslkInvalidLibException (removes unused
build_info parameter), and updates warning labels/env vars from XFORMERS
to MSLK. Also removes the dead _built_with_cuda check in common.py.

_register_extensions() is kept intact for pip/OSS builds on both CUDA and ROCm.

Reviewed By: cthi

Differential Revision: D96328593
