### PR TITLE
Fix Nova publishing

### DIFF
--- a/.github/scripts/nova_dir.bash
+++ b/.github/scripts/nova_dir.bash
@@ -9,7 +9,15 @@
 MSLK_DIR="/__w/MSLK/MSLK"
 export MSLK_REPO="${MSLK_DIR}/${REPOSITORY}"
 
-export BUILD_FROM_NOVA=0
+################################################################################
+# Because we have a custom setup.py with extra flags, we have to do clean /
+# build_wheel during the pre-script stage, since we have no control over the
+# invocation of setup.py in the Nova build stage.
+#
+# As such, set the flag here so that setup.py will skip these steps in Nova
+# workflow in the build stage.
+################################################################################
+export BUILD_FROM_NOVA=1
 
 # Disable HIP FMHA build in the manywheel CI (the runner is too small)
 export MSLK_BUILD_HIP_FMHA=0

--- a/.github/scripts/nova_prescript.bash
+++ b/.github/scripts/nova_prescript.bash
@@ -136,7 +136,14 @@ if [[ ${CHANNEL} == "" ]]; then
   export CHANNEL="nightly"
 fi
 
+################################################################################
+# Build the wheel
+#
+# The build is performed in the pre-script stage of the build workflow since we
+# have no control over the invocation of setup.py in the actual build stage.
+################################################################################
+
+build_mslk_package "${BUILD_ENV_NAME}" "${CHANNEL}" "${mslk_build_target}/${mslk_build_variant}"
 end_time=$(date +%s)
 runtime=$((end_time-start_time))
-start_time=${end_time}
-echo "[NOVA] Time taken to prepare to build the package: ${runtime} seconds / $(display_time ${runtime})"
+echo "[NOVA] Time taken to build the package: ${runtime} seconds / $(display_time ${runtime})"


### PR DESCRIPTION
Summary:
Undo D93869885 and fix nova publishing.  The original changes in D93869885 did not take Nova publishing into account

As such, packages were published to the test and release channels with the nightly naming convention, see 
https://download.pytorch.org/whl/test/cu130/mslk/ for instance

Also compare the nova build logs for 
mslk: https://github.com/meta-pytorch/MSLK/actions/runs/23344432401/job/67905970295
fbgemm_gpu: https://github.com/pytorch/FBGEMM/actions/runs/23025692444

Differential Revision: D97516668


