### PR TITLE
Apply fixup patch to fbsource

### DIFF
--- a/mslk/attention/fmha/cute_blackwell.py
+++ b/mslk/attention/fmha/cute_blackwell.py
@@ -356,7 +356,7 @@ class FwOp(AttentionFwOpBase):
         PagedBlockDiagonalCausalWithOffsetPaddedKeysMask,
         PagedBlockDiagonalCausalLocalPaddedKeysMask,
         # Prefill FWD does not support paged + gappy kv
-        # PagedBlockDiagonalGappyKeysMask,
+        # PagedBlockDiagonalGappyKeysMask, 
         # PagedBlockDiagonalCausalWithOffsetGappyKeysMask,
     )
     SUPPORTS_DROPOUT = False


### PR DESCRIPTION
Summary:
This is an automatically generated fixup patch to bring fbsource back into sync with
facebookexternal/MSLK-NV's main branch on GitHub. Land this patch as soon as possible, as the difference
reflected on here is already on GitHub and future changes may depend on these
changes!

<< DO NOT EDIT BELOW THIS LINE >>
diff-train-skip-merge

Generated by: https://www.internalfb.com/intern/sandcastle/job/22518000667118393/

GitHub Repo: facebookexternal/MSLK-NV

Reviewed By: henrylhtsang

Differential Revision: D96955714


