### PR TITLE
Apply fixup patch to fbsource

### DIFF
--- a/mslk/attention/fmha/cute_blackwell.py
+++ b/mslk/attention/fmha/cute_blackwell.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+# @nolint # fbcode
 # pyre-unsafe
 
 from typing import Any, Iterable, List, Mapping, Optional, Set, Tuple, Union

--- a/mslk/attention/fmha/cute_hopper.py
+++ b/mslk/attention/fmha/cute_hopper.py
@@ -310,12 +310,17 @@ class BwOp(AttentionBwOpBase):
     SUPPORTED_DTYPES = FwOp.SUPPORTED_DTYPES
     SUPPORTED_MAX_K = FwOp.SUPPORTED_MAX_K
     SUPPORTED_MIN_K = FwOp.SUPPORTED_MIN_K
-    # SM90 backward does NOT support varlen (cu_seqlens) or local attention (window_size).
-    # Only non-varlen causal masks are supported.
     SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
         type(None),
         LowerTriangularMask,
         LowerTriangularFromBottomRightMask,
+        BlockDiagonalCausalFromBottomRightMask,
+        BlockDiagonalMask,
+        BlockDiagonalCausalMask,
+        LocalAttentionFromBottomRightMask,
+        LowerTriangularFromBottomRightLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionMask,
+        BlockDiagonalCausalLocalAttentionFromBottomRightMask,
     )
     SUPPORTS_ATTN_BIAS_GRAD = False
     SUPPORTS_DROPOUT = FwOp.SUPPORTS_DROPOUT
@@ -340,8 +345,31 @@ class BwOp(AttentionBwOpBase):
             or d.value.ndim not in [4, 5]
         ):
             reasons.append("Only supports BMHK and BMGHK formats")
-        if _is_causal(d.attn_bias) and d.key.shape[1] > d.query.shape[1]:
-            reasons.append("SM90 causal requires Mq >= Mkv")
+
+            return reasons
+
+        (
+            _,
+            cu_seqlens_q,
+            _,
+            cu_seqlens_k,
+            _,
+            _,
+            _,
+        ) = _convert_input_format(d)
+
+        if isinstance(d.attn_bias, BlockDiagonalCausalMask):
+            if not _is_seqlen_q_le_seqlen_k(
+                d.attn_bias.q_seqinfo.seqstart_py,  # pyre-fixme[16]
+                d.attn_bias.k_seqinfo.seqstart_py,  # pyre-fixme[16]
+            ):
+                reasons.append("seqlens_k must be >= seqlens_q")
+
+        # SM90 top-left causal backward has a kernel limitation when Mkv > Mq
+        if _is_causal(d.attn_bias) and not _is_bottom_right(d.attn_bias):
+            if d.key.shape[1] > d.query.shape[1]:
+                reasons.append("SM90 top-left causal backward requires Mq >= Mkv")
+
         return reasons
 
     @classmethod
@@ -373,6 +401,8 @@ class BwOp(AttentionBwOpBase):
             _,
         ) = _convert_input_format(inp)
 
+        window_left, window_right = _window_size(inp.attn_bias)
+
         is_varlen = cu_seqlens_q is not None
         if query_ndim == 5:
             grad, _ = bmghk2bmhk(grad)
@@ -396,6 +426,8 @@ class BwOp(AttentionBwOpBase):
                     max_seq_len_q=max_seq_len_q,
                     max_seq_len_k=max_seq_len_k,
                     causal=_is_causal(inp.attn_bias),
+                    window_left=window_left,
+                    window_right=window_right,
                     bottom_right=_is_bottom_right(inp.attn_bias),
                     deterministic=deterministic,
                 )
@@ -411,3 +443,15 @@ class BwOp(AttentionBwOpBase):
         grads.dk = grads.dk.reshape(dk_shape)
         grads.dv = grads.dv.reshape(dv_shape)
         return grads
+
+
+def _is_seqlen_q_le_seqlen_k(
+    cu_seqlens_q_py: List[int], cu_seqlens_k_py: List[int]
+) -> bool:
+    if len(cu_seqlens_q_py) < 2 or len(cu_seqlens_k_py) < 2:
+        return True
+    cu_seqlens_q = torch.as_tensor(cu_seqlens_q_py, dtype=torch.int, device="cpu")
+    cu_seqlens_k = torch.as_tensor(cu_seqlens_k_py, dtype=torch.int, device="cpu")
+    seqlens_q = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+    seqlens_k = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
+    return torch.all(seqlens_k >= seqlens_q).item()  # pyre-fixme[7]


### PR DESCRIPTION
Summary:
This is an automatically generated fixup patch to bring fbsource back into sync with
facebookexternal/MSLK-NV's main branch on GitHub. Land this patch as soon as possible, as the difference
reflected on here is already on GitHub and future changes may depend on these
changes!

<< DO NOT EDIT BELOW THIS LINE >>
diff-train-skip-merge

Generated by: https://www.internalfb.com/intern/sandcastle/job/27021600302938370/

GitHub Repo: facebookexternal/MSLK-NV

Reviewed By: henrylhtsang

Differential Revision: D97016304
