### PR TITLE
Move sparse_attn from fb/ to mslk/ and scale to 1M+ sequences

### DIFF
--- a/mslk/attention/flash_attn/block_sparsity.py
+++ b/mslk/attention/flash_attn/block_sparsity.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+try:
+    from mslk.fb.mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+except ImportError:
+    from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
+
+__all__ = ["BlockSparseTensorsTorch"]

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,0 +1,18 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+from mslk.attention.sparse_attn.reference import nsa_forward_reference
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+__all__ = [
+    "nsa_forward",
+    "nsa_forward_reference",
+    "compress_kv",
+    "score_and_select_blocks",
+    "build_fa4_block_sparse_tensors",
+    "compute_gates",
+    "gate_and_combine",
+]

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -1,0 +1,50 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""KV compression for NSA: mean-pool KV into blocks and apply learned projection."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def compress_kv(
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None = None,  # (H_kv, D, D) or None
+    W_v: Tensor | None = None,  # (H_kv, D, D) or None
+) -> tuple[Tensor, Tensor]:
+    """Compress K, V by mean-pooling over blocks and applying optional linear projection.
+
+    Args:
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        block_size: Number of positions to pool together.
+        W_k: Optional per-head projection weight for keys.
+        W_v: Optional per-head projection weight for values.
+
+    Returns:
+        K_cmp: Compressed keys, shape (B, N // block_size, H_kv, D).
+        V_cmp: Compressed values, shape (B, N // block_size, H_kv, D).
+    """
+    B, N, H_kv, D = K.shape
+    assert N % block_size == 0, f"Sequence length {N} must be divisible by block_size {block_size}"
+
+    N_cmp = N // block_size
+
+    # Reshape into blocks and mean-pool
+    K_cmp = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)  # (B, N_cmp, H_kv, D)
+    V_cmp = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+
+    # Apply per-head linear projection if provided
+    if W_k is not None:
+        # W_k: (H_kv, D, D)
+        # K_cmp: (B, N_cmp, H_kv, D) -> einsum over D
+        K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
+
+    if W_v is not None:
+        V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
+
+    return K_cmp, V_cmp

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -1,0 +1,88 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Output gating and combination for NSA's three attention branches."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def compute_gates(
+    Q: Tensor,  # (B, N, H, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Compute per-head sigmoid gates for the three NSA branches.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        gate_proj_weight: Learned gate projection, shape (H, 3, D).
+            If None, returns uniform gates (1/3 each).
+        chunk_size: If set, process the sequence dimension in chunks to
+            reduce peak float32 memory usage. Recommended for N > 32K.
+
+    Returns:
+        gates: Sigmoid gates, shape (B, N, H, 3).
+    """
+    if gate_proj_weight is None:
+        B, N, H, D = Q.shape
+        return torch.ones(B, N, H, 3, device=Q.device, dtype=Q.dtype) / 3.0
+
+    if chunk_size is None:
+        # Original path for short sequences
+        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        return gate_logits.sigmoid().to(Q.dtype)
+
+    # Chunked path: process sequence in chunks to bound float32 intermediates
+    B, N, H, D = Q.shape
+    gates = torch.empty(B, N, H, 3, device=Q.device, dtype=Q.dtype)
+    w = gate_proj_weight.float()
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q[:, start:end].float(), w)
+        gates[:, start:end] = gate_logits.sigmoid().to(Q.dtype)
+    return gates
+
+
+def gate_and_combine(
+    O_cmp: Tensor,  # (B, N, H, D)
+    O_slc: Tensor,  # (B, N, H, D)
+    O_sld: Tensor,  # (B, N, H, D)
+    gates: Tensor,  # (B, N, H, 3)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Combine three attention branch outputs with sigmoid gates.
+
+    Args:
+        O_cmp: Compressed attention output, shape (B, N, H, D).
+        O_slc: Selected attention output, shape (B, N, H, D).
+        O_sld: Sliding window attention output, shape (B, N, H, D).
+        gates: Sigmoid gates, shape (B, N, H, 3).
+        chunk_size: If set, process the sequence dimension in chunks to
+            reduce peak float32 memory usage. Recommended for N > 32K.
+
+    Returns:
+        Combined output, shape (B, N, H, D).
+    """
+    if chunk_size is None:
+        # Original path for short sequences
+        g = gates.float()
+        return (
+            g[..., 0:1] * O_cmp.float()
+            + g[..., 1:2] * O_slc.float()
+            + g[..., 2:3] * O_sld.float()
+        ).to(O_cmp.dtype)
+
+    # Chunked path: avoid materializing 3 full (B,N,H,D) float32 tensors at once
+    B, N, H, D = O_cmp.shape
+    out = torch.empty(B, N, H, D, dtype=O_cmp.dtype, device=O_cmp.device)
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        g = gates[:, start:end].float()
+        out[:, start:end] = (
+            g[..., 0:1] * O_cmp[:, start:end].float()
+            + g[..., 1:2] * O_slc[:, start:end].float()
+            + g[..., 2:3] * O_sld[:, start:end].float()
+        ).to(O_cmp.dtype)
+    return out

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -1,0 +1,200 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""End-to-end NSA (Native Sparse Attention) forward pass using FA4.
+
+Orchestrates the three attention branches:
+1. Compressed attention (FA4 on short KV sequence)
+2. Selected attention (FA4 with block sparsity)
+3. Sliding window attention (FA4 with window_size)
+
+Then gates and combines the outputs.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+
+def _make_compressed_causal_mask(compress_block_size: int) -> Callable:
+    """Create a CuteDSL mask_mod for compressed attention causal masking.
+
+    Block j (at kv_idx=j) represents positions [j*block_size, (j+1)*block_size).
+    Query at position q_idx can attend to block j iff j * block_size <= q_idx.
+    """
+    import cutlass.cute as cute
+
+    @cute.jit
+    def compressed_causal_mask(
+        batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+    ):
+        return kv_idx * compress_block_size <= q_idx
+
+    return compressed_causal_mask
+
+
+def _fa4_fwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+) -> Tuple[Tensor, Tensor]:
+    """Call FA4's forward pass (low-level, supports block sparsity and mask_mod).
+
+    Uses _flash_attn_fwd from the fb interface which supports block_sparse_tensors
+    and mask_mod.
+
+    All inputs are (B, N, H, D) layout.
+    Returns (output, lse).
+    """
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+
+    # mask_mod is not compatible with pack_gqa=True in FA4, so disable it
+    pack_gqa = False if mask_mod is not None else None
+
+    out, lse = _flash_attn_fwd(
+        q, k, v,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        block_sparse_tensors=block_sparse_tensors,
+        mask_mod=mask_mod,
+        pack_gqa=pack_gqa,
+        return_lse=True,
+    )
+    return out, lse
+
+
+def _fa4_fwd_simple(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size: tuple[int, int] | None = None,
+) -> Tuple[Tensor, Tensor]:
+    """Call FA4 via the autograd interface (for branches without block sparsity)."""
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    return flash_attn_func(
+        q, k, v,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+    )
+
+
+def nsa_forward(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    n_block_size: int = 128,
+) -> Tensor:
+    """NSA forward pass using FA4 for all attention branches.
+
+    Orchestrates:
+    1. KV compression (mean-pool + optional projection)
+    2. Block scoring and top-k selection
+    3. Three FA4 calls: compressed, selected (block-sparse), sliding window
+    4. Gating and combination
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        compress_block_size: Number of KV positions per block for compression.
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        window_size: Sliding window size (left window, causal).
+        W_k_compress: Per-head key compression weights, shape (H_kv, D, D).
+        W_v_compress: Per-head value compression weights, shape (H_kv, D, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        causal: Whether to use causal masking.
+        softmax_scale: Attention scaling factor (default: 1/sqrt(D)).
+        q_tile_size: Query tile size for block selection (FA4 CTA tile: 2*128=256).
+        n_block_size: FA4 KV block size (128 for SM100).
+
+    Returns:
+        Output tensor, shape (B, N, H, D).
+    """
+    B, N, H, D = Q.shape
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # Step 1: Compress KV
+    K_cmp, V_cmp = compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+    # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
+
+    # Step 2: Score blocks and select top-k
+    block_indices = score_and_select_blocks(
+        Q, K_cmp, num_selected_blocks, compress_block_size,
+        causal=causal, q_tile_size=q_tile_size, softmax_scale=softmax_scale,
+    )
+    # block_indices: (B, H, N_q_tiles, k) int32
+
+    # Step 3: Build FA4 sparsity masks for selected attention
+    sparse_tensors = build_fa4_block_sparse_tensors(
+        block_indices, compress_block_size,
+        n_block_size=n_block_size, seqlen_k=N,
+    )
+
+    # Step 4: Run three FA4 branches
+
+    # Branch 1: Compressed attention — block-aware causal masking on short KV
+    # Standard causal=True gives wrong masking for compressed KV since N_cmp << N:
+    # it masks based on kv_j > q_i, but we need kv_j * compress_block_size > q_i.
+    compressed_mask = _make_compressed_causal_mask(compress_block_size) if causal else None
+    O_cmp, lse_cmp = _fa4_fwd(
+        Q, K_cmp, V_cmp,
+        causal=False,
+        softmax_scale=softmax_scale,
+        mask_mod=compressed_mask,
+    )
+
+    # Branch 2: Selected attention — block-sparse attention on full KV
+    O_slc, lse_slc = _fa4_fwd(
+        Q, K, V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        block_sparse_tensors=sparse_tensors,
+    )
+
+    # Branch 3: Sliding window attention
+    O_sld, lse_sld = _fa4_fwd_simple(
+        Q, K, V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        window_size=(window_size, 0),  # (left, right=0 for causal)
+    )
+
+    # Step 5: Gate and combine
+    # Use chunked gating for long sequences to avoid materializing
+    # 3 full (B,N,H,D) float32 tensors simultaneously.
+    gate_chunk = 4096 if N > 32768 else None
+    gates = compute_gates(Q, gate_proj_weight, chunk_size=gate_chunk)  # (B, N, H, 3)
+    O = gate_and_combine(O_cmp, O_slc, O_sld, gates, chunk_size=gate_chunk)
+
+    return O

