### PR TITLE
Fix ImportError not caught in cute_blackwell/cute_hopper _get_operator()

### DIFF
--- a/mslk/attention/fmha/cute_blackwell.py
+++ b/mslk/attention/fmha/cute_blackwell.py
@@ -75,7 +75,7 @@ def _get_operator(name: str):
         import mslk.attention.flash_attn.interface as flash_attn
 
         return getattr(flash_attn, name)  # type: ignore  # pyre-ignore
-    except (RuntimeError, ModuleNotFoundError, AttributeError):
+    except (RuntimeError, ModuleNotFoundError, AttributeError, ImportError):
         return no_such_operator
 
 

--- a/mslk/attention/fmha/cute_hopper.py
+++ b/mslk/attention/fmha/cute_hopper.py
@@ -49,7 +49,7 @@ def _get_operator(name: str):
         import mslk.attention.flash_attn.interface as flash_attn
 
         return getattr(flash_attn, name)
-    except (RuntimeError, ModuleNotFoundError, AttributeError):
+    except (RuntimeError, ModuleNotFoundError, AttributeError, ImportError):
         return no_such_operator
 
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/MSLK-NV/pull/170

D93160757 added `cute_blackwell` and D96362702 added `cute_hopper` as
eager imports in `mslk.attention.fmha.__init__`. Both modules call
`_get_operator()` at class-definition time, which imports
`mslk.attention.flash_attn.interface`. That module transitively loads
`cutlass._mlir` -> `libcuda.so.1`.

On devservers without a GPU, the missing shared library raises
`ImportError`. The existing `except` clause catches
`(RuntimeError, ModuleNotFoundError, AttributeError)` but not
`ImportError` -- `ModuleNotFoundError` is a subclass of `ImportError`,
so catching the child does not catch the parent.

This breaks all APS launcher invocations on GPU-less devservers
(e.g., `buck2 run ... //aps_models/ads/gmp:launcher_with_publish`)
because the model registry eagerly imports all registered models,
including those that transitively pull in `mslk.attention.fmha`.

Fix: add `ImportError` to the exception tuple in `_get_operator()` in
both `cute_blackwell.py` and `cute_hopper.py`. The function already
returns a safe `no_such_operator` fallback when the import fails, so
this is the intended graceful-degradation path.

Differential Revision: D96689708


