### PR TITLE
Guard backward op schema behind FMHA_OMIT_BACKWARD preprocessor define

### DIFF
--- a/csrc/attention/ck/fmha/attention.cpp
+++ b/csrc/attention/ck/fmha/attention.cpp
@@ -33,8 +33,10 @@ TORCH_LIBRARY_FRAGMENT(xformers, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention_forward_decoder_splitk_ck(Tensor query, Tensor key, "
       " Tensor value, Tensor? seq_positions, float scale, int split_k) -> Tensor"));
+#ifndef FMHA_OMIT_BACKWARD
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention_backward_ck(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor? attn_bias, Tensor? seqstart_q, Tensor? seqstart_k, int? max_seqlen_q, int? max_seqlen_k, Tensor? seqlen_k, Tensor logsumexp, Tensor output, float dropout_p, int rng_seed, int rng_offset, int custom_mask_type, float? scale, int? window_size) -> (Tensor, Tensor, Tensor, Tensor)"));
+#endif
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::_ck_rand_uniform(float p, Tensor out) -> Tensor"));
 #endif


### PR DESCRIPTION
Summary:
When FMHA_OMIT_BACKWARD is True, the backward kernel sources are excluded but
the operator schema was still declared, causing a confusing runtime error instead
of a clean no_such_operator fallback. Pass -DFMHA_OMIT_BACKWARD=1 from the BUCK
file and wrap the backward schema declaration in #ifndef so get_operator returns
no_such_operator when backward is omitted.

Reviewed By: cthi

Differential Revision: D96481331