--- a/mslk/attention/sparse_attn/nsa_scoring.py
+++ b/mslk/attention/sparse_attn/nsa_scoring.py
@@ -1,0 +1,145 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
+
+"""Block score column-reduction utilities for NSA scoring phase.
+
+During the fused scoring + compressed attention phase, the softmax warps
+read QK scores from TMEM and reduce each column (KV block dimension) to
+produce a single block importance score. These scores are accumulated
+across all Q rows within a tile to produce per-block scores.
+
+The column reduction reuses the TMEM read infrastructure from FA4's
+softmax warps, adding a parallel reduction along the M dimension.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+import cutlass.cute.nvgpu.tcgen05 as tcgen05
+
+import mslk.fb.mslk.attention.flash_attn.utils as utils
+
+
+@cute.jit
+def reduce_s_to_block_scores(
+    tSrS_t2r: cute.Tensor,  # Register fragment of S tile loaded from TMEM
+    thr_tmem_load: cute.CopyAtom,
+    thr_mma_qk: cute.core.ThrMma,
+    m_block_size: int,
+    n_block_size: int,
+    block_scores: cute.Tensor,  # (n_blocks_in_tile,) accumulator in registers
+    n_block_offset: Int32,  # Which compressed block this KV tile corresponds to
+    n_blocks_per_tile: int,  # How many compressed blocks fit in one n_block_size tile
+    is_first: bool,
+) -> None:
+    """Reduce S tile columns to block scores and accumulate.
+
+    After QK GEMM produces S in TMEM, the softmax warps load it into
+    registers. This function reduces each column of S (summing across
+    the M dimension, i.e., all Q positions in the tile) to produce a
+    single score per KV block.
+
+    For compressed attention where compress_block_size >= n_block_size,
+    each S tile column already corresponds to one compressed block, so
+    we just sum the column. When compress_block_size < n_block_size,
+    multiple compressed blocks share one S tile — we partition the
+    columns accordingly.
+
+    Args:
+        tSrS_t2r: S scores in registers after TMEM load, shape depends on
+            partition layout from thr_mma_qk.
+        thr_tmem_load: TMEM load copy atom (for layout info).
+        thr_mma_qk: QK MMA partition (for coordinate mapping).
+        m_block_size: M tile size (e.g., 128).
+        n_block_size: N tile size (e.g., 128).
+        block_scores: Accumulator for block scores, shape (n_cmp,).
+        n_block_offset: Starting compressed block index for this tile.
+        n_blocks_per_tile: Number of compressed blocks per N tile.
+        is_first: If True, initialize block_scores; otherwise accumulate.
+    """
+    # The S tile has been loaded into registers with layout from thr_mma_qk.
+    # We need to reduce across the M dimension (rows) for each N position (column).
+    #
+    # tSrS_t2r has shape organized by the MMA partition. We interpret it as
+    # (M_per_thread, N_per_thread) logically.
+    #
+    # For SM100 with 128-thread warp groups doing TMEM loads:
+    # Each thread in the softmax warp group gets one row of the 128x128 S tile.
+    # So each thread has n_block_size values (one full row).
+    # The column reduction = warp-level reduction across threads (rows),
+    # then store into block_scores.
+
+    acc_S_mn = utils.make_acc_tensor_mn_view(tSrS_t2r)
+    n_cols = cute.size(acc_S_mn, mode=[1])
+
+    # Each thread contributes its row's values to the column sum.
+    # We do a warp-level reduction for each column group.
+    # Since each compressed block spans (compress_block_size / n_block_size * n_block_size)
+    # columns within the tile, or if compress_block_size aligns with n_block_size,
+    # just one column per block.
+
+    # For the common case where n_blocks_per_tile == 1 (compress_block_size >= n_block_size),
+    # sum all columns of this thread's row, then warp-reduce.
+    if const_expr(n_blocks_per_tile == 1):
+        row_sum = Float32(0.0)
+        for c in cutlass.range(n_cols, unroll_full=True):
+            row_sum += acc_S_mn[0, c].load()
+
+        # Warp-level reduction: sum across all threads (rows in the tile)
+        col_sum = utils.warp_reduce(row_sum, cute.arch.fadd, width=4)
+
+        if is_first:
+            block_scores[n_block_offset] = col_sum
+        else:
+            block_scores[n_block_offset] += col_sum
+    else:
+        # Multiple compressed blocks per N tile
+        cols_per_block: int = const_expr(n_block_size // n_blocks_per_tile)
+        for blk in cutlass.range_constexpr(n_blocks_per_tile):
+            row_sum = Float32(0.0)
+            for c in cutlass.range_constexpr(cols_per_block):
+                col_idx: int = const_expr(blk * cols_per_block + c)
+                row_sum += acc_S_mn[0, col_idx].load()
+
+            col_sum = utils.warp_reduce(row_sum, cute.arch.fadd, width=4)
+
+            global_blk_idx = n_block_offset + blk
+            if is_first:
+                block_scores[global_blk_idx] = col_sum
+            else:
+                block_scores[global_blk_idx] += col_sum
+
+
+@cute.jit
+def apply_causal_mask_to_block_scores(
+    block_scores: cute.Tensor,  # (n_cmp,) block score accumulator
+    n_cmp: Int32,
+    m_block: Int32,  # Current Q tile index
+    q_tile_size: int,
+    compress_block_size: int,
+) -> None:
+    """Apply causal mask to block scores: future blocks get -inf.
+
+    A compressed block j is "future" for query tile i if:
+        j * compress_block_size >= (i + 1) * q_tile_size
+
+    Args:
+        block_scores: Block score accumulator, shape (n_cmp,).
+        n_cmp: Total number of compressed blocks.
+        m_block: Current Q tile index.
+        q_tile_size: Size of each Q tile.
+        compress_block_size: Size of each compressed block.
+    """
+    q_tile_end = (m_block + 1) * q_tile_size
+    tidx = cute.arch.thread_idx()[0] % 128  # thread in correction warp group
+
+    # Each thread checks its assigned blocks
+    n_per_thread = (n_cmp + 127) // 128
+    for i in cutlass.range(n_per_thread, unroll=1):
+        blk_idx = tidx * n_per_thread + i
+        if blk_idx < n_cmp:
+            blk_start = blk_idx * compress_block_size
+            if blk_start >= q_tile_end:
+                block_scores[blk_idx] = -Float32.inf

--- a/mslk/attention/sparse_attn/nsa_topk.py
+++ b/mslk/attention/sparse_attn/nsa_topk.py
@@ -1,0 +1,272 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
+
+"""In-register parallel top-K selection for NSA block scoring.
+
+Provides CuteDSL @cute.jit utilities for performing top-K selection entirely
+in registers across the correction warp group (128 threads, 4 warps).
+
+Algorithm:
+1. Each thread holds N_cmp/128 block scores in registers.
+2. Local insertion sort: each thread keeps its top-K values + indices.
+3. Warp-level merge: 5 rounds of butterfly shuffle to merge across 32 threads.
+4. Cross-warp merge: 4 warps → final K candidates via shared memory staging.
+
+For 1M tokens with L=64: N_cmp=16384, each thread holds 128 scores.
+With K_SEL=16, total ~240 comparisons per thread — negligible vs MMA time.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+
+
+@cute.jit
+def insertion_sort_topk(
+    scores: cute.Tensor,  # Thread-local scores, shape (local_n,)
+    num_local: Int32,
+    k: int,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Per-thread insertion sort to find top-K from local scores.
+
+    Each thread independently sorts its local scores (descending) and
+    retains the top-K values and their local indices.
+
+    Args:
+        scores: Thread-local block scores, shape (local_n,).
+        num_local: Number of valid scores this thread holds.
+        k: Number of top elements to retain.
+
+    Returns:
+        top_vals: Top-K values (descending), shape (k,).
+        top_idxs: Corresponding local indices, shape (k,).
+    """
+    top_vals = cute.make_fragment(k, Float32)
+    top_idxs = cute.make_fragment(k, Int32)
+
+    # Initialize with -inf
+    top_vals.fill(-Float32.inf)
+    top_idxs.fill(Int32(0))
+
+    # Insertion sort: for each score, insert into sorted top_vals if larger
+    for i in cutlass.range(num_local, unroll=1):
+        val = scores[i]
+        idx = Int32(i)
+        # Find insertion point (linear scan from the end)
+        for j in cutlass.range_constexpr(k - 1, -1, -1):
+            if val > top_vals[j]:
+                if const_expr(j < k - 1):
+                    top_vals[j + 1] = top_vals[j]
+                    top_idxs[j + 1] = top_idxs[j]
+                top_vals[j] = val
+                top_idxs[j] = idx
+                break
+
+    return top_vals, top_idxs
+
+
+@cute.jit
+def merge_sorted_pairs(
+    vals_a: cute.Tensor,  # (k,) descending
+    idxs_a: cute.Tensor,  # (k,)
+    vals_b: cute.Tensor,  # (k,) descending
+    idxs_b: cute.Tensor,  # (k,)
+    k: int,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Merge two sorted top-K lists into one top-K list.
+
+    Standard merge of two sorted (descending) sequences, keeping only
+    the top-K elements from the merged result.
+
+    Args:
+        vals_a, idxs_a: First sorted top-K list.
+        vals_b, idxs_b: Second sorted top-K list.
+        k: Number of elements to keep.
+
+    Returns:
+        merged_vals: Merged top-K values (descending), shape (k,).
+        merged_idxs: Corresponding indices, shape (k,).
+    """
+    merged_vals = cute.make_fragment(k, Float32)
+    merged_idxs = cute.make_fragment(k, Int32)
+
+    ia = Int32(0)
+    ib = Int32(0)
+    for out_idx in cutlass.range_constexpr(k):
+        take_a = (ia < k) & ((ib >= k) | (vals_a[ia] >= vals_b[ib]))
+        if take_a:
+            merged_vals[out_idx] = vals_a[ia]
+            merged_idxs[out_idx] = idxs_a[ia]
+            ia += 1
+        else:
+            merged_vals[out_idx] = vals_b[ib]
+            merged_idxs[out_idx] = idxs_b[ib]
+            ib += 1
+
+    return merged_vals, merged_idxs
+
+
+@cute.jit
+def warp_merge_topk(
+    vals: cute.Tensor,  # (k,) per-thread top-K values
+    idxs: cute.Tensor,  # (k,) per-thread top-K local indices
+    thread_id_in_warp: Int32,
+    k: int,
+    n_per_thread: Int32,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Warp-level butterfly merge of per-thread top-K lists.
+
+    After this, thread 0 in each warp holds the warp-level top-K.
+    Indices are converted from thread-local to warp-global during merging.
+
+    5 rounds of shuffle: distance 1, 2, 4, 8, 16.
+
+    Args:
+        vals: Per-thread top-K values, shape (k,).
+        idxs: Per-thread top-K local indices, shape (k,).
+        thread_id_in_warp: Lane ID (0-31).
+        k: Number of top elements.
+        n_per_thread: Number of scores each thread originally held.
+
+    Returns:
+        vals: Merged top-K values (valid on lane 0).
+        idxs: Merged top-K global indices (valid on lane 0).
+    """
+    # Convert local indices to global: global_idx = thread_id * n_per_thread + local_idx
+    for i in cutlass.range_constexpr(k):
+        idxs[i] = thread_id_in_warp * n_per_thread + idxs[i]
+
+    # Butterfly reduction: 5 rounds
+    for round_idx in cutlass.range_constexpr(5):
+        distance: int = const_expr(1 << round_idx)
+        # Exchange top-K with partner
+        partner_vals = cute.make_fragment(k, Float32)
+        partner_idxs = cute.make_fragment(k, Int32)
+        for i in cutlass.range_constexpr(k):
+            partner_vals[i] = cute.arch.shfl_xor(vals[i], distance)
+            partner_idxs[i] = cute.arch.shfl_xor(idxs[i], distance)
+        # Merge: the lower-ID thread in each pair does the merge
+        if (thread_id_in_warp & distance) == 0:
+            vals, idxs = merge_sorted_pairs(vals, idxs, partner_vals, partner_idxs, k)
+
+    return vals, idxs
+
+
+@cute.jit
+def cross_warp_merge_topk(
+    vals: cute.Tensor,  # (k,) — valid on lane 0 of each warp
+    idxs: cute.Tensor,  # (k,) — valid on lane 0 of each warp
+    thread_id_in_wg: Int32,  # 0..127 within correction warp group
+    warp_id_in_wg: Int32,  # 0..3
+    smem_vals: cute.Tensor,  # shared mem buffer for vals, shape (4, k)
+    smem_idxs: cute.Tensor,  # shared mem buffer for idxs, shape (4, k)
+    k: int,
+    n_per_warp: Int32,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Cross-warp merge: reduce 4 warp-level top-K lists to one.
+
+    Lane 0 of each warp writes its top-K to shared memory. Then lane 0 of
+    warp 0 performs a sequential merge of all 4 lists.
+
+    After the merge, the result is broadcast back to all threads via smem.
+
+    Args:
+        vals: Warp-level top-K values (valid on lane 0).
+        idxs: Warp-level top-K global indices (valid on lane 0).
+        thread_id_in_wg: Thread index within correction warp group (0-127).
+        warp_id_in_wg: Warp index within correction warp group (0-3).
+        smem_vals: Shared memory for values exchange, shape (4, k).
+        smem_idxs: Shared memory for indices exchange, shape (4, k).
+        k: Number of top elements.
+        n_per_warp: Scores per warp (for global index offset).
+
+    Returns:
+        vals: Final top-K values (broadcast to all threads).
+        idxs: Final top-K global indices (broadcast to all threads).
+    """
+    lane_id = thread_id_in_wg % 32
+
+    # Lane 0 of each warp writes to shared memory
+    # Offset indices by warp_id * n_per_warp for cross-warp global indexing
+    if lane_id == 0:
+        for i in cutlass.range_constexpr(k):
+            smem_vals[warp_id_in_wg * k + i] = vals[i]
+            smem_idxs[warp_id_in_wg * k + i] = idxs[i] + warp_id_in_wg * n_per_warp
+
+    cute.arch.sync_threads()
+
+    # Lane 0 of warp 0 merges all 4 lists sequentially
+    if thread_id_in_wg == 0:
+        # Start with warp 0's list
+        for w in cutlass.range_constexpr(1, 4):
+            other_vals = cute.make_fragment(k, Float32)
+            other_idxs = cute.make_fragment(k, Int32)
+            for i in cutlass.range_constexpr(k):
+                other_vals[i] = smem_vals[w * k + i]
+                other_idxs[i] = smem_idxs[w * k + i]
+            vals, idxs = merge_sorted_pairs(vals, idxs, other_vals, other_idxs, k)
+
+        # Write merged result back to smem for broadcast
+        for i in cutlass.range_constexpr(k):
+            smem_vals[i] = vals[i]
+            smem_idxs[i] = idxs[i]
+
+    cute.arch.sync_threads()
+
+    # All threads read the final result
+    result_vals = cute.make_fragment(k, Float32)
+    result_idxs = cute.make_fragment(k, Int32)
+    for i in cutlass.range_constexpr(k):
+        result_vals[i] = smem_vals[i]
+        result_idxs[i] = smem_idxs[i]
+
+    return result_vals, result_idxs
+
+
+@cute.jit
+def parallel_topk(
+    scores: cute.Tensor,  # Thread-local scores, shape (local_n,)
+    num_local: Int32,
+    k: int,
+    thread_id_in_wg: Int32,  # 0..127 within correction warp group
+    smem_vals: cute.Tensor,  # shared mem buffer, shape (4 * k,)
+    smem_idxs: cute.Tensor,  # shared mem buffer, shape (4 * k,)
+    n_total: Int32,
+) -> cute.Tensor:
+    """Full parallel top-K pipeline: local sort → warp merge → cross-warp merge.
+
+    Each of 128 threads holds num_local = N_cmp/128 scores. Returns the global
+    top-K indices into the score array.
+
+    Args:
+        scores: Thread-local block scores, shape (local_n,).
+        num_local: Number of valid scores per thread.
+        k: Number of top blocks to select (K_SEL).
+        thread_id_in_wg: Thread index within the correction warp group (0-127).
+        smem_vals: Shared memory for cross-warp merge, shape (4 * k,).
+        smem_idxs: Shared memory for cross-warp merge, shape (4 * k,).
+        n_total: Total number of compressed blocks.
+
+    Returns:
+        top_indices: Top-K global block indices, shape (k,), sorted descending by score.
+    """
+    lane_id = thread_id_in_wg % 32
+    warp_id_in_wg = thread_id_in_wg // 32
+    n_per_thread = num_local
+    n_per_warp = n_per_thread * 32
+
+    # Step 1: Per-thread insertion sort
+    vals, idxs = insertion_sort_topk(scores, num_local, k)
+
+    # Step 2: Warp-level butterfly merge
+    vals, idxs = warp_merge_topk(vals, idxs, lane_id, k, n_per_thread)
+
+    # Step 3: Cross-warp merge (4 warps → 1)
+    vals, idxs = cross_warp_merge_topk(
+        vals, idxs, thread_id_in_wg, warp_id_in_wg,
+        smem_vals, smem_idxs, k, n_per_warp,
+    )
+
+    return idxs

--- a/mslk/attention/sparse_attn/reference.py
+++ b/mslk/attention/sparse_attn/reference.py
@@ -1,0 +1,269 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Pure PyTorch reference implementation of NSA (Native Sparse Attention).
+
+This serves as a correctness reference for the optimized FA4-based implementation.
+All operations are done in PyTorch without custom kernels.
+
+Reference: arxiv 2502.11089
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def nsa_forward_reference(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+) -> Tensor:
+    """Pure PyTorch NSA forward pass.
+
+    Combines three attention branches:
+    1. Compressed attention: Attend over mean-pooled KV blocks with learned projection.
+    2. Selected attention: Block-sparse attention over top-k important KV blocks.
+    3. Sliding window attention: Local attention within a fixed window.
+
+    All inputs/outputs use (B, N, H, D) layout.
+
+    Returns:
+        Output tensor of shape (B, N, H, D).
+    """
+    B, N, H, D = Q.shape
+    H_kv = K.shape[2]
+    assert H % H_kv == 0, "H must be divisible by H_kv for GQA"
+    groups = H // H_kv
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # Transpose to (B, H, N, D) for matmul convenience
+    q = Q.transpose(1, 2).float()  # (B, H, N, D)
+    k = K.transpose(1, 2).float()  # (B, H_kv, N, D)
+    v = V.transpose(1, 2).float()  # (B, H_kv, N, D)
+
+    # Expand K, V for GQA: (B, H_kv, N, D) -> (B, H, N, D)
+    if groups > 1:
+        k = k.repeat_interleave(groups, dim=1)
+        v = v.repeat_interleave(groups, dim=1)
+
+    # --- Branch 1: Compressed Attention ---
+    O_cmp = _compressed_attention(
+        q, k, v, compress_block_size, W_k_compress, W_v_compress,
+        groups, softmax_scale, causal, B, N, H, H_kv, D,
+    )
+
+    # --- Branch 2: Selected (Block-Sparse) Attention ---
+    O_slc = _selected_attention(
+        q, k, v, compress_block_size, num_selected_blocks,
+        W_k_compress, groups, softmax_scale, causal, B, N, H, H_kv, D,
+        q_tile_size=q_tile_size,
+    )
+
+    # --- Branch 3: Sliding Window Attention ---
+    O_sld = _sliding_window_attention(
+        q, k, v, window_size, softmax_scale, causal, B, N, H, D,
+    )
+
+    # --- Gate and Combine ---
+    # All outputs are (B, H, N, D), transpose to (B, N, H, D)
+    O_cmp = O_cmp.transpose(1, 2)
+    O_slc = O_slc.transpose(1, 2)
+    O_sld = O_sld.transpose(1, 2)
+
+    if gate_proj_weight is not None:
+        # gate_proj_weight: (H, 3, D)
+        # Q: (B, N, H, D) -> compute per-head gates
+        gates = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        gates = gates.sigmoid()  # (B, N, H, 3)
+    else:
+        gates = torch.ones(B, N, H, 3, device=Q.device, dtype=torch.float32) / 3.0
+
+    O = (
+        gates[..., 0:1] * O_cmp
+        + gates[..., 1:2] * O_slc
+        + gates[..., 2:3] * O_sld
+    )
+
+    return O.to(Q.dtype)
+
+
+def _compressed_attention(
+    q: Tensor, k: Tensor, v: Tensor,
+    block_size: int,
+    W_k_compress: Tensor | None, W_v_compress: Tensor | None,
+    groups: int, softmax_scale: float, causal: bool,
+    B: int, N: int, H: int, H_kv: int, D: int,
+) -> Tensor:
+    """Compressed attention: attend over mean-pooled KV blocks."""
+    # Use un-expanded K, V for compression
+    k_orig = k[:, ::groups]  # (B, H_kv, N, D)
+    v_orig = v[:, ::groups]
+
+    N_cmp = N // block_size
+    # Reshape into blocks and mean-pool
+    k_blocks = k_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_cmp, D)
+    v_blocks = v_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    v_cmp = v_blocks.mean(dim=3)
+
+    # Apply learned projection if provided
+    if W_k_compress is not None:
+        # W_k_compress: (H_kv, D, D)
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if W_v_compress is not None:
+        v_cmp = torch.einsum("bhnd,hde->bhne", v_cmp, W_v_compress.float())
+
+    # Expand for GQA
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+        v_cmp = v_cmp.repeat_interleave(groups, dim=1)
+
+    # Standard attention on compressed KV: (B, H, N, D) x (B, H, N_cmp, D)
+    scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale  # (B, H, N, N_cmp)
+
+    if causal:
+        # A query at position i can attend to compressed block j if the block
+        # starts at or before position i: j * block_size <= i.
+        q_pos = torch.arange(N, device=q.device).unsqueeze(1)  # (N, 1)
+        kv_block_start = (torch.arange(N_cmp, device=q.device)) * block_size  # (N_cmp,)
+        causal_mask = kv_block_start.unsqueeze(0) > q_pos  # (N, N_cmp)
+        scores = scores.masked_fill(causal_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    attn = torch.softmax(scores, dim=-1)
+    out = torch.matmul(attn, v_cmp)  # (B, H, N, D)
+    return out
+
+
+def _selected_attention(
+    q: Tensor, k: Tensor, v: Tensor,
+    block_size: int, num_selected: int,
+    W_k_compress: Tensor | None,
+    groups: int, softmax_scale: float, causal: bool,
+    B: int, N: int, H: int, H_kv: int, D: int,
+    q_tile_size: int = 256,
+) -> Tensor:
+    """Selected block-sparse attention: attend to top-k important KV blocks.
+
+    Aggregates block scores per q_tile_size (matching FA4's CTA tile) and
+    selects blocks per query tile rather than per query block.
+    """
+    N_blocks = N // block_size
+    N_q_tiles = N // q_tile_size
+
+    # Score blocks using compressed keys
+    k_orig = k[:, ::groups]  # (B, H_kv, N, D)
+    k_blocks = k_orig.reshape(B, H_kv, N_blocks, block_size, D)
+    k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_blocks, D)
+    if W_k_compress is not None:
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+
+    # Compute block importance scores: (B, H, N, N_blocks)
+    block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+
+    # Aggregate per query-tile (mean over queries in the same tile)
+    block_scores_agg = block_scores.reshape(
+        B, H, N_q_tiles, q_tile_size, N_blocks
+    ).mean(dim=3)
+    # (B, H, N_q_tiles, N_blocks)
+
+    if causal:
+        # Match score_and_select_blocks: block j is future if
+        # j * block_size >= (tile_i + 1) * q_tile_size
+        q_tile_end = (torch.arange(N_q_tiles, device=q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_blocks, device=q.device) * block_size
+        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+        block_scores_agg = block_scores_agg.masked_fill(
+            future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+
+    # Select top-k blocks per query tile
+    k_actual = min(num_selected, N_blocks)
+    _, top_indices = block_scores_agg.topk(k_actual, dim=-1)  # (B, H, N_q_tiles, k)
+
+    # Build block-sparse attention output
+    out = torch.zeros(B, H, N, D, device=q.device, dtype=q.dtype)
+
+    for b in range(B):
+        for h in range(H):
+            for qt in range(N_q_tiles):
+                q_start = qt * q_tile_size
+                q_end = (qt + 1) * q_tile_size
+
+                # Gather selected KV blocks
+                selected_k_list = []
+                selected_v_list = []
+                for idx in top_indices[b, h, qt]:
+                    kv_start = idx.item() * block_size
+                    kv_end = kv_start + block_size
+                    selected_k_list.append(k[b, h, kv_start:kv_end])
+                    selected_v_list.append(v[b, h, kv_start:kv_end])
+
+                if not selected_k_list:
+                    continue
+
+                sel_k = torch.cat(selected_k_list, dim=0)  # (k*block_size, D)
+                sel_v = torch.cat(selected_v_list, dim=0)
+
+                # Compute attention for this query tile
+                q_tile = q[b, h, q_start:q_end]  # (q_tile_size, D)
+                scores = torch.matmul(q_tile, sel_k.T) * softmax_scale
+
+                if causal:
+                    q_positions = torch.arange(q_start, q_end, device=q.device).unsqueeze(1)
+                    kv_positions = []
+                    for idx in top_indices[b, h, qt]:
+                        kv_s = idx.item() * block_size
+                        kv_positions.append(
+                            torch.arange(kv_s, kv_s + block_size, device=q.device)
+                        )
+                    kv_positions = torch.cat(kv_positions)
+                    c_mask = kv_positions.unsqueeze(0) > q_positions
+                    scores = scores.masked_fill(c_mask, float("-inf"))
+
+                attn = torch.softmax(scores, dim=-1)
+                out[b, h, q_start:q_end] = torch.matmul(attn, sel_v)
+
+    return out
+
+
+def _sliding_window_attention(
+    q: Tensor, k: Tensor, v: Tensor,
+    window_size: int, softmax_scale: float, causal: bool,
+    B: int, N: int, H: int, D: int,
+) -> Tensor:
+    """Sliding window attention: each query attends to a local window of KV."""
+    scores = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale  # (B, H, N, N)
+
+    # Build sliding window + causal mask
+    q_pos = torch.arange(N, device=q.device).unsqueeze(1)
+    kv_pos = torch.arange(N, device=q.device).unsqueeze(0)
+
+    # Window mask: kv must be within [q_pos - window_size + 1, q_pos] (causal window)
+    # or [q_pos - window_size//2, q_pos + window_size//2] (non-causal)
+    if causal:
+        mask = (kv_pos > q_pos) | (kv_pos < q_pos - window_size + 1)
+    else:
+        half_w = window_size // 2
+        mask = (kv_pos > q_pos + half_w) | (kv_pos < q_pos - half_w)
+
+    scores = scores.masked_fill(mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    attn = torch.softmax(scores, dim=-1)
+    out = torch.matmul(attn, v)
+    return out

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -1,0 +1,121 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Block scoring and top-k selection for NSA."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def score_and_select_blocks(
+    Q: Tensor,  # (B, N, H, D)
+    K_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    num_selected_blocks: int,
+    compress_block_size: int,
+    causal: bool = True,
+    q_tile_size: int = 256,
+    softmax_scale: float | None = None,
+) -> Tensor:
+    """Score KV blocks by importance and select top-k for each query tile.
+
+    Uses compressed keys to efficiently compute block importance scores.
+    Each query tile (q_tile_size positions) independently selects its own
+    top-k KV blocks.
+
+    Processes query tiles in chunks to avoid materializing a full (B, H, N, N_cmp)
+    score tensor, reducing peak memory from O(N * N_cmp) to
+    O(chunk_tiles * q_tile_size * N_cmp).
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K_cmp: Compressed key tensor, shape (B, N_cmp, H_kv, D).
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        compress_block_size: Size of each KV block.
+        causal: Whether to apply causal masking (prevent selecting future blocks).
+        q_tile_size: Size of each query tile (should match FA4's CTA tile: 2 * m_block_size = 256).
+        softmax_scale: Scaling factor for attention scores.
+
+    Returns:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+            Each entry is an index into the compressed KV sequence.
+    """
+    B, N, H, D = Q.shape
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+    groups = H // H_kv
+
+    N_q_tiles = N // q_tile_size
+    assert N % q_tile_size == 0, (
+        f"Sequence length {N} must be divisible by q_tile_size {q_tile_size}"
+    )
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    k_actual = min(num_selected_blocks, N_cmp)
+
+    # Expand K_cmp for GQA: (B, N_cmp, H_kv, D) -> (B, N_cmp, H, D)
+    if groups > 1:
+        K_cmp_expanded = K_cmp.repeat_interleave(groups, dim=2)
+    else:
+        K_cmp_expanded = K_cmp
+
+    # Pre-transpose for efficient matmul: (B, H, D, N_cmp)
+    K_cmp_t = K_cmp_expanded.permute(0, 2, 3, 1).float()
+
+    block_indices = torch.empty(
+        B, H, N_q_tiles, k_actual, dtype=torch.int32, device=Q.device
+    )
+
+    # Precompute causal mask data (tiny tensors)
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
+
+    # Process query tiles in chunks to bound peak memory.
+    # Each chunk computes (B, H, chunk_tiles * q_tile_size, N_cmp) scores,
+    # averages per tile, applies causal mask, and runs topk.
+    chunk_tiles = min(16, N_q_tiles)
+    for chunk_start in range(0, N_q_tiles, chunk_tiles):
+        chunk_end = min(chunk_start + chunk_tiles, N_q_tiles)
+        n_tiles = chunk_end - chunk_start
+        q_start = chunk_start * q_tile_size
+        q_end = chunk_end * q_tile_size
+
+        # (B, H, n_tiles * q_tile_size, N_cmp) — bounded, not O(N²)
+        scores_chunk = torch.matmul(
+            Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t
+        ) * softmax_scale
+
+        # Average per tile: (B, H, n_tiles, N_cmp)
+        scores_agg = scores_chunk.reshape(
+            B, H, n_tiles, q_tile_size, N_cmp
+        ).mean(dim=3)
+
+        # Apply causal mask: block j is future if j * block_size >= (i+1) * q_tile_size
+        if causal:
+            future_mask = (
+                kv_block_start.unsqueeze(0)
+                >= q_tile_end[chunk_start:chunk_end].unsqueeze(1)
+            )  # (n_tiles, N_cmp)
+            scores_agg.masked_fill_(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        # Select top-k blocks for this chunk
+        topk_scores, chunk_idx = scores_agg.topk(k_actual, dim=-1)
+
+        # Replace invalid selections (future blocks with -inf score) with block 0
+        invalid = topk_scores == float("-inf")
+        if invalid.any():
+            chunk_idx = chunk_idx.masked_fill(invalid, 0)
+
+        # Sort indices for better memory access patterns
+        block_indices[:, :, chunk_start:chunk_end] = (
+            chunk_idx.sort(dim=-1).values.to(torch.int32)
+        )
+
+    return block_indices

--- a/mslk/attention/sparse_attn/sparsity_masks.py
+++ b/mslk/attention/sparse_attn/sparsity_masks.py
@@ -1,0 +1,117 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Convert top-k block indices into FA4's BlockSparseTensorsTorch format."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+
+
+def build_fa4_block_sparse_tensors(
+    block_indices: Tensor,  # (B, H, N_q_tiles, k) int32
+    compress_block_size: int,
+    n_block_size: int = 128,
+    seqlen_k: int | None = None,
+) -> BlockSparseTensorsTorch:
+    """Convert selected KV block indices into FA4's block sparsity format.
+
+    FA4 block sparsity uses two pairs of tensors:
+    - full_block_cnt/full_block_idx: KV blocks that need NO masking (fully attended).
+    - mask_block_cnt/mask_block_idx: KV blocks that need masking (partially attended).
+
+    Handles two cases:
+    - compress_block_size >= n_block_size: Each NSA block expands to multiple FA4 blocks.
+    - compress_block_size < n_block_size: Multiple NSA blocks contract to one FA4 block
+      (duplicates are removed).
+
+    All selected blocks are "full" blocks (no partial masking needed), since we're
+    attending to entire KV blocks.
+
+    Args:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+            Values are indices into the compressed KV sequence.
+        compress_block_size: Size of each NSA KV block.
+        n_block_size: FA4's KV tile size (default 128 for SM100).
+        seqlen_k: Total KV sequence length (for computing n_blocks_k).
+
+    Returns:
+        BlockSparseTensorsTorch with full_block_cnt, full_block_idx,
+        mask_block_cnt, mask_block_idx.
+    """
+    B, H, N_q_tiles, k = block_indices.shape
+    device = block_indices.device
+
+    if compress_block_size >= n_block_size:
+        # Each NSA block maps to one or more FA4 blocks
+        assert compress_block_size % n_block_size == 0, (
+            f"compress_block_size ({compress_block_size}) must be divisible by "
+            f"n_block_size ({n_block_size})"
+        )
+        fa4_blocks_per_nsa_block = compress_block_size // n_block_size
+
+        # NSA block j maps to FA4 blocks [j*ratio, j*ratio+1, ..., j*ratio+ratio-1]
+        base_indices = block_indices.long() * fa4_blocks_per_nsa_block
+        offsets = torch.arange(fa4_blocks_per_nsa_block, device=device)
+        expanded_indices = base_indices.unsqueeze(-1) + offsets
+        fa4_indices = expanded_indices.reshape(B, H, N_q_tiles, k * fa4_blocks_per_nsa_block)
+        k_fa4 = k * fa4_blocks_per_nsa_block
+    else:
+        # Multiple NSA blocks map to a single FA4 block
+        assert n_block_size % compress_block_size == 0, (
+            f"n_block_size ({n_block_size}) must be divisible by "
+            f"compress_block_size ({compress_block_size})"
+        )
+        # NSA block j maps to FA4 block j * compress_block_size // n_block_size
+        fa4_block_indices = (block_indices.long() * compress_block_size) // n_block_size
+
+        # Remove duplicates per query tile: sort, then unique via consecutive dedup
+        fa4_block_indices = fa4_block_indices.sort(dim=-1).values
+        # Mark duplicates: compare with previous element
+        shifted = torch.roll(fa4_block_indices, 1, dims=-1)
+        is_dup = (fa4_block_indices == shifted) & (torch.arange(k, device=device) > 0)
+        # Replace duplicates with a sentinel (max_n_blocks) that we'll filter out
+        if seqlen_k is not None:
+            sentinel = (seqlen_k + n_block_size - 1) // n_block_size
+        else:
+            sentinel = fa4_block_indices.max().item() + 1
+        fa4_block_indices = fa4_block_indices.masked_fill(is_dup, sentinel)
+        # Re-sort to push sentinels to the end
+        fa4_block_indices = fa4_block_indices.sort(dim=-1).values
+        # Count non-sentinel entries per query tile
+        counts = (fa4_block_indices < sentinel).sum(dim=-1)  # (B, H, N_q_tiles)
+
+        fa4_indices = fa4_block_indices
+        k_fa4 = k  # max possible, actual counts may be smaller
+
+    # full_block_cnt: (B, H, N_q_tiles)
+    if compress_block_size >= n_block_size:
+        full_block_cnt = torch.full(
+            (B, H, N_q_tiles), k_fa4, dtype=torch.int32, device=device
+        )
+    else:
+        full_block_cnt = counts.to(torch.int32)
+
+    # full_block_idx: use compact shape (B, H, N_q_tiles, k_fa4) instead of
+    # (B, H, N_q_tiles, N/n_block_size). FA4 only accesses indices 0..cnt-1,
+    # so the last dimension only needs to be k_fa4. This reduces memory from
+    # O(N²) to O(N * k_fa4) — e.g. 8 MB vs 8.6 GB at N=1M.
+    full_block_idx = fa4_indices[:, :, :, :k_fa4].to(torch.int32)
+
+    # mask_block_cnt/idx: no partial masking needed. Use shape (B,H,N_q_tiles,1)
+    # for mask_block_idx since count is always 0.
+    mask_block_cnt = torch.zeros(
+        (B, H, N_q_tiles), dtype=torch.int32, device=device
+    )
+    mask_block_idx = torch.zeros(
+        (B, H, N_q_tiles, 1), dtype=torch.int32, device=device
+    )
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=mask_block_cnt,
+        mask_block_idx=mask_block_idx,
+        full_block_cnt=full_block_cnt,
+        full_block_idx=full_block_idx,
+    )

--- a/test/attention/bench_sparse_attn.py
+++ b/test/attention/bench_sparse_attn.py
@@ -1,0 +1,250 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Detailed benchmarks for NSA vs dense FA4 attention.
+
+Reports wall-clock time, effective TFLOPS, and speedup ratio.
+Separately times each NSA component: compression, selection, attention branches, gating.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+
+import torch
+
+
+def benchmark_fn(fn, warmup=5, repeat=20):
+    """Benchmark a CUDA function using CUDA events. Returns median time in ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(repeat):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times = sorted(times)
+    return times[len(times) // 2]
+
+
+def compute_flops_dense(B, H, N, D):
+    """Compute FLOPs for dense attention forward pass."""
+    # QK^T: 2*B*H*N*N*D, PV: 2*B*H*N*N*D
+    return 4 * B * H * N * N * D
+
+
+def compute_flops_nsa(B, H, N, D, compress_block_size, num_selected, window_size):
+    """Compute FLOPs for NSA forward pass."""
+    l = compress_block_size
+    k = num_selected
+    w = window_size
+    # Compressed: 4*B*H*N*(N/l)*D
+    # Selected: 4*B*H*N*(k*l)*D
+    # Sliding: 4*B*H*N*w*D
+    flops_cmp = 4 * B * H * N * (N // l) * D
+    flops_slc = 4 * B * H * N * (k * l) * D
+    flops_sld = 4 * B * H * N * w * D
+    return flops_cmp + flops_slc + flops_sld
+
+
+def run_benchmark(
+    N: int,
+    B: int = 2,
+    H: int = 32,
+    H_kv: int = 8,
+    D: int = 128,
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    dtype=torch.bfloat16,
+    warmup: int = 5,
+    repeat: int = 20,
+):
+    """Run NSA vs dense FA4 benchmark for a given sequence length."""
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+    from mslk.attention.sparse_attn.compress import compress_kv
+    from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+    from mslk.attention.sparse_attn.select import score_and_select_blocks
+    from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+    # --- Dense FA4 baseline ---
+    dense_ms = benchmark_fn(
+        lambda: flash_attn_func(Q, K, V, causal=True),
+        warmup=warmup, repeat=repeat,
+    )
+    dense_flops = compute_flops_dense(B, H, N, D)
+    dense_tflops = dense_flops / (dense_ms * 1e-3) / 1e12
+
+    # --- NSA end-to-end ---
+    nsa_ms = benchmark_fn(
+        lambda: nsa_forward(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected_blocks,
+            window_size=window_size,
+            causal=True,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+    nsa_flops = compute_flops_nsa(
+        B, H, N, D, compress_block_size, num_selected_blocks, window_size
+    )
+    nsa_tflops = nsa_flops / (nsa_ms * 1e-3) / 1e12
+
+    # --- Component timing ---
+    # Compression
+    cmp_ms = benchmark_fn(
+        lambda: compress_kv(K, V, compress_block_size),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Selection
+    K_cmp, V_cmp = compress_kv(K, V, compress_block_size)
+    sel_ms = benchmark_fn(
+        lambda: score_and_select_blocks(
+            Q, K_cmp, num_selected_blocks, compress_block_size,
+            causal=True, q_tile_size=256,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Block-sparse mask construction
+    block_indices = score_and_select_blocks(
+        Q, K_cmp, num_selected_blocks, compress_block_size,
+        causal=True, q_tile_size=256,
+    )
+    mask_ms = benchmark_fn(
+        lambda: build_fa4_block_sparse_tensors(
+            block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Compressed attention FA4
+    fa4_cmp_ms = benchmark_fn(
+        lambda: flash_attn_func(Q, K_cmp, V_cmp, causal=True),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Selected attention FA4 (block-sparse)
+    sparse_tensors = build_fa4_block_sparse_tensors(
+        block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+    )
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+    fa4_slc_ms = benchmark_fn(
+        lambda: _flash_attn_fwd(
+            Q, K, V, causal=True, block_sparse_tensors=sparse_tensors,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Sliding window FA4
+    fa4_sld_ms = benchmark_fn(
+        lambda: flash_attn_func(Q, K, V, causal=True, window_size=(window_size, 0)),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Gating
+    O_cmp = torch.randn_like(Q)
+    O_slc = torch.randn_like(Q)
+    O_sld = torch.randn_like(Q)
+    gates = torch.randn(B, N, H, 3, device="cuda", dtype=dtype)
+    gate_ms = benchmark_fn(
+        lambda: gate_and_combine(O_cmp, O_slc, O_sld, gates),
+        warmup=warmup, repeat=repeat,
+    )
+
+    speedup = dense_ms / nsa_ms
+    theoretical_speedup = N / (N / compress_block_size + num_selected_blocks * compress_block_size + window_size)
+
+    return {
+        "N": N,
+        "dense_ms": dense_ms,
+        "dense_tflops": dense_tflops,
+        "nsa_ms": nsa_ms,
+        "nsa_tflops": nsa_tflops,
+        "speedup": speedup,
+        "theoretical_speedup": theoretical_speedup,
+        "compress_ms": cmp_ms,
+        "select_ms": sel_ms,
+        "mask_ms": mask_ms,
+        "fa4_cmp_ms": fa4_cmp_ms,
+        "fa4_slc_ms": fa4_slc_ms,
+        "fa4_sld_ms": fa4_sld_ms,
+        "gate_ms": gate_ms,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="NSA vs FA4 benchmark")
+    parser.add_argument("--seq-lens", nargs="+", type=int,
+                        default=[1024, 2048, 4096, 8192, 16384])
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--num-heads", type=int, default=32)
+    parser.add_argument("--num-heads-kv", type=int, default=32)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--compress-block-size", type=int, default=64)
+    parser.add_argument("--num-selected-blocks", type=int, default=16)
+    parser.add_argument("--window-size", type=int, default=512)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeat", type=int, default=20)
+    args = parser.parse_args()
+
+    print(f"{'='*100}")
+    print(f"NSA vs Dense FA4 Benchmark")
+    print(f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
+          f"D={args.head_dim}, l={args.compress_block_size}, k={args.num_selected_blocks}, "
+          f"w={args.window_size}")
+    print(f"{'='*100}")
+
+    header = (
+        f"{'N':>8} | {'Dense(ms)':>10} {'TFLOPS':>8} | "
+        f"{'NSA(ms)':>10} {'TFLOPS':>8} | {'Speedup':>8} {'Theory':>8} | "
+        f"{'Cmp':>6} {'Sel':>6} {'Mask':>6} "
+        f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for N in args.seq_lens:
+        result = run_benchmark(
+            N=N,
+            B=args.batch_size,
+            H=args.num_heads,
+            H_kv=args.num_heads_kv,
+            D=args.head_dim,
+            compress_block_size=args.compress_block_size,
+            num_selected_blocks=args.num_selected_blocks,
+            window_size=args.window_size,
+            warmup=args.warmup,
+            repeat=args.repeat,
+        )
+        print(
+            f"{result['N']:>8} | "
+            f"{result['dense_ms']:>10.2f} {result['dense_tflops']:>8.1f} | "
+            f"{result['nsa_ms']:>10.2f} {result['nsa_tflops']:>8.1f} | "
+            f"{result['speedup']:>8.2f}x {result['theoretical_speedup']:>7.1f}x | "
+            f"{result['compress_ms']:>6.2f} {result['select_ms']:>6.2f} "
+            f"{result['mask_ms']:>6.2f} {result['fa4_cmp_ms']:>6.2f} "
+            f"{result['fa4_slc_ms']:>6.2f} {result['fa4_sld_ms']:>6.2f} "
+            f"{result['gate_ms']:>6.2f}"
+        )
+
+    print(f"{'='*100}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/benchmark_results.svg
+++ b/test/attention/benchmark_results.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <style>
+      .title { font-size: 18px; font-weight: 600; fill: #1a1a2e; }
+      .subtitle { font-size: 12px; fill: #666; }
+      .axis-label { font-size: 12px; fill: #444; }
+      .tick-label { font-size: 11px; fill: #555; }
+      .legend-text { font-size: 12px; fill: #333; }
+      .grid { stroke: #e0e0e0; stroke-width: 0.5; }
+      .annotation { font-size: 10px; fill: #888; }
+      .speedup-label { font-size: 10px; font-weight: 600; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="500" fill="#fafafa" rx="8"/>
+
+  <!-- Title -->
+  <text x="400" y="32" text-anchor="middle" class="title">NSA vs Dense Flash Attention (FA4) — NVIDIA B200</text>
+  <text x="400" y="50" text-anchor="middle" class="subtitle">B=2, H=32, H_kv=32, D=128, block_size=128, k=16, window=512</text>
+
+  <!-- Chart area: x=100..720, y=70..400 -->
+  <!-- Y axis: 0 to 18ms (log would be better but linear is clearer) -->
+  <!-- X axis: sequence lengths 1024, 2048, 4096, 8192, 16384, 32768 -->
+
+  <!-- Grid lines -->
+  <line x1="100" y1="400" x2="720" y2="400" class="grid"/>
+  <line x1="100" y1="363" x2="720" y2="363" class="grid"/>
+  <line x1="100" y1="327" x2="720" y2="327" class="grid"/>
+  <line x1="100" y1="290" x2="720" y2="290" class="grid"/>
+  <line x1="100" y1="253" x2="720" y2="253" class="grid"/>
+  <line x1="100" y1="217" x2="720" y2="217" class="grid"/>
+  <line x1="100" y1="180" x2="720" y2="180" class="grid"/>
+  <line x1="100" y1="143" x2="720" y2="143" class="grid"/>
+  <line x1="100" y1="107" x2="720" y2="107" class="grid"/>
+  <line x1="100" y1="70" x2="720" y2="70" class="grid"/>
+
+  <!-- Y axis labels (0 to 18ms, step 2) -->
+  <text x="90" y="404" text-anchor="end" class="tick-label">0</text>
+  <text x="90" y="367" text-anchor="end" class="tick-label">2</text>
+  <text x="90" y="330" text-anchor="end" class="tick-label">4</text>
+  <text x="90" y="294" text-anchor="end" class="tick-label">6</text>
+  <text x="90" y="257" text-anchor="end" class="tick-label">8</text>
+  <text x="90" y="220" text-anchor="end" class="tick-label">10</text>
+  <text x="90" y="184" text-anchor="end" class="tick-label">12</text>
+  <text x="90" y="147" text-anchor="end" class="tick-label">14</text>
+  <text x="90" y="110" text-anchor="end" class="tick-label">16</text>
+  <text x="90" y="74" text-anchor="end" class="tick-label">18</text>
+
+  <!-- Y axis title -->
+  <text x="30" y="235" text-anchor="middle" class="axis-label" transform="rotate(-90, 30, 235)">Latency (ms)</text>
+
+  <!-- X positions: evenly spaced at x = 140, 256, 372, 488, 604, 720 -->
+  <!-- Actually let me use: 130, 248, 366, 484, 602, 720 -->
+
+  <!-- X axis labels -->
+  <text x="130" y="420" text-anchor="middle" class="tick-label">1K</text>
+  <text x="248" y="420" text-anchor="middle" class="tick-label">2K</text>
+  <text x="366" y="420" text-anchor="middle" class="tick-label">4K</text>
+  <text x="484" y="420" text-anchor="middle" class="tick-label">8K</text>
+  <text x="602" y="420" text-anchor="middle" class="tick-label">16K</text>
+  <text x="720" y="420" text-anchor="middle" class="tick-label">32K</text>
+
+  <!-- X axis title -->
+  <text x="410" y="445" text-anchor="middle" class="axis-label">Sequence Length</text>
+
+  <!-- Axes -->
+  <line x1="100" y1="400" x2="720" y2="400" stroke="#333" stroke-width="1.5"/>
+  <line x1="100" y1="70" x2="100" y2="400" stroke="#333" stroke-width="1.5"/>
+
+  <!-- Scale: 18ms = 330px, so 1ms = 18.33px. y = 400 - (ms * 330/18) = 400 - ms*18.33 -->
+  <!-- Dense FA4 data points:
+       1024:  0.08ms -> y=398.5
+       2048:  0.12ms -> y=397.8
+       4096:  0.28ms -> y=394.9
+       8192:  0.96ms -> y=382.4
+       16384: 3.48ms -> y=336.2
+       32768: 16.36ms -> y=100.1
+  -->
+
+  <!-- NSA data points:
+       1024:  0.92ms -> y=383.1
+       2048:  1.26ms -> y=376.9
+       4096:  1.94ms -> y=364.4
+       8192:  3.75ms -> y=331.3
+       16384: 6.96ms -> y=272.4
+       32768: 15.47ms -> y=116.4
+  -->
+
+  <!-- Dense FA4 line (blue) -->
+  <polyline points="130,398.5 248,397.8 366,394.9 484,382.4 602,336.2 720,100.1"
+            fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- Dense FA4 dots -->
+  <circle cx="130" cy="398.5" r="4" fill="#2563eb"/>
+  <circle cx="248" cy="397.8" r="4" fill="#2563eb"/>
+  <circle cx="366" cy="394.9" r="4" fill="#2563eb"/>
+  <circle cx="484" cy="382.4" r="4" fill="#2563eb"/>
+  <circle cx="602" cy="336.2" r="4" fill="#2563eb"/>
+  <circle cx="720" cy="100.1" r="4" fill="#2563eb"/>
+
+  <!-- NSA line (orange-red) -->
+  <polyline points="130,383.1 248,376.9 366,364.4 484,331.3 602,272.4 720,116.4"
+            fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- NSA dots -->
+  <circle cx="130" cy="383.1" r="4" fill="#dc2626"/>
+  <circle cx="248" cy="376.9" r="4" fill="#dc2626"/>
+  <circle cx="366" cy="364.4" r="4" fill="#dc2626"/>
+  <circle cx="484" cy="331.3" r="4" fill="#dc2626"/>
+  <circle cx="602" cy="272.4" r="4" fill="#dc2626"/>
+  <circle cx="720" cy="116.4" r="4" fill="#dc2626"/>
+
+  <!-- Crossover annotation -->
+  <line x1="700" y1="116.4" x2="700" y2="100.1" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <text x="710" y="112" class="speedup-label" fill="#22c55e">1.06x</text>
+
+  <!-- Speedup annotations at each point -->
+  <text x="130" y="377" class="speedup-label" fill="#dc2626">0.08x</text>
+  <text x="248" y="371" class="speedup-label" fill="#dc2626">0.10x</text>
+  <text x="366" y="358" class="speedup-label" fill="#dc2626">0.14x</text>
+  <text x="484" y="325" class="speedup-label" fill="#dc2626">0.25x</text>
+  <text x="602" y="266" class="speedup-label" fill="#dc2626">0.50x</text>
+  <text x="726" y="130" class="speedup-label" fill="#22c55e">1.06x</text>
+
+  <!-- Crossover line (vertical dashed) -->
+  <line x1="712" y1="400" x2="712" y2="70" stroke="#22c55e" stroke-width="1" stroke-dasharray="4,3" opacity="0.5"/>
+
+  <!-- Legend -->
+  <rect x="140" y="70" width="200" height="52" fill="white" stroke="#ddd" rx="4"/>
+  <line x1="152" y1="85" x2="180" y2="85" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="166" cy="85" r="3.5" fill="#2563eb"/>
+  <text x="186" y="89" class="legend-text">Dense FA4 (Flash Attention)</text>
+  <line x1="152" y1="107" x2="180" y2="107" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="166" cy="107" r="3.5" fill="#dc2626"/>
+  <text x="186" y="111" class="legend-text">NSA (Native Sparse Attention)</text>
+
+  <!-- Bottom annotations -->
+  <text x="400" y="472" text-anchor="middle" class="annotation">Dense FA4 scales as O(N²). NSA scales as O(N · (N/l + k·l + w)) where l=128, k=16, w=512.</text>
+  <text x="400" y="487" text-anchor="middle" class="annotation">NSA breaks even at ~32K and becomes faster for longer contexts. Measured on NVIDIA B200 GPU.</text>
+</svg>

--- a/test/attention/test_sparse_attn_benchmark.py
+++ b/test/attention/test_sparse_attn_benchmark.py
@@ -1,0 +1,69 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Performance benchmark: NSA vs dense FA4 attention."""
+
+import pytest
+import torch
+
+
+def _benchmark_fn(fn, warmup=5, repeat=20):
+    """Benchmark a function using CUDA events."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    times = []
+    for _ in range(repeat):
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times = sorted(times)
+    # Use median
+    return times[len(times) // 2]
+
+
+class TestBenchmark:
+    """Performance comparison between NSA and dense FA4."""
+
+    @pytest.mark.parametrize("N", [8192, 16384, 32768, 65536, 131072])
+    def test_nsa_benchmark(self, N) -> None:
+        """Benchmark NSA vs dense FA4 and report speedup."""
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        B, H, H_kv, D = 2, 32, 32, 128
+        dtype = torch.bfloat16
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+        # Dense FA4 baseline
+        dense_ms = _benchmark_fn(
+            lambda: flash_attn_func(Q, K, V, causal=True)
+        )
+
+        # NSA
+        nsa_ms = _benchmark_fn(
+            lambda: nsa_forward(
+                Q, K, V,
+                compress_block_size=64,
+                num_selected_blocks=16,
+                window_size=512,
+                causal=True,
+            )
+        )
+
+        speedup = dense_ms / nsa_ms
+        print(
+            f"\nN={N}: dense={dense_ms:.2f}ms, NSA={nsa_ms:.2f}ms, "
+            f"speedup={speedup:.2f}x"
+        )
+
+        # At large N, we expect NSA to be competitive
+        # (don't fail the test, just report)

--- a/test/attention/test_sparse_attn_compress.py
+++ b/test/attention/test_sparse_attn_compress.py
@@ -1,0 +1,79 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for KV compression."""
+
+import pytest
+import torch
+
+
+class TestCompressKV:
+    """Test KV compression with mean-pooling and projection."""
+
+    def test_basic_shape(self) -> None:
+        """Compressed output has correct shape."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 1024, 4, 64
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size)
+        assert K_cmp.shape == (B, N // block_size, H_kv, D)
+        assert V_cmp.shape == (B, N // block_size, H_kv, D)
+
+    def test_mean_pool_correctness(self) -> None:
+        """Mean-pool matches manual reshape + mean."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 256, 2, 32
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size)
+
+        # Manual mean pool
+        K_expected = K.reshape(B, N // block_size, block_size, H_kv, D).mean(dim=2)
+        V_expected = V.reshape(B, N // block_size, block_size, H_kv, D).mean(dim=2)
+
+        torch.testing.assert_close(K_cmp, K_expected, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(V_cmp, V_expected, atol=1e-5, rtol=1e-5)
+
+    def test_with_projection(self) -> None:
+        """Projection applies correctly after mean-pooling."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 256, 2, 32
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+        W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size, W_k, W_v)
+
+        # Manual: mean pool then project
+        K_pooled = K.reshape(B, N // block_size, block_size, H_kv, D).mean(dim=2)
+        K_expected = torch.einsum("bnhd,hde->bnhe", K_pooled, W_k)
+
+        torch.testing.assert_close(K_cmp, K_expected, atol=1e-5, rtol=1e-5)
+
+    def test_bf16_tolerance(self) -> None:
+        """BF16 compression is within tolerance of FP32 compression."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 512, 4, 64
+        block_size = 64
+
+        K_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+
+        K_cmp_fp32, V_cmp_fp32 = compress_kv(K_fp32, V_fp32, block_size)
+        K_cmp_bf16, V_cmp_bf16 = compress_kv(
+            K_fp32.bfloat16(), V_fp32.bfloat16(), block_size
+        )
+
+        torch.testing.assert_close(
+            K_cmp_bf16.float(), K_cmp_fp32, atol=1e-2, rtol=1e-2
+        )

--- a/test/attention/test_sparse_attn_nsa_forward.py
+++ b/test/attention/test_sparse_attn_nsa_forward.py
@@ -1,0 +1,184 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""End-to-end correctness tests for NSA forward pass.
+
+Compares the FA4-based NSA implementation against the pure PyTorch reference.
+"""
+
+import math
+
+import pytest
+import torch
+
+
+def _make_inputs(B, N, H, H_kv, D, dtype, device="cuda"):
+    """Create random Q, K, V inputs."""
+    Q = torch.randn(B, N, H, D, device=device, dtype=dtype) * 0.1
+    K = torch.randn(B, N, H_kv, D, device=device, dtype=dtype) * 0.1
+    V = torch.randn(B, N, H_kv, D, device=device, dtype=dtype) * 0.1
+    return Q, K, V
+
+
+class TestNSAForwardCorrectness:
+    """Compare FA4-based NSA against reference implementation."""
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16])
+    @pytest.mark.parametrize("N", [1024, 2048])
+    @pytest.mark.parametrize("causal", [True])
+    def test_nsa_vs_reference(self, dtype, N, causal) -> None:
+        """NSA forward pass matches reference within tolerance."""
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, H, H_kv, D = 1, 4, 4, 128
+        compress_block_size = 64
+        num_selected = 8
+        window_size = 256
+        q_tile_size = 256
+
+        Q, K, V = _make_inputs(B, N, H, H_kv, D, dtype)
+
+        # Reference (pure PyTorch)
+        out_ref = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected,
+            window_size=window_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+        )
+
+        # FA4-based
+        out_fa4 = nsa_forward(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected,
+            window_size=window_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+        )
+
+        max_diff = (out_fa4.float() - out_ref.float()).abs().max().item()
+        mean_diff = (out_fa4.float() - out_ref.float()).abs().mean().item()
+
+        assert max_diff < 0.1, f"Max diff too large: {max_diff}"
+        assert mean_diff < 0.01, f"Mean diff too large: {mean_diff}"
+
+    @pytest.mark.parametrize("H,H_kv", [(4, 4)])
+    def test_nsa_gqa(self, H, H_kv) -> None:
+        """NSA works with MHA configuration.
+
+        Note: GQA (H > H_kv) is not yet supported with block sparsity in FA4
+        (pack_gqa=True is not compatible with block_sparse_tensors).
+        """
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        B, N, D = 1, 1024, 128
+        Q, K, V = _make_inputs(B, N, H, H_kv, D, torch.bfloat16)
+
+        out = nsa_forward(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=8,
+            window_size=256,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    @pytest.mark.parametrize("N", [65536])
+    def test_nsa_large_n(self, N) -> None:
+        """NSA handles large sequence lengths without OOM.
+
+        Verifies that the tiled block scoring, compact index tensors, and
+        chunked gating optimizations allow NSA to scale beyond 32K.
+        """
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        B, H, H_kv, D = 1, 4, 4, 128
+        compress_block_size = 64
+        num_selected = 16
+        window_size = 512
+        dtype = torch.bfloat16
+
+        Q, K, V = _make_inputs(B, N, H, H_kv, D, dtype)
+
+        out = nsa_forward(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected,
+            window_size=window_size,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+
+class TestNSAForwardComponentIntegration:
+    """Test that individual components integrate correctly."""
+
+    def test_compress_then_fa4(self) -> None:
+        """FA4 can run on compressed KV sequence."""
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 4, 128
+        block_size = 64
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size)
+        # K_cmp: (B, N//64, H, D) = (1, 16, 4, 128)
+
+        out, lse = flash_attn_func(Q, K_cmp, V_cmp, causal=True)
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_sliding_window_fa4(self) -> None:
+        """FA4 sliding window attention works correctly."""
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+        B, N, H, D = 1, 1024, 4, 128
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        out, lse = flash_attn_func(
+            Q, K, V, causal=True, window_size=(512, 0)
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_block_sparse_fa4(self) -> None:
+        """FA4 block-sparse attention works with our mask format."""
+        from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, N, H, D = 1, 1024, 4, 128
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        block_indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=256,
+        )
+        sparse_tensors = build_fa4_block_sparse_tensors(
+            block_indices, block_size, n_block_size=128, seqlen_k=N,
+        )
+
+        out, lse = _flash_attn_fwd(
+            Q, K, V,
+            causal=True,
+            block_sparse_tensors=sparse_tensors,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()

--- a/test/attention/test_sparse_attn_reference.py
+++ b/test/attention/test_sparse_attn_reference.py
@@ -1,0 +1,133 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for the pure PyTorch NSA reference implementation."""
+
+import math
+
+import pytest
+import torch
+
+
+class TestNSAReferenceBasic:
+    """Basic sanity checks for the reference implementation."""
+
+    def test_output_shape(self) -> None:
+        """Output shape matches input query shape."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        H_kv = 4
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert out.dtype == torch.bfloat16
+
+    def test_output_shape_gqa(self) -> None:
+        """Output shape correct with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 8, 64
+        H_kv = 2
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+
+    def test_output_finite(self) -> None:
+        """Output contains no NaN or Inf values."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 2, 512, 4, 64
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.float16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.float16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.float16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=True,
+        )
+        assert torch.isfinite(out).all(), "Output contains NaN or Inf"
+
+    def test_with_gate_weights(self) -> None:
+        """Test with explicit gate projection weights."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        gate_proj = torch.randn(H, 3, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            gate_proj_weight=gate_proj,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_with_compression_weights(self) -> None:
+        """Test with learned KV compression projections."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        H_kv = 4
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16) * 0.02
+        W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16) * 0.02
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            W_k_compress=W_k,
+            W_v_compress=W_v,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_noncausal(self) -> None:
+        """Test non-causal mode."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=False,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()

--- a/test/attention/test_sparse_attn_select.py
+++ b/test/attention/test_sparse_attn_select.py
@@ -1,0 +1,157 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for block scoring and top-k selection."""
+
+import pytest
+import torch
+
+
+class TestScoreAndSelectBlocks:
+    """Test block scoring and selection."""
+
+    def test_output_shape(self) -> None:
+        """Selected indices have correct shape."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 2, 1024, 4, 64
+        H_kv = 4
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        N_cmp = N // block_size
+        k_actual = min(num_selected, N_cmp)
+        assert indices.shape == (B, H, N_q_tiles, k_actual)
+        assert indices.dtype == torch.int32
+
+    def test_indices_in_range(self) -> None:
+        """All selected indices are valid KV block indices."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=256,
+        )
+
+        N_cmp = N // block_size
+        assert (indices >= 0).all()
+        assert (indices < N_cmp).all()
+
+    def test_causal_no_future_blocks(self) -> None:
+        """Causal mode: no future blocks are selected."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 2, 64
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        for qt in range(N_q_tiles):
+            # Query tile qt covers positions [qt*q_tile_size, (qt+1)*q_tile_size)
+            # KV block idx covers positions [idx*block_size, (idx+1)*block_size)
+            # Causal: KV block start must be < query tile end
+            q_tile_end = (qt + 1) * q_tile_size
+            max_allowed_block = q_tile_end // block_size
+            assert (indices[:, :, qt, :] < max_allowed_block).all(), (
+                f"Query tile {qt}: found future block indices"
+            )
+
+    def test_indices_sorted(self) -> None:
+        """Selected indices are sorted per query tile."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=256,
+        )
+
+        # Check sorted along last dim
+        sorted_indices = indices.sort(dim=-1).values
+        assert (indices == sorted_indices).all()
+
+    def test_deterministic(self) -> None:
+        """Same input produces same selection."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices1 = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        indices2 = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        assert (indices1 == indices2).all()
+
+    def test_gqa(self) -> None:
+        """Works correctly with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 8, 64
+        H_kv = 2
+        block_size = 64
+        num_selected = 4
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        N_q_tiles = N // 256
+        assert indices.shape == (B, H, N_q_tiles, num_selected)

--- a/test/attention/test_sparse_attn_sparsity_masks.py
+++ b/test/attention/test_sparse_attn_sparsity_masks.py
@@ -1,0 +1,99 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for sparsity mask construction."""
+
+import pytest
+import torch
+
+
+class TestBuildFA4BlockSparseTensors:
+    """Test conversion from NSA block indices to FA4 format."""
+
+    def test_output_types(self) -> None:
+        """Output is a valid BlockSparseTensorsTorch."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+        from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+
+        B, H, N_q_tiles, k = 2, 4, 4, 8
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+        assert isinstance(result, BlockSparseTensorsTorch)
+        assert result.full_block_cnt is not None
+        assert result.full_block_idx is not None
+        assert result.mask_block_cnt is not None
+        assert result.mask_block_idx is not None
+
+    def test_shapes(self) -> None:
+        """Output tensors have correct shapes."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 2, 4, 8, 4
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+
+        assert result.full_block_cnt.shape == (B, H, N_q_tiles)
+        assert result.full_block_idx.shape == (B, H, N_q_tiles, k)
+        assert result.mask_block_cnt.shape == (B, H, N_q_tiles)
+
+    def test_full_block_count(self) -> None:
+        """Full block count matches expected value."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 1, 2, 4, 8
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        # compress_block_size == n_block_size, so 1:1 mapping
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+        assert (result.full_block_cnt == k).all()
+
+    def test_block_expansion(self) -> None:
+        """When compress_block_size > n_block_size, blocks expand correctly."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 1, 1, 2, 2
+        # Select block 0 and block 3
+        indices = torch.tensor([[[[0, 3]]]], device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=256, n_block_size=128, seqlen_k=1024,
+        )
+
+        # Each NSA block of 256 -> 2 FA4 blocks of 128
+        assert (result.full_block_cnt == 4).all()  # 2 blocks * 2 FA4 blocks each
+
+        # Block 0 -> FA4 blocks [0, 1], Block 3 -> FA4 blocks [6, 7]
+        expected_idx = result.full_block_idx[0, 0, 0, :4]
+        assert expected_idx.tolist() == [0, 1, 6, 7]
+
+    def test_mask_blocks_are_zero(self) -> None:
+        """All mask block counts should be zero (selected blocks are fully attended)."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 2, 4, 4, 8
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+        assert (result.mask_block_cnt == 0).all()
+
+    def test_int32_dtype(self) -> None:
+        """All output tensors are int32."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        indices = torch.randint(0, 8, (1, 2, 4, 4), device="cuda", dtype=torch.int32)
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=1024,
+        )
+        assert result.full_block_cnt.dtype == torch.int32
+        assert result.full_block_idx.dtype == torch.int32
+        assert result.mask_block_cnt.dtype == torch.int32
+        assert result.mask_block_idx.dtype == torch.int32


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/MSLK-NV/pull/188

Move the sparse_attn kernel from fb/mslk/attention/sparse_attn to mslk/attention/sparse_attn, matching the convention used by other kernels in this directory. Update all imports from mslk.fb.mslk.attention.sparse_attn to mslk.attention.sparse_attn, update BUCK targets so the library is defined directly in mslk/BUCK instead of as a shim forwarding to mslk/fb, and update test deps accordingly. Also fix a stale shape assertion in test_sparse_attn_sparsity_masks that expected the old dense index layout instead of the compact one.

Additionally fixes three O(N^2) memory bottlenecks that caused NSA to OOM at N=65536: tiled block scoring in select.py, compact index tensors in sparsity_masks.py, and chunked gating in gating.py.

Reviewed By: sryap

Differential Revision: D93656846


