### PR TITLE
Add support for optional global scale

### DIFF
--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -5316,7 +5316,7 @@ def cal_global_scale_mx4_as_nvfp4(x: torch.Tensor):
 
 def triton_quantize_nvfp4(
     x: torch.Tensor,
-    global_scale: torch.Tensor,
+    global_scale: torch.Tensor | None,
     use_e8m0_scale: bool = False,
     use_precise_math: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -5324,7 +5324,8 @@ def triton_quantize_nvfp4(
 
     Args:
         x (torch.Tensor): Input tensor to be quantized.
-        global_scale (torch.Tensor): Per-tensor scale for two-level quantization.
+        global_scale (torch.Tensor | None): Per-tensor scale for two-level quantization.
+            If None, the global scale is not applied (treated as 1.0).
         use_e8m0_scale (bool): Whether to use E8M0 for quantization. If True will mimic mx4's e8m0 scaling factor in nvfp4's fp8 local scale.
         use_precise_math (bool): Whether to use precise math for quantization.
             If disabled the kernel would multiply by the reciprocal instead of dividing when computing scales.
@@ -5364,6 +5365,11 @@ def triton_quantize_nvfp4(
     if M_PER_BLOCK != 128:
         grid = (grid[0], grid[1] + 1)
 
+    use_global_scale = global_scale is not None
+    if not use_global_scale:
+        # Pass a dummy pointer; the kernel won't load from it.
+        global_scale = x.new_empty(())
+
     triton_quantize_nvfp4_kernel[grid](
         x,
         global_scale,
@@ -5381,6 +5387,8 @@ def triton_quantize_nvfp4(
         USE_E8M0_SCALE=use_e8m0_scale,
         # pyre-ignore[6]
         USE_PRECISE_MATH=use_precise_math,
+        # pyre-ignore[6]
+        USE_GLOBAL_SCALE=use_global_scale,
     )
 
     # reshape back to original shape
@@ -5404,6 +5412,7 @@ def triton_quantize_nvfp4_kernel(
     USE_MASK: tl.constexpr,
     USE_E8M0_SCALE: tl.constexpr,
     USE_PRECISE_MATH: tl.constexpr,
+    USE_GLOBAL_SCALE: tl.constexpr,
 ):
     E4M3_EPS = 1.5258789e-05
     FP8_E4M3_MAX = 448.0
@@ -5442,7 +5451,10 @@ def triton_quantize_nvfp4_kernel(
         mask = None
         other = None
 
-    global_scale = tl.load(global_scale_ptr)  # Scalar
+    if USE_GLOBAL_SCALE:
+        global_scale = tl.load(global_scale_ptr)  # Scalar
+    else:
+        global_scale = 1.0
 
     x = tl.load(
         x_ptr + offs_m * stride_xm + offs_n * stride_xn, mask=mask, other=other

--- a/test/quantize/triton/fp4_quantize_test.py
+++ b/test/quantize/triton/fp4_quantize_test.py
@@ -285,23 +285,29 @@ class TestNVFp4Quantize:
             (4000, 4080),  # large square matrix with m and n padding
         ],
     )
-    def test_numerical_correctness(self, problem_shape):
+    @pytest.mark.parametrize("use_global_scale", [True, False])
+    def test_numerical_correctness(self, problem_shape, use_global_scale):
         """
         Quantize against torch NVFP4 reference and compare for numerical correctness.
+        When use_global_scale is False, quantize without global scale.
         """
         torch.manual_seed(0)
         M, N = problem_shape
         x = torch.randn(M, N, dtype=torch.bfloat16, device=self.device)
 
-        x_global_scale = global_scale_nvfp4(x)
+        if use_global_scale:
+            x_global_scale = global_scale_nvfp4(x)
+        else:
+            x_global_scale = None
+
         x_fp4, x_scales = triton_quantize_nvfp4(x, x_global_scale)
         x_fp4_ref, x_scales_ref, x_global_scale_ref = data_to_nvfp4_with_global_scale(
-            x, 16
+            x, 16, skip_global_scale=not use_global_scale
         )
-        # Compare the scales with padding to ensure the padding zero'd out.
         x_scales_ref = _to_blocked(x_scales_ref).view(x_scales.shape)
 
-        torch.testing.assert_close(x_global_scale, x_global_scale_ref.reciprocal())
+        if use_global_scale:
+            torch.testing.assert_close(x_global_scale, x_global_scale_ref.reciprocal())
         assert torch.equal(x_scales, x_scales_ref)
         assert torch.equal(x_fp4, x_fp4_ref)
 
@@ -389,21 +395,24 @@ class TestNVFp4RmsQuantize:
 
 
 # When the below functions is added to Torch core, remove it and use it there instead.
-def data_to_nvfp4_with_global_scale(x, block_size):
+def data_to_nvfp4_with_global_scale(x, block_size, skip_global_scale=False):
     # Simple (slow) reference implementation of NVFP4 two-level-scaling
     orig_shape = x.shape
     x = x.reshape(-1, block_size).to(torch.float32)
 
+    if skip_global_scale:
+        S_enc = torch.tensor(1.0, dtype=torch.float32)
+    else:
+        # Per-tensor max
+        global_max = x.abs().max()
+        assert global_max.dtype == torch.float32
+
+        # Global encoding scale for block-scales
+        S_enc = (FP8_E4M3_MAX * FP4_E2M1_MAX) / global_max
+
     # Per-block-amax
     block_max = torch.amax(torch.abs(x), 1) + 1e-12
 
-    # Per-tensor max
-    global_max = x.abs().max()
-    assert global_max.dtype == torch.float32
-
-    # Constants
-    # Global encoding scale for block-scales
-    S_enc = (FP8_E4M3_MAX * FP4_E2M1_MAX) / global_max
     S_dec = 1.0 / S_enc
 
     # Per-block decode-scale


### PR DESCRIPTION
Summary: Some users may want to skip the global scale for various reasons, e.g. their distribution doesn't need it, or handle the global scale upstream/downstream.

Differential Revision: D97112059


