### PR TITLE
Fix CK fmha

### DIFF
--- a/mslk/attention/fmha/utils/op_common.py
+++ b/mslk/attention/fmha/utils/op_common.py
@@ -9,6 +9,8 @@ from typing import Any, List, Type, TypeVar
 
 import torch
 
+from . import cpp_lib as _cpp_lib  # noqa: F401 -- loads _C_hip native extension
+
 
 def get_operator(library: str, name: str):
     def no_such_operator(*args, **kwargs):


### PR DESCRIPTION
Summary: I believe there was a very subtle bug when the cpp_lib.py got cleaned up in D96328593. The `cpp_lib.py` is responsbiel to load the `.so` (see `_register_extensions`) for CK, but an import of it was removed in `common.py`. As such the torch op registrations for CK would not be loaded as the python module code would not run due to lack of any import.

Differential Revision: D97407414


