### PR TITLE
Try to fix ROCM tests (#236)

### DIFF
--- a/.github/workflows/_mslk_rocm_test.yml
+++ b/.github/workflows/_mslk_rocm_test.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Setup Build Container
       run: |
         apt update -y
-        apt install -y git jq wget
+        apt install -y git jq wget libdw-dev
         git config --global --add safe.directory '*'
 
     - name: Merge Extra Environment Variables

--- a/.github/workflows/mslk_ci_rocm.yml
+++ b/.github/workflows/mslk_ci_rocm.yml
@@ -18,6 +18,7 @@ on:
       # Workflow and CI scripts
       - '.github/scripts/generate_ci_matrix.py'
       - '.github/workflows/mslk_ci_rocm.yml'
+      - '.github/workflows/_mslk_rocm_test.yml'
       - 'ci/scripts/utils_rocm.bash'
       # CMake ROCm/HIP configuration
       - 'cmake/Hip.cmake'


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/meta-pytorch/MSLK/pull/236

For some reason, the rocm torch nightly now start looking for this `libdw.so.1` and the test is broken to import torch without it.

This started in this nightly that @q10  identified: 2.12.0.dev20260313+rocm7.1.

Reviewed By: bottler

Differential Revision: D97298661


