### PR TITLE
Use FA4 CuteDSL backward for compressed + sliding window; fix causal bug

### DIFF
--- a/docs/nsa_vs_dense_perf.svg
+++ b/docs/nsa_vs_dense_perf.svg
@@ -16,12 +16,13 @@
   <rect width="900" height="560" rx="12" fill="url(#bg)" stroke="#dde1e6" stroke-width="1"/>
 
   <!-- Title -->
-  <text x="450" y="36" text-anchor="middle" font-size="18" font-weight="700" fill="#1a1a2e">Dense FA4 vs NSA Sparse Attention — Fused Selection Kernel</text>
-  <text x="450" y="56" text-anchor="middle" font-size="12" fill="#6b7280">B=1, H=8, H_kv=2, D=128 | k=16 selected blocks, w=512 window | bf16 on B200</text>
+  <text x="450" y="36" text-anchor="middle" font-size="18" font-weight="700" fill="#1a1a2e">Dense FA4 vs NSA Sparse Attention — NVIDIA B200</text>
+  <text x="450" y="56" text-anchor="middle" font-size="12" fill="#6b7280">B=1, H=8, H_kv=2, D=128 | k=16 selected blocks, w=512 | bf16 | Fused CuteDSL kernels</text>
 
   <!-- Chart area: x=100..820, y=80..440 (log-log) -->
-  <!-- X: 2^10..2^20 (1K..1M), 72px per octave -->
+  <!-- X: 2^10..2^22 (1K..4M), 60px per octave -->
   <!-- Y: 0.1ms..100s, 6 decades, 60px per decade -->
+  <!-- x = 100 + 60 * (log2(N) - 10) -->
   <!-- y = 440 - 60 * (log10(t_ms) + 1) -->
 
   <!-- Horizontal grid -->
@@ -50,31 +51,35 @@
   <!-- Vertical grid -->
   <g stroke="#e5e7eb" stroke-width="0.7" stroke-dasharray="4,3">
     <line x1="100" y1="80" x2="100" y2="440"/>
-    <line x1="172" y1="80" x2="172" y2="440"/>
-    <line x1="244" y1="80" x2="244" y2="440"/>
-    <line x1="316" y1="80" x2="316" y2="440"/>
-    <line x1="388" y1="80" x2="388" y2="440"/>
+    <line x1="160" y1="80" x2="160" y2="440"/>
+    <line x1="220" y1="80" x2="220" y2="440"/>
+    <line x1="280" y1="80" x2="280" y2="440"/>
+    <line x1="340" y1="80" x2="340" y2="440"/>
+    <line x1="400" y1="80" x2="400" y2="440"/>
     <line x1="460" y1="80" x2="460" y2="440"/>
-    <line x1="532" y1="80" x2="532" y2="440"/>
-    <line x1="604" y1="80" x2="604" y2="440"/>
-    <line x1="676" y1="80" x2="676" y2="440"/>
-    <line x1="748" y1="80" x2="748" y2="440"/>
+    <line x1="520" y1="80" x2="520" y2="440"/>
+    <line x1="580" y1="80" x2="580" y2="440"/>
+    <line x1="640" y1="80" x2="640" y2="440"/>
+    <line x1="700" y1="80" x2="700" y2="440"/>
+    <line x1="760" y1="80" x2="760" y2="440"/>
     <line x1="820" y1="80" x2="820" y2="440"/>
   </g>
 
   <!-- X axis labels -->
   <g font-size="10" fill="#6b7280" text-anchor="middle">
     <text x="100" y="458">1K</text>
-    <text x="172" y="458">2K</text>
-    <text x="244" y="458">4K</text>
-    <text x="316" y="458">8K</text>
-    <text x="388" y="458">16K</text>
-    <text x="460" y="458">32K</text>
-    <text x="532" y="458">64K</text>
-    <text x="604" y="458">128K</text>
-    <text x="676" y="458">256K</text>
-    <text x="748" y="458">512K</text>
-    <text x="820" y="458">1M</text>
+    <text x="160" y="458">2K</text>
+    <text x="220" y="458">4K</text>
+    <text x="280" y="458">8K</text>
+    <text x="340" y="458">16K</text>
+    <text x="400" y="458">32K</text>
+    <text x="460" y="458">64K</text>
+    <text x="520" y="458">128K</text>
+    <text x="580" y="458">256K</text>
+    <text x="640" y="458">512K</text>
+    <text x="700" y="458">1M</text>
+    <text x="760" y="458">2M</text>
+    <text x="820" y="458">4M</text>
   </g>
   <text x="460" y="480" text-anchor="middle" font-size="13" font-weight="600" fill="#374151">Sequence length (tokens)</text>
 
@@ -83,141 +88,138 @@
   <line x1="100" y1="80" x2="100" y2="440" stroke="#9ca3af" stroke-width="1.5"/>
 
   <!--
-    MEASURED DATA (B200, B=1, H=8, H_kv=2, D=128, k=16, w=512, bf16):
+    MEASURED DATA (B200, bf16, CUDA_VISIBLE_DEVICES isolated per run):
+    Config: B=1, H=8, H_kv=2, D=128, k=16, w=512
+    Fused compress, fused select, fused gating kernels active.
+    All data measured end-to-end, no interpolation or scaling.
 
-    N       Dense    NSA-old   NSA l=32  NSA l=64  NSA l=128
-            (ms)     l=64(ms)  new(ms)   new(ms)   new(ms)
-    4K      0.18     1.13      1.08      1.06      0.91      measured
-    8K      0.15     1.21      0.95      0.93      0.78      measured
-    16K     0.43     1.69      0.94      0.95      0.79      measured
-    32K     1.62     4.39      1.15      1.09      1.04      measured
-    64K     7.61     8.14      2.15      1.73      1.47      measured
-    128K    29.71    24.08     5.76      4.11      3.11      measured
-    256K    118.63   81.37     18.29     11.79     8.12      measured
-    512K    474.50   302.66    66.55     37.90     23.76     measured
-    1M      1944     1190      251       133       73        measured (H=4,H_kv=1 scaled 2x)
+    Dense FA4 (from l=64 run, GPU 1):
+    4K:   0.19ms    8K:   0.15ms    16K:  0.44ms    32K:  1.67ms
+    64K:  8.17ms    128K: 32.03ms   256K: 126.72ms  512K: 506.70ms
+    1M:   2026.53ms 2M:   7626.38ms 3M:   18150.16ms
 
-    1M measured with H=4,H_kv=1 (half heads to fit 12GB GPU), times scaled 2x
-    to H=8 equivalent. Dense at 1M validates: 972*2=1944 vs 474.5*4=1898 (2.4% err).
+    NSA l=32 (GPU 3):
+    4K:   1.36ms    8K:   1.09ms    16K:  1.09ms    32K:  1.28ms
+    64K:  2.30ms    128K: 5.90ms    256K: 18.67ms   512K: 66.43ms
+    1M:   254.07ms  (7.97x vs dense)
 
+    NSA l=64 (GPU 1):
+    4K:   1.18ms    8K:   1.07ms    16K:  1.07ms    32K:  1.46ms
+    64K:  1.87ms    128K: 4.11ms    256K: 11.51ms   512K: 37.54ms
+    1M:   139.90ms  2M:   503.71ms  3M:   1117.56ms (16.24x vs dense)
+
+    NSA l=128 (GPU 4):
+    4K:   1.06ms    8K:   0.95ms    16K:  0.94ms    32K:  1.31ms
+    64K:  2.03ms    128K: 3.16ms    256K: 8.05ms    512K: 23.94ms
+    1M:   76.85ms   2M:   282.68ms  3M:   616.48ms  (29.44x vs dense)
+
+    x = 100 + 60 * (log2(N) - 10)
     y = 440 - 60 * (log10(t_ms) + 1)
   -->
 
   <!-- ===== Dense FA4 ===== -->
   <polyline
-    points="244,424.7 316,429.4 388,402.0 460,367.4 532,327.1 604,291.6 676,255.6 748,219.4 820,182.7"
+    points="220,423.3 280,429.4 340,401.4 400,366.6 460,325.3 520,289.7 580,253.8 640,217.7 700,181.6 760,147.1 795,124.5"
     fill="none" stroke="#e74c3c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
     filter="url(#lineShadow)"/>
   <g fill="#e74c3c">
-    <circle cx="244" cy="424.7" r="3"/>
-    <circle cx="316" cy="429.4" r="3"/>
-    <circle cx="388" cy="402.0" r="3"/>
-    <circle cx="460" cy="367.4" r="3"/>
-    <circle cx="532" cy="327.1" r="3"/>
-    <circle cx="604" cy="291.6" r="3"/>
-    <circle cx="676" cy="255.6" r="3"/>
-    <circle cx="748" cy="219.4" r="3"/>
-    <circle cx="820" cy="182.7" r="3"/>
+    <circle cx="220" cy="423.3" r="3"/>
+    <circle cx="280" cy="429.4" r="3"/>
+    <circle cx="340" cy="401.4" r="3"/>
+    <circle cx="400" cy="366.6" r="3"/>
+    <circle cx="460" cy="325.3" r="3"/>
+    <circle cx="520" cy="289.7" r="3"/>
+    <circle cx="580" cy="253.8" r="3"/>
+    <circle cx="640" cy="217.7" r="3"/>
+    <circle cx="700" cy="181.6" r="3"/>
+    <circle cx="760" cy="147.1" r="3"/>
+    <circle cx="795" cy="124.5" r="3"/>
   </g>
 
-  <!-- ===== NSA-old l=64 (PyTorch selection — the bottleneck we fixed) ===== -->
+  <!-- ===== NSA l=32 (fused CuteDSL) ===== -->
   <polyline
-    points="244,376.8 316,375.0 388,366.3 460,341.5 532,325.3 604,297.1 676,265.3 748,231.1 820,195.4"
-    fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-    stroke-dasharray="6,4"
-    filter="url(#lineShadow)"/>
-  <g fill="#f59e0b">
-    <circle cx="460" cy="341.5" r="2.5"/>
-    <circle cx="532" cy="325.3" r="2.5"/>
-    <circle cx="604" cy="297.1" r="2.5"/>
-    <circle cx="676" cy="265.3" r="2.5"/>
-    <circle cx="748" cy="231.1" r="2.5"/>
-  </g>
-
-  <!-- ===== NSA-new l=32 (fused CuteDSL) ===== -->
-  <polyline
-    points="244,378.0 316,381.3 388,381.6 460,376.3 532,360.1 604,334.4 676,304.3 748,270.6 820,236.0"
+    points="220,372.0 280,377.8 340,377.8 400,373.6 460,358.3 520,333.7 580,303.7 640,270.7 700,235.7"
     fill="none" stroke="#a3e635" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
     stroke-dasharray="8,4"
     filter="url(#lineShadow)"/>
   <g fill="#a3e635">
-    <circle cx="460" cy="376.3" r="2.5"/>
-    <circle cx="532" cy="360.1" r="2.5"/>
-    <circle cx="604" cy="334.4" r="2.5"/>
-    <circle cx="676" cy="304.3" r="2.5"/>
-    <circle cx="748" cy="270.6" r="2.5"/>
-    <circle cx="820" cy="236.0" r="2.5"/>
+    <circle cx="220" cy="372.0" r="2.5"/>
+    <circle cx="280" cy="377.8" r="2.5"/>
+    <circle cx="340" cy="377.8" r="2.5"/>
+    <circle cx="400" cy="373.6" r="2.5"/>
+    <circle cx="460" cy="358.3" r="2.5"/>
+    <circle cx="520" cy="333.7" r="2.5"/>
+    <circle cx="580" cy="303.7" r="2.5"/>
+    <circle cx="640" cy="270.7" r="2.5"/>
+    <circle cx="700" cy="235.7" r="2.5"/>
   </g>
 
-  <!-- ===== NSA-new l=64 (fused CuteDSL) ===== -->
+  <!-- ===== NSA l=64 (fused CuteDSL) ===== -->
   <polyline
-    points="244,378.5 316,381.9 388,381.3 460,377.8 532,365.7 604,343.2 676,315.7 748,285.3 820,252.6"
+    points="220,375.7 280,378.2 340,378.2 400,370.1 460,363.7 520,343.2 580,316.3 640,285.5 700,251.3 760,217.9 795,197.1"
     fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
     filter="url(#lineShadow)"/>
   <g fill="#22c55e">
-    <circle cx="244" cy="378.5" r="3"/>
-    <circle cx="316" cy="381.9" r="3"/>
-    <circle cx="388" cy="381.3" r="3"/>
-    <circle cx="460" cy="377.8" r="3"/>
-    <circle cx="532" cy="365.7" r="3"/>
-    <circle cx="604" cy="343.2" r="3"/>
-    <circle cx="676" cy="315.7" r="3"/>
-    <circle cx="748" cy="285.3" r="3"/>
-    <circle cx="820" cy="252.6" r="3"/>
+    <circle cx="220" cy="375.7" r="3"/>
+    <circle cx="280" cy="378.2" r="3"/>
+    <circle cx="340" cy="378.2" r="3"/>
+    <circle cx="400" cy="370.1" r="3"/>
+    <circle cx="460" cy="363.7" r="3"/>
+    <circle cx="520" cy="343.2" r="3"/>
+    <circle cx="580" cy="316.3" r="3"/>
+    <circle cx="640" cy="285.5" r="3"/>
+    <circle cx="700" cy="251.3" r="3"/>
+    <circle cx="760" cy="217.9" r="3"/>
+    <circle cx="795" cy="197.1" r="3"/>
   </g>
 
-  <!-- ===== NSA-new l=128 (fused CuteDSL) ===== -->
+  <!-- ===== NSA l=128 (fused CuteDSL) ===== -->
   <polyline
-    points="244,382.5 316,386.5 388,386.1 460,379.0 532,370.0 604,350.4 676,325.4 748,297.4 820,268.2"
+    points="220,378.5 280,381.3 340,381.6 400,373.0 460,361.6 520,350.0 580,325.7 640,297.3 700,266.9 760,232.9 795,212.6"
     fill="none" stroke="#059669" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
     filter="url(#lineShadow)"/>
   <g fill="#059669">
-    <circle cx="244" cy="382.5" r="3.5"/>
-    <circle cx="316" cy="386.5" r="3.5"/>
-    <circle cx="388" cy="386.1" r="3.5"/>
-    <circle cx="460" cy="379.0" r="3.5"/>
-    <circle cx="532" cy="370.0" r="3.5"/>
-    <circle cx="604" cy="350.4" r="3.5"/>
-    <circle cx="676" cy="325.4" r="3.5"/>
-    <circle cx="748" cy="297.4" r="3.5"/>
-    <circle cx="820" cy="268.2" r="3.5"/>
+    <circle cx="220" cy="378.5" r="3.5"/>
+    <circle cx="280" cy="381.3" r="3.5"/>
+    <circle cx="340" cy="381.6" r="3.5"/>
+    <circle cx="400" cy="373.0" r="3.5"/>
+    <circle cx="460" cy="361.6" r="3.5"/>
+    <circle cx="520" cy="350.0" r="3.5"/>
+    <circle cx="580" cy="325.7" r="3.5"/>
+    <circle cx="640" cy="297.3" r="3.5"/>
+    <circle cx="700" cy="266.9" r="3.5"/>
+    <circle cx="760" cy="232.9" r="3.5"/>
+    <circle cx="795" cy="212.6" r="3.5"/>
   </g>
 
-  <!-- Speedup annotation: old l=64 vs new l=64 at N=1M -->
-  <line x1="820" y1="197" x2="820" y2="250" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="807" y="222" font-size="9" font-weight="600" fill="#7c3aed" text-anchor="end">8.9x</text>
-  <text x="807" y="232" font-size="8" fill="#7c3aed" text-anchor="end">faster</text>
+  <!-- Speedup bracket: Dense vs NSA l=128 at N=3M -->
+  <line x1="795" y1="127" x2="795" y2="210" stroke="#7c3aed" stroke-width="1.5"/>
+  <line x1="791" y1="127" x2="799" y2="127" stroke="#7c3aed" stroke-width="1.5"/>
+  <line x1="791" y1="210" x2="799" y2="210" stroke="#7c3aed" stroke-width="1.5"/>
 
-  <!-- Speedup labels at N=1M (measured) -->
+  <!-- Speedup labels at N=3M (vs dense) -->
   <g font-size="9" font-weight="600">
-    <text x="835" y="234" fill="#a3e635">7.7x</text>
-    <text x="835" y="250" fill="#22c55e">14.6x</text>
-    <text x="835" y="266" fill="#059669">26.5x</text>
+    <text x="808" y="193" fill="#a3e635">8.0x</text>
+    <text x="808" y="203" fill="#22c55e">16.2x</text>
+    <text x="808" y="213" fill="#059669">29.4x</text>
   </g>
 
   <!-- Scaling annotations -->
   <g font-size="9" fill="#6b7280" font-style="italic">
-    <text x="800" y="170" text-anchor="end">O(N²)</text>
+    <text x="775" y="115" text-anchor="end">O(N&#xB2;)</text>
   </g>
 
   <!-- "l" labels at right side of each NSA curve -->
   <g font-size="10" font-weight="600">
-    <text x="828" y="242" fill="#a3e635">l=32</text>
-    <text x="828" y="258" fill="#22c55e">l=64</text>
-    <text x="828" y="274" fill="#059669">l=128</text>
+    <text x="708" y="232" fill="#a3e635">l=32</text>
+    <text x="808" y="200" fill="#22c55e">l=64</text>
+    <text x="808" y="218" fill="#059669">l=128</text>
   </g>
 
-  <!-- NSA-old label -->
-  <text x="828" y="200" font-size="9" font-weight="500" fill="#f59e0b">old l=64</text>
-
   <!-- Crossover annotation -->
-  <text x="445" y="395" text-anchor="middle" font-size="8" fill="#7c3aed" font-weight="500">NSA faster than dense</text>
-  <text x="445" y="404" text-anchor="middle" font-size="8" fill="#7c3aed">above N ~24K</text>
-  <line x1="445" y1="375" x2="445" y2="387" stroke="#7c3aed" stroke-width="0.8" stroke-dasharray="2,2"/>
-
-  <!-- Old crossover annotation -->
-  <text x="610" y="302" text-anchor="start" font-size="7" fill="#f59e0b">old: barely faster</text>
-  <text x="610" y="310" text-anchor="start" font-size="7" fill="#f59e0b">than dense at 128K</text>
+  <text x="380" y="395" text-anchor="middle" font-size="8" fill="#7c3aed" font-weight="500">NSA faster than dense</text>
+  <text x="380" y="404" text-anchor="middle" font-size="8" fill="#7c3aed">above N ~24K</text>
+  <line x1="380" y1="375" x2="380" y2="387" stroke="#7c3aed" stroke-width="0.8" stroke-dasharray="2,2"/>
 
   <!-- Legend -->
   <g transform="translate(110, 495)" filter="url(#shadow)">
@@ -227,20 +229,18 @@
     <circle cx="24" cy="16" r="3" fill="#e74c3c"/>
     <text x="40" y="20" font-size="10" fill="#374151" font-weight="500">Dense FA4</text>
 
-    <line x1="115" y1="16" x2="135" y2="16" stroke="#f59e0b" stroke-width="2" stroke-dasharray="6,4"/>
-    <text x="141" y="20" font-size="10" fill="#374151" font-weight="500">NSA old l=64 (PyTorch select)</text>
+    <line x1="115" y1="16" x2="135" y2="16" stroke="#a3e635" stroke-width="2" stroke-dasharray="8,4"/>
+    <circle cx="125" cy="16" r="2.5" fill="#a3e635"/>
+    <text x="141" y="20" font-size="10" fill="#374151" font-weight="500">NSA l=32</text>
 
-    <line x1="350" y1="16" x2="370" y2="16" stroke="#a3e635" stroke-width="2" stroke-dasharray="8,4"/>
-    <text x="376" y="20" font-size="10" fill="#374151" font-weight="500">l=32</text>
+    <line x1="230" y1="16" x2="250" y2="16" stroke="#22c55e" stroke-width="2.5"/>
+    <circle cx="240" cy="16" r="3" fill="#22c55e"/>
+    <text x="256" y="20" font-size="10" fill="#374151" font-weight="500">NSA l=64</text>
 
-    <line x1="14" y1="40" x2="34" y2="40" stroke="#22c55e" stroke-width="2.5"/>
-    <circle cx="24" cy="40" r="3" fill="#22c55e"/>
-    <text x="40" y="44" font-size="10" fill="#374151" font-weight="500">NSA fused l=64</text>
+    <line x1="340" y1="16" x2="360" y2="16" stroke="#059669" stroke-width="2.5"/>
+    <circle cx="350" cy="16" r="3.5" fill="#059669"/>
+    <text x="366" y="20" font-size="10" fill="#374151" font-weight="500">NSA l=128</text>
 
-    <line x1="155" y1="40" x2="175" y2="40" stroke="#059669" stroke-width="2.5"/>
-    <circle cx="165" cy="40" r="3" fill="#059669"/>
-    <text x="181" y="44" font-size="10" fill="#374151" font-weight="500">l=128</text>
-
-    <text x="260" y="44" font-size="9" fill="#9ca3af">Measured on B200, 4K&#x2013;512K at H=8, 1M at H=4 (scaled)</text>
+    <text x="14" y="44" font-size="9" fill="#9ca3af">All data measured on B200 (180GB). B=1, H=8, H_kv=2, D=128. Fused compress, select, gating kernels. No interpolated points.</text>
   </g>
 </svg>

--- a/docs/nsa_vs_dense_perf.svg
+++ b/docs/nsa_vs_dense_perf.svg
@@ -1,0 +1,246 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Inter, -apple-system, system-ui, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fafbfc"/>
+      <stop offset="100%" stop-color="#f0f2f5"/>
+    </linearGradient>
+    <filter id="shadow" x="-2%" y="-2%" width="104%" height="104%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.08"/>
+    </filter>
+    <filter id="lineShadow">
+      <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="560" rx="12" fill="url(#bg)" stroke="#dde1e6" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="450" y="36" text-anchor="middle" font-size="18" font-weight="700" fill="#1a1a2e">Dense FA4 vs NSA Sparse Attention — Fused Selection Kernel</text>
+  <text x="450" y="56" text-anchor="middle" font-size="12" fill="#6b7280">B=1, H=8, H_kv=2, D=128 | k=16 selected blocks, w=512 window | bf16 on B200</text>
+
+  <!-- Chart area: x=100..820, y=80..440 (log-log) -->
+  <!-- X: 2^10..2^20 (1K..1M), 72px per octave -->
+  <!-- Y: 0.1ms..100s, 6 decades, 60px per decade -->
+  <!-- y = 440 - 60 * (log10(t_ms) + 1) -->
+
+  <!-- Horizontal grid -->
+  <g stroke="#e5e7eb" stroke-width="0.7" stroke-dasharray="4,3">
+    <line x1="100" y1="80" x2="820" y2="80"/>
+    <line x1="100" y1="140" x2="820" y2="140"/>
+    <line x1="100" y1="200" x2="820" y2="200"/>
+    <line x1="100" y1="260" x2="820" y2="260"/>
+    <line x1="100" y1="320" x2="820" y2="320"/>
+    <line x1="100" y1="380" x2="820" y2="380"/>
+    <line x1="100" y1="440" x2="820" y2="440"/>
+  </g>
+
+  <!-- Y axis labels -->
+  <g font-size="11" fill="#6b7280" text-anchor="end">
+    <text x="92" y="84">100s</text>
+    <text x="92" y="144">10s</text>
+    <text x="92" y="204">1s</text>
+    <text x="92" y="264">100ms</text>
+    <text x="92" y="324">10ms</text>
+    <text x="92" y="384">1ms</text>
+    <text x="92" y="444">0.1ms</text>
+  </g>
+  <text x="20" y="260" text-anchor="middle" font-size="13" font-weight="600" fill="#374151" transform="rotate(-90, 20, 260)">Wall-clock time</text>
+
+  <!-- Vertical grid -->
+  <g stroke="#e5e7eb" stroke-width="0.7" stroke-dasharray="4,3">
+    <line x1="100" y1="80" x2="100" y2="440"/>
+    <line x1="172" y1="80" x2="172" y2="440"/>
+    <line x1="244" y1="80" x2="244" y2="440"/>
+    <line x1="316" y1="80" x2="316" y2="440"/>
+    <line x1="388" y1="80" x2="388" y2="440"/>
+    <line x1="460" y1="80" x2="460" y2="440"/>
+    <line x1="532" y1="80" x2="532" y2="440"/>
+    <line x1="604" y1="80" x2="604" y2="440"/>
+    <line x1="676" y1="80" x2="676" y2="440"/>
+    <line x1="748" y1="80" x2="748" y2="440"/>
+    <line x1="820" y1="80" x2="820" y2="440"/>
+  </g>
+
+  <!-- X axis labels -->
+  <g font-size="10" fill="#6b7280" text-anchor="middle">
+    <text x="100" y="458">1K</text>
+    <text x="172" y="458">2K</text>
+    <text x="244" y="458">4K</text>
+    <text x="316" y="458">8K</text>
+    <text x="388" y="458">16K</text>
+    <text x="460" y="458">32K</text>
+    <text x="532" y="458">64K</text>
+    <text x="604" y="458">128K</text>
+    <text x="676" y="458">256K</text>
+    <text x="748" y="458">512K</text>
+    <text x="820" y="458">1M</text>
+  </g>
+  <text x="460" y="480" text-anchor="middle" font-size="13" font-weight="600" fill="#374151">Sequence length (tokens)</text>
+
+  <!-- Axes -->
+  <line x1="100" y1="440" x2="820" y2="440" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="100" y1="80" x2="100" y2="440" stroke="#9ca3af" stroke-width="1.5"/>
+
+  <!--
+    MEASURED DATA (B200, B=1, H=8, H_kv=2, D=128, k=16, w=512, bf16):
+
+    N       Dense    NSA-old   NSA l=32  NSA l=64  NSA l=128
+            (ms)     l=64(ms)  new(ms)   new(ms)   new(ms)
+    4K      0.18     1.13      1.08      1.06      0.91      measured
+    8K      0.15     1.21      0.95      0.93      0.78      measured
+    16K     0.43     1.69      0.94      0.95      0.79      measured
+    32K     1.62     4.39      1.15      1.09      1.04      measured
+    64K     7.61     8.14      2.15      1.73      1.47      measured
+    128K    29.71    24.08     5.76      4.11      3.11      measured
+    256K    118.63   81.37     18.29     11.79     8.12      measured
+    512K    474.50   302.66    66.55     37.90     23.76     measured
+    1M      1944     1190      251       133       73        measured (H=4,H_kv=1 scaled 2x)
+
+    1M measured with H=4,H_kv=1 (half heads to fit 12GB GPU), times scaled 2x
+    to H=8 equivalent. Dense at 1M validates: 972*2=1944 vs 474.5*4=1898 (2.4% err).
+
+    y = 440 - 60 * (log10(t_ms) + 1)
+  -->
+
+  <!-- ===== Dense FA4 ===== -->
+  <polyline
+    points="244,424.7 316,429.4 388,402.0 460,367.4 532,327.1 604,291.6 676,255.6 748,219.4 820,182.7"
+    fill="none" stroke="#e74c3c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+    filter="url(#lineShadow)"/>
+  <g fill="#e74c3c">
+    <circle cx="244" cy="424.7" r="3"/>
+    <circle cx="316" cy="429.4" r="3"/>
+    <circle cx="388" cy="402.0" r="3"/>
+    <circle cx="460" cy="367.4" r="3"/>
+    <circle cx="532" cy="327.1" r="3"/>
+    <circle cx="604" cy="291.6" r="3"/>
+    <circle cx="676" cy="255.6" r="3"/>
+    <circle cx="748" cy="219.4" r="3"/>
+    <circle cx="820" cy="182.7" r="3"/>
+  </g>
+
+  <!-- ===== NSA-old l=64 (PyTorch selection — the bottleneck we fixed) ===== -->
+  <polyline
+    points="244,376.8 316,375.0 388,366.3 460,341.5 532,325.3 604,297.1 676,265.3 748,231.1 820,195.4"
+    fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+    stroke-dasharray="6,4"
+    filter="url(#lineShadow)"/>
+  <g fill="#f59e0b">
+    <circle cx="460" cy="341.5" r="2.5"/>
+    <circle cx="532" cy="325.3" r="2.5"/>
+    <circle cx="604" cy="297.1" r="2.5"/>
+    <circle cx="676" cy="265.3" r="2.5"/>
+    <circle cx="748" cy="231.1" r="2.5"/>
+  </g>
+
+  <!-- ===== NSA-new l=32 (fused CuteDSL) ===== -->
+  <polyline
+    points="244,378.0 316,381.3 388,381.6 460,376.3 532,360.1 604,334.4 676,304.3 748,270.6 820,236.0"
+    fill="none" stroke="#a3e635" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+    stroke-dasharray="8,4"
+    filter="url(#lineShadow)"/>
+  <g fill="#a3e635">
+    <circle cx="460" cy="376.3" r="2.5"/>
+    <circle cx="532" cy="360.1" r="2.5"/>
+    <circle cx="604" cy="334.4" r="2.5"/>
+    <circle cx="676" cy="304.3" r="2.5"/>
+    <circle cx="748" cy="270.6" r="2.5"/>
+    <circle cx="820" cy="236.0" r="2.5"/>
+  </g>
+
+  <!-- ===== NSA-new l=64 (fused CuteDSL) ===== -->
+  <polyline
+    points="244,378.5 316,381.9 388,381.3 460,377.8 532,365.7 604,343.2 676,315.7 748,285.3 820,252.6"
+    fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+    filter="url(#lineShadow)"/>
+  <g fill="#22c55e">
+    <circle cx="244" cy="378.5" r="3"/>
+    <circle cx="316" cy="381.9" r="3"/>
+    <circle cx="388" cy="381.3" r="3"/>
+    <circle cx="460" cy="377.8" r="3"/>
+    <circle cx="532" cy="365.7" r="3"/>
+    <circle cx="604" cy="343.2" r="3"/>
+    <circle cx="676" cy="315.7" r="3"/>
+    <circle cx="748" cy="285.3" r="3"/>
+    <circle cx="820" cy="252.6" r="3"/>
+  </g>
+
+  <!-- ===== NSA-new l=128 (fused CuteDSL) ===== -->
+  <polyline
+    points="244,382.5 316,386.5 388,386.1 460,379.0 532,370.0 604,350.4 676,325.4 748,297.4 820,268.2"
+    fill="none" stroke="#059669" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+    filter="url(#lineShadow)"/>
+  <g fill="#059669">
+    <circle cx="244" cy="382.5" r="3.5"/>
+    <circle cx="316" cy="386.5" r="3.5"/>
+    <circle cx="388" cy="386.1" r="3.5"/>
+    <circle cx="460" cy="379.0" r="3.5"/>
+    <circle cx="532" cy="370.0" r="3.5"/>
+    <circle cx="604" cy="350.4" r="3.5"/>
+    <circle cx="676" cy="325.4" r="3.5"/>
+    <circle cx="748" cy="297.4" r="3.5"/>
+    <circle cx="820" cy="268.2" r="3.5"/>
+  </g>
+
+  <!-- Speedup annotation: old l=64 vs new l=64 at N=1M -->
+  <line x1="820" y1="197" x2="820" y2="250" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="807" y="222" font-size="9" font-weight="600" fill="#7c3aed" text-anchor="end">8.9x</text>
+  <text x="807" y="232" font-size="8" fill="#7c3aed" text-anchor="end">faster</text>
+
+  <!-- Speedup labels at N=1M (measured) -->
+  <g font-size="9" font-weight="600">
+    <text x="835" y="234" fill="#a3e635">7.7x</text>
+    <text x="835" y="250" fill="#22c55e">14.6x</text>
+    <text x="835" y="266" fill="#059669">26.5x</text>
+  </g>
+
+  <!-- Scaling annotations -->
+  <g font-size="9" fill="#6b7280" font-style="italic">
+    <text x="800" y="170" text-anchor="end">O(N²)</text>
+  </g>
+
+  <!-- "l" labels at right side of each NSA curve -->
+  <g font-size="10" font-weight="600">
+    <text x="828" y="242" fill="#a3e635">l=32</text>
+    <text x="828" y="258" fill="#22c55e">l=64</text>
+    <text x="828" y="274" fill="#059669">l=128</text>
+  </g>
+
+  <!-- NSA-old label -->
+  <text x="828" y="200" font-size="9" font-weight="500" fill="#f59e0b">old l=64</text>
+
+  <!-- Crossover annotation -->
+  <text x="445" y="395" text-anchor="middle" font-size="8" fill="#7c3aed" font-weight="500">NSA faster than dense</text>
+  <text x="445" y="404" text-anchor="middle" font-size="8" fill="#7c3aed">above N ~24K</text>
+  <line x1="445" y1="375" x2="445" y2="387" stroke="#7c3aed" stroke-width="0.8" stroke-dasharray="2,2"/>
+
+  <!-- Old crossover annotation -->
+  <text x="610" y="302" text-anchor="start" font-size="7" fill="#f59e0b">old: barely faster</text>
+  <text x="610" y="310" text-anchor="start" font-size="7" fill="#f59e0b">than dense at 128K</text>
+
+  <!-- Legend -->
+  <g transform="translate(110, 495)" filter="url(#shadow)">
+    <rect x="0" y="0" width="700" height="52" rx="8" fill="white" stroke="#e5e7eb" stroke-width="1"/>
+
+    <line x1="14" y1="16" x2="34" y2="16" stroke="#e74c3c" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="24" cy="16" r="3" fill="#e74c3c"/>
+    <text x="40" y="20" font-size="10" fill="#374151" font-weight="500">Dense FA4</text>
+
+    <line x1="115" y1="16" x2="135" y2="16" stroke="#f59e0b" stroke-width="2" stroke-dasharray="6,4"/>
+    <text x="141" y="20" font-size="10" fill="#374151" font-weight="500">NSA old l=64 (PyTorch select)</text>
+
+    <line x1="350" y1="16" x2="370" y2="16" stroke="#a3e635" stroke-width="2" stroke-dasharray="8,4"/>
+    <text x="376" y="20" font-size="10" fill="#374151" font-weight="500">l=32</text>
+
+    <line x1="14" y1="40" x2="34" y2="40" stroke="#22c55e" stroke-width="2.5"/>
+    <circle cx="24" cy="40" r="3" fill="#22c55e"/>
+    <text x="40" y="44" font-size="10" fill="#374151" font-weight="500">NSA fused l=64</text>
+
+    <line x1="155" y1="40" x2="175" y2="40" stroke="#059669" stroke-width="2.5"/>
+    <circle cx="165" cy="40" r="3" fill="#059669"/>
+    <text x="181" y="44" font-size="10" fill="#374151" font-weight="500">l=128</text>
+
+    <text x="260" y="44" font-size="9" fill="#9ca3af">Measured on B200, 4K&#x2013;512K at H=8, 1M at H=4 (scaled)</text>
+  </g>
+</svg>

--- a/mslk/attention/flash_attn/block_sparsity.py
+++ b/mslk/attention/flash_attn/block_sparsity.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+try:
+    from mslk.fb.mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+except ImportError:
+    from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
+
+__all__ = ["BlockSparseTensorsTorch"]

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -6,8 +6,12 @@ from mslk.attention.sparse_attn.gating import (
     fused_gate_and_combine,
     gate_and_combine,
 )
+from mslk.attention.sparse_attn.nsa_autograd import nsa
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward
-from mslk.attention.sparse_attn.reference import nsa_forward_reference
+from mslk.attention.sparse_attn.reference import (
+    nsa_backward_reference,
+    nsa_forward_reference,
+)
 from mslk.attention.sparse_attn.select import (
     fused_score_and_select_blocks,
     score_and_select_blocks,
@@ -15,8 +19,10 @@ from mslk.attention.sparse_attn.select import (
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 
 __all__ = [
+    "nsa",
     "nsa_forward",
     "nsa_forward_reference",
+    "nsa_backward_reference",
     "compress_kv",
     "fused_compress_kv",
     "score_and_select_blocks",

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -8,7 +8,10 @@ from mslk.attention.sparse_attn.gating import (
 )
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward
 from mslk.attention.sparse_attn.reference import nsa_forward_reference
-from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.select import (
+    fused_score_and_select_blocks,
+    score_and_select_blocks,
+)
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 
 __all__ = [
@@ -16,6 +19,7 @@ __all__ = [
     "nsa_forward_reference",
     "compress_kv",
     "score_and_select_blocks",
+    "fused_score_and_select_blocks",
     "build_fa4_block_sparse_tensors",
     "compute_gates",
     "fused_gate_and_combine",

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,6 +1,6 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
 from mslk.attention.sparse_attn.gating import (
     compute_gates,
     fused_gate_and_combine,
@@ -18,6 +18,7 @@ __all__ = [
     "nsa_forward",
     "nsa_forward_reference",
     "compress_kv",
+    "fused_compress_kv",
     "score_and_select_blocks",
     "fused_score_and_select_blocks",
     "build_fa4_block_sparse_tensors",

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,0 +1,18 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+from mslk.attention.sparse_attn.reference import nsa_forward_reference
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+__all__ = [
+    "nsa_forward",
+    "nsa_forward_reference",
+    "compress_kv",
+    "score_and_select_blocks",
+    "build_fa4_block_sparse_tensors",
+    "compute_gates",
+    "gate_and_combine",
+]

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,7 +1,11 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 from mslk.attention.sparse_attn.compress import compress_kv
-from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.gating import (
+    compute_gates,
+    fused_gate_and_combine,
+    gate_and_combine,
+)
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward
 from mslk.attention.sparse_attn.reference import nsa_forward_reference
 from mslk.attention.sparse_attn.select import score_and_select_blocks
@@ -14,5 +18,6 @@ __all__ = [
     "score_and_select_blocks",
     "build_fa4_block_sparse_tensors",
     "compute_gates",
+    "fused_gate_and_combine",
     "gate_and_combine",
 ]

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -37,7 +37,9 @@ def compress_kv(
         V_cmp: Compressed values, shape (B, N // block_size, H_kv, D).
     """
     B, N, H_kv, D = K.shape
-    assert N % block_size == 0, f"Sequence length {N} must be divisible by block_size {block_size}"
+    assert N % block_size == 0, (
+        f"Sequence length {N} must be divisible by block_size {block_size}"
+    )
 
     N_cmp = N // block_size
 
@@ -84,9 +86,7 @@ def _make_fused_compress_kernel(cute_dtype: Type, D: int, block_size: int):
 
     class _Kernel:
         @cute.jit
-        def __call__(
-            self, mK, mV, mK_out, mV_out, N_cmp, H_kv, N, stream
-        ):
+        def __call__(self, mK, mV, mK_out, mV_out, N_cmp, H_kv, N, stream):
             grid_x = mK_out.shape[0]  # B * N_cmp * H_kv
             self.kernel(mK, mV, mK_out, mV_out, N_cmp, H_kv, N).launch(
                 grid=[grid_x, 1, 1],
@@ -113,11 +113,15 @@ def _make_fused_compress_kernel(cute_dtype: Type, D: int, block_size: int):
                     acc_v = Float32(0.0)
 
                     for t in cutlass.range_constexpr(block_size):
-                        input_row = b * N * H_kv + (j * const_expr(block_size) + const_expr(t)) * H_kv + h
+                        input_row = cutlass.Int64(
+                            b * N * H_kv
+                            + (j * const_expr(block_size) + const_expr(t)) * H_kv
+                            + h
+                        )
                         acc_k += Float32(mK[input_row, d])
                         acc_v += Float32(mV[input_row, d])
 
-                    output_row = b * N_cmp * H_kv + j * H_kv + h
+                    output_row = cutlass.Int64(b * N_cmp * H_kv + j * H_kv + h)
                     mK_out[output_row, d] = cute_dtype(acc_k * inv_block_size)
                     mV_out[output_row, d] = cute_dtype(acc_v * inv_block_size)
 
@@ -156,7 +160,9 @@ def fused_compress_kv(
     from cutlass.cute.runtime import from_dlpack
 
     B, N, H_kv, D = K.shape
-    assert N % block_size == 0, f"Sequence length {N} must be divisible by block_size {block_size}"
+    assert N % block_size == 0, (
+        f"Sequence length {N} must be divisible by block_size {block_size}"
+    )
 
     N_cmp = N // block_size
 

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -213,3 +213,151 @@ def fused_compress_kv(
         V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
 
     return K_cmp, V_cmp
+
+
+# ---------------------------------------------------------------------------
+# CuteDSL fused compression backward kernel (mean-pool scatter)
+# ---------------------------------------------------------------------------
+
+_fused_compress_bwd_compile_cache: dict = {}
+
+
+def _make_fused_compress_bwd_kernel(cute_dtype: Type, D: int, block_size: int):
+    """Create CuteDSL kernel for compression backward (mean-pool scatter).
+
+    Each thread block handles one output position (b, pos, h).
+    Reads dK_cmp[b, pos//block_size, h, :] and writes
+    dK[b, pos, h, :] = dK_cmp[b, block, h, :] / block_size.
+    Processes both K and V simultaneously.
+
+    Grid: B * N * H_kv
+    Block: 128 threads
+    """
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass import const_expr, Float32
+
+    THREADS_PER_BLOCK = 128
+    D_PER_THREAD = math.ceil(D / THREADS_PER_BLOCK)
+
+    class _Kernel:
+        @cute.jit
+        def __call__(self, mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv, stream):
+            grid_x = mDK.shape[0]
+            self.kernel(mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv):
+            tidx = cute.arch.thread_idx()[0]
+            bidx = cute.arch.block_idx()[0]
+
+            b = bidx // (N * H_kv)
+            pos = (bidx % (N * H_kv)) // H_kv
+            h = bidx % H_kv
+
+            block_idx = pos // const_expr(block_size)
+            inv_block_size = const_expr(1.0 / block_size)
+
+            N_cmp = N // const_expr(block_size)
+            input_row = cutlass.Int64(b * N_cmp * H_kv + block_idx * H_kv + h)
+
+            for e in cutlass.range_constexpr(D_PER_THREAD):
+                d = tidx + const_expr(e * THREADS_PER_BLOCK)
+                if d < const_expr(D):
+                    dk = Float32(mDK_cmp[input_row, d]) * inv_block_size
+                    dv = Float32(mDV_cmp[input_row, d]) * inv_block_size
+                    mDK[bidx, d] = cute_dtype(dk)
+                    mDV[bidx, d] = cute_dtype(dv)
+
+    return _Kernel()
+
+
+def fused_compress_kv_backward(
+    dK_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    dV_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None = None,
+    W_v: Tensor | None = None,
+) -> tuple[Tensor, Tensor, Tensor | None, Tensor | None]:
+    """Backward through KV compression: CuteDSL scatter + PyTorch projection.
+
+    Returns (dK, dV, dW_k, dW_v).
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H_kv, D = K.shape
+    N_cmp = N // block_size
+
+    dW_k = None
+    dW_v = None
+
+    # Projection backward (PyTorch)
+    if W_k is not None:
+        K_cmp_mean = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+        dW_k = torch.einsum("bnhd,bnhe->hde", K_cmp_mean.float(), dK_cmp.float()).to(
+            W_k.dtype
+        )
+        dK_cmp = torch.einsum("bnhe,hde->bnhd", dK_cmp.float(), W_k.float()).to(
+            dK_cmp.dtype
+        )
+
+    if W_v is not None:
+        V_cmp_mean = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+        dW_v = torch.einsum("bnhd,bnhe->hde", V_cmp_mean.float(), dV_cmp.float()).to(
+            W_v.dtype
+        )
+        dV_cmp = torch.einsum("bnhe,hde->bnhd", dV_cmp.float(), W_v.float()).to(
+            dV_cmp.dtype
+        )
+
+    # Mean-pool backward via CuteDSL scatter kernel
+    dK = torch.empty(B, N, H_kv, D, device=K.device, dtype=K.dtype)
+    dV = torch.empty(B, N, H_kv, D, device=V.device, dtype=V.dtype)
+
+    M_out = B * N * H_kv
+    M_in = B * N_cmp * H_kv
+
+    dK_cmp_2d = dK_cmp.reshape(M_in, D).contiguous()
+    dV_cmp_2d = dV_cmp.reshape(M_in, D).contiguous()
+    dK_2d = dK.reshape(M_out, D)
+    dV_2d = dV.reshape(M_out, D)
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[K.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mDK_cmp = to_cute(dK_cmp_2d)
+    mDV_cmp = to_cute(dV_cmp_2d)
+    mDK = to_cute(dK_2d)
+    mDV = to_cute(dV_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, block_size)
+    if compile_key not in _fused_compress_bwd_compile_cache:
+        kernel_op = _make_fused_compress_bwd_kernel(cute_dtype, D, block_size)
+        _fused_compress_bwd_compile_cache[compile_key] = cute.compile(
+            kernel_op, mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv, current_stream
+        )
+    _fused_compress_bwd_compile_cache[compile_key](
+        mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv, current_stream
+    )
+
+    return dK, dV, dW_k, dW_v

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -1,0 +1,50 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""KV compression for NSA: mean-pool KV into blocks and apply learned projection."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def compress_kv(
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None = None,  # (H_kv, D, D) or None
+    W_v: Tensor | None = None,  # (H_kv, D, D) or None
+) -> tuple[Tensor, Tensor]:
+    """Compress K, V by mean-pooling over blocks and applying optional linear projection.
+
+    Args:
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        block_size: Number of positions to pool together.
+        W_k: Optional per-head projection weight for keys.
+        W_v: Optional per-head projection weight for values.
+
+    Returns:
+        K_cmp: Compressed keys, shape (B, N // block_size, H_kv, D).
+        V_cmp: Compressed values, shape (B, N // block_size, H_kv, D).
+    """
+    B, N, H_kv, D = K.shape
+    assert N % block_size == 0, f"Sequence length {N} must be divisible by block_size {block_size}"
+
+    N_cmp = N // block_size
+
+    # Reshape into blocks and mean-pool
+    K_cmp = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)  # (B, N_cmp, H_kv, D)
+    V_cmp = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+
+    # Apply per-head linear projection if provided
+    if W_k is not None:
+        # W_k: (H_kv, D, D)
+        # K_cmp: (B, N_cmp, H_kv, D) -> einsum over D
+        K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
+
+    if W_v is not None:
+        V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
+
+    return K_cmp, V_cmp

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -1,11 +1,18 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-ignore-all-errors
 
-"""KV compression for NSA: mean-pool KV into blocks and apply learned projection."""
+"""KV compression for NSA: mean-pool KV into blocks and apply learned projection.
+
+Includes both a PyTorch reference (compress_kv) and a fused CuteDSL kernel
+(fused_compress_kv) that processes both K and V in a single kernel launch.
+"""
 
 from __future__ import annotations
 
+import math
+from typing import Type
+
 import torch
-import torch.nn.functional as F
 from torch import Tensor
 
 
@@ -42,6 +49,158 @@ def compress_kv(
     if W_k is not None:
         # W_k: (H_kv, D, D)
         # K_cmp: (B, N_cmp, H_kv, D) -> einsum over D
+        K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
+
+    if W_v is not None:
+        V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
+
+    return K_cmp, V_cmp
+
+
+# ---------------------------------------------------------------------------
+# CuteDSL fused compression kernel
+# ---------------------------------------------------------------------------
+
+_fused_compress_compile_cache: dict = {}
+
+
+def _make_fused_compress_kernel(cute_dtype: Type, D: int, block_size: int):
+    """Create and return a compiled CuteDSL kernel for fused KV compression.
+
+    Each thread block handles one output element (b, j, h) — one compressed
+    block for one KV head. It reads block_size input positions for both K and V,
+    accumulates in float32, divides by block_size, and writes the mean.
+
+    Grid: B * N_cmp * H_kv (one block per output row)
+    Block: 128 threads
+    Each thread handles elements d = tidx, tidx+128, ... of the D dimension.
+    """
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass import const_expr, Float32
+
+    THREADS_PER_BLOCK = 128
+    D_PER_THREAD = math.ceil(D / THREADS_PER_BLOCK)
+
+    class _Kernel:
+        @cute.jit
+        def __call__(
+            self, mK, mV, mK_out, mV_out, N_cmp, H_kv, N, stream
+        ):
+            grid_x = mK_out.shape[0]  # B * N_cmp * H_kv
+            self.kernel(mK, mV, mK_out, mV_out, N_cmp, H_kv, N).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, mK, mV, mK_out, mV_out, N_cmp, H_kv, N):
+            tidx = cute.arch.thread_idx()[0]
+            bidx = cute.arch.block_idx()[0]
+
+            # Decompose block index into (b, j, h)
+            b = bidx // (N_cmp * H_kv)
+            j = (bidx % (N_cmp * H_kv)) // H_kv
+            h = bidx % H_kv
+
+            inv_block_size = const_expr(1.0 / block_size)
+
+            for e in cutlass.range_constexpr(D_PER_THREAD):
+                d = tidx + const_expr(e * THREADS_PER_BLOCK)
+                if d < const_expr(D):
+                    acc_k = Float32(0.0)
+                    acc_v = Float32(0.0)
+
+                    for t in cutlass.range_constexpr(block_size):
+                        input_row = b * N * H_kv + (j * const_expr(block_size) + const_expr(t)) * H_kv + h
+                        acc_k += Float32(mK[input_row, d])
+                        acc_v += Float32(mV[input_row, d])
+
+                    output_row = b * N_cmp * H_kv + j * H_kv + h
+                    mK_out[output_row, d] = cute_dtype(acc_k * inv_block_size)
+                    mV_out[output_row, d] = cute_dtype(acc_v * inv_block_size)
+
+    return _Kernel()
+
+
+def fused_compress_kv(
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None = None,  # (H_kv, D, D) or None
+    W_v: Tensor | None = None,  # (H_kv, D, D) or None
+) -> tuple[Tensor, Tensor]:
+    """Fused KV compression using a CuteDSL kernel.
+
+    Replaces compress_kv's two PyTorch mean-reduction calls with a single
+    fused kernel launch that processes both K and V simultaneously.
+
+    The optional W_k/W_v projections remain in PyTorch since they're rarely
+    used and would require a separate, more complex kernel.
+
+    Args:
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        block_size: Number of positions to pool together.
+        W_k: Optional per-head projection weight for keys.
+        W_v: Optional per-head projection weight for values.
+
+    Returns:
+        K_cmp: Compressed keys, shape (B, N // block_size, H_kv, D).
+        V_cmp: Compressed values, shape (B, N // block_size, H_kv, D).
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H_kv, D = K.shape
+    assert N % block_size == 0, f"Sequence length {N} must be divisible by block_size {block_size}"
+
+    N_cmp = N // block_size
+
+    # Allocate outputs
+    K_cmp = torch.empty(B, N_cmp, H_kv, D, device=K.device, dtype=K.dtype)
+    V_cmp = torch.empty(B, N_cmp, H_kv, D, device=V.device, dtype=V.dtype)
+
+    # Reshape to 2D: (B*N*H_kv, D) and (B*N_cmp*H_kv, D)
+    K_2d = K.reshape(B * N * H_kv, D).contiguous()
+    V_2d = V.reshape(B * N * H_kv, D).contiguous()
+    K_out_2d = K_cmp.reshape(B * N_cmp * H_kv, D)
+    V_out_2d = V_cmp.reshape(B * N_cmp * H_kv, D)
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[K.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mK = to_cute(K_2d)
+    mV = to_cute(V_2d)
+    mK_out = to_cute(K_out_2d)
+    mV_out = to_cute(V_out_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, block_size)
+    if compile_key not in _fused_compress_compile_cache:
+        kernel_op = _make_fused_compress_kernel(cute_dtype, D, block_size)
+        _fused_compress_compile_cache[compile_key] = cute.compile(
+            kernel_op, mK, mV, mK_out, mV_out, N_cmp, H_kv, N, current_stream
+        )
+    _fused_compress_compile_cache[compile_key](
+        mK, mV, mK_out, mV_out, N_cmp, H_kv, N, current_stream
+    )
+
+    # Apply optional projections in PyTorch (rare path)
+    if W_k is not None:
         K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
 
     if W_v is not None:

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -54,7 +54,7 @@ def _make_fused_gating_kernel(cute_dtype: Type, D: int, has_gate_weight: bool):
             warp_id = cute.arch.warp_idx()
             bidx = cute.arch.block_idx()[0]
 
-            row = bidx * WARPS_PER_BLOCK + warp_id
+            row = cutlass.Int64(bidx * WARPS_PER_BLOCK + warp_id)
             num_rows = mQ.shape[0]
 
             if row < num_rows:

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -1,0 +1,88 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Output gating and combination for NSA's three attention branches."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def compute_gates(
+    Q: Tensor,  # (B, N, H, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Compute per-head sigmoid gates for the three NSA branches.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        gate_proj_weight: Learned gate projection, shape (H, 3, D).
+            If None, returns uniform gates (1/3 each).
+        chunk_size: If set, process the sequence dimension in chunks to
+            reduce peak float32 memory usage. Recommended for N > 32K.
+
+    Returns:
+        gates: Sigmoid gates, shape (B, N, H, 3).
+    """
+    if gate_proj_weight is None:
+        B, N, H, D = Q.shape
+        return torch.ones(B, N, H, 3, device=Q.device, dtype=Q.dtype) / 3.0
+
+    if chunk_size is None:
+        # Original path for short sequences
+        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        return gate_logits.sigmoid().to(Q.dtype)
+
+    # Chunked path: process sequence in chunks to bound float32 intermediates
+    B, N, H, D = Q.shape
+    gates = torch.empty(B, N, H, 3, device=Q.device, dtype=Q.dtype)
+    w = gate_proj_weight.float()
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q[:, start:end].float(), w)
+        gates[:, start:end] = gate_logits.sigmoid().to(Q.dtype)
+    return gates
+
+
+def gate_and_combine(
+    O_cmp: Tensor,  # (B, N, H, D)
+    O_slc: Tensor,  # (B, N, H, D)
+    O_sld: Tensor,  # (B, N, H, D)
+    gates: Tensor,  # (B, N, H, 3)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Combine three attention branch outputs with sigmoid gates.
+
+    Args:
+        O_cmp: Compressed attention output, shape (B, N, H, D).
+        O_slc: Selected attention output, shape (B, N, H, D).
+        O_sld: Sliding window attention output, shape (B, N, H, D).
+        gates: Sigmoid gates, shape (B, N, H, 3).
+        chunk_size: If set, process the sequence dimension in chunks to
+            reduce peak float32 memory usage. Recommended for N > 32K.
+
+    Returns:
+        Combined output, shape (B, N, H, D).
+    """
+    if chunk_size is None:
+        # Original path for short sequences
+        g = gates.float()
+        return (
+            g[..., 0:1] * O_cmp.float()
+            + g[..., 1:2] * O_slc.float()
+            + g[..., 2:3] * O_sld.float()
+        ).to(O_cmp.dtype)
+
+    # Chunked path: avoid materializing 3 full (B,N,H,D) float32 tensors at once
+    B, N, H, D = O_cmp.shape
+    out = torch.empty(B, N, H, D, dtype=O_cmp.dtype, device=O_cmp.device)
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        g = gates[:, start:end].float()
+        out[:, start:end] = (
+            g[..., 0:1] * O_cmp[:, start:end].float()
+            + g[..., 1:2] * O_slc[:, start:end].float()
+            + g[..., 2:3] * O_sld[:, start:end].float()
+        ).to(O_cmp.dtype)
+    return out

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -182,6 +182,272 @@ def fused_gate_and_combine(
 
 
 # ---------------------------------------------------------------------------
+# CuteDSL fused gating backward kernel
+# ---------------------------------------------------------------------------
+
+_fused_gating_bwd_compile_cache: dict = {}
+
+
+def _make_fused_gating_bwd_kernel(cute_dtype: Type, D: int):
+    """Create CuteDSL kernel for fused gating backward.
+
+    Computes per-row:
+    - dO_cmp = g0 * dO, dO_slc = g1 * dO, dO_sld = g2 * dO
+    - dot_i = sum_d(dO[d] * O_i[d]) for each branch i
+    - d_logit_i = dot_i * gi * (1 - gi)
+    - dQ_gate[d] = sum_i(d_logit_i * W_i[d])
+
+    Does NOT compute dW_gate (requires cross-row reduction, done in PyTorch).
+    """
+    import cutlass
+    import cutlass.cute as cute
+
+    WARPS_PER_BLOCK = 4
+    THREADS_PER_BLOCK = WARPS_PER_BLOCK * 32
+    elems_per_thread = D // 32
+
+    class _Kernel:
+        @cute.jit
+        def __call__(
+            self,
+            mQ,
+            mdO,
+            mO_cmp,
+            mO_slc,
+            mO_sld,
+            mW,
+            mGates,
+            mdO_cmp,
+            mdO_slc,
+            mdO_sld,
+            mdQ_gate,
+            H,
+            stream,
+        ):
+            num_rows = mQ.shape[0]
+            grid_x = cute.ceil_div(num_rows, WARPS_PER_BLOCK)
+            self.kernel(
+                mQ,
+                mdO,
+                mO_cmp,
+                mO_slc,
+                mO_sld,
+                mW,
+                mGates,
+                mdO_cmp,
+                mdO_slc,
+                mdO_sld,
+                mdQ_gate,
+                H,
+            ).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(
+            self,
+            mQ,
+            mdO,
+            mO_cmp,
+            mO_slc,
+            mO_sld,
+            mW,
+            mGates,
+            mdO_cmp,
+            mdO_slc,
+            mdO_sld,
+            mdQ_gate,
+            H,
+        ):
+            lane_id = cute.arch.lane_idx()
+            warp_id = cute.arch.warp_idx()
+            bidx = cute.arch.block_idx()[0]
+
+            row = cutlass.Int64(bidx * WARPS_PER_BLOCK + warp_id)
+            num_rows = mQ.shape[0]
+
+            if row < num_rows:
+                ept = cutlass.const_expr(elems_per_thread)
+                head_idx = row % H
+
+                # Read gates for this row
+                g0 = cutlass.Float32(mGates[row, 0])
+                g1 = cutlass.Float32(mGates[row, 1])
+                g2 = cutlass.Float32(mGates[row, 2])
+
+                # Phase 1: Compute dot products dO·O_i via warp reduction
+                dot0 = cutlass.Float32(0.0)
+                dot1 = cutlass.Float32(0.0)
+                dot2 = cutlass.Float32(0.0)
+                for e in cutlass.range_constexpr(ept):
+                    d = lane_id * ept + e
+                    dO_val = cutlass.Float32(mdO[row, d])
+                    dot0 += dO_val * cutlass.Float32(mO_cmp[row, d])
+                    dot1 += dO_val * cutlass.Float32(mO_slc[row, d])
+                    dot2 += dO_val * cutlass.Float32(mO_sld[row, d])
+
+                for i in cutlass.range_constexpr(5):
+                    dot0 += cute.arch.shuffle_sync_bfly(dot0, offset=1 << i)
+                    dot1 += cute.arch.shuffle_sync_bfly(dot1, offset=1 << i)
+                    dot2 += cute.arch.shuffle_sync_bfly(dot2, offset=1 << i)
+
+                # Phase 2: Sigmoid derivative and d_logit
+                d_logit0 = dot0 * g0 * (1.0 - g0)
+                d_logit1 = dot1 * g1 * (1.0 - g1)
+                d_logit2 = dot2 * g2 * (1.0 - g2)
+
+                # Phase 3: Write outputs per element
+                for e in cutlass.range_constexpr(ept):
+                    d = lane_id * ept + e
+                    dO_val = cutlass.Float32(mdO[row, d])
+
+                    # dO_i = gi * dO
+                    mdO_cmp[row, d] = cute_dtype(g0 * dO_val)
+                    mdO_slc[row, d] = cute_dtype(g1 * dO_val)
+                    mdO_sld[row, d] = cute_dtype(g2 * dO_val)
+
+                    # dQ_gate = sum_i(d_logit_i * W_i[d])
+                    dq = (
+                        d_logit0 * cutlass.Float32(mW[head_idx, d])
+                        + d_logit1 * cutlass.Float32(mW[head_idx, D + d])
+                        + d_logit2 * cutlass.Float32(mW[head_idx, 2 * D + d])
+                    )
+                    mdQ_gate[row, d] = cute_dtype(dq)
+
+    return _Kernel()
+
+
+def fused_gating_backward(
+    Q: Tensor,  # (B, N, H, D)
+    dO: Tensor,  # (B, N, H, D)
+    O_cmp: Tensor,  # (B, N, H, D)
+    O_slc: Tensor,  # (B, N, H, D)
+    O_sld: Tensor,  # (B, N, H, D)
+    gates: Tensor,  # (B, N, H, 3)
+    gate_proj_weight: Tensor,  # (H, 3, D)
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+    """Fused gating backward using CuteDSL kernel + PyTorch for dW_gate.
+
+    The CuteDSL kernel computes dO_cmp, dO_slc, dO_sld, dQ_gate in one launch.
+    dW_gate is computed via PyTorch einsum (cross-row reduction).
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        dO: Upstream gradient, shape (B, N, H, D).
+        O_cmp, O_slc, O_sld: Branch outputs, shape (B, N, H, D).
+        gates: Sigmoid gate values, shape (B, N, H, 3).
+        gate_proj_weight: Gate weights, shape (H, 3, D).
+
+    Returns:
+        (dO_cmp, dO_slc, dO_sld, dQ_gate, dW_gate)
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H, D = Q.shape
+    assert D % 32 == 0, f"D={D} must be divisible by 32"
+
+    M = B * N * H
+
+    # Allocate outputs
+    dO_cmp = torch.empty_like(dO)
+    dO_slc = torch.empty_like(dO)
+    dO_sld = torch.empty_like(dO)
+    dQ_gate = torch.empty_like(Q)
+
+    # Reshape to 2D
+    Q_2d = Q.reshape(M, D).contiguous()
+    dO_2d = dO.reshape(M, D).contiguous()
+    O_cmp_2d = O_cmp.reshape(M, D).contiguous()
+    O_slc_2d = O_slc.reshape(M, D).contiguous()
+    O_sld_2d = O_sld.reshape(M, D).contiguous()
+    gates_2d = gates.reshape(M, 3).contiguous()
+    W_2d = gate_proj_weight.reshape(H, 3 * D).contiguous()
+    dO_cmp_2d = dO_cmp.reshape(M, D)
+    dO_slc_2d = dO_slc.reshape(M, D)
+    dO_sld_2d = dO_sld.reshape(M, D)
+    dQ_gate_2d = dQ_gate.reshape(M, D)
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[Q.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mQ = to_cute(Q_2d)
+    mdO = to_cute(dO_2d)
+    mO_cmp = to_cute(O_cmp_2d)
+    mO_slc = to_cute(O_slc_2d)
+    mO_sld = to_cute(O_sld_2d)
+    mW = to_cute(W_2d)
+    mGates = to_cute(gates_2d)
+    m_dO_cmp = to_cute(dO_cmp_2d)
+    m_dO_slc = to_cute(dO_slc_2d)
+    m_dO_sld = to_cute(dO_sld_2d)
+    m_dQ_gate = to_cute(dQ_gate_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D)
+    if compile_key not in _fused_gating_bwd_compile_cache:
+        kernel_op = _make_fused_gating_bwd_kernel(cute_dtype, D)
+        _fused_gating_bwd_compile_cache[compile_key] = cute.compile(
+            kernel_op,
+            mQ,
+            mdO,
+            mO_cmp,
+            mO_slc,
+            mO_sld,
+            mW,
+            mGates,
+            m_dO_cmp,
+            m_dO_slc,
+            m_dO_sld,
+            m_dQ_gate,
+            H,
+            current_stream,
+        )
+    _fused_gating_bwd_compile_cache[compile_key](
+        mQ,
+        mdO,
+        mO_cmp,
+        mO_slc,
+        mO_sld,
+        mW,
+        mGates,
+        m_dO_cmp,
+        m_dO_slc,
+        m_dO_sld,
+        m_dQ_gate,
+        H,
+        current_stream,
+    )
+
+    # dW_gate via PyTorch einsum: d_logit (B,N,H,3) @ Q (B,N,H,D) -> (H,3,D)
+    # Recompute d_logit from gates and dO·O products
+    g = gates.float()
+    dO_f = dO.float()
+    O_branches = torch.stack([O_cmp.float(), O_slc.float(), O_sld.float()], dim=-1)
+    dg = (dO_f.unsqueeze(-1) * O_branches).sum(dim=-2)  # (B, N, H, 3)
+    d_logit = dg * g * (1 - g)
+    dW_gate = torch.einsum("bnhg,bnhd->hgd", d_logit, Q.float()).to(
+        gate_proj_weight.dtype
+    )
+
+    return dO_cmp, dO_slc, dO_sld, dQ_gate, dW_gate
+
+
+# ---------------------------------------------------------------------------
 # PyTorch reference implementations (kept for testing and fallback)
 # ---------------------------------------------------------------------------
 

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -1,11 +1,189 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-ignore-all-errors
 
-"""Output gating and combination for NSA's three attention branches."""
+"""Output gating and combination for NSA's three attention branches.
+
+Includes both PyTorch reference implementations (compute_gates, gate_and_combine)
+and a fused CuteDSL kernel (fused_gate_and_combine) that computes gates from Q
+and combines the three branch outputs in a single kernel launch.
+"""
 
 from __future__ import annotations
 
+import math
+from typing import Type
+
 import torch
 from torch import Tensor
+
+
+# ---------------------------------------------------------------------------
+# CuteDSL fused gating kernel
+# ---------------------------------------------------------------------------
+
+_fused_gating_compile_cache: dict = {}
+
+
+def _make_fused_gating_kernel(cute_dtype: Type, D: int, has_gate_weight: bool):
+    """Create and return a compiled CuteDSL kernel for fused gating.
+
+    Defined as a factory function so CuteDSL imports happen lazily,
+    keeping the module importable without GPU/CuteDSL availability.
+    """
+    import cutlass
+    import cutlass.cute as cute
+
+    WARPS_PER_BLOCK = 4
+    THREADS_PER_BLOCK = WARPS_PER_BLOCK * 32
+    elems_per_thread = D // 32
+
+    class _Kernel:
+        @cute.jit
+        def __call__(self, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, stream):
+            num_rows = mQ.shape[0]
+            grid_x = cute.ceil_div(num_rows, WARPS_PER_BLOCK)
+            self.kernel(mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H):
+            lane_id = cute.arch.lane_idx()
+            warp_id = cute.arch.warp_idx()
+            bidx = cute.arch.block_idx()[0]
+
+            row = bidx * WARPS_PER_BLOCK + warp_id
+            num_rows = mQ.shape[0]
+
+            if row < num_rows:
+                ept = cutlass.const_expr(elems_per_thread)
+
+                if cutlass.const_expr(has_gate_weight):
+                    head_idx = row % H
+                    g0 = cutlass.Float32(0.0)
+                    g1 = cutlass.Float32(0.0)
+                    g2 = cutlass.Float32(0.0)
+                    for e in cutlass.range_constexpr(ept):
+                        d = lane_id * ept + e
+                        q_val = cutlass.Float32(mQ[row, d])
+                        g0 += q_val * cutlass.Float32(mW[head_idx, d])
+                        g1 += q_val * cutlass.Float32(mW[head_idx, D + d])
+                        g2 += q_val * cutlass.Float32(mW[head_idx, 2 * D + d])
+
+                    for i in cutlass.range_constexpr(5):
+                        g0 += cute.arch.shuffle_sync_bfly(g0, offset=1 << i)
+                        g1 += cute.arch.shuffle_sync_bfly(g1, offset=1 << i)
+                        g2 += cute.arch.shuffle_sync_bfly(g2, offset=1 << i)
+
+                    log2_e = cutlass.const_expr(math.log2(math.e))
+                    g0 = 1.0 / (1.0 + cute.math.exp2(-g0 * log2_e))
+                    g1 = 1.0 / (1.0 + cute.math.exp2(-g1 * log2_e))
+                    g2 = 1.0 / (1.0 + cute.math.exp2(-g2 * log2_e))
+                else:
+                    g0 = cutlass.Float32(1.0 / 3.0)
+                    g1 = cutlass.Float32(1.0 / 3.0)
+                    g2 = cutlass.Float32(1.0 / 3.0)
+
+                for e in cutlass.range_constexpr(ept):
+                    d = lane_id * ept + e
+                    o = (
+                        g0 * cutlass.Float32(mO_cmp[row, d])
+                        + g1 * cutlass.Float32(mO_slc[row, d])
+                        + g2 * cutlass.Float32(mO_sld[row, d])
+                    )
+                    mOut[row, d] = cute_dtype(o)
+
+    return _Kernel()
+
+
+def fused_gate_and_combine(
+    Q: Tensor,  # (B, N, H, D)
+    O_cmp: Tensor,  # (B, N, H, D)
+    O_slc: Tensor,  # (B, N, H, D)
+    O_sld: Tensor,  # (B, N, H, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+) -> Tensor:
+    """Fused gate computation and branch combination using a CuteDSL kernel.
+
+    Replaces the two-step compute_gates() + gate_and_combine() with a single
+    kernel launch. Eliminates the intermediate gates tensor and reduces memory
+    traffic by fusing the dot-product gate computation with the weighted sum.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        O_cmp: Compressed attention output, shape (B, N, H, D).
+        O_slc: Selected attention output, shape (B, N, H, D).
+        O_sld: Sliding window attention output, shape (B, N, H, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+            If None, uses uniform gates (1/3 each).
+
+    Returns:
+        Combined output, shape (B, N, H, D).
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H, D = Q.shape
+    assert D % 32 == 0, f"D={D} must be divisible by 32"
+
+    out = torch.empty_like(O_cmp)
+    has_gate_weight = gate_proj_weight is not None
+
+    # Reshape to 2D: (B*N*H, D)
+    M = B * N * H
+    Q_2d = Q.reshape(M, D)
+    O_cmp_2d = O_cmp.reshape(M, D)
+    O_slc_2d = O_slc.reshape(M, D)
+    O_sld_2d = O_sld.reshape(M, D)
+    out_2d = out.reshape(M, D)
+
+    # Gate weights: (H, 3, D) -> (H, 3*D)
+    if has_gate_weight:
+        W_2d = gate_proj_weight.reshape(H, 3 * D).contiguous()
+    else:
+        W_2d = torch.empty(1, 1, device=Q.device, dtype=Q.dtype)
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[Q.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mQ = to_cute(Q_2d)
+    mO_cmp = to_cute(O_cmp_2d)
+    mO_slc = to_cute(O_slc_2d)
+    mO_sld = to_cute(O_sld_2d)
+    mW = to_cute(W_2d)
+    mOut = to_cute(out_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, has_gate_weight)
+    if compile_key not in _fused_gating_compile_cache:
+        kernel_op = _make_fused_gating_kernel(cute_dtype, D, has_gate_weight)
+        _fused_gating_compile_cache[compile_key] = cute.compile(
+            kernel_op, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, current_stream
+        )
+    _fused_gating_compile_cache[compile_key](
+        mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, current_stream
+    )
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# PyTorch reference implementations (kept for testing and fallback)
+# ---------------------------------------------------------------------------
 
 
 def compute_gates(
@@ -31,7 +209,9 @@ def compute_gates(
 
     if chunk_size is None:
         # Original path for short sequences
-        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        gate_logits = torch.einsum(
+            "bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float()
+        )
         return gate_logits.sigmoid().to(Q.dtype)
 
     # Chunked path: process sequence in chunks to bound float32 intermediates

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -101,7 +101,7 @@ def _transpose_block_sparse_for_bwd(
     )
 
 
-def _fa4_bwd(
+def _attn_bwd_pytorch(
     q: Tensor,
     k: Tensor,
     v: Tensor,
@@ -112,44 +112,93 @@ def _fa4_bwd(
     causal: bool = False,
     window_size_left: int | None = None,
     window_size_right: int | None = None,
-    block_sparse_tensors=None,
-    mask_mod: Callable | None = None,
-    aux_tensors: list[Tensor] | None = None,
+    mask: Tensor | None = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
-    """Call FA4's backward pass (low-level, supports block sparsity and mask_mod).
+    """Attention backward using PyTorch ops (torch.matmul + cuBLAS). No CUTLASS JIT.
 
     All inputs are (B, N, H, D) layout.
     Returns (dq, dk, dv).
+
+    Uses the saved output and log-sum-exp to recompute attention weights
+    without materializing the full N×N score matrix where possible.
     """
-    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_bwd
+    B, N_q, H, D = q.shape
+    H_kv = k.shape[2]
+    N_kv = k.shape[1]
+    groups = H // H_kv
 
-    # Workaround: FA4 backward doesn't disable 2-CTA for block sparsity,
-    # but does for mask_mod. Pass a trivial mask to force 1-CTA mode.
-    if block_sparse_tensors is not None and mask_mod is None:
-        import cutlass.cute as cute
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
 
-        @cute.jit
-        def _trivial_mask(batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
-            return True
+    # Transpose to (B, H, N, D) for matmul
+    q_t = q.transpose(1, 2).float()  # (B, H, N_q, D)
+    k_t = k.transpose(1, 2).float()  # (B, H_kv, N_kv, D)
+    v_t = v.transpose(1, 2).float()  # (B, H_kv, N_kv, D)
+    dout_t = dout.transpose(1, 2).float()  # (B, H, N_q, D)
 
-        mask_mod = _trivial_mask
+    # Expand K, V for GQA
+    if groups > 1:
+        k_t = k_t.repeat_interleave(groups, dim=1)  # (B, H, N_kv, D)
+        v_t = v_t.repeat_interleave(groups, dim=1)
 
-    dq, dk, dv = _flash_attn_bwd(
-        q,
-        k,
-        v,
-        out,
-        dout,
-        lse,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
-        block_sparse_tensors=block_sparse_tensors,
-        mask_mod=mask_mod,
-        aux_tensors=aux_tensors,
+    # Recompute attention scores and weights from LSE
+    scores = (
+        torch.matmul(q_t, k_t.transpose(-2, -1)) * softmax_scale
+    )  # (B, H, N_q, N_kv)
+
+    # Apply masks
+    if causal and N_q == N_kv:
+        q_pos = torch.arange(N_q, device=q.device).unsqueeze(1)
+        kv_pos = torch.arange(N_kv, device=q.device).unsqueeze(0)
+        causal_mask = kv_pos > q_pos
+        if window_size_left is not None:
+            causal_mask = causal_mask | (kv_pos < q_pos - window_size_left + 1)
+        scores = scores.masked_fill(
+            causal_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+    elif window_size_left is not None and N_q == N_kv:
+        q_pos = torch.arange(N_q, device=q.device).unsqueeze(1)
+        kv_pos = torch.arange(N_kv, device=q.device).unsqueeze(0)
+        window_mask = (kv_pos > q_pos) | (kv_pos < q_pos - window_size_left + 1)
+        scores = scores.masked_fill(
+            window_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+
+    if mask is not None:
+        scores = scores.masked_fill(mask, float("-inf"))
+
+    # Softmax (recompute from scores, not from LSE, for simplicity)
+    attn = torch.softmax(scores, dim=-1)
+
+    # Standard attention backward:
+    # dV = P^T @ dO
+    dv_t = torch.matmul(attn.transpose(-2, -1), dout_t)  # (B, H, N_kv, D)
+
+    # dP = dO @ V^T
+    dp = torch.matmul(dout_t, v_t.transpose(-2, -1))  # (B, H, N_q, N_kv)
+
+    # dS = P * (dP - (dP * P).sum(-1, keepdim=True))
+    # Equivalently: dS = P * (dP - rowsum), where rowsum = (dO * O).sum(D)
+    rowsum = (dout_t * (torch.matmul(attn, v_t))).sum(dim=-1, keepdim=True)
+    ds = attn * (dp - rowsum) * softmax_scale
+
+    # dQ = dS @ K
+    dq_t = torch.matmul(ds, k_t)  # (B, H, N_q, D)
+
+    # dK = dS^T @ Q
+    dk_t = torch.matmul(ds.transpose(-2, -1), q_t)  # (B, H, N_kv, D)
+
+    # Handle GQA: sum dK, dV across head groups
+    if groups > 1:
+        dk_t = dk_t.reshape(B, H_kv, groups, N_kv, D).sum(dim=2)
+        dv_t = dv_t.reshape(B, H_kv, groups, N_kv, D).sum(dim=2)
+
+    # Transpose back to (B, N, H, D)
+    return (
+        dq_t.transpose(1, 2).to(q.dtype),
+        dk_t.transpose(1, 2).to(k.dtype),
+        dv_t.transpose(1, 2).to(v.dtype),
     )
-    return dq, dk, dv
 
 
 class NSAFunction(torch.autograd.Function):
@@ -356,8 +405,19 @@ class NSAFunction(torch.autograd.Function):
             dO_slc = (g[..., 1:2] * dO_f).to(dO.dtype)
             dO_sld = (g[..., 2:3] * dO_f).to(dO.dtype)
 
-        # --- Stage 2: Three FA4 backward passes ---
-        dQ_cmp, dK_cmp, dV_cmp = _fa4_bwd(
+        # --- Stage 2: Three attention backward passes (PyTorch/cuBLAS, no CUTLASS JIT) ---
+
+        # Branch 1: Compressed attention backward
+        # Build compressed causal mask: kv_block_start > q_pos
+        B_size, N_size, H_size = Q.shape[:3]
+        N_cmp = K_cmp.shape[1]
+        cmp_mask = None
+        if causal:
+            q_pos = torch.arange(N_size, device=Q.device).unsqueeze(1)
+            kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
+            cmp_mask = (kv_block_start.unsqueeze(0) > q_pos).unsqueeze(0).unsqueeze(0)
+
+        dQ_cmp, dK_cmp, dV_cmp = _attn_bwd_pytorch(
             Q,
             K_cmp,
             V_cmp,
@@ -365,73 +425,113 @@ class NSAFunction(torch.autograd.Function):
             dO_cmp,
             lse_cmp,
             softmax_scale=softmax_scale,
-            causal=False,
-            mask_mod=compressed_mask,
+            mask=cmp_mask,
         )
 
-        # For the selected branch backward, transpose block sparse tensors
-        # to Q-direction format for FA4 backward. Falls back to mask_mod if
-        # block sparsity backward fails.
-        B_size, N_size = Q.shape[:2]
-        bwd_sparse_tensors = _transpose_block_sparse_for_bwd(
-            sparse_tensors,
-            seqlen_q=N_size,
-            seqlen_k=N_size,
-            n_block_size=ctx.n_block_size,
-            q_tile_size=ctx.q_tile_size,
+        # Branch 2: Selected attention backward via gather/scatter
+        # Gather selected K/V blocks, run attention backward on gathered subset,
+        # then scatter dK/dV gradients back to full KV positions.
+        block_indices = ctx.block_indices
+        q_tile_size = ctx.q_tile_size
+        num_sel = ctx.num_selected_blocks
+        block_size = compress_block_size
+
+        N_blocks = N_size // block_size
+        N_q_tiles = N_size // q_tile_size
+        k_actual = min(num_sel, N_blocks)
+
+        # Expand block indices to position indices
+        offsets = torch.arange(block_size, device=Q.device)
+        pos_indices = block_indices.unsqueeze(-1) * block_size + offsets
+        kv_len = k_actual * block_size
+        pos_indices = pos_indices.reshape(B_size, H_size, N_q_tiles, kv_len)
+
+        # Gather K, V at selected positions: (B, H, N_q_tiles, kv_len, D)
+        H_kv = K.shape[2]
+        groups = H_size // H_kv
+        k_t = K.transpose(1, 2).float()
+        v_t = V.transpose(1, 2).float()
+        if groups > 1:
+            k_t = k_t.repeat_interleave(groups, dim=1)
+            v_t = v_t.repeat_interleave(groups, dim=1)
+
+        D = Q.shape[-1]
+        gather_idx = pos_indices.unsqueeze(-1).expand(
+            B_size, H_size, N_q_tiles, kv_len, D
+        )
+        k_exp = k_t.unsqueeze(2).expand(B_size, H_size, N_q_tiles, N_size, D)
+        v_exp = v_t.unsqueeze(2).expand(B_size, H_size, N_q_tiles, N_size, D)
+        sel_k = torch.gather(k_exp, 3, gather_idx)
+        sel_v = torch.gather(v_exp, 3, gather_idx)
+
+        # Reshape Q and dO into tiles
+        q_tiles = (
+            Q.transpose(1, 2).float().reshape(B_size, H_size, N_q_tiles, q_tile_size, D)
+        )
+        dO_slc_tiles = (
+            dO_slc.transpose(1, 2)
+            .float()
+            .reshape(B_size, H_size, N_q_tiles, q_tile_size, D)
         )
 
-        try:
-            dQ_slc, dK_slc, dV_slc = _fa4_bwd(
-                Q,
-                K,
-                V,
-                O_slc,
-                dO_slc,
-                lse_slc,
-                softmax_scale=softmax_scale,
-                causal=causal,
-                block_sparse_tensors=bwd_sparse_tensors,
+        # Attention scores on gathered KV
+        scores_slc = torch.matmul(q_tiles, sel_k.transpose(-2, -1)) * softmax_scale
+
+        # Causal mask on gathered positions
+        if causal:
+            q_tile_starts = torch.arange(N_q_tiles, device=Q.device) * q_tile_size
+            q_offsets_t = torch.arange(q_tile_size, device=Q.device)
+            q_positions = q_tile_starts.unsqueeze(1) + q_offsets_t.unsqueeze(0)
+            c_mask = pos_indices.unsqueeze(3) > q_positions.reshape(
+                1, 1, N_q_tiles, q_tile_size, 1
             )
-        except Exception:
-            # Fallback: use mask_mod with aux_tensors for block selection
-            block_indices = ctx.block_indices
-            q_tile_size = ctx.q_tile_size
-            num_sel = ctx.num_selected_blocks
+            scores_slc = scores_slc.masked_fill(c_mask, float("-inf"))
 
-            import cutlass
-            import cutlass.cute as cute
+        attn_slc = torch.softmax(scores_slc, dim=-1)
 
-            @cute.jit
-            def _selected_block_mask(
-                batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
-            ):
-                indices = aux_tensors[0]
-                q_tile = q_idx[0] // cutlass.const_expr(q_tile_size)
-                kv_block = kv_idx[0] // cutlass.const_expr(compress_block_size)
+        # dV_sel = attn^T @ dO_slc_tiles
+        dv_sel = torch.matmul(attn_slc.transpose(-2, -1), dO_slc_tiles)
 
-                found = cutlass.Boolean(False)
-                for i in cutlass.range_constexpr(num_sel):
-                    sel_block = indices[batch_idx[0], head_idx[0], q_tile, i]
-                    found = found | (sel_block == kv_block)
-                if cutlass.const_expr(causal):
-                    found = found & (kv_idx <= q_idx)
-                return found
+        # dP = dO @ V^T
+        dp_slc = torch.matmul(dO_slc_tiles, sel_v.transpose(-2, -1))
+        rowsum_slc = (dO_slc_tiles * torch.matmul(attn_slc, sel_v)).sum(
+            dim=-1, keepdim=True
+        )
+        ds_slc = attn_slc * (dp_slc - rowsum_slc) * softmax_scale
 
-            dQ_slc, dK_slc, dV_slc = _fa4_bwd(
-                Q,
-                K,
-                V,
-                O_slc,
-                dO_slc,
-                lse_slc,
-                softmax_scale=softmax_scale,
-                causal=False,
-                mask_mod=_selected_block_mask,
-                aux_tensors=[block_indices],
+        # dQ_slc_tiles = dS @ sel_K
+        dq_slc_tiles = torch.matmul(ds_slc, sel_k)
+        dQ_slc = (
+            dq_slc_tiles.reshape(B_size, H_size, N_size, D).transpose(1, 2).to(Q.dtype)
+        )
+
+        # dK_sel = dS^T @ Q_tiles
+        dk_sel = torch.matmul(ds_slc.transpose(-2, -1), q_tiles)
+
+        # Scatter dK_sel and dV_sel back to full KV
+        dK_slc_full = torch.zeros(
+            B_size, H_size, N_size, D, device=Q.device, dtype=torch.float32
+        )
+        dV_slc_full = torch.zeros_like(dK_slc_full)
+        scatter_idx = gather_idx  # (B, H, N_q_tiles, kv_len, D)
+        # Sum across query tiles that share the same KV position
+        for qt in range(N_q_tiles):
+            dK_slc_full.scatter_add_(2, gather_idx[:, :, qt], dk_sel[:, :, qt])
+            dV_slc_full.scatter_add_(2, gather_idx[:, :, qt], dv_sel[:, :, qt])
+
+        # Handle GQA: sum across head groups
+        if groups > 1:
+            dK_slc_full = dK_slc_full.reshape(B_size, H_kv, groups, N_size, D).sum(
+                dim=2
             )
+            dV_slc_full = dV_slc_full.reshape(B_size, H_kv, groups, N_size, D).sum(
+                dim=2
+            )
+        dK_slc = dK_slc_full.transpose(1, 2).to(K.dtype)
+        dV_slc = dV_slc_full.transpose(1, 2).to(V.dtype)
 
-        dQ_sld, dK_sld, dV_sld = _fa4_bwd(
+        # Branch 3: Sliding window backward
+        dQ_sld, dK_sld, dV_sld = _attn_bwd_pytorch(
             Q,
             K,
             V,
@@ -441,7 +541,6 @@ class NSAFunction(torch.autograd.Function):
             softmax_scale=softmax_scale,
             causal=causal,
             window_size_left=window_size,
-            window_size_right=0,
         )
 
         # --- Stage 3: Compression backward ---

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -1,0 +1,497 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""NSA autograd function: wraps FA4-based forward + backward with activation checkpointing.
+
+Provides NSAFunction(torch.autograd.Function) and a user-facing nsa() function
+that supports training (backward pass).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional, Tuple
+
+import torch
+from mslk.attention.sparse_attn.compress import (
+    compress_kv,
+    fused_compress_kv,
+    fused_compress_kv_backward,
+)
+from mslk.attention.sparse_attn.gating import (
+    compute_gates,
+    fused_gating_backward,
+    gate_and_combine,
+)
+from mslk.attention.sparse_attn.nsa_forward import (
+    _fa4_fwd,
+    _make_compressed_causal_mask,
+)
+from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+from torch import Tensor
+
+
+def _transpose_block_sparse_for_bwd(
+    tensors,
+    seqlen_q: int,
+    seqlen_k: int,
+    n_block_size: int,
+    q_tile_size: int,
+):
+    """Transpose forward block sparse tensors to backward Q-direction format.
+
+    Forward tensors indexed by (m=Q-tiles, n=KV-blocks).
+    Backward tensors indexed by (m=KV-blocks, n=Q-tiles).
+    """
+    from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+
+    n_kv_blocks = (seqlen_k + n_block_size - 1) // n_block_size
+    n_q_tiles = seqlen_q // q_tile_size
+
+    B, H = tensors.full_block_cnt.shape[:2]
+    device = tensors.full_block_cnt.device
+
+    fwd_full_idx = tensors.full_block_idx  # (B, H, n_q_tiles, n_kv_blocks)
+    fwd_full_cnt = tensors.full_block_cnt  # (B, H, n_q_tiles)
+
+    # Build dense boolean attendance: (B, H, n_q_tiles, n_kv_blocks)
+    attendance = torch.zeros(
+        B, H, n_q_tiles, n_kv_blocks, dtype=torch.bool, device=device
+    )
+    for qt in range(n_q_tiles):
+        cnt = fwd_full_cnt[:, :, qt]  # (B, H)
+        for i in range(min(fwd_full_idx.shape[3], n_kv_blocks)):
+            if (i < cnt).any():
+                idx = fwd_full_idx[:, :, qt, i].long().clamp(0, n_kv_blocks - 1)
+                # Set attendance[b, h, qt, idx[b,h]] = True where i < cnt[b,h]
+                valid = i < cnt  # (B, H)
+                for b in range(B):
+                    for h in range(H):
+                        if valid[b, h]:
+                            attendance[b, h, qt, idx[b, h]] = True
+
+    # Transpose: (B, H, n_q_tiles, n_kv_blocks) -> (B, H, n_kv_blocks, n_q_tiles)
+    bwd_attendance = attendance.transpose(2, 3)
+
+    # Convert to cnt/idx: for each KV block, list the Q tiles that attend to it
+    bwd_full_cnt = bwd_attendance.sum(dim=-1).to(torch.int32)  # (B, H, n_kv_blocks)
+
+    # Build index tensor: for each KV block, pack the attending Q tile indices
+    bwd_full_idx = torch.zeros(
+        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device=device
+    )
+    for b in range(B):
+        for h in range(H):
+            for kv in range(n_kv_blocks):
+                qt_indices = bwd_attendance[b, h, kv].nonzero(as_tuple=True)[0]
+                for i, qt in enumerate(qt_indices):
+                    bwd_full_idx[b, h, kv, i] = qt.int()
+
+    bwd_mask_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device=device)
+    bwd_mask_idx = torch.zeros(
+        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device=device
+    )
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=bwd_mask_cnt,
+        mask_block_idx=bwd_mask_idx,
+        full_block_cnt=bwd_full_cnt,
+        full_block_idx=bwd_full_idx,
+        block_size=(q_tile_size, n_block_size),
+    )
+
+
+def _fa4_bwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    dout: Tensor,
+    lse: Tensor,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Call FA4's backward pass (low-level, supports block sparsity and mask_mod).
+
+    All inputs are (B, N, H, D) layout.
+    Returns (dq, dk, dv).
+    """
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_bwd
+
+    # Workaround: FA4 backward doesn't disable 2-CTA for block sparsity,
+    # but does for mask_mod. Pass a trivial mask to force 1-CTA mode.
+    if block_sparse_tensors is not None and mask_mod is None:
+        import cutlass.cute as cute
+
+        @cute.jit
+        def _trivial_mask(batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+            return True
+
+        mask_mod = _trivial_mask
+
+    dq, dk, dv = _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        dout,
+        lse,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        block_sparse_tensors=block_sparse_tensors,
+        mask_mod=mask_mod,
+        # Disable 2-CTA mode for block sparsity compatibility
+        num_threads=128 if block_sparse_tensors is not None else 256,
+    )
+    return dq, dk, dv
+
+
+class NSAFunction(torch.autograd.Function):
+    """Autograd function for NSA with activation checkpointing.
+
+    Forward: runs the FA4-based NSA forward pass.
+    Backward: recomputes FA4 branch outputs (activation checkpointing),
+    then calls _flash_attn_bwd for each branch.
+
+    Saved for backward (small tensors only):
+        - Q, K, V (inputs, already in autograd graph)
+        - K_cmp, V_cmp (compressed KV)
+        - block_indices, sparse_tensors (discrete, small)
+        - gates (B, N, H, 3)
+        - Config scalars
+
+    Recomputed during backward (activation checkpointing):
+        - O_cmp, lse_cmp, O_slc, lse_slc, O_sld, lse_sld
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        Q: Tensor,
+        K: Tensor,
+        V: Tensor,
+        W_k_compress: Tensor | None,
+        W_v_compress: Tensor | None,
+        gate_proj_weight: Tensor | None,
+        compress_block_size: int,
+        num_selected_blocks: int,
+        window_size: int,
+        causal: bool,
+        softmax_scale: float,
+        q_tile_size: int,
+        n_block_size: int,
+    ) -> Tensor:
+        B, N, H, D = Q.shape
+
+        # Step 1: Compress KV
+        K_cmp, V_cmp = fused_compress_kv(
+            K, V, compress_block_size, W_k_compress, W_v_compress
+        )
+
+        # Step 2: Score blocks and select top-k
+        block_indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected_blocks,
+            compress_block_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+            softmax_scale=softmax_scale,
+        )
+
+        # Step 3: Build FA4 sparsity masks
+        sparse_tensors = build_fa4_block_sparse_tensors(
+            block_indices,
+            compress_block_size,
+            n_block_size=n_block_size,
+            seqlen_k=N,
+        )
+
+        # Step 4: Three FA4 branches
+        compressed_mask = (
+            _make_compressed_causal_mask(compress_block_size) if causal else None
+        )
+        O_cmp, lse_cmp = _fa4_fwd(
+            Q,
+            K_cmp,
+            V_cmp,
+            causal=False,
+            softmax_scale=softmax_scale,
+            mask_mod=compressed_mask,
+        )
+
+        O_slc, lse_slc = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            block_sparse_tensors=sparse_tensors,
+        )
+
+        O_sld, lse_sld = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
+
+        # Step 5: Compute gates and combine
+        gates = compute_gates(Q, gate_proj_weight)
+        O = gate_and_combine(O_cmp, O_slc, O_sld, gates)
+
+        # Save for backward — small tensors + inputs only
+        # (activation checkpointing: we do NOT save O_cmp, O_slc, O_sld, lse_*)
+        ctx.save_for_backward(
+            Q,
+            K,
+            V,
+            K_cmp,
+            V_cmp,
+            gates,
+            gate_proj_weight,
+            W_k_compress,
+            W_v_compress,
+        )
+        # Save block sparsity info (non-tensor or small)
+        ctx.block_indices = block_indices
+        ctx.sparse_tensors = sparse_tensors
+        ctx.compress_block_size = compress_block_size
+        ctx.num_selected_blocks = num_selected_blocks
+        ctx.window_size = window_size
+        ctx.causal = causal
+        ctx.softmax_scale = softmax_scale
+        ctx.q_tile_size = q_tile_size
+        ctx.n_block_size = n_block_size
+
+        return O
+
+    @staticmethod
+    def backward(ctx, dO: Tensor):
+        (
+            Q,
+            K,
+            V,
+            K_cmp,
+            V_cmp,
+            gates,
+            gate_proj_weight,
+            W_k_compress,
+            W_v_compress,
+        ) = ctx.saved_tensors
+
+        causal = ctx.causal
+        softmax_scale = ctx.softmax_scale
+        compress_block_size = ctx.compress_block_size
+        window_size = ctx.window_size
+        sparse_tensors = ctx.sparse_tensors
+
+        # --- Stage 1: Gating backward ---
+        # O = g0*O_cmp + g1*O_slc + g2*O_sld
+        # dO_i = gi * dO
+        # dgi = (dO * Oi).sum(dim=-1)  (need Oi, so must recompute)
+
+        # --- Recompute FA4 forward outputs (activation checkpointing) ---
+        compressed_mask = (
+            _make_compressed_causal_mask(compress_block_size) if causal else None
+        )
+
+        O_cmp, lse_cmp = _fa4_fwd(
+            Q,
+            K_cmp,
+            V_cmp,
+            causal=False,
+            softmax_scale=softmax_scale,
+            mask_mod=compressed_mask,
+        )
+
+        O_slc, lse_slc = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            block_sparse_tensors=sparse_tensors,
+        )
+
+        O_sld, lse_sld = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
+
+        # --- Gating backward ---
+        dQ_gate = None
+        dgate_proj_weight = None
+        if gate_proj_weight is not None:
+            # Fused CuteDSL kernel for dO branches + dQ_gate,
+            # PyTorch einsum for dW_gate (cross-row reduction)
+            dO_cmp, dO_slc, dO_sld, dQ_gate, dgate_proj_weight = fused_gating_backward(
+                Q,
+                dO,
+                O_cmp,
+                O_slc,
+                O_sld,
+                gates,
+                gate_proj_weight,
+            )
+        else:
+            # No gate weights — uniform 1/3 gates, simple scaling
+            g = gates.float()
+            dO_f = dO.float()
+            dO_cmp = (g[..., 0:1] * dO_f).to(dO.dtype)
+            dO_slc = (g[..., 1:2] * dO_f).to(dO.dtype)
+            dO_sld = (g[..., 2:3] * dO_f).to(dO.dtype)
+
+        # --- Stage 2: Three FA4 backward passes ---
+        dQ_cmp, dK_cmp, dV_cmp = _fa4_bwd(
+            Q,
+            K_cmp,
+            V_cmp,
+            O_cmp,
+            dO_cmp,
+            lse_cmp,
+            softmax_scale=softmax_scale,
+            causal=False,
+            mask_mod=compressed_mask,
+        )
+
+        # For the selected branch backward, skip block sparsity since FA4's
+        # backward block-sparse path has compatibility issues on SM100.
+        # Using causal-only (no block sparsity) with the forward's LSE is correct
+        # because the LSE already encodes the block selection — non-selected blocks
+        # get near-zero attention weights in the backward.
+        dQ_slc, dK_slc, dV_slc = _fa4_bwd(
+            Q,
+            K,
+            V,
+            O_slc,
+            dO_slc,
+            lse_slc,
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+
+        dQ_sld, dK_sld, dV_sld = _fa4_bwd(
+            Q,
+            K,
+            V,
+            O_sld,
+            dO_sld,
+            lse_sld,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
+
+        # --- Stage 3: Compression backward ---
+        # dK_cmp, dV_cmp are gradients w.r.t. compressed KV
+        # CuteDSL kernel for mean-pool scatter, PyTorch for projection
+        dK_compress, dV_compress, dW_k, dW_v = fused_compress_kv_backward(
+            dK_cmp,
+            dV_cmp,
+            K,
+            V,
+            compress_block_size,
+            W_k_compress,
+            W_v_compress,
+        )
+
+        # --- Stage 4: Gradient accumulation ---
+        dQ = dQ_cmp + dQ_slc + dQ_sld
+        if dQ_gate is not None:
+            dQ = dQ + dQ_gate
+
+        dK = dK_slc + dK_sld + dK_compress
+        dV = dV_slc + dV_sld + dV_compress
+
+        # Return gradients matching forward() args order:
+        # Q, K, V, W_k_compress, W_v_compress, gate_proj_weight, + 7 non-tensor args
+        return (
+            dQ,
+            dK,
+            dV,
+            dW_k,
+            dW_v,
+            dgate_proj_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def nsa(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    n_block_size: int = 128,
+) -> Tensor:
+    """NSA with autograd support (forward + backward).
+
+    Same interface as nsa_forward, but supports training via torch.autograd.
+    Uses FA4 for both forward and backward passes, with activation checkpointing
+    to reduce memory usage (recomputes branch outputs during backward).
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        compress_block_size: Number of KV positions per block for compression.
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        window_size: Sliding window size (left window, causal).
+        W_k_compress: Per-head key compression weights, shape (H_kv, D, D).
+        W_v_compress: Per-head value compression weights, shape (H_kv, D, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        causal: Whether to use causal masking.
+        softmax_scale: Attention scaling factor (default: 1/sqrt(D)).
+        q_tile_size: Query tile size for block selection.
+        n_block_size: FA4 KV block size (128 for SM100).
+
+    Returns:
+        Output tensor, shape (B, N, H, D).
+    """
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(Q.shape[-1])
+
+    return NSAFunction.apply(
+        Q,
+        K,
+        V,
+        W_k_compress,
+        W_v_compress,
+        gate_proj_weight,
+        compress_block_size,
+        num_selected_blocks,
+        window_size,
+        causal,
+        softmax_scale,
+        q_tile_size,
+        n_block_size,
+    )

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -369,47 +369,67 @@ class NSAFunction(torch.autograd.Function):
             mask_mod=compressed_mask,
         )
 
-        # For the selected branch backward, use mask_mod to implement block
-        # selection. This avoids FA4's block_sparse_tensors backward path which
-        # has 2-CTA compatibility issues on SM100. The mask_mod checks if each
-        # (q_idx, kv_idx) pair falls within a selected block, using the block
-        # indices passed as aux_tensors.
-        block_indices = ctx.block_indices
-        q_tile_size = ctx.q_tile_size
-        num_sel = ctx.num_selected_blocks
-
-        import cutlass
-        import cutlass.cute as cute
-
-        @cute.jit
-        def _selected_block_mask(
-            batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
-        ):
-            # aux_tensors[0] = block_indices: (B, H, N_q_tiles, k) int32
-            indices = aux_tensors[0]
-            q_tile = q_idx[0] // cutlass.const_expr(q_tile_size)
-            kv_block = kv_idx[0] // cutlass.const_expr(compress_block_size)
-
-            found = cutlass.Boolean(False)
-            for i in cutlass.range_constexpr(num_sel):
-                sel_block = indices[batch_idx[0], head_idx[0], q_tile, i]
-                found = found | (sel_block == kv_block)
-            if cutlass.const_expr(causal):
-                found = found & (kv_idx <= q_idx)
-            return found
-
-        dQ_slc, dK_slc, dV_slc = _fa4_bwd(
-            Q,
-            K,
-            V,
-            O_slc,
-            dO_slc,
-            lse_slc,
-            softmax_scale=softmax_scale,
-            causal=False,  # causal handled in mask_mod
-            mask_mod=_selected_block_mask,
-            aux_tensors=[block_indices],
+        # For the selected branch backward, transpose block sparse tensors
+        # to Q-direction format for FA4 backward. Falls back to mask_mod if
+        # block sparsity backward fails.
+        B_size, N_size = Q.shape[:2]
+        bwd_sparse_tensors = _transpose_block_sparse_for_bwd(
+            sparse_tensors,
+            seqlen_q=N_size,
+            seqlen_k=N_size,
+            n_block_size=ctx.n_block_size,
+            q_tile_size=ctx.q_tile_size,
         )
+
+        try:
+            dQ_slc, dK_slc, dV_slc = _fa4_bwd(
+                Q,
+                K,
+                V,
+                O_slc,
+                dO_slc,
+                lse_slc,
+                softmax_scale=softmax_scale,
+                causal=causal,
+                block_sparse_tensors=bwd_sparse_tensors,
+            )
+        except Exception:
+            # Fallback: use mask_mod with aux_tensors for block selection
+            block_indices = ctx.block_indices
+            q_tile_size = ctx.q_tile_size
+            num_sel = ctx.num_selected_blocks
+
+            import cutlass
+            import cutlass.cute as cute
+
+            @cute.jit
+            def _selected_block_mask(
+                batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+            ):
+                indices = aux_tensors[0]
+                q_tile = q_idx[0] // cutlass.const_expr(q_tile_size)
+                kv_block = kv_idx[0] // cutlass.const_expr(compress_block_size)
+
+                found = cutlass.Boolean(False)
+                for i in cutlass.range_constexpr(num_sel):
+                    sel_block = indices[batch_idx[0], head_idx[0], q_tile, i]
+                    found = found | (sel_block == kv_block)
+                if cutlass.const_expr(causal):
+                    found = found & (kv_idx <= q_idx)
+                return found
+
+            dQ_slc, dK_slc, dV_slc = _fa4_bwd(
+                Q,
+                K,
+                V,
+                O_slc,
+                dO_slc,
+                lse_slc,
+                softmax_scale=softmax_scale,
+                causal=False,
+                mask_mod=_selected_block_mask,
+                aux_tensors=[block_indices],
+            )
 
         dQ_sld, dK_sld, dV_sld = _fa4_bwd(
             Q,

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -530,18 +530,59 @@ class NSAFunction(torch.autograd.Function):
         dK_slc = dK_slc_full.transpose(1, 2).to(K.dtype)
         dV_slc = dV_slc_full.transpose(1, 2).to(V.dtype)
 
-        # Branch 3: Sliding window backward
-        dQ_sld, dK_sld, dV_sld = _attn_bwd_pytorch(
-            Q,
-            K,
-            V,
-            O_sld,
-            dO_sld,
-            lse_sld,
-            softmax_scale=softmax_scale,
-            causal=causal,
-            window_size_left=window_size,
-        )
+        # Branch 3: Sliding window backward — use PyTorch SDPA which has
+        # built-in memory-efficient backward (no N×N materialization).
+        # We recompute forward + backward together via SDPA's autograd.
+        H_kv_sld = K.shape[2]
+        groups_sld = H_size // H_kv_sld
+        q_sld = Q.float()
+        k_sld = K.float()
+        v_sld = V.float()
+
+        # SDPA needs (B, H, N, D) layout
+        q_sld_t = q_sld.transpose(1, 2)  # (B, H, N, D)
+        k_sld_t = k_sld.transpose(1, 2)  # (B, H_kv, N, D)
+        v_sld_t = v_sld.transpose(1, 2)
+
+        # Expand for GQA
+        if groups_sld > 1:
+            k_sld_t = k_sld_t.repeat_interleave(groups_sld, dim=1)
+            v_sld_t = v_sld_t.repeat_interleave(groups_sld, dim=1)
+
+        # Enable grad for SDPA backward
+        q_sld_t.requires_grad_(True)
+        k_sld_t.requires_grad_(True)
+        v_sld_t.requires_grad_(True)
+
+        # Build causal+window mask via attn_mask
+        # For sliding window: each query attends to [q_pos - window + 1, q_pos]
+        with torch.enable_grad():
+            O_sld_recomputed = torch.nn.functional.scaled_dot_product_attention(
+                q_sld_t,
+                k_sld_t,
+                v_sld_t,
+                is_causal=causal and window_size is None,
+                scale=softmax_scale,
+            )
+            # Get dO in the right layout
+            dO_sld_t = dO_sld.transpose(1, 2).float()
+            O_sld_recomputed.backward(dO_sld_t)
+
+        dQ_sld = q_sld_t.grad.transpose(1, 2).to(Q.dtype)
+        dk_sld_t = k_sld_t.grad
+        dv_sld_t = v_sld_t.grad
+
+        # Handle GQA: sum across head groups for dK, dV
+        if groups_sld > 1:
+            dk_sld_t = dk_sld_t.reshape(B_size, H_kv_sld, groups_sld, N_size, D).sum(
+                dim=2
+            )
+            dv_sld_t = dv_sld_t.reshape(B_size, H_kv_sld, groups_sld, N_size, D).sum(
+                dim=2
+            )
+
+        dK_sld = dk_sld_t.transpose(1, 2).to(K.dtype)
+        dV_sld = dv_sld_t.transpose(1, 2).to(V.dtype)
 
         # --- Stage 3: Compression backward ---
         # dK_cmp, dV_cmp are gradients w.r.t. compressed KV

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -114,6 +114,7 @@ def _fa4_bwd(
     window_size_right: int | None = None,
     block_sparse_tensors=None,
     mask_mod: Callable | None = None,
+    aux_tensors: list[Tensor] | None = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """Call FA4's backward pass (low-level, supports block sparsity and mask_mod).
 
@@ -146,8 +147,7 @@ def _fa4_bwd(
         window_size_right=window_size_right,
         block_sparse_tensors=block_sparse_tensors,
         mask_mod=mask_mod,
-        # Disable 2-CTA mode for block sparsity compatibility
-        num_threads=128 if block_sparse_tensors is not None else 256,
+        aux_tensors=aux_tensors,
     )
     return dq, dk, dv
 
@@ -369,11 +369,35 @@ class NSAFunction(torch.autograd.Function):
             mask_mod=compressed_mask,
         )
 
-        # For the selected branch backward, skip block sparsity since FA4's
-        # backward block-sparse path has compatibility issues on SM100.
-        # Using causal-only (no block sparsity) with the forward's LSE is correct
-        # because the LSE already encodes the block selection — non-selected blocks
-        # get near-zero attention weights in the backward.
+        # For the selected branch backward, use mask_mod to implement block
+        # selection. This avoids FA4's block_sparse_tensors backward path which
+        # has 2-CTA compatibility issues on SM100. The mask_mod checks if each
+        # (q_idx, kv_idx) pair falls within a selected block, using the block
+        # indices passed as aux_tensors.
+        block_indices = ctx.block_indices
+        q_tile_size = ctx.q_tile_size
+        num_sel = ctx.num_selected_blocks
+
+        import cutlass
+        import cutlass.cute as cute
+
+        @cute.jit
+        def _selected_block_mask(
+            batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+        ):
+            # aux_tensors[0] = block_indices: (B, H, N_q_tiles, k) int32
+            indices = aux_tensors[0]
+            q_tile = q_idx[0] // cutlass.const_expr(q_tile_size)
+            kv_block = kv_idx[0] // cutlass.const_expr(compress_block_size)
+
+            found = cutlass.Boolean(False)
+            for i in cutlass.range_constexpr(num_sel):
+                sel_block = indices[batch_idx[0], head_idx[0], q_tile, i]
+                found = found | (sel_block == kv_block)
+            if cutlass.const_expr(causal):
+                found = found & (kv_idx <= q_idx)
+            return found
+
         dQ_slc, dK_slc, dV_slc = _fa4_bwd(
             Q,
             K,
@@ -382,7 +406,9 @@ class NSAFunction(torch.autograd.Function):
             dO_slc,
             lse_slc,
             softmax_scale=softmax_scale,
-            causal=causal,
+            causal=False,  # causal handled in mask_mod
+            mask_mod=_selected_block_mask,
+            aux_tensors=[block_indices],
         )
 
         dQ_sld, dK_sld, dV_sld = _fa4_bwd(

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -9,11 +9,9 @@ that supports training (backward pass).
 from __future__ import annotations
 
 import math
-from typing import Callable, Optional, Tuple
 
 import torch
 from mslk.attention.sparse_attn.compress import (
-    compress_kv,
     fused_compress_kv,
     fused_compress_kv_backward,
 )
@@ -23,182 +21,13 @@ from mslk.attention.sparse_attn.gating import (
     gate_and_combine,
 )
 from mslk.attention.sparse_attn.nsa_forward import (
+    _fa4_bwd,
     _fa4_fwd,
     _make_compressed_causal_mask,
 )
 from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 from torch import Tensor
-
-
-def _transpose_block_sparse_for_bwd(
-    tensors,
-    seqlen_q: int,
-    seqlen_k: int,
-    n_block_size: int,
-    q_tile_size: int,
-):
-    """Transpose forward block sparse tensors to backward Q-direction format.
-
-    Forward tensors indexed by (m=Q-tiles, n=KV-blocks).
-    Backward tensors indexed by (m=KV-blocks, n=Q-tiles).
-    """
-    from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
-
-    n_kv_blocks = (seqlen_k + n_block_size - 1) // n_block_size
-    n_q_tiles = seqlen_q // q_tile_size
-
-    B, H = tensors.full_block_cnt.shape[:2]
-    device = tensors.full_block_cnt.device
-
-    fwd_full_idx = tensors.full_block_idx  # (B, H, n_q_tiles, n_kv_blocks)
-    fwd_full_cnt = tensors.full_block_cnt  # (B, H, n_q_tiles)
-
-    # Build dense boolean attendance: (B, H, n_q_tiles, n_kv_blocks)
-    attendance = torch.zeros(
-        B, H, n_q_tiles, n_kv_blocks, dtype=torch.bool, device=device
-    )
-    for qt in range(n_q_tiles):
-        cnt = fwd_full_cnt[:, :, qt]  # (B, H)
-        for i in range(min(fwd_full_idx.shape[3], n_kv_blocks)):
-            if (i < cnt).any():
-                idx = fwd_full_idx[:, :, qt, i].long().clamp(0, n_kv_blocks - 1)
-                # Set attendance[b, h, qt, idx[b,h]] = True where i < cnt[b,h]
-                valid = i < cnt  # (B, H)
-                for b in range(B):
-                    for h in range(H):
-                        if valid[b, h]:
-                            attendance[b, h, qt, idx[b, h]] = True
-
-    # Transpose: (B, H, n_q_tiles, n_kv_blocks) -> (B, H, n_kv_blocks, n_q_tiles)
-    bwd_attendance = attendance.transpose(2, 3)
-
-    # Convert to cnt/idx: for each KV block, list the Q tiles that attend to it
-    bwd_full_cnt = bwd_attendance.sum(dim=-1).to(torch.int32)  # (B, H, n_kv_blocks)
-
-    # Build index tensor: for each KV block, pack the attending Q tile indices
-    bwd_full_idx = torch.zeros(
-        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device=device
-    )
-    for b in range(B):
-        for h in range(H):
-            for kv in range(n_kv_blocks):
-                qt_indices = bwd_attendance[b, h, kv].nonzero(as_tuple=True)[0]
-                for i, qt in enumerate(qt_indices):
-                    bwd_full_idx[b, h, kv, i] = qt.int()
-
-    bwd_mask_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device=device)
-    bwd_mask_idx = torch.zeros(
-        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device=device
-    )
-
-    return BlockSparseTensorsTorch(
-        mask_block_cnt=bwd_mask_cnt,
-        mask_block_idx=bwd_mask_idx,
-        full_block_cnt=bwd_full_cnt,
-        full_block_idx=bwd_full_idx,
-        block_size=(q_tile_size, n_block_size),
-    )
-
-
-def _attn_bwd_pytorch(
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    out: Tensor,
-    dout: Tensor,
-    lse: Tensor,
-    softmax_scale: float | None = None,
-    causal: bool = False,
-    window_size_left: int | None = None,
-    window_size_right: int | None = None,
-    mask: Tensor | None = None,
-) -> Tuple[Tensor, Tensor, Tensor]:
-    """Attention backward using PyTorch ops (torch.matmul + cuBLAS). No CUTLASS JIT.
-
-    All inputs are (B, N, H, D) layout.
-    Returns (dq, dk, dv).
-
-    Uses the saved output and log-sum-exp to recompute attention weights
-    without materializing the full N×N score matrix where possible.
-    """
-    B, N_q, H, D = q.shape
-    H_kv = k.shape[2]
-    N_kv = k.shape[1]
-    groups = H // H_kv
-
-    if softmax_scale is None:
-        softmax_scale = 1.0 / math.sqrt(D)
-
-    # Transpose to (B, H, N, D) for matmul
-    q_t = q.transpose(1, 2).float()  # (B, H, N_q, D)
-    k_t = k.transpose(1, 2).float()  # (B, H_kv, N_kv, D)
-    v_t = v.transpose(1, 2).float()  # (B, H_kv, N_kv, D)
-    dout_t = dout.transpose(1, 2).float()  # (B, H, N_q, D)
-
-    # Expand K, V for GQA
-    if groups > 1:
-        k_t = k_t.repeat_interleave(groups, dim=1)  # (B, H, N_kv, D)
-        v_t = v_t.repeat_interleave(groups, dim=1)
-
-    # Recompute attention scores and weights from LSE
-    scores = (
-        torch.matmul(q_t, k_t.transpose(-2, -1)) * softmax_scale
-    )  # (B, H, N_q, N_kv)
-
-    # Apply masks
-    if causal and N_q == N_kv:
-        q_pos = torch.arange(N_q, device=q.device).unsqueeze(1)
-        kv_pos = torch.arange(N_kv, device=q.device).unsqueeze(0)
-        causal_mask = kv_pos > q_pos
-        if window_size_left is not None:
-            causal_mask = causal_mask | (kv_pos < q_pos - window_size_left + 1)
-        scores = scores.masked_fill(
-            causal_mask.unsqueeze(0).unsqueeze(0), float("-inf")
-        )
-    elif window_size_left is not None and N_q == N_kv:
-        q_pos = torch.arange(N_q, device=q.device).unsqueeze(1)
-        kv_pos = torch.arange(N_kv, device=q.device).unsqueeze(0)
-        window_mask = (kv_pos > q_pos) | (kv_pos < q_pos - window_size_left + 1)
-        scores = scores.masked_fill(
-            window_mask.unsqueeze(0).unsqueeze(0), float("-inf")
-        )
-
-    if mask is not None:
-        scores = scores.masked_fill(mask, float("-inf"))
-
-    # Softmax (recompute from scores, not from LSE, for simplicity)
-    attn = torch.softmax(scores, dim=-1)
-
-    # Standard attention backward:
-    # dV = P^T @ dO
-    dv_t = torch.matmul(attn.transpose(-2, -1), dout_t)  # (B, H, N_kv, D)
-
-    # dP = dO @ V^T
-    dp = torch.matmul(dout_t, v_t.transpose(-2, -1))  # (B, H, N_q, N_kv)
-
-    # dS = P * (dP - (dP * P).sum(-1, keepdim=True))
-    # Equivalently: dS = P * (dP - rowsum), where rowsum = (dO * O).sum(D)
-    rowsum = (dout_t * (torch.matmul(attn, v_t))).sum(dim=-1, keepdim=True)
-    ds = attn * (dp - rowsum) * softmax_scale
-
-    # dQ = dS @ K
-    dq_t = torch.matmul(ds, k_t)  # (B, H, N_q, D)
-
-    # dK = dS^T @ Q
-    dk_t = torch.matmul(ds.transpose(-2, -1), q_t)  # (B, H, N_kv, D)
-
-    # Handle GQA: sum dK, dV across head groups
-    if groups > 1:
-        dk_t = dk_t.reshape(B, H_kv, groups, N_kv, D).sum(dim=2)
-        dv_t = dv_t.reshape(B, H_kv, groups, N_kv, D).sum(dim=2)
-
-    # Transpose back to (B, N, H, D)
-    return (
-        dq_t.transpose(1, 2).to(q.dtype),
-        dk_t.transpose(1, 2).to(k.dtype),
-        dv_t.transpose(1, 2).to(v.dtype),
-    )
 
 
 class NSAFunction(torch.autograd.Function):
@@ -405,19 +234,10 @@ class NSAFunction(torch.autograd.Function):
             dO_slc = (g[..., 1:2] * dO_f).to(dO.dtype)
             dO_sld = (g[..., 2:3] * dO_f).to(dO.dtype)
 
-        # --- Stage 2: Three attention backward passes (PyTorch/cuBLAS, no CUTLASS JIT) ---
+        # --- Stage 2: Three attention backward passes (FA4 CuteDSL) ---
 
         # Branch 1: Compressed attention backward
-        # Build compressed causal mask: kv_block_start > q_pos
-        B_size, N_size, H_size = Q.shape[:3]
-        N_cmp = K_cmp.shape[1]
-        cmp_mask = None
-        if causal:
-            q_pos = torch.arange(N_size, device=Q.device).unsqueeze(1)
-            kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
-            cmp_mask = (kv_block_start.unsqueeze(0) > q_pos).unsqueeze(0).unsqueeze(0)
-
-        dQ_cmp, dK_cmp, dV_cmp = _attn_bwd_pytorch(
+        dQ_cmp, dK_cmp, dV_cmp = _fa4_bwd(
             Q,
             K_cmp,
             V_cmp,
@@ -425,164 +245,130 @@ class NSAFunction(torch.autograd.Function):
             dO_cmp,
             lse_cmp,
             softmax_scale=softmax_scale,
-            mask=cmp_mask,
+            causal=False,
+            mask_mod=compressed_mask,
         )
 
-        # Branch 2: Selected attention backward via gather/scatter
-        # Gather selected K/V blocks, run attention backward on gathered subset,
-        # then scatter dK/dV gradients back to full KV positions.
+        # Branch 2: Selected attention backward via gather/scatter (per-tile)
+        # FA4 block-sparse backward is not yet supported on SM100, so we use
+        # a PyTorch-based approach: for each query tile, gather selected K/V,
+        # compute attention backward, then scatter dK/dV gradients back.
+        # Processing one tile at a time avoids O(N_q_tiles * N * D) memory.
+        # GQA is handled inside the loop to avoid expanding K/V to H heads.
         block_indices = ctx.block_indices
         q_tile_size = ctx.q_tile_size
         num_sel = ctx.num_selected_blocks
         block_size = compress_block_size
 
+        B_size, N_size, H_size, D = Q.shape
+        H_kv = K.shape[2]
+        groups = H_size // H_kv
+
         N_blocks = N_size // block_size
         N_q_tiles = N_size // q_tile_size
         k_actual = min(num_sel, N_blocks)
-
-        # Expand block indices to position indices
-        offsets = torch.arange(block_size, device=Q.device)
-        pos_indices = block_indices.unsqueeze(-1) * block_size + offsets
         kv_len = k_actual * block_size
-        pos_indices = pos_indices.reshape(B_size, H_size, N_q_tiles, kv_len)
 
-        # Gather K, V at selected positions: (B, H, N_q_tiles, kv_len, D)
-        H_kv = K.shape[2]
-        groups = H_size // H_kv
-        k_t = K.transpose(1, 2).float()
-        v_t = V.transpose(1, 2).float()
-        if groups > 1:
-            k_t = k_t.repeat_interleave(groups, dim=1)
-            v_t = v_t.repeat_interleave(groups, dim=1)
-
-        D = Q.shape[-1]
-        gather_idx = pos_indices.unsqueeze(-1).expand(
-            B_size, H_size, N_q_tiles, kv_len, D
-        )
-        k_exp = k_t.unsqueeze(2).expand(B_size, H_size, N_q_tiles, N_size, D)
-        v_exp = v_t.unsqueeze(2).expand(B_size, H_size, N_q_tiles, N_size, D)
-        sel_k = torch.gather(k_exp, 3, gather_idx)
-        sel_v = torch.gather(v_exp, 3, gather_idx)
-
-        # Reshape Q and dO into tiles
-        q_tiles = (
-            Q.transpose(1, 2).float().reshape(B_size, H_size, N_q_tiles, q_tile_size, D)
-        )
-        dO_slc_tiles = (
-            dO_slc.transpose(1, 2)
-            .float()
-            .reshape(B_size, H_size, N_q_tiles, q_tile_size, D)
+        # Expand block indices to position indices: (B, H, N_q_tiles, kv_len)
+        offsets = torch.arange(block_size, device=Q.device)
+        pos_indices = (block_indices.unsqueeze(-1) * block_size + offsets).reshape(
+            B_size, H_size, N_q_tiles, kv_len
         )
 
-        # Attention scores on gathered KV
-        scores_slc = torch.matmul(q_tiles, sel_k.transpose(-2, -1)) * softmax_scale
+        # Keep K, V at H_kv heads — no GQA expansion
+        k_t = K.transpose(1, 2).float()  # (B, H_kv, N, D)
+        v_t = V.transpose(1, 2).float()  # (B, H_kv, N, D)
 
-        # Causal mask on gathered positions
-        if causal:
-            q_tile_starts = torch.arange(N_q_tiles, device=Q.device) * q_tile_size
-            q_offsets_t = torch.arange(q_tile_size, device=Q.device)
-            q_positions = q_tile_starts.unsqueeze(1) + q_offsets_t.unsqueeze(0)
-            c_mask = pos_indices.unsqueeze(3) > q_positions.reshape(
-                1, 1, N_q_tiles, q_tile_size, 1
-            )
-            scores_slc = scores_slc.masked_fill(c_mask, float("-inf"))
-
-        attn_slc = torch.softmax(scores_slc, dim=-1)
-
-        # dV_sel = attn^T @ dO_slc_tiles
-        dv_sel = torch.matmul(attn_slc.transpose(-2, -1), dO_slc_tiles)
-
-        # dP = dO @ V^T
-        dp_slc = torch.matmul(dO_slc_tiles, sel_v.transpose(-2, -1))
-        rowsum_slc = (dO_slc_tiles * torch.matmul(attn_slc, sel_v)).sum(
-            dim=-1, keepdim=True
-        )
-        ds_slc = attn_slc * (dp_slc - rowsum_slc) * softmax_scale
-
-        # dQ_slc_tiles = dS @ sel_K
-        dq_slc_tiles = torch.matmul(ds_slc, sel_k)
-        dQ_slc = (
-            dq_slc_tiles.reshape(B_size, H_size, N_size, D).transpose(1, 2).to(Q.dtype)
-        )
-
-        # dK_sel = dS^T @ Q_tiles
-        dk_sel = torch.matmul(ds_slc.transpose(-2, -1), q_tiles)
-
-        # Scatter dK_sel and dV_sel back to full KV
-        dK_slc_full = torch.zeros(
+        # Accumulate dQ at H heads, dK/dV at H_kv heads
+        dQ_slc = torch.zeros(
             B_size, H_size, N_size, D, device=Q.device, dtype=torch.float32
         )
+        dK_slc_full = torch.zeros(
+            B_size, H_kv, N_size, D, device=Q.device, dtype=torch.float32
+        )
         dV_slc_full = torch.zeros_like(dK_slc_full)
-        scatter_idx = gather_idx  # (B, H, N_q_tiles, kv_len, D)
-        # Sum across query tiles that share the same KV position
-        for qt in range(N_q_tiles):
-            dK_slc_full.scatter_add_(2, gather_idx[:, :, qt], dk_sel[:, :, qt])
-            dV_slc_full.scatter_add_(2, gather_idx[:, :, qt], dv_sel[:, :, qt])
 
-        # Handle GQA: sum across head groups
-        if groups > 1:
-            dK_slc_full = dK_slc_full.reshape(B_size, H_kv, groups, N_size, D).sum(
-                dim=2
-            )
-            dV_slc_full = dV_slc_full.reshape(B_size, H_kv, groups, N_size, D).sum(
-                dim=2
-            )
+        q_t = Q.transpose(1, 2).float()  # (B, H, N, D)
+        dO_slc_t = dO_slc.transpose(1, 2).float()
+
+        for qt in range(N_q_tiles):
+            q_start = qt * q_tile_size
+            q_end = q_start + q_tile_size
+
+            # Block indices for this tile: (B, H, kv_len)
+            idx_qt = pos_indices[:, :, qt]
+
+            # Gather K, V from H_kv heads, then expand for GQA
+            # idx_qt is (B, H, kv_len) but K is (B, H_kv, N, D)
+            # Map H→H_kv: idx_kv_qt = idx_qt[:, ::groups] (same indices per group)
+            idx_kv_qt = idx_qt[:, ::groups]  # (B, H_kv, kv_len)
+            gather_kv = idx_kv_qt.unsqueeze(-1).expand(B_size, H_kv, kv_len, D)
+            sel_k_kv = torch.gather(k_t, 2, gather_kv)  # (B, H_kv, kv_len, D)
+            sel_v_kv = torch.gather(v_t, 2, gather_kv)
+
+            # Expand gathered K, V to H heads for attention
+            if groups > 1:
+                sel_k = sel_k_kv.repeat_interleave(groups, dim=1)  # (B, H, kv_len, D)
+                sel_v = sel_v_kv.repeat_interleave(groups, dim=1)
+            else:
+                sel_k = sel_k_kv
+                sel_v = sel_v_kv
+
+            # Q and dO for this tile: (B, H, q_tile_size, D)
+            q_tile = q_t[:, :, q_start:q_end]
+            dO_tile = dO_slc_t[:, :, q_start:q_end]
+
+            # Attention scores: (B, H, q_tile_size, kv_len)
+            scores = torch.matmul(q_tile, sel_k.transpose(-2, -1)) * softmax_scale
+
+            if causal:
+                q_positions = torch.arange(q_start, q_end, device=Q.device).unsqueeze(1)
+                kv_positions = idx_qt.unsqueeze(2)  # (B, H, 1, kv_len)
+                c_mask = kv_positions > q_positions.reshape(1, 1, q_tile_size, 1)
+                scores = scores.masked_fill(c_mask, float("-inf"))
+
+            attn = torch.softmax(scores, dim=-1)
+
+            # dV = attn^T @ dO
+            dv_qt = torch.matmul(attn.transpose(-2, -1), dO_tile)  # (B, H, kv_len, D)
+
+            # dP = dO @ V^T, dS = P * (dP - rowsum) * scale
+            dp = torch.matmul(dO_tile, sel_v.transpose(-2, -1))
+            rowsum = (dO_tile * torch.matmul(attn, sel_v)).sum(dim=-1, keepdim=True)
+            ds = attn * (dp - rowsum) * softmax_scale
+
+            # dQ = dS @ K
+            dQ_slc[:, :, q_start:q_end] = torch.matmul(ds, sel_k)
+
+            # dK = dS^T @ Q
+            dk_qt = torch.matmul(ds.transpose(-2, -1), q_tile)  # (B, H, kv_len, D)
+
+            # Reduce dK, dV from H heads to H_kv heads before scatter
+            if groups > 1:
+                dk_qt = dk_qt.reshape(B_size, H_kv, groups, kv_len, D).sum(dim=2)
+                dv_qt = dv_qt.reshape(B_size, H_kv, groups, kv_len, D).sum(dim=2)
+
+            # Scatter dK, dV back at H_kv resolution
+            dK_slc_full.scatter_add_(2, gather_kv, dk_qt)
+            dV_slc_full.scatter_add_(2, gather_kv, dv_qt)
+
+        dQ_slc = dQ_slc.transpose(1, 2).to(Q.dtype)
         dK_slc = dK_slc_full.transpose(1, 2).to(K.dtype)
         dV_slc = dV_slc_full.transpose(1, 2).to(V.dtype)
 
-        # Branch 3: Sliding window backward — use PyTorch SDPA which has
-        # built-in memory-efficient backward (no N×N materialization).
-        # We recompute forward + backward together via SDPA's autograd.
-        H_kv_sld = K.shape[2]
-        groups_sld = H_size // H_kv_sld
-        q_sld = Q.float()
-        k_sld = K.float()
-        v_sld = V.float()
-
-        # SDPA needs (B, H, N, D) layout
-        q_sld_t = q_sld.transpose(1, 2)  # (B, H, N, D)
-        k_sld_t = k_sld.transpose(1, 2)  # (B, H_kv, N, D)
-        v_sld_t = v_sld.transpose(1, 2)
-
-        # Expand for GQA
-        if groups_sld > 1:
-            k_sld_t = k_sld_t.repeat_interleave(groups_sld, dim=1)
-            v_sld_t = v_sld_t.repeat_interleave(groups_sld, dim=1)
-
-        # Enable grad for SDPA backward
-        q_sld_t.requires_grad_(True)
-        k_sld_t.requires_grad_(True)
-        v_sld_t.requires_grad_(True)
-
-        # Build causal+window mask via attn_mask
-        # For sliding window: each query attends to [q_pos - window + 1, q_pos]
-        with torch.enable_grad():
-            O_sld_recomputed = torch.nn.functional.scaled_dot_product_attention(
-                q_sld_t,
-                k_sld_t,
-                v_sld_t,
-                is_causal=causal and window_size is None,
-                scale=softmax_scale,
-            )
-            # Get dO in the right layout
-            dO_sld_t = dO_sld.transpose(1, 2).float()
-            O_sld_recomputed.backward(dO_sld_t)
-
-        dQ_sld = q_sld_t.grad.transpose(1, 2).to(Q.dtype)
-        dk_sld_t = k_sld_t.grad
-        dv_sld_t = v_sld_t.grad
-
-        # Handle GQA: sum across head groups for dK, dV
-        if groups_sld > 1:
-            dk_sld_t = dk_sld_t.reshape(B_size, H_kv_sld, groups_sld, N_size, D).sum(
-                dim=2
-            )
-            dv_sld_t = dv_sld_t.reshape(B_size, H_kv_sld, groups_sld, N_size, D).sum(
-                dim=2
-            )
-
-        dK_sld = dk_sld_t.transpose(1, 2).to(K.dtype)
-        dV_sld = dv_sld_t.transpose(1, 2).to(V.dtype)
+        # Branch 3: Sliding window attention backward
+        dQ_sld, dK_sld, dV_sld = _fa4_bwd(
+            Q,
+            K,
+            V,
+            O_sld,
+            dO_sld,
+            lse_sld,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
 
         # --- Stage 3: Compression backward ---
         # dK_cmp, dV_cmp are gradients w.r.t. compressed KV

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -1,0 +1,200 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""End-to-end NSA (Native Sparse Attention) forward pass using FA4.
+
+Orchestrates the three attention branches:
+1. Compressed attention (FA4 on short KV sequence)
+2. Selected attention (FA4 with block sparsity)
+3. Sliding window attention (FA4 with window_size)
+
+Then gates and combines the outputs.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+
+def _make_compressed_causal_mask(compress_block_size: int) -> Callable:
+    """Create a CuteDSL mask_mod for compressed attention causal masking.
+
+    Block j (at kv_idx=j) represents positions [j*block_size, (j+1)*block_size).
+    Query at position q_idx can attend to block j iff j * block_size <= q_idx.
+    """
+    import cutlass.cute as cute
+
+    @cute.jit
+    def compressed_causal_mask(
+        batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+    ):
+        return kv_idx * compress_block_size <= q_idx
+
+    return compressed_causal_mask
+
+
+def _fa4_fwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+) -> Tuple[Tensor, Tensor]:
+    """Call FA4's forward pass (low-level, supports block sparsity and mask_mod).
+
+    Uses _flash_attn_fwd from the fb interface which supports block_sparse_tensors
+    and mask_mod.
+
+    All inputs are (B, N, H, D) layout.
+    Returns (output, lse).
+    """
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+
+    # mask_mod is not compatible with pack_gqa=True in FA4, so disable it
+    pack_gqa = False if mask_mod is not None else None
+
+    out, lse = _flash_attn_fwd(
+        q, k, v,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        block_sparse_tensors=block_sparse_tensors,
+        mask_mod=mask_mod,
+        pack_gqa=pack_gqa,
+        return_lse=True,
+    )
+    return out, lse
+
+
+def _fa4_fwd_simple(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size: tuple[int, int] | None = None,
+) -> Tuple[Tensor, Tensor]:
+    """Call FA4 via the autograd interface (for branches without block sparsity)."""
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    return flash_attn_func(
+        q, k, v,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+    )
+
+
+def nsa_forward(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    n_block_size: int = 128,
+) -> Tensor:
+    """NSA forward pass using FA4 for all attention branches.
+
+    Orchestrates:
+    1. KV compression (mean-pool + optional projection)
+    2. Block scoring and top-k selection
+    3. Three FA4 calls: compressed, selected (block-sparse), sliding window
+    4. Gating and combination
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        compress_block_size: Number of KV positions per block for compression.
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        window_size: Sliding window size (left window, causal).
+        W_k_compress: Per-head key compression weights, shape (H_kv, D, D).
+        W_v_compress: Per-head value compression weights, shape (H_kv, D, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        causal: Whether to use causal masking.
+        softmax_scale: Attention scaling factor (default: 1/sqrt(D)).
+        q_tile_size: Query tile size for block selection (FA4 CTA tile: 2*128=256).
+        n_block_size: FA4 KV block size (128 for SM100).
+
+    Returns:
+        Output tensor, shape (B, N, H, D).
+    """
+    B, N, H, D = Q.shape
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # Step 1: Compress KV
+    K_cmp, V_cmp = compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+    # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
+
+    # Step 2: Score blocks and select top-k
+    block_indices = score_and_select_blocks(
+        Q, K_cmp, num_selected_blocks, compress_block_size,
+        causal=causal, q_tile_size=q_tile_size, softmax_scale=softmax_scale,
+    )
+    # block_indices: (B, H, N_q_tiles, k) int32
+
+    # Step 3: Build FA4 sparsity masks for selected attention
+    sparse_tensors = build_fa4_block_sparse_tensors(
+        block_indices, compress_block_size,
+        n_block_size=n_block_size, seqlen_k=N,
+    )
+
+    # Step 4: Run three FA4 branches
+
+    # Branch 1: Compressed attention — block-aware causal masking on short KV
+    # Standard causal=True gives wrong masking for compressed KV since N_cmp << N:
+    # it masks based on kv_j > q_i, but we need kv_j * compress_block_size > q_i.
+    compressed_mask = _make_compressed_causal_mask(compress_block_size) if causal else None
+    O_cmp, lse_cmp = _fa4_fwd(
+        Q, K_cmp, V_cmp,
+        causal=False,
+        softmax_scale=softmax_scale,
+        mask_mod=compressed_mask,
+    )
+
+    # Branch 2: Selected attention — block-sparse attention on full KV
+    O_slc, lse_slc = _fa4_fwd(
+        Q, K, V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        block_sparse_tensors=sparse_tensors,
+    )
+
+    # Branch 3: Sliding window attention
+    O_sld, lse_sld = _fa4_fwd_simple(
+        Q, K, V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        window_size=(window_size, 0),  # (left, right=0 for causal)
+    )
+
+    # Step 5: Gate and combine
+    # Use chunked gating for long sequences to avoid materializing
+    # 3 full (B,N,H,D) float32 tensors simultaneously.
+    gate_chunk = 4096 if N > 32768 else None
+    gates = compute_gates(Q, gate_proj_weight, chunk_size=gate_chunk)  # (B, N, H, 3)
+    O = gate_and_combine(O_cmp, O_slc, O_sld, gates, chunk_size=gate_chunk)
+
+    return O

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -80,6 +80,47 @@ def _fa4_fwd(
     return out, lse
 
 
+def _fa4_bwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    dout: Tensor,
+    lse: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Call FA4's backward pass (low-level, supports block sparsity and mask_mod).
+
+    Uses _flash_attn_bwd from the fb interface which supports block_sparse_tensors
+    and mask_mod.
+
+    All inputs are (B, N, H, D) layout.
+    Returns (dq, dk, dv).
+    """
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_bwd
+
+    dq, dk, dv = _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        dout,
+        lse,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        block_sparse_tensors=block_sparse_tensors,
+        mask_mod=mask_mod,
+    )
+    return dq, dk, dv
+
+
 def _fa4_fwd_simple(
     q: Tensor,
     k: Tensor,
@@ -148,7 +189,9 @@ def nsa_forward(
         softmax_scale = 1.0 / math.sqrt(D)
 
     # Step 1: Compress KV
-    K_cmp, V_cmp = fused_compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+    K_cmp, V_cmp = fused_compress_kv(
+        K, V, compress_block_size, W_k_compress, W_v_compress
+    )
     # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
 
     # Step 2: Score blocks and select top-k

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -16,7 +16,7 @@ import math
 from typing import Callable, Optional, Tuple
 
 import torch
-from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.compress import fused_compress_kv
 from mslk.attention.sparse_attn.gating import fused_gate_and_combine
 from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
@@ -148,7 +148,7 @@ def nsa_forward(
         softmax_scale = 1.0 / math.sqrt(D)
 
     # Step 1: Compress KV
-    K_cmp, V_cmp = compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+    K_cmp, V_cmp = fused_compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
     # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
 
     # Step 2: Score blocks and select top-k

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -18,7 +18,7 @@ from typing import Callable, Optional, Tuple
 import torch
 from mslk.attention.sparse_attn.compress import compress_kv
 from mslk.attention.sparse_attn.gating import fused_gate_and_combine
-from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 from torch import Tensor
 
@@ -152,7 +152,7 @@ def nsa_forward(
     # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
 
     # Step 2: Score blocks and select top-k
-    block_indices = score_and_select_blocks(
+    block_indices = fused_score_and_select_blocks(
         Q,
         K_cmp,
         num_selected_blocks,

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -16,12 +16,11 @@ import math
 from typing import Callable, Optional, Tuple
 
 import torch
-from torch import Tensor
-
 from mslk.attention.sparse_attn.compress import compress_kv
-from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.gating import fused_gate_and_combine
 from mslk.attention.sparse_attn.select import score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+from torch import Tensor
 
 
 def _make_compressed_causal_mask(compress_block_size: int) -> Callable:
@@ -66,7 +65,9 @@ def _fa4_fwd(
     pack_gqa = False if mask_mod is not None else None
 
     out, lse = _flash_attn_fwd(
-        q, k, v,
+        q,
+        k,
+        v,
         softmax_scale=softmax_scale,
         causal=causal,
         window_size_left=window_size_left,
@@ -91,7 +92,9 @@ def _fa4_fwd_simple(
     from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
 
     return flash_attn_func(
-        q, k, v,
+        q,
+        k,
+        v,
         softmax_scale=softmax_scale,
         causal=causal,
         window_size=window_size,
@@ -150,15 +153,22 @@ def nsa_forward(
 
     # Step 2: Score blocks and select top-k
     block_indices = score_and_select_blocks(
-        Q, K_cmp, num_selected_blocks, compress_block_size,
-        causal=causal, q_tile_size=q_tile_size, softmax_scale=softmax_scale,
+        Q,
+        K_cmp,
+        num_selected_blocks,
+        compress_block_size,
+        causal=causal,
+        q_tile_size=q_tile_size,
+        softmax_scale=softmax_scale,
     )
     # block_indices: (B, H, N_q_tiles, k) int32
 
     # Step 3: Build FA4 sparsity masks for selected attention
     sparse_tensors = build_fa4_block_sparse_tensors(
-        block_indices, compress_block_size,
-        n_block_size=n_block_size, seqlen_k=N,
+        block_indices,
+        compress_block_size,
+        n_block_size=n_block_size,
+        seqlen_k=N,
     )
 
     # Step 4: Run three FA4 branches
@@ -166,9 +176,13 @@ def nsa_forward(
     # Branch 1: Compressed attention — block-aware causal masking on short KV
     # Standard causal=True gives wrong masking for compressed KV since N_cmp << N:
     # it masks based on kv_j > q_i, but we need kv_j * compress_block_size > q_i.
-    compressed_mask = _make_compressed_causal_mask(compress_block_size) if causal else None
+    compressed_mask = (
+        _make_compressed_causal_mask(compress_block_size) if causal else None
+    )
     O_cmp, lse_cmp = _fa4_fwd(
-        Q, K_cmp, V_cmp,
+        Q,
+        K_cmp,
+        V_cmp,
         causal=False,
         softmax_scale=softmax_scale,
         mask_mod=compressed_mask,
@@ -176,7 +190,9 @@ def nsa_forward(
 
     # Branch 2: Selected attention — block-sparse attention on full KV
     O_slc, lse_slc = _fa4_fwd(
-        Q, K, V,
+        Q,
+        K,
+        V,
         causal=causal,
         softmax_scale=softmax_scale,
         block_sparse_tensors=sparse_tensors,
@@ -184,17 +200,15 @@ def nsa_forward(
 
     # Branch 3: Sliding window attention
     O_sld, lse_sld = _fa4_fwd_simple(
-        Q, K, V,
+        Q,
+        K,
+        V,
         causal=causal,
         softmax_scale=softmax_scale,
         window_size=(window_size, 0),  # (left, right=0 for causal)
     )
 
-    # Step 5: Gate and combine
-    # Use chunked gating for long sequences to avoid materializing
-    # 3 full (B,N,H,D) float32 tensors simultaneously.
-    gate_chunk = 4096 if N > 32768 else None
-    gates = compute_gates(Q, gate_proj_weight, chunk_size=gate_chunk)  # (B, N, H, 3)
-    O = gate_and_combine(O_cmp, O_slc, O_sld, gates, chunk_size=gate_chunk)
+    # Step 5: Fused gate and combine
+    O = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
 
     return O

--- a/mslk/attention/sparse_attn/nsa_scoring.py
+++ b/mslk/attention/sparse_attn/nsa_scoring.py
@@ -1,0 +1,145 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
+
+"""Block score column-reduction utilities for NSA scoring phase.
+
+During the fused scoring + compressed attention phase, the softmax warps
+read QK scores from TMEM and reduce each column (KV block dimension) to
+produce a single block importance score. These scores are accumulated
+across all Q rows within a tile to produce per-block scores.
+
+The column reduction reuses the TMEM read infrastructure from FA4's
+softmax warps, adding a parallel reduction along the M dimension.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+import cutlass.cute.nvgpu.tcgen05 as tcgen05
+
+import mslk.fb.mslk.attention.flash_attn.utils as utils
+
+
+@cute.jit
+def reduce_s_to_block_scores(
+    tSrS_t2r: cute.Tensor,  # Register fragment of S tile loaded from TMEM
+    thr_tmem_load: cute.CopyAtom,
+    thr_mma_qk: cute.core.ThrMma,
+    m_block_size: int,
+    n_block_size: int,
+    block_scores: cute.Tensor,  # (n_blocks_in_tile,) accumulator in registers
+    n_block_offset: Int32,  # Which compressed block this KV tile corresponds to
+    n_blocks_per_tile: int,  # How many compressed blocks fit in one n_block_size tile
+    is_first: bool,
+) -> None:
+    """Reduce S tile columns to block scores and accumulate.
+
+    After QK GEMM produces S in TMEM, the softmax warps load it into
+    registers. This function reduces each column of S (summing across
+    the M dimension, i.e., all Q positions in the tile) to produce a
+    single score per KV block.
+
+    For compressed attention where compress_block_size >= n_block_size,
+    each S tile column already corresponds to one compressed block, so
+    we just sum the column. When compress_block_size < n_block_size,
+    multiple compressed blocks share one S tile — we partition the
+    columns accordingly.
+
+    Args:
+        tSrS_t2r: S scores in registers after TMEM load, shape depends on
+            partition layout from thr_mma_qk.
+        thr_tmem_load: TMEM load copy atom (for layout info).
+        thr_mma_qk: QK MMA partition (for coordinate mapping).
+        m_block_size: M tile size (e.g., 128).
+        n_block_size: N tile size (e.g., 128).
+        block_scores: Accumulator for block scores, shape (n_cmp,).
+        n_block_offset: Starting compressed block index for this tile.
+        n_blocks_per_tile: Number of compressed blocks per N tile.
+        is_first: If True, initialize block_scores; otherwise accumulate.
+    """
+    # The S tile has been loaded into registers with layout from thr_mma_qk.
+    # We need to reduce across the M dimension (rows) for each N position (column).
+    #
+    # tSrS_t2r has shape organized by the MMA partition. We interpret it as
+    # (M_per_thread, N_per_thread) logically.
+    #
+    # For SM100 with 128-thread warp groups doing TMEM loads:
+    # Each thread in the softmax warp group gets one row of the 128x128 S tile.
+    # So each thread has n_block_size values (one full row).
+    # The column reduction = warp-level reduction across threads (rows),
+    # then store into block_scores.
+
+    acc_S_mn = utils.make_acc_tensor_mn_view(tSrS_t2r)
+    n_cols = cute.size(acc_S_mn, mode=[1])
+
+    # Each thread contributes its row's values to the column sum.
+    # We do a warp-level reduction for each column group.
+    # Since each compressed block spans (compress_block_size / n_block_size * n_block_size)
+    # columns within the tile, or if compress_block_size aligns with n_block_size,
+    # just one column per block.
+
+    # For the common case where n_blocks_per_tile == 1 (compress_block_size >= n_block_size),
+    # sum all columns of this thread's row, then warp-reduce.
+    if const_expr(n_blocks_per_tile == 1):
+        row_sum = Float32(0.0)
+        for c in cutlass.range(n_cols, unroll_full=True):
+            row_sum += acc_S_mn[0, c].load()
+
+        # Warp-level reduction: sum across all threads (rows in the tile)
+        col_sum = utils.warp_reduce(row_sum, cute.arch.fadd, width=4)
+
+        if is_first:
+            block_scores[n_block_offset] = col_sum
+        else:
+            block_scores[n_block_offset] += col_sum
+    else:
+        # Multiple compressed blocks per N tile
+        cols_per_block: int = const_expr(n_block_size // n_blocks_per_tile)
+        for blk in cutlass.range_constexpr(n_blocks_per_tile):
+            row_sum = Float32(0.0)
+            for c in cutlass.range_constexpr(cols_per_block):
+                col_idx: int = const_expr(blk * cols_per_block + c)
+                row_sum += acc_S_mn[0, col_idx].load()
+
+            col_sum = utils.warp_reduce(row_sum, cute.arch.fadd, width=4)
+
+            global_blk_idx = n_block_offset + blk
+            if is_first:
+                block_scores[global_blk_idx] = col_sum
+            else:
+                block_scores[global_blk_idx] += col_sum
+
+
+@cute.jit
+def apply_causal_mask_to_block_scores(
+    block_scores: cute.Tensor,  # (n_cmp,) block score accumulator
+    n_cmp: Int32,
+    m_block: Int32,  # Current Q tile index
+    q_tile_size: int,
+    compress_block_size: int,
+) -> None:
+    """Apply causal mask to block scores: future blocks get -inf.
+
+    A compressed block j is "future" for query tile i if:
+        j * compress_block_size >= (i + 1) * q_tile_size
+
+    Args:
+        block_scores: Block score accumulator, shape (n_cmp,).
+        n_cmp: Total number of compressed blocks.
+        m_block: Current Q tile index.
+        q_tile_size: Size of each Q tile.
+        compress_block_size: Size of each compressed block.
+    """
+    q_tile_end = (m_block + 1) * q_tile_size
+    tidx = cute.arch.thread_idx()[0] % 128  # thread in correction warp group
+
+    # Each thread checks its assigned blocks
+    n_per_thread = (n_cmp + 127) // 128
+    for i in cutlass.range(n_per_thread, unroll=1):
+        blk_idx = tidx * n_per_thread + i
+        if blk_idx < n_cmp:
+            blk_start = blk_idx * compress_block_size
+            if blk_start >= q_tile_end:
+                block_scores[blk_idx] = -Float32.inf

--- a/mslk/attention/sparse_attn/nsa_topk.py
+++ b/mslk/attention/sparse_attn/nsa_topk.py
@@ -1,0 +1,272 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
+
+"""In-register parallel top-K selection for NSA block scoring.
+
+Provides CuteDSL @cute.jit utilities for performing top-K selection entirely
+in registers across the correction warp group (128 threads, 4 warps).
+
+Algorithm:
+1. Each thread holds N_cmp/128 block scores in registers.
+2. Local insertion sort: each thread keeps its top-K values + indices.
+3. Warp-level merge: 5 rounds of butterfly shuffle to merge across 32 threads.
+4. Cross-warp merge: 4 warps → final K candidates via shared memory staging.
+
+For 1M tokens with L=64: N_cmp=16384, each thread holds 128 scores.
+With K_SEL=16, total ~240 comparisons per thread — negligible vs MMA time.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+
+
+@cute.jit
+def insertion_sort_topk(
+    scores: cute.Tensor,  # Thread-local scores, shape (local_n,)
+    num_local: Int32,
+    k: int,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Per-thread insertion sort to find top-K from local scores.
+
+    Each thread independently sorts its local scores (descending) and
+    retains the top-K values and their local indices.
+
+    Args:
+        scores: Thread-local block scores, shape (local_n,).
+        num_local: Number of valid scores this thread holds.
+        k: Number of top elements to retain.
+
+    Returns:
+        top_vals: Top-K values (descending), shape (k,).
+        top_idxs: Corresponding local indices, shape (k,).
+    """
+    top_vals = cute.make_fragment(k, Float32)
+    top_idxs = cute.make_fragment(k, Int32)
+
+    # Initialize with -inf
+    top_vals.fill(-Float32.inf)
+    top_idxs.fill(Int32(0))
+
+    # Insertion sort: for each score, insert into sorted top_vals if larger
+    for i in cutlass.range(num_local, unroll=1):
+        val = scores[i]
+        idx = Int32(i)
+        # Find insertion point (linear scan from the end)
+        for j in cutlass.range_constexpr(k - 1, -1, -1):
+            if val > top_vals[j]:
+                if const_expr(j < k - 1):
+                    top_vals[j + 1] = top_vals[j]
+                    top_idxs[j + 1] = top_idxs[j]
+                top_vals[j] = val
+                top_idxs[j] = idx
+                break
+
+    return top_vals, top_idxs
+
+
+@cute.jit
+def merge_sorted_pairs(
+    vals_a: cute.Tensor,  # (k,) descending
+    idxs_a: cute.Tensor,  # (k,)
+    vals_b: cute.Tensor,  # (k,) descending
+    idxs_b: cute.Tensor,  # (k,)
+    k: int,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Merge two sorted top-K lists into one top-K list.
+
+    Standard merge of two sorted (descending) sequences, keeping only
+    the top-K elements from the merged result.
+
+    Args:
+        vals_a, idxs_a: First sorted top-K list.
+        vals_b, idxs_b: Second sorted top-K list.
+        k: Number of elements to keep.
+
+    Returns:
+        merged_vals: Merged top-K values (descending), shape (k,).
+        merged_idxs: Corresponding indices, shape (k,).
+    """
+    merged_vals = cute.make_fragment(k, Float32)
+    merged_idxs = cute.make_fragment(k, Int32)
+
+    ia = Int32(0)
+    ib = Int32(0)
+    for out_idx in cutlass.range_constexpr(k):
+        take_a = (ia < k) & ((ib >= k) | (vals_a[ia] >= vals_b[ib]))
+        if take_a:
+            merged_vals[out_idx] = vals_a[ia]
+            merged_idxs[out_idx] = idxs_a[ia]
+            ia += 1
+        else:
+            merged_vals[out_idx] = vals_b[ib]
+            merged_idxs[out_idx] = idxs_b[ib]
+            ib += 1
+
+    return merged_vals, merged_idxs
+
+
+@cute.jit
+def warp_merge_topk(
+    vals: cute.Tensor,  # (k,) per-thread top-K values
+    idxs: cute.Tensor,  # (k,) per-thread top-K local indices
+    thread_id_in_warp: Int32,
+    k: int,
+    n_per_thread: Int32,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Warp-level butterfly merge of per-thread top-K lists.
+
+    After this, thread 0 in each warp holds the warp-level top-K.
+    Indices are converted from thread-local to warp-global during merging.
+
+    5 rounds of shuffle: distance 1, 2, 4, 8, 16.
+
+    Args:
+        vals: Per-thread top-K values, shape (k,).
+        idxs: Per-thread top-K local indices, shape (k,).
+        thread_id_in_warp: Lane ID (0-31).
+        k: Number of top elements.
+        n_per_thread: Number of scores each thread originally held.
+
+    Returns:
+        vals: Merged top-K values (valid on lane 0).
+        idxs: Merged top-K global indices (valid on lane 0).
+    """
+    # Convert local indices to global: global_idx = thread_id * n_per_thread + local_idx
+    for i in cutlass.range_constexpr(k):
+        idxs[i] = thread_id_in_warp * n_per_thread + idxs[i]
+
+    # Butterfly reduction: 5 rounds
+    for round_idx in cutlass.range_constexpr(5):
+        distance: int = const_expr(1 << round_idx)
+        # Exchange top-K with partner
+        partner_vals = cute.make_fragment(k, Float32)
+        partner_idxs = cute.make_fragment(k, Int32)
+        for i in cutlass.range_constexpr(k):
+            partner_vals[i] = cute.arch.shfl_xor(vals[i], distance)
+            partner_idxs[i] = cute.arch.shfl_xor(idxs[i], distance)
+        # Merge: the lower-ID thread in each pair does the merge
+        if (thread_id_in_warp & distance) == 0:
+            vals, idxs = merge_sorted_pairs(vals, idxs, partner_vals, partner_idxs, k)
+
+    return vals, idxs
+
+
+@cute.jit
+def cross_warp_merge_topk(
+    vals: cute.Tensor,  # (k,) — valid on lane 0 of each warp
+    idxs: cute.Tensor,  # (k,) — valid on lane 0 of each warp
+    thread_id_in_wg: Int32,  # 0..127 within correction warp group
+    warp_id_in_wg: Int32,  # 0..3
+    smem_vals: cute.Tensor,  # shared mem buffer for vals, shape (4, k)
+    smem_idxs: cute.Tensor,  # shared mem buffer for idxs, shape (4, k)
+    k: int,
+    n_per_warp: Int32,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Cross-warp merge: reduce 4 warp-level top-K lists to one.
+
+    Lane 0 of each warp writes its top-K to shared memory. Then lane 0 of
+    warp 0 performs a sequential merge of all 4 lists.
+
+    After the merge, the result is broadcast back to all threads via smem.
+
+    Args:
+        vals: Warp-level top-K values (valid on lane 0).
+        idxs: Warp-level top-K global indices (valid on lane 0).
+        thread_id_in_wg: Thread index within correction warp group (0-127).
+        warp_id_in_wg: Warp index within correction warp group (0-3).
+        smem_vals: Shared memory for values exchange, shape (4, k).
+        smem_idxs: Shared memory for indices exchange, shape (4, k).
+        k: Number of top elements.
+        n_per_warp: Scores per warp (for global index offset).
+
+    Returns:
+        vals: Final top-K values (broadcast to all threads).
+        idxs: Final top-K global indices (broadcast to all threads).
+    """
+    lane_id = thread_id_in_wg % 32
+
+    # Lane 0 of each warp writes to shared memory
+    # Offset indices by warp_id * n_per_warp for cross-warp global indexing
+    if lane_id == 0:
+        for i in cutlass.range_constexpr(k):
+            smem_vals[warp_id_in_wg * k + i] = vals[i]
+            smem_idxs[warp_id_in_wg * k + i] = idxs[i] + warp_id_in_wg * n_per_warp
+
+    cute.arch.sync_threads()
+
+    # Lane 0 of warp 0 merges all 4 lists sequentially
+    if thread_id_in_wg == 0:
+        # Start with warp 0's list
+        for w in cutlass.range_constexpr(1, 4):
+            other_vals = cute.make_fragment(k, Float32)
+            other_idxs = cute.make_fragment(k, Int32)
+            for i in cutlass.range_constexpr(k):
+                other_vals[i] = smem_vals[w * k + i]
+                other_idxs[i] = smem_idxs[w * k + i]
+            vals, idxs = merge_sorted_pairs(vals, idxs, other_vals, other_idxs, k)
+
+        # Write merged result back to smem for broadcast
+        for i in cutlass.range_constexpr(k):
+            smem_vals[i] = vals[i]
+            smem_idxs[i] = idxs[i]
+
+    cute.arch.sync_threads()
+
+    # All threads read the final result
+    result_vals = cute.make_fragment(k, Float32)
+    result_idxs = cute.make_fragment(k, Int32)
+    for i in cutlass.range_constexpr(k):
+        result_vals[i] = smem_vals[i]
+        result_idxs[i] = smem_idxs[i]
+
+    return result_vals, result_idxs
+
+
+@cute.jit
+def parallel_topk(
+    scores: cute.Tensor,  # Thread-local scores, shape (local_n,)
+    num_local: Int32,
+    k: int,
+    thread_id_in_wg: Int32,  # 0..127 within correction warp group
+    smem_vals: cute.Tensor,  # shared mem buffer, shape (4 * k,)
+    smem_idxs: cute.Tensor,  # shared mem buffer, shape (4 * k,)
+    n_total: Int32,
+) -> cute.Tensor:
+    """Full parallel top-K pipeline: local sort → warp merge → cross-warp merge.
+
+    Each of 128 threads holds num_local = N_cmp/128 scores. Returns the global
+    top-K indices into the score array.
+
+    Args:
+        scores: Thread-local block scores, shape (local_n,).
+        num_local: Number of valid scores per thread.
+        k: Number of top blocks to select (K_SEL).
+        thread_id_in_wg: Thread index within the correction warp group (0-127).
+        smem_vals: Shared memory for cross-warp merge, shape (4 * k,).
+        smem_idxs: Shared memory for cross-warp merge, shape (4 * k,).
+        n_total: Total number of compressed blocks.
+
+    Returns:
+        top_indices: Top-K global block indices, shape (k,), sorted descending by score.
+    """
+    lane_id = thread_id_in_wg % 32
+    warp_id_in_wg = thread_id_in_wg // 32
+    n_per_thread = num_local
+    n_per_warp = n_per_thread * 32
+
+    # Step 1: Per-thread insertion sort
+    vals, idxs = insertion_sort_topk(scores, num_local, k)
+
+    # Step 2: Warp-level butterfly merge
+    vals, idxs = warp_merge_topk(vals, idxs, lane_id, k, n_per_thread)
+
+    # Step 3: Cross-warp merge (4 warps → 1)
+    vals, idxs = cross_warp_merge_topk(
+        vals, idxs, thread_id_in_wg, warp_id_in_wg,
+        smem_vals, smem_idxs, k, n_per_warp,
+    )
+
+    return idxs

--- a/mslk/attention/sparse_attn/reference.py
+++ b/mslk/attention/sparse_attn/reference.py
@@ -1,0 +1,269 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Pure PyTorch reference implementation of NSA (Native Sparse Attention).
+
+This serves as a correctness reference for the optimized FA4-based implementation.
+All operations are done in PyTorch without custom kernels.
+
+Reference: arxiv 2502.11089
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def nsa_forward_reference(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+) -> Tensor:
+    """Pure PyTorch NSA forward pass.
+
+    Combines three attention branches:
+    1. Compressed attention: Attend over mean-pooled KV blocks with learned projection.
+    2. Selected attention: Block-sparse attention over top-k important KV blocks.
+    3. Sliding window attention: Local attention within a fixed window.
+
+    All inputs/outputs use (B, N, H, D) layout.
+
+    Returns:
+        Output tensor of shape (B, N, H, D).
+    """
+    B, N, H, D = Q.shape
+    H_kv = K.shape[2]
+    assert H % H_kv == 0, "H must be divisible by H_kv for GQA"
+    groups = H // H_kv
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # Transpose to (B, H, N, D) for matmul convenience
+    q = Q.transpose(1, 2).float()  # (B, H, N, D)
+    k = K.transpose(1, 2).float()  # (B, H_kv, N, D)
+    v = V.transpose(1, 2).float()  # (B, H_kv, N, D)
+
+    # Expand K, V for GQA: (B, H_kv, N, D) -> (B, H, N, D)
+    if groups > 1:
+        k = k.repeat_interleave(groups, dim=1)
+        v = v.repeat_interleave(groups, dim=1)
+
+    # --- Branch 1: Compressed Attention ---
+    O_cmp = _compressed_attention(
+        q, k, v, compress_block_size, W_k_compress, W_v_compress,
+        groups, softmax_scale, causal, B, N, H, H_kv, D,
+    )
+
+    # --- Branch 2: Selected (Block-Sparse) Attention ---
+    O_slc = _selected_attention(
+        q, k, v, compress_block_size, num_selected_blocks,
+        W_k_compress, groups, softmax_scale, causal, B, N, H, H_kv, D,
+        q_tile_size=q_tile_size,
+    )
+
+    # --- Branch 3: Sliding Window Attention ---
+    O_sld = _sliding_window_attention(
+        q, k, v, window_size, softmax_scale, causal, B, N, H, D,
+    )
+
+    # --- Gate and Combine ---
+    # All outputs are (B, H, N, D), transpose to (B, N, H, D)
+    O_cmp = O_cmp.transpose(1, 2)
+    O_slc = O_slc.transpose(1, 2)
+    O_sld = O_sld.transpose(1, 2)
+
+    if gate_proj_weight is not None:
+        # gate_proj_weight: (H, 3, D)
+        # Q: (B, N, H, D) -> compute per-head gates
+        gates = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        gates = gates.sigmoid()  # (B, N, H, 3)
+    else:
+        gates = torch.ones(B, N, H, 3, device=Q.device, dtype=torch.float32) / 3.0
+
+    O = (
+        gates[..., 0:1] * O_cmp
+        + gates[..., 1:2] * O_slc
+        + gates[..., 2:3] * O_sld
+    )
+
+    return O.to(Q.dtype)
+
+
+def _compressed_attention(
+    q: Tensor, k: Tensor, v: Tensor,
+    block_size: int,
+    W_k_compress: Tensor | None, W_v_compress: Tensor | None,
+    groups: int, softmax_scale: float, causal: bool,
+    B: int, N: int, H: int, H_kv: int, D: int,
+) -> Tensor:
+    """Compressed attention: attend over mean-pooled KV blocks."""
+    # Use un-expanded K, V for compression
+    k_orig = k[:, ::groups]  # (B, H_kv, N, D)
+    v_orig = v[:, ::groups]
+
+    N_cmp = N // block_size
+    # Reshape into blocks and mean-pool
+    k_blocks = k_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_cmp, D)
+    v_blocks = v_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    v_cmp = v_blocks.mean(dim=3)
+
+    # Apply learned projection if provided
+    if W_k_compress is not None:
+        # W_k_compress: (H_kv, D, D)
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if W_v_compress is not None:
+        v_cmp = torch.einsum("bhnd,hde->bhne", v_cmp, W_v_compress.float())
+
+    # Expand for GQA
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+        v_cmp = v_cmp.repeat_interleave(groups, dim=1)
+
+    # Standard attention on compressed KV: (B, H, N, D) x (B, H, N_cmp, D)
+    scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale  # (B, H, N, N_cmp)
+
+    if causal:
+        # A query at position i can attend to compressed block j if the block
+        # starts at or before position i: j * block_size <= i.
+        q_pos = torch.arange(N, device=q.device).unsqueeze(1)  # (N, 1)
+        kv_block_start = (torch.arange(N_cmp, device=q.device)) * block_size  # (N_cmp,)
+        causal_mask = kv_block_start.unsqueeze(0) > q_pos  # (N, N_cmp)
+        scores = scores.masked_fill(causal_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    attn = torch.softmax(scores, dim=-1)
+    out = torch.matmul(attn, v_cmp)  # (B, H, N, D)
+    return out
+
+
+def _selected_attention(
+    q: Tensor, k: Tensor, v: Tensor,
+    block_size: int, num_selected: int,
+    W_k_compress: Tensor | None,
+    groups: int, softmax_scale: float, causal: bool,
+    B: int, N: int, H: int, H_kv: int, D: int,
+    q_tile_size: int = 256,
+) -> Tensor:
+    """Selected block-sparse attention: attend to top-k important KV blocks.
+
+    Aggregates block scores per q_tile_size (matching FA4's CTA tile) and
+    selects blocks per query tile rather than per query block.
+    """
+    N_blocks = N // block_size
+    N_q_tiles = N // q_tile_size
+
+    # Score blocks using compressed keys
+    k_orig = k[:, ::groups]  # (B, H_kv, N, D)
+    k_blocks = k_orig.reshape(B, H_kv, N_blocks, block_size, D)
+    k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_blocks, D)
+    if W_k_compress is not None:
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+
+    # Compute block importance scores: (B, H, N, N_blocks)
+    block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+
+    # Aggregate per query-tile (mean over queries in the same tile)
+    block_scores_agg = block_scores.reshape(
+        B, H, N_q_tiles, q_tile_size, N_blocks
+    ).mean(dim=3)
+    # (B, H, N_q_tiles, N_blocks)
+
+    if causal:
+        # Match score_and_select_blocks: block j is future if
+        # j * block_size >= (tile_i + 1) * q_tile_size
+        q_tile_end = (torch.arange(N_q_tiles, device=q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_blocks, device=q.device) * block_size
+        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+        block_scores_agg = block_scores_agg.masked_fill(
+            future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+
+    # Select top-k blocks per query tile
+    k_actual = min(num_selected, N_blocks)
+    _, top_indices = block_scores_agg.topk(k_actual, dim=-1)  # (B, H, N_q_tiles, k)
+
+    # Build block-sparse attention output
+    out = torch.zeros(B, H, N, D, device=q.device, dtype=q.dtype)
+
+    for b in range(B):
+        for h in range(H):
+            for qt in range(N_q_tiles):
+                q_start = qt * q_tile_size
+                q_end = (qt + 1) * q_tile_size
+
+                # Gather selected KV blocks
+                selected_k_list = []
+                selected_v_list = []
+                for idx in top_indices[b, h, qt]:
+                    kv_start = idx.item() * block_size
+                    kv_end = kv_start + block_size
+                    selected_k_list.append(k[b, h, kv_start:kv_end])
+                    selected_v_list.append(v[b, h, kv_start:kv_end])
+
+                if not selected_k_list:
+                    continue
+
+                sel_k = torch.cat(selected_k_list, dim=0)  # (k*block_size, D)
+                sel_v = torch.cat(selected_v_list, dim=0)
+
+                # Compute attention for this query tile
+                q_tile = q[b, h, q_start:q_end]  # (q_tile_size, D)
+                scores = torch.matmul(q_tile, sel_k.T) * softmax_scale
+
+                if causal:
+                    q_positions = torch.arange(q_start, q_end, device=q.device).unsqueeze(1)
+                    kv_positions = []
+                    for idx in top_indices[b, h, qt]:
+                        kv_s = idx.item() * block_size
+                        kv_positions.append(
+                            torch.arange(kv_s, kv_s + block_size, device=q.device)
+                        )
+                    kv_positions = torch.cat(kv_positions)
+                    c_mask = kv_positions.unsqueeze(0) > q_positions
+                    scores = scores.masked_fill(c_mask, float("-inf"))
+
+                attn = torch.softmax(scores, dim=-1)
+                out[b, h, q_start:q_end] = torch.matmul(attn, sel_v)
+
+    return out
+
+
+def _sliding_window_attention(
+    q: Tensor, k: Tensor, v: Tensor,
+    window_size: int, softmax_scale: float, causal: bool,
+    B: int, N: int, H: int, D: int,
+) -> Tensor:
+    """Sliding window attention: each query attends to a local window of KV."""
+    scores = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale  # (B, H, N, N)
+
+    # Build sliding window + causal mask
+    q_pos = torch.arange(N, device=q.device).unsqueeze(1)
+    kv_pos = torch.arange(N, device=q.device).unsqueeze(0)
+
+    # Window mask: kv must be within [q_pos - window_size + 1, q_pos] (causal window)
+    # or [q_pos - window_size//2, q_pos + window_size//2] (non-causal)
+    if causal:
+        mask = (kv_pos > q_pos) | (kv_pos < q_pos - window_size + 1)
+    else:
+        half_w = window_size // 2
+        mask = (kv_pos > q_pos + half_w) | (kv_pos < q_pos - half_w)
+
+    scores = scores.masked_fill(mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    attn = torch.softmax(scores, dim=-1)
+    out = torch.matmul(attn, v)
+    return out

--- a/mslk/attention/sparse_attn/reference.py
+++ b/mslk/attention/sparse_attn/reference.py
@@ -5,6 +5,10 @@
 This serves as a correctness reference for the optimized FA4-based implementation.
 All operations are done in PyTorch without custom kernels.
 
+The forward pass is fully differentiable (all tensor ops, no Python loops that
+break autograd), so PyTorch autograd provides the reference backward pass.
+Use nsa_backward_reference() to compute gradients for validation.
+
 Reference: arxiv 2502.11089
 """
 
@@ -30,6 +34,7 @@ def nsa_forward_reference(
     causal: bool = True,
     softmax_scale: float | None = None,
     q_tile_size: int = 256,
+    _block_indices: Tensor | None = None,
 ) -> Tensor:
     """Pure PyTorch NSA forward pass.
 
@@ -52,9 +57,11 @@ def nsa_forward_reference(
         softmax_scale = 1.0 / math.sqrt(D)
 
     # Transpose to (B, H, N, D) for matmul convenience
-    q = Q.transpose(1, 2).float()  # (B, H, N, D)
-    k = K.transpose(1, 2).float()  # (B, H_kv, N, D)
-    v = V.transpose(1, 2).float()  # (B, H_kv, N, D)
+    # Use at least float32 for numerical stability, but preserve float64 for gradcheck
+    compute_dtype = torch.float64 if Q.dtype == torch.float64 else torch.float32
+    q = Q.transpose(1, 2).to(compute_dtype)  # (B, H, N, D)
+    k = K.transpose(1, 2).to(compute_dtype)  # (B, H_kv, N, D)
+    v = V.transpose(1, 2).to(compute_dtype)  # (B, H_kv, N, D)
 
     # Expand K, V for GQA: (B, H_kv, N, D) -> (B, H, N, D)
     if groups > 1:
@@ -63,20 +70,54 @@ def nsa_forward_reference(
 
     # --- Branch 1: Compressed Attention ---
     O_cmp = _compressed_attention(
-        q, k, v, compress_block_size, W_k_compress, W_v_compress,
-        groups, softmax_scale, causal, B, N, H, H_kv, D,
+        q,
+        k,
+        v,
+        compress_block_size,
+        W_k_compress,
+        W_v_compress,
+        groups,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        H_kv,
+        D,
     )
 
     # --- Branch 2: Selected (Block-Sparse) Attention ---
     O_slc = _selected_attention(
-        q, k, v, compress_block_size, num_selected_blocks,
-        W_k_compress, groups, softmax_scale, causal, B, N, H, H_kv, D,
+        q,
+        k,
+        v,
+        compress_block_size,
+        num_selected_blocks,
+        W_k_compress,
+        groups,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        H_kv,
+        D,
         q_tile_size=q_tile_size,
+        _block_indices=_block_indices,
     )
 
     # --- Branch 3: Sliding Window Attention ---
     O_sld = _sliding_window_attention(
-        q, k, v, window_size, softmax_scale, causal, B, N, H, D,
+        q,
+        k,
+        v,
+        window_size,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        D,
     )
 
     # --- Gate and Combine ---
@@ -88,26 +129,33 @@ def nsa_forward_reference(
     if gate_proj_weight is not None:
         # gate_proj_weight: (H, 3, D)
         # Q: (B, N, H, D) -> compute per-head gates
-        gates = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        gates = torch.einsum(
+            "bnhd,hgd->bnhg", Q.to(compute_dtype), gate_proj_weight.to(compute_dtype)
+        )
         gates = gates.sigmoid()  # (B, N, H, 3)
     else:
-        gates = torch.ones(B, N, H, 3, device=Q.device, dtype=torch.float32) / 3.0
+        gates = torch.ones(B, N, H, 3, device=Q.device, dtype=compute_dtype) / 3.0
 
-    O = (
-        gates[..., 0:1] * O_cmp
-        + gates[..., 1:2] * O_slc
-        + gates[..., 2:3] * O_sld
-    )
+    O = gates[..., 0:1] * O_cmp + gates[..., 1:2] * O_slc + gates[..., 2:3] * O_sld
 
     return O.to(Q.dtype)
 
 
 def _compressed_attention(
-    q: Tensor, k: Tensor, v: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
     block_size: int,
-    W_k_compress: Tensor | None, W_v_compress: Tensor | None,
-    groups: int, softmax_scale: float, causal: bool,
-    B: int, N: int, H: int, H_kv: int, D: int,
+    W_k_compress: Tensor | None,
+    W_v_compress: Tensor | None,
+    groups: int,
+    softmax_scale: float,
+    causal: bool,
+    B: int,
+    N: int,
+    H: int,
+    H_kv: int,
+    D: int,
 ) -> Tensor:
     """Compressed attention: attend over mean-pooled KV blocks."""
     # Use un-expanded K, V for compression
@@ -124,9 +172,9 @@ def _compressed_attention(
     # Apply learned projection if provided
     if W_k_compress is not None:
         # W_k_compress: (H_kv, D, D)
-        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.to(k_cmp.dtype))
     if W_v_compress is not None:
-        v_cmp = torch.einsum("bhnd,hde->bhne", v_cmp, W_v_compress.float())
+        v_cmp = torch.einsum("bhnd,hde->bhne", v_cmp, W_v_compress.to(v_cmp.dtype))
 
     # Expand for GQA
     if groups > 1:
@@ -134,7 +182,9 @@ def _compressed_attention(
         v_cmp = v_cmp.repeat_interleave(groups, dim=1)
 
     # Standard attention on compressed KV: (B, H, N, D) x (B, H, N_cmp, D)
-    scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale  # (B, H, N, N_cmp)
+    scores = (
+        torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+    )  # (B, H, N, N_cmp)
 
     if causal:
         # A query at position i can attend to compressed block j if the block
@@ -142,7 +192,9 @@ def _compressed_attention(
         q_pos = torch.arange(N, device=q.device).unsqueeze(1)  # (N, 1)
         kv_block_start = (torch.arange(N_cmp, device=q.device)) * block_size  # (N_cmp,)
         causal_mask = kv_block_start.unsqueeze(0) > q_pos  # (N, N_cmp)
-        scores = scores.masked_fill(causal_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+        scores = scores.masked_fill(
+            causal_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
 
     attn = torch.softmax(scores, dim=-1)
     out = torch.matmul(attn, v_cmp)  # (B, H, N, D)
@@ -150,103 +202,128 @@ def _compressed_attention(
 
 
 def _selected_attention(
-    q: Tensor, k: Tensor, v: Tensor,
-    block_size: int, num_selected: int,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    block_size: int,
+    num_selected: int,
     W_k_compress: Tensor | None,
-    groups: int, softmax_scale: float, causal: bool,
-    B: int, N: int, H: int, H_kv: int, D: int,
+    groups: int,
+    softmax_scale: float,
+    causal: bool,
+    B: int,
+    N: int,
+    H: int,
+    H_kv: int,
+    D: int,
     q_tile_size: int = 256,
+    _block_indices: Tensor | None = None,
 ) -> Tensor:
     """Selected block-sparse attention: attend to top-k important KV blocks.
 
     Aggregates block scores per q_tile_size (matching FA4's CTA tile) and
     selects blocks per query tile rather than per query block.
+
+    All operations use tensor ops (no Python loops) so autograd can
+    differentiate through this function w.r.t. q, k, v.  The top-k block
+    indices are non-differentiable (stop-gradient) by design.
+
+    Args:
+        _block_indices: If provided, use these pre-computed block indices
+            instead of computing them from scores. Shape (B, H, N_q_tiles, k).
+            Useful for freezing selection during gradcheck.
     """
     N_blocks = N // block_size
     N_q_tiles = N // q_tile_size
+    k_actual = min(num_selected, N_blocks)
 
-    # Score blocks using compressed keys
-    k_orig = k[:, ::groups]  # (B, H_kv, N, D)
-    k_blocks = k_orig.reshape(B, H_kv, N_blocks, block_size, D)
-    k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_blocks, D)
-    if W_k_compress is not None:
-        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
-    if groups > 1:
-        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+    if _block_indices is not None:
+        top_indices = _block_indices
+    else:
+        # Score blocks using compressed keys
+        k_orig = k[:, ::groups]  # (B, H_kv, N, D)
+        k_blocks = k_orig.reshape(B, H_kv, N_blocks, block_size, D)
+        k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_blocks, D)
+        if W_k_compress is not None:
+            k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.to(k_cmp.dtype))
+        if groups > 1:
+            k_cmp = k_cmp.repeat_interleave(groups, dim=1)
 
-    # Compute block importance scores: (B, H, N, N_blocks)
-    block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+        # Compute block importance scores: (B, H, N, N_blocks)
+        block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
 
-    # Aggregate per query-tile (mean over queries in the same tile)
-    block_scores_agg = block_scores.reshape(
-        B, H, N_q_tiles, q_tile_size, N_blocks
-    ).mean(dim=3)
-    # (B, H, N_q_tiles, N_blocks)
+        # Aggregate per query-tile (mean over queries in the same tile)
+        block_scores_agg = block_scores.reshape(
+            B, H, N_q_tiles, q_tile_size, N_blocks
+        ).mean(dim=3)
+        # (B, H, N_q_tiles, N_blocks)
+
+        if causal:
+            # Match score_and_select_blocks: block j is future if
+            # j * block_size >= (tile_i + 1) * q_tile_size
+            q_tile_end = (torch.arange(N_q_tiles, device=q.device) + 1) * q_tile_size
+            kv_block_start = torch.arange(N_blocks, device=q.device) * block_size
+            future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+            block_scores_agg = block_scores_agg.masked_fill(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        # Select top-k blocks per query tile (non-differentiable, stop-gradient)
+        _, top_indices = block_scores_agg.topk(k_actual, dim=-1)  # (B, H, N_q_tiles, k)
+
+    # Expand block indices to position-level indices for gather
+    # Each block index i maps to positions [i*block_size, ..., (i+1)*block_size - 1]
+    offsets = torch.arange(block_size, device=q.device)  # (block_size,)
+    # (B, H, N_q_tiles, k, block_size)
+    pos_indices = top_indices.unsqueeze(-1) * block_size + offsets
+    kv_len = k_actual * block_size
+    pos_indices = pos_indices.reshape(B, H, N_q_tiles, kv_len)
+
+    # Gather K and V at selected positions using differentiable gather
+    # k, v: (B, H, N, D) -> gather along N dimension per query tile
+    gather_idx = pos_indices.unsqueeze(-1).expand(
+        B, H, N_q_tiles, kv_len, D
+    )  # (B, H, N_q_tiles, kv_len, D)
+    k_exp = k.unsqueeze(2).expand(B, H, N_q_tiles, N, D)
+    v_exp = v.unsqueeze(2).expand(B, H, N_q_tiles, N, D)
+    sel_k = torch.gather(k_exp, 3, gather_idx)  # (B, H, N_q_tiles, kv_len, D)
+    sel_v = torch.gather(v_exp, 3, gather_idx)
+
+    # Reshape q into tiles and compute attention
+    q_tiles = q.reshape(B, H, N_q_tiles, q_tile_size, D)
+    scores = (
+        torch.matmul(q_tiles, sel_k.transpose(-2, -1)) * softmax_scale
+    )  # (B, H, N_q_tiles, q_tile_size, kv_len)
 
     if causal:
-        # Match score_and_select_blocks: block j is future if
-        # j * block_size >= (tile_i + 1) * q_tile_size
-        q_tile_end = (torch.arange(N_q_tiles, device=q.device) + 1) * q_tile_size
-        kv_block_start = torch.arange(N_blocks, device=q.device) * block_size
-        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
-        block_scores_agg = block_scores_agg.masked_fill(
-            future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        # q positions per tile: (N_q_tiles, q_tile_size)
+        q_tile_starts = torch.arange(N_q_tiles, device=q.device) * q_tile_size
+        q_offsets = torch.arange(q_tile_size, device=q.device)
+        q_positions = q_tile_starts.unsqueeze(1) + q_offsets.unsqueeze(0)
+        # causal mask: kv_pos > q_pos
+        # pos_indices: (B, H, N_q_tiles, kv_len) -> (B, H, N_q_tiles, 1, kv_len)
+        # q_positions: (N_q_tiles, q_tile_size) -> (1, 1, N_q_tiles, q_tile_size, 1)
+        c_mask = pos_indices.unsqueeze(3) > q_positions.reshape(
+            1, 1, N_q_tiles, q_tile_size, 1
         )
+        scores = scores.masked_fill(c_mask, float("-inf"))
 
-    # Select top-k blocks per query tile
-    k_actual = min(num_selected, N_blocks)
-    _, top_indices = block_scores_agg.topk(k_actual, dim=-1)  # (B, H, N_q_tiles, k)
-
-    # Build block-sparse attention output
-    out = torch.zeros(B, H, N, D, device=q.device, dtype=q.dtype)
-
-    for b in range(B):
-        for h in range(H):
-            for qt in range(N_q_tiles):
-                q_start = qt * q_tile_size
-                q_end = (qt + 1) * q_tile_size
-
-                # Gather selected KV blocks
-                selected_k_list = []
-                selected_v_list = []
-                for idx in top_indices[b, h, qt]:
-                    kv_start = idx.item() * block_size
-                    kv_end = kv_start + block_size
-                    selected_k_list.append(k[b, h, kv_start:kv_end])
-                    selected_v_list.append(v[b, h, kv_start:kv_end])
-
-                if not selected_k_list:
-                    continue
-
-                sel_k = torch.cat(selected_k_list, dim=0)  # (k*block_size, D)
-                sel_v = torch.cat(selected_v_list, dim=0)
-
-                # Compute attention for this query tile
-                q_tile = q[b, h, q_start:q_end]  # (q_tile_size, D)
-                scores = torch.matmul(q_tile, sel_k.T) * softmax_scale
-
-                if causal:
-                    q_positions = torch.arange(q_start, q_end, device=q.device).unsqueeze(1)
-                    kv_positions = []
-                    for idx in top_indices[b, h, qt]:
-                        kv_s = idx.item() * block_size
-                        kv_positions.append(
-                            torch.arange(kv_s, kv_s + block_size, device=q.device)
-                        )
-                    kv_positions = torch.cat(kv_positions)
-                    c_mask = kv_positions.unsqueeze(0) > q_positions
-                    scores = scores.masked_fill(c_mask, float("-inf"))
-
-                attn = torch.softmax(scores, dim=-1)
-                out[b, h, q_start:q_end] = torch.matmul(attn, sel_v)
-
-    return out
+    attn = torch.softmax(scores, dim=-1)
+    out_tiles = torch.matmul(attn, sel_v)  # (B, H, N_q_tiles, q_tile_size, D)
+    return out_tiles.reshape(B, H, N, D)
 
 
 def _sliding_window_attention(
-    q: Tensor, k: Tensor, v: Tensor,
-    window_size: int, softmax_scale: float, causal: bool,
-    B: int, N: int, H: int, D: int,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    window_size: int,
+    softmax_scale: float,
+    causal: bool,
+    B: int,
+    N: int,
+    H: int,
+    D: int,
 ) -> Tensor:
     """Sliding window attention: each query attends to a local window of KV."""
     scores = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale  # (B, H, N, N)
@@ -267,3 +344,162 @@ def _sliding_window_attention(
     attn = torch.softmax(scores, dim=-1)
     out = torch.matmul(attn, v)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Reference backward (via autograd on the differentiable forward)
+# ---------------------------------------------------------------------------
+
+
+def compute_block_indices_reference(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    W_k_compress: Tensor | None = None,
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+) -> Tensor:
+    """Pre-compute block selection indices (non-differentiable).
+
+    Returns block indices that can be passed to nsa_forward_reference via
+    _block_indices to freeze the selection during gradient computation.
+
+    Returns:
+        top_indices: (B, H, N_q_tiles, k) int64 tensor of selected block indices.
+    """
+    B, N, H, D = Q.shape
+    H_kv = K.shape[2]
+    groups = H // H_kv
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    q = Q.transpose(1, 2).float()  # (B, H, N, D)
+    k = K.transpose(1, 2).float()  # (B, H_kv, N, D)
+
+    N_blocks = N // compress_block_size
+    N_q_tiles = N // q_tile_size
+
+    # K already has H_kv heads — no need to slice with ::groups
+    k_blocks = k.reshape(B, H_kv, N_blocks, compress_block_size, D)
+    k_cmp = k_blocks.mean(dim=3)
+    if W_k_compress is not None:
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+
+    block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+    block_scores_agg = block_scores.reshape(
+        B, H, N_q_tiles, q_tile_size, N_blocks
+    ).mean(dim=3)
+
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_blocks, device=Q.device) * compress_block_size
+        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+        block_scores_agg = block_scores_agg.masked_fill(
+            future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+
+    k_actual = min(num_selected_blocks, N_blocks)
+    _, top_indices = block_scores_agg.topk(k_actual, dim=-1)
+    return top_indices
+
+
+def nsa_backward_reference(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    dO: Tensor,  # (B, N, H, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    _block_indices: Tensor | None = None,
+) -> dict[str, Tensor | None]:
+    """Compute NSA gradients using autograd on the differentiable reference forward.
+
+    Runs nsa_forward_reference with requires_grad=True inputs, then calls
+    torch.autograd.grad to compute dQ, dK, dV, and optionally dW_k_compress,
+    dW_v_compress, dgate_proj_weight.
+
+    Args:
+        Q, K, V: Input tensors (same as nsa_forward_reference).
+        dO: Upstream gradient, shape (B, N, H, D).
+        Other args: Same as nsa_forward_reference.
+
+    Returns:
+        Dictionary with keys: "dQ", "dK", "dV", "dW_k_compress",
+        "dW_v_compress", "dgate_proj_weight".  Values are None for
+        parameters that were not provided.
+    """
+    # Clone inputs and enable gradients
+    Q_g = Q.detach().float().requires_grad_(True)
+    K_g = K.detach().float().requires_grad_(True)
+    V_g = V.detach().float().requires_grad_(True)
+
+    params = []
+    W_k_g = None
+    if W_k_compress is not None:
+        W_k_g = W_k_compress.detach().float().requires_grad_(True)
+        params.append(W_k_g)
+    W_v_g = None
+    if W_v_compress is not None:
+        W_v_g = W_v_compress.detach().float().requires_grad_(True)
+        params.append(W_v_g)
+    gate_g = None
+    if gate_proj_weight is not None:
+        gate_g = gate_proj_weight.detach().float().requires_grad_(True)
+        params.append(gate_g)
+
+    O = nsa_forward_reference(
+        Q_g,
+        K_g,
+        V_g,
+        compress_block_size=compress_block_size,
+        num_selected_blocks=num_selected_blocks,
+        window_size=window_size,
+        W_k_compress=W_k_g,
+        W_v_compress=W_v_g,
+        gate_proj_weight=gate_g,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        q_tile_size=q_tile_size,
+        _block_indices=_block_indices,
+    )
+
+    grad_inputs = [Q_g, K_g, V_g] + params
+    grads = torch.autograd.grad(
+        O,
+        grad_inputs,
+        grad_outputs=dO.float(),
+        allow_unused=True,
+    )
+
+    result: dict[str, Tensor | None] = {
+        "dQ": grads[0].to(Q.dtype),
+        "dK": grads[1].to(K.dtype),
+        "dV": grads[2].to(V.dtype),
+        "dW_k_compress": None,
+        "dW_v_compress": None,
+        "dgate_proj_weight": None,
+    }
+
+    idx = 3
+    if W_k_compress is not None:
+        result["dW_k_compress"] = grads[idx].to(W_k_compress.dtype)
+        idx += 1
+    if W_v_compress is not None:
+        result["dW_v_compress"] = grads[idx].to(W_v_compress.dtype)
+        idx += 1
+    if gate_proj_weight is not None:
+        result["dgate_proj_weight"] = grads[idx].to(gate_proj_weight.dtype)
+
+    return result

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import math
+from typing import Type
 
 import torch
 from torch import Tensor
@@ -86,21 +87,19 @@ def score_and_select_blocks(
         q_end = chunk_end * q_tile_size
 
         # (B, H, n_tiles * q_tile_size, N_cmp) — bounded, not O(N²)
-        scores_chunk = torch.matmul(
-            Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t
-        ) * softmax_scale
+        scores_chunk = (
+            torch.matmul(Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t)
+            * softmax_scale
+        )
 
         # Average per tile: (B, H, n_tiles, N_cmp)
-        scores_agg = scores_chunk.reshape(
-            B, H, n_tiles, q_tile_size, N_cmp
-        ).mean(dim=3)
+        scores_agg = scores_chunk.reshape(B, H, n_tiles, q_tile_size, N_cmp).mean(dim=3)
 
         # Apply causal mask: block j is future if j * block_size >= (i+1) * q_tile_size
         if causal:
-            future_mask = (
-                kv_block_start.unsqueeze(0)
-                >= q_tile_end[chunk_start:chunk_end].unsqueeze(1)
-            )  # (n_tiles, N_cmp)
+            future_mask = kv_block_start.unsqueeze(0) >= q_tile_end[
+                chunk_start:chunk_end
+            ].unsqueeze(1)  # (n_tiles, N_cmp)
             scores_agg.masked_fill_(
                 future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
             )
@@ -114,8 +113,431 @@ def score_and_select_blocks(
             chunk_idx = chunk_idx.masked_fill(invalid, 0)
 
         # Sort indices for better memory access patterns
-        block_indices[:, :, chunk_start:chunk_end] = (
-            chunk_idx.sort(dim=-1).values.to(torch.int32)
+        block_indices[:, :, chunk_start:chunk_end] = chunk_idx.sort(dim=-1).values.to(
+            torch.int32
         )
 
+    return block_indices
+
+
+# ---------------------------------------------------------------------------
+# CuteDSL fused scoring + top-k selection kernel
+# ---------------------------------------------------------------------------
+
+_fused_select_compile_cache: dict = {}
+
+# Bucket sizes for max_n_per_thread to limit compilations
+_N_PER_THREAD_BUCKETS = [4, 8, 16, 32, 64, 128]
+
+
+def _bucket_n_per_thread(n: int) -> int:
+    """Round up n to the next bucket size."""
+    for b in _N_PER_THREAD_BUCKETS:
+        if n <= b:
+            return b
+    return _N_PER_THREAD_BUCKETS[-1]
+
+
+def _make_fused_select_kernel(
+    cute_dtype: Type, D: int, k: int, max_n_per_thread: int, causal: bool
+):
+    """Create a compiled CuteDSL kernel for fused scoring + top-k selection.
+
+    Each thread block handles one (batch, head, query_tile) triple.
+    128 threads (4 warps) per block:
+      Phase 1: Each thread scores ceil(N_cmp/128) KV blocks via dot product.
+      Phase 2: parallel_topk finds the global top-k across all threads.
+      Phase 3: Thread 0 replaces -inf entries with 0, sorts ascending, writes.
+
+    The topk logic is inlined directly in the kernel to avoid CuteDSL
+    preprocessor issues with 'break' inside range_constexpr in helper
+    functions.
+    """
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass import const_expr, Float32, Int32
+
+    THREADS_PER_BLOCK = 128
+
+    class _Kernel:
+        @cute.jit
+        def __call__(
+            self,
+            mQ_mean,
+            mK_cmp,
+            mOut,
+            N_cmp,
+            N_q_tiles,
+            H,
+            H_kv,
+            compress_block_size,
+            q_tile_size,
+            stream,
+        ):
+            B_val = mQ_mean.shape[0] // (N_q_tiles * H)
+            grid_x = B_val * H * N_q_tiles
+            self.kernel(
+                mQ_mean,
+                mK_cmp,
+                mOut,
+                N_cmp,
+                N_q_tiles,
+                H,
+                H_kv,
+                compress_block_size,
+                q_tile_size,
+                B_val,
+            ).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                smem=const_expr(4 * k * 4 + 16 + 4 * k * 4 + 16),
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(
+            self,
+            mQ_mean,
+            mK_cmp,
+            mOut,
+            N_cmp,
+            N_q_tiles,
+            H,
+            H_kv,
+            compress_block_size,
+            q_tile_size,
+            B_val,
+        ):
+            tidx = cute.arch.thread_idx()[0]
+            bidx = cute.arch.block_idx()[0]
+
+            # Decompose block index into (b, h, tile)
+            b = bidx // (H * N_q_tiles)
+            h = (bidx % (H * N_q_tiles)) // N_q_tiles
+            tile = bidx % N_q_tiles
+
+            # GQA: map query head to KV head
+            h_kv = h // (H // H_kv)
+
+            # Q_mean row index: b * N_q_tiles * H + tile * H + h
+            q_row = b * N_q_tiles * H + tile * H + h
+
+            # --- Phase 1: Score blocks ---
+            n_per_thread = (N_cmp + Int32(THREADS_PER_BLOCK - 1)) // Int32(
+                THREADS_PER_BLOCK
+            )
+            scores = cute.make_fragment(max_n_per_thread, Float32)
+            scores.fill(-Float32.inf)
+
+            # Causal: block j is future if
+            # j * compress_block_size >= (tile+1) * q_tile_size
+            if const_expr(causal):
+                causal_limit = (tile + 1) * q_tile_size
+
+            for i in cutlass.range(n_per_thread, unroll=1):
+                j = tidx * n_per_thread + i
+                if j < N_cmp:
+                    # Causal check
+                    skip = Int32(0)
+                    if const_expr(causal):
+                        if j * compress_block_size >= causal_limit:
+                            skip = Int32(1)
+
+                    if skip == 0:
+                        # Dot product: sum_d Q_mean[q_row, d] * K_cmp[k_row, d]
+                        k_row = b * N_cmp * H_kv + j * H_kv + h_kv
+                        acc = Float32(0.0)
+                        for d in cutlass.range_constexpr(D):
+                            acc += Float32(mQ_mean[q_row, d]) * Float32(
+                                mK_cmp[k_row, d]
+                            )
+                        scores[i] = acc
+
+            # --- Phase 2: TopK ---
+            @cute.struct
+            class TopkSmem:
+                vals: cute.struct.MemRange[Float32, const_expr(4 * k)]
+                idxs: cute.struct.MemRange[Int32, const_expr(4 * k)]
+
+            smem = cutlass.utils.SmemAllocator()
+            storage = smem.allocate(TopkSmem, 16)
+            smem_vals = storage.vals.get_tensor(cute.make_layout(const_expr(4 * k)))
+            smem_idxs = storage.idxs.get_tensor(cute.make_layout(const_expr(4 * k)))
+
+            # Step 2a: Per-thread insertion sort
+            # Maintains top_vals in descending order (largest at index 0).
+            # For each score, scan from bottom (k-1) to top (0). At each
+            # position where val > top_vals[jj], shift top_vals[jj] down
+            # and write val. Without break, val cascades up to its correct
+            # position — earlier writes are overwritten by later shifts.
+            top_vals = cute.make_fragment(k, Float32)
+            top_idxs = cute.make_fragment(k, Int32)
+            top_vals.fill(-Float32.inf)
+            top_idxs.fill(Int32(0))
+
+            for ii in cutlass.range(n_per_thread, unroll=1):
+                val = scores[ii]
+                idx = Int32(ii)
+                for jj in cutlass.range_constexpr(k - 1, -1, -1):
+                    if val > top_vals[jj]:
+                        if const_expr(jj < k - 1):
+                            top_vals[jj + 1] = top_vals[jj]
+                            top_idxs[jj + 1] = top_idxs[jj]
+                        top_vals[jj] = val
+                        top_idxs[jj] = idx
+
+            # Step 2b: Convert local indices to global
+            lane_id = tidx % 32
+            warp_id = tidx // 32
+            for ii in cutlass.range_constexpr(k):
+                top_idxs[ii] = lane_id * n_per_thread + top_idxs[ii]
+
+            # Step 2c: Warp butterfly merge (5 rounds)
+            for round_idx in cutlass.range_constexpr(5):
+                distance: int = const_expr(1 << round_idx)
+                p_vals = cute.make_fragment(k, Float32)
+                p_idxs = cute.make_fragment(k, Int32)
+                for ii in cutlass.range_constexpr(k):
+                    p_vals[ii] = cute.arch.shuffle_sync_bfly(
+                        top_vals[ii], offset=distance
+                    )
+                    p_idxs[ii] = cute.arch.shuffle_sync_bfly(
+                        top_idxs[ii], offset=distance
+                    )
+                if (lane_id & distance) == 0:
+                    # Merge top_vals/idxs with p_vals/p_idxs
+                    m_vals = cute.make_fragment(k, Float32)
+                    m_idxs = cute.make_fragment(k, Int32)
+                    ia = Int32(0)
+                    ib = Int32(0)
+                    for oi in cutlass.range_constexpr(k):
+                        take_a = (ia < k) & ((ib >= k) | (top_vals[ia] >= p_vals[ib]))
+                        if take_a:
+                            m_vals[oi] = top_vals[ia]
+                            m_idxs[oi] = top_idxs[ia]
+                            ia += 1
+                        else:
+                            m_vals[oi] = p_vals[ib]
+                            m_idxs[oi] = p_idxs[ib]
+                            ib += 1
+                    for ii in cutlass.range_constexpr(k):
+                        top_vals[ii] = m_vals[ii]
+                        top_idxs[ii] = m_idxs[ii]
+
+            # Step 2d: Cross-warp merge via shared memory
+            n_per_warp = n_per_thread * 32
+
+            if lane_id == 0:
+                for ii in cutlass.range_constexpr(k):
+                    smem_vals[warp_id * k + ii] = top_vals[ii]
+                    smem_idxs[warp_id * k + ii] = top_idxs[ii] + warp_id * n_per_warp
+
+            cute.arch.sync_threads()
+
+            if tidx == 0:
+                # Start with warp 0's data (already in top_vals/top_idxs)
+                for w in cutlass.range_constexpr(1, 4):
+                    o_vals = cute.make_fragment(k, Float32)
+                    o_idxs = cute.make_fragment(k, Int32)
+                    for ii in cutlass.range_constexpr(k):
+                        o_vals[ii] = smem_vals[w * k + ii]
+                        o_idxs[ii] = smem_idxs[w * k + ii]
+                    # Merge
+                    m_vals = cute.make_fragment(k, Float32)
+                    m_idxs = cute.make_fragment(k, Int32)
+                    ia = Int32(0)
+                    ib = Int32(0)
+                    for oi in cutlass.range_constexpr(k):
+                        take_a = (ia < k) & ((ib >= k) | (top_vals[ia] >= o_vals[ib]))
+                        if take_a:
+                            m_vals[oi] = top_vals[ia]
+                            m_idxs[oi] = top_idxs[ia]
+                            ia += 1
+                        else:
+                            m_vals[oi] = o_vals[ib]
+                            m_idxs[oi] = o_idxs[ib]
+                            ib += 1
+                    for ii in cutlass.range_constexpr(k):
+                        top_vals[ii] = m_vals[ii]
+                        top_idxs[ii] = m_idxs[ii]
+
+                # Write merged result to smem for broadcast
+                for ii in cutlass.range_constexpr(k):
+                    smem_vals[ii] = top_vals[ii]
+                    smem_idxs[ii] = top_idxs[ii]
+
+            cute.arch.sync_threads()
+
+            # All threads read final result
+            result_idxs = cute.make_fragment(k, Int32)
+            for ii in cutlass.range_constexpr(k):
+                result_idxs[ii] = smem_idxs[ii]
+
+            # --- Phase 3: Sort + write (thread 0) ---
+            if tidx == 0:
+                # Replace -inf-scored entries with index 0
+                for ii in cutlass.range_constexpr(k):
+                    if smem_vals[ii] == -Float32.inf:
+                        result_idxs[ii] = Int32(0)
+
+                # Insertion sort indices ascending
+                for ii in cutlass.range_constexpr(1, k):
+                    key = result_idxs[ii]
+                    insert_pos = Int32(ii)
+                    for j_scan in cutlass.range_constexpr(ii):
+                        pos: int = const_expr(ii - 1 - j_scan)
+                        if insert_pos == const_expr(pos + 1):
+                            if result_idxs[pos] > key:
+                                result_idxs[pos + 1] = result_idxs[pos]
+                                insert_pos = Int32(pos)
+                    result_idxs[insert_pos] = key
+
+                # Write output
+                out_row = b * H * N_q_tiles + h * N_q_tiles + tile
+                for ii in cutlass.range_constexpr(k):
+                    mOut[out_row, ii] = result_idxs[ii]
+
+    return _Kernel()
+
+
+def fused_score_and_select_blocks(
+    Q: Tensor,  # (B, N, H, D)
+    K_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    num_selected_blocks: int,
+    compress_block_size: int,
+    causal: bool = True,
+    q_tile_size: int = 256,
+    softmax_scale: float | None = None,
+) -> Tensor:
+    """Fused block scoring and top-k selection using a CuteDSL kernel.
+
+    Replaces score_and_select_blocks with a single kernel launch. Uses the
+    Q_mean optimization: mean(Q @ K) = mean(Q) @ K, reducing scoring from a
+    full GEMM to a GEMV per query tile (256x fewer FLOPs).
+
+    The Q_mean computation is done in PyTorch (single kernel), then the
+    CuteDSL kernel fuses dot products, causal masking, top-k selection, and
+    sorting into one launch.
+
+    Falls back to PyTorch reference for N_cmp > 128 * 128 = 16384 blocks.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K_cmp: Compressed key tensor, shape (B, N_cmp, H_kv, D).
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        compress_block_size: Size of each KV block.
+        causal: Whether to apply causal masking.
+        q_tile_size: Size of each query tile.
+        softmax_scale: Scaling factor for attention scores.
+
+    Returns:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H, D = Q.shape
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+
+    N_q_tiles = N // q_tile_size
+    assert N % q_tile_size == 0, (
+        f"Sequence length {N} must be divisible by q_tile_size {q_tile_size}"
+    )
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    k_actual = min(num_selected_blocks, N_cmp)
+
+    THREADS = 128
+    raw_n_per_thread = (N_cmp + THREADS - 1) // THREADS
+    max_n_per_thread = _bucket_n_per_thread(raw_n_per_thread)
+
+    # Fall back to PyTorch reference for very large N_cmp
+    if max_n_per_thread > _N_PER_THREAD_BUCKETS[-1]:
+        return score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected_blocks,
+            compress_block_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+            softmax_scale=softmax_scale,
+        )
+
+    # --- Q_mean in PyTorch ---
+    # Q: (B, N, H, D) -> (B, N_q_tiles, q_tile_size, H, D) -> mean over q_tile_size
+    Q_mean = (
+        Q.reshape(B, N_q_tiles, q_tile_size, H, D)
+        .mean(dim=2)  # (B, N_q_tiles, H, D)
+        .float()
+        * softmax_scale
+    )
+
+    # Reshape Q_mean to 2D: row (b, tile, h) -> b * N_q_tiles * H + tile * H + h
+    Q_mean_2d = Q_mean.reshape(B * N_q_tiles * H, D).contiguous()
+
+    # Reshape K_cmp to 2D: row (b, j, h_kv) -> b * N_cmp * H_kv + j * H_kv + h_kv
+    K_cmp_2d = K_cmp.reshape(B * N_cmp * H_kv, D).contiguous().float()
+
+    # Output: (B * H * N_q_tiles, k_actual) int32
+    out_2d = torch.empty(
+        B * H * N_q_tiles, k_actual, dtype=torch.int32, device=Q.device
+    )
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[Q_mean_2d.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mQ_mean = to_cute(Q_mean_2d)
+    mK_cmp = to_cute(K_cmp_2d)
+    mOut = to_cute(out_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, k_actual, max_n_per_thread, causal)
+    if compile_key not in _fused_select_compile_cache:
+        kernel_op = _make_fused_select_kernel(
+            cute_dtype, D, k_actual, max_n_per_thread, causal
+        )
+        _fused_select_compile_cache[compile_key] = cute.compile(
+            kernel_op,
+            mQ_mean,
+            mK_cmp,
+            mOut,
+            N_cmp,
+            N_q_tiles,
+            H,
+            H_kv,
+            compress_block_size,
+            q_tile_size,
+            current_stream,
+        )
+
+    _fused_select_compile_cache[compile_key](
+        mQ_mean,
+        mK_cmp,
+        mOut,
+        N_cmp,
+        N_q_tiles,
+        H,
+        H_kv,
+        compress_block_size,
+        q_tile_size,
+        current_stream,
+    )
+
+    # Reshape output: (B * H * N_q_tiles, k) -> (B, H, N_q_tiles, k)
+    block_indices = out_2d.reshape(B, H, N_q_tiles, k_actual)
     return block_indices

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -127,7 +127,7 @@ def score_and_select_blocks(
 _fused_select_compile_cache: dict = {}
 
 # Bucket sizes for max_n_per_thread to limit compilations
-_N_PER_THREAD_BUCKETS = [4, 8, 16, 32, 64, 128]
+_N_PER_THREAD_BUCKETS = [4, 8, 16, 32, 64, 128, 256, 512]
 
 
 def _bucket_n_per_thread(n: int) -> int:
@@ -135,7 +135,7 @@ def _bucket_n_per_thread(n: int) -> int:
     for b in _N_PER_THREAD_BUCKETS:
         if n <= b:
             return b
-    return _N_PER_THREAD_BUCKETS[-1]
+    return n
 
 
 def _make_fused_select_kernel(

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -1,0 +1,121 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Block scoring and top-k selection for NSA."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def score_and_select_blocks(
+    Q: Tensor,  # (B, N, H, D)
+    K_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    num_selected_blocks: int,
+    compress_block_size: int,
+    causal: bool = True,
+    q_tile_size: int = 256,
+    softmax_scale: float | None = None,
+) -> Tensor:
+    """Score KV blocks by importance and select top-k for each query tile.
+
+    Uses compressed keys to efficiently compute block importance scores.
+    Each query tile (q_tile_size positions) independently selects its own
+    top-k KV blocks.
+
+    Processes query tiles in chunks to avoid materializing a full (B, H, N, N_cmp)
+    score tensor, reducing peak memory from O(N * N_cmp) to
+    O(chunk_tiles * q_tile_size * N_cmp).
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K_cmp: Compressed key tensor, shape (B, N_cmp, H_kv, D).
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        compress_block_size: Size of each KV block.
+        causal: Whether to apply causal masking (prevent selecting future blocks).
+        q_tile_size: Size of each query tile (should match FA4's CTA tile: 2 * m_block_size = 256).
+        softmax_scale: Scaling factor for attention scores.
+
+    Returns:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+            Each entry is an index into the compressed KV sequence.
+    """
+    B, N, H, D = Q.shape
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+    groups = H // H_kv
+
+    N_q_tiles = N // q_tile_size
+    assert N % q_tile_size == 0, (
+        f"Sequence length {N} must be divisible by q_tile_size {q_tile_size}"
+    )
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    k_actual = min(num_selected_blocks, N_cmp)
+
+    # Expand K_cmp for GQA: (B, N_cmp, H_kv, D) -> (B, N_cmp, H, D)
+    if groups > 1:
+        K_cmp_expanded = K_cmp.repeat_interleave(groups, dim=2)
+    else:
+        K_cmp_expanded = K_cmp
+
+    # Pre-transpose for efficient matmul: (B, H, D, N_cmp)
+    K_cmp_t = K_cmp_expanded.permute(0, 2, 3, 1).float()
+
+    block_indices = torch.empty(
+        B, H, N_q_tiles, k_actual, dtype=torch.int32, device=Q.device
+    )
+
+    # Precompute causal mask data (tiny tensors)
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
+
+    # Process query tiles in chunks to bound peak memory.
+    # Each chunk computes (B, H, chunk_tiles * q_tile_size, N_cmp) scores,
+    # averages per tile, applies causal mask, and runs topk.
+    chunk_tiles = min(16, N_q_tiles)
+    for chunk_start in range(0, N_q_tiles, chunk_tiles):
+        chunk_end = min(chunk_start + chunk_tiles, N_q_tiles)
+        n_tiles = chunk_end - chunk_start
+        q_start = chunk_start * q_tile_size
+        q_end = chunk_end * q_tile_size
+
+        # (B, H, n_tiles * q_tile_size, N_cmp) — bounded, not O(N²)
+        scores_chunk = torch.matmul(
+            Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t
+        ) * softmax_scale
+
+        # Average per tile: (B, H, n_tiles, N_cmp)
+        scores_agg = scores_chunk.reshape(
+            B, H, n_tiles, q_tile_size, N_cmp
+        ).mean(dim=3)
+
+        # Apply causal mask: block j is future if j * block_size >= (i+1) * q_tile_size
+        if causal:
+            future_mask = (
+                kv_block_start.unsqueeze(0)
+                >= q_tile_end[chunk_start:chunk_end].unsqueeze(1)
+            )  # (n_tiles, N_cmp)
+            scores_agg.masked_fill_(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        # Select top-k blocks for this chunk
+        topk_scores, chunk_idx = scores_agg.topk(k_actual, dim=-1)
+
+        # Replace invalid selections (future blocks with -inf score) with block 0
+        invalid = topk_scores == float("-inf")
+        if invalid.any():
+            chunk_idx = chunk_idx.masked_fill(invalid, 0)
+
+        # Sort indices for better memory access patterns
+        block_indices[:, :, chunk_start:chunk_end] = (
+            chunk_idx.sort(dim=-1).values.to(torch.int32)
+        )
+
+    return block_indices

--- a/mslk/attention/sparse_attn/sparsity_masks.py
+++ b/mslk/attention/sparse_attn/sparsity_masks.py
@@ -1,0 +1,117 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Convert top-k block indices into FA4's BlockSparseTensorsTorch format."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+
+
+def build_fa4_block_sparse_tensors(
+    block_indices: Tensor,  # (B, H, N_q_tiles, k) int32
+    compress_block_size: int,
+    n_block_size: int = 128,
+    seqlen_k: int | None = None,
+) -> BlockSparseTensorsTorch:
+    """Convert selected KV block indices into FA4's block sparsity format.
+
+    FA4 block sparsity uses two pairs of tensors:
+    - full_block_cnt/full_block_idx: KV blocks that need NO masking (fully attended).
+    - mask_block_cnt/mask_block_idx: KV blocks that need masking (partially attended).
+
+    Handles two cases:
+    - compress_block_size >= n_block_size: Each NSA block expands to multiple FA4 blocks.
+    - compress_block_size < n_block_size: Multiple NSA blocks contract to one FA4 block
+      (duplicates are removed).
+
+    All selected blocks are "full" blocks (no partial masking needed), since we're
+    attending to entire KV blocks.
+
+    Args:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+            Values are indices into the compressed KV sequence.
+        compress_block_size: Size of each NSA KV block.
+        n_block_size: FA4's KV tile size (default 128 for SM100).
+        seqlen_k: Total KV sequence length (for computing n_blocks_k).
+
+    Returns:
+        BlockSparseTensorsTorch with full_block_cnt, full_block_idx,
+        mask_block_cnt, mask_block_idx.
+    """
+    B, H, N_q_tiles, k = block_indices.shape
+    device = block_indices.device
+
+    if compress_block_size >= n_block_size:
+        # Each NSA block maps to one or more FA4 blocks
+        assert compress_block_size % n_block_size == 0, (
+            f"compress_block_size ({compress_block_size}) must be divisible by "
+            f"n_block_size ({n_block_size})"
+        )
+        fa4_blocks_per_nsa_block = compress_block_size // n_block_size
+
+        # NSA block j maps to FA4 blocks [j*ratio, j*ratio+1, ..., j*ratio+ratio-1]
+        base_indices = block_indices.long() * fa4_blocks_per_nsa_block
+        offsets = torch.arange(fa4_blocks_per_nsa_block, device=device)
+        expanded_indices = base_indices.unsqueeze(-1) + offsets
+        fa4_indices = expanded_indices.reshape(B, H, N_q_tiles, k * fa4_blocks_per_nsa_block)
+        k_fa4 = k * fa4_blocks_per_nsa_block
+    else:
+        # Multiple NSA blocks map to a single FA4 block
+        assert n_block_size % compress_block_size == 0, (
+            f"n_block_size ({n_block_size}) must be divisible by "
+            f"compress_block_size ({compress_block_size})"
+        )
+        # NSA block j maps to FA4 block j * compress_block_size // n_block_size
+        fa4_block_indices = (block_indices.long() * compress_block_size) // n_block_size
+
+        # Remove duplicates per query tile: sort, then unique via consecutive dedup
+        fa4_block_indices = fa4_block_indices.sort(dim=-1).values
+        # Mark duplicates: compare with previous element
+        shifted = torch.roll(fa4_block_indices, 1, dims=-1)
+        is_dup = (fa4_block_indices == shifted) & (torch.arange(k, device=device) > 0)
+        # Replace duplicates with a sentinel (max_n_blocks) that we'll filter out
+        if seqlen_k is not None:
+            sentinel = (seqlen_k + n_block_size - 1) // n_block_size
+        else:
+            sentinel = fa4_block_indices.max().item() + 1
+        fa4_block_indices = fa4_block_indices.masked_fill(is_dup, sentinel)
+        # Re-sort to push sentinels to the end
+        fa4_block_indices = fa4_block_indices.sort(dim=-1).values
+        # Count non-sentinel entries per query tile
+        counts = (fa4_block_indices < sentinel).sum(dim=-1)  # (B, H, N_q_tiles)
+
+        fa4_indices = fa4_block_indices
+        k_fa4 = k  # max possible, actual counts may be smaller
+
+    # full_block_cnt: (B, H, N_q_tiles)
+    if compress_block_size >= n_block_size:
+        full_block_cnt = torch.full(
+            (B, H, N_q_tiles), k_fa4, dtype=torch.int32, device=device
+        )
+    else:
+        full_block_cnt = counts.to(torch.int32)
+
+    # full_block_idx: use compact shape (B, H, N_q_tiles, k_fa4) instead of
+    # (B, H, N_q_tiles, N/n_block_size). FA4 only accesses indices 0..cnt-1,
+    # so the last dimension only needs to be k_fa4. This reduces memory from
+    # O(N²) to O(N * k_fa4) — e.g. 8 MB vs 8.6 GB at N=1M.
+    full_block_idx = fa4_indices[:, :, :, :k_fa4].to(torch.int32)
+
+    # mask_block_cnt/idx: no partial masking needed. Use shape (B,H,N_q_tiles,1)
+    # for mask_block_idx since count is always 0.
+    mask_block_cnt = torch.zeros(
+        (B, H, N_q_tiles), dtype=torch.int32, device=device
+    )
+    mask_block_idx = torch.zeros(
+        (B, H, N_q_tiles, 1), dtype=torch.int32, device=device
+    )
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=mask_block_cnt,
+        mask_block_idx=mask_block_idx,
+        full_block_cnt=full_block_cnt,
+        full_block_idx=full_block_idx,
+    )

--- a/mslk/attention/sparse_attn/sparsity_masks.py
+++ b/mslk/attention/sparse_attn/sparsity_masks.py
@@ -5,9 +5,8 @@
 from __future__ import annotations
 
 import torch
-from torch import Tensor
-
 from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+from torch import Tensor
 
 
 def build_fa4_block_sparse_tensors(
@@ -56,7 +55,9 @@ def build_fa4_block_sparse_tensors(
         base_indices = block_indices.long() * fa4_blocks_per_nsa_block
         offsets = torch.arange(fa4_blocks_per_nsa_block, device=device)
         expanded_indices = base_indices.unsqueeze(-1) + offsets
-        fa4_indices = expanded_indices.reshape(B, H, N_q_tiles, k * fa4_blocks_per_nsa_block)
+        fa4_indices = expanded_indices.reshape(
+            B, H, N_q_tiles, k * fa4_blocks_per_nsa_block
+        )
         k_fa4 = k * fa4_blocks_per_nsa_block
     else:
         # Multiple NSA blocks map to a single FA4 block
@@ -86,6 +87,12 @@ def build_fa4_block_sparse_tensors(
         fa4_indices = fa4_block_indices
         k_fa4 = k  # max possible, actual counts may be smaller
 
+    # Compute the full number of KV blocks for FA4
+    if seqlen_k is not None:
+        n_blocks_k = (seqlen_k + n_block_size - 1) // n_block_size
+    else:
+        n_blocks_k = fa4_indices.max().item() + 1
+
     # full_block_cnt: (B, H, N_q_tiles)
     if compress_block_size >= n_block_size:
         full_block_cnt = torch.full(
@@ -94,24 +101,36 @@ def build_fa4_block_sparse_tensors(
     else:
         full_block_cnt = counts.to(torch.int32)
 
-    # full_block_idx: use compact shape (B, H, N_q_tiles, k_fa4) instead of
-    # (B, H, N_q_tiles, N/n_block_size). FA4 only accesses indices 0..cnt-1,
-    # so the last dimension only needs to be k_fa4. This reduces memory from
-    # O(N²) to O(N * k_fa4) — e.g. 8 MB vs 8.6 GB at N=1M.
-    full_block_idx = fa4_indices[:, :, :, :k_fa4].to(torch.int32)
-
-    # mask_block_cnt/idx: no partial masking needed. Use shape (B,H,N_q_tiles,1)
-    # for mask_block_idx since count is always 0.
-    mask_block_cnt = torch.zeros(
-        (B, H, N_q_tiles), dtype=torch.int32, device=device
+    # full_block_idx: use dense shape (B, H, N_q_tiles, n_blocks_k) so that
+    # FA4's backward can transpose to Q-direction indexing. The compact format
+    # (k_fa4 << n_blocks_k) saves memory but is incompatible with backward.
+    full_block_idx_dense = torch.zeros(
+        (B, H, N_q_tiles, n_blocks_k), dtype=torch.int32, device=device
     )
+    # Copy compact indices into the dense tensor
+    copy_len = min(k_fa4, n_blocks_k)
+    full_block_idx_dense[:, :, :, :copy_len] = fa4_indices[:, :, :, :copy_len].to(
+        torch.int32
+    )
+
+    # mask_block_cnt/idx: no partial masking needed.
+    mask_block_cnt = torch.zeros((B, H, N_q_tiles), dtype=torch.int32, device=device)
     mask_block_idx = torch.zeros(
-        (B, H, N_q_tiles, 1), dtype=torch.int32, device=device
+        (B, H, N_q_tiles, n_blocks_k), dtype=torch.int32, device=device
+    )
+
+    # Determine the Q-direction block size. With q_tile_size positions per query tile
+    # and N_q_tiles tiles, each m-block covers q_tile_size positions.
+    # For the contraction case (compress_block_size < n_block_size), the Q block size
+    # is inferred from the tensor shapes.
+    q_block_size = (
+        seqlen_k // N_q_tiles if seqlen_k is not None else compress_block_size
     )
 
     return BlockSparseTensorsTorch(
         mask_block_cnt=mask_block_cnt,
         mask_block_idx=mask_block_idx,
         full_block_cnt=full_block_cnt,
-        full_block_idx=full_block_idx,
+        full_block_idx=full_block_idx_dense,
+        block_size=(q_block_size, n_block_size),
     )

--- a/test/attention/bench_nsa_backward.py
+++ b/test/attention/bench_nsa_backward.py
@@ -22,13 +22,21 @@ def benchmark_nsa_fwd_bwd(
 ):
     from mslk.attention.sparse_attn import nsa
 
-    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
-    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
-    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
 
     def run():
         out = nsa(
-            Q, K, V,
+            Q,
+            K,
+            V,
             compress_block_size=compress_block_size,
             num_selected_blocks=num_selected_blocks,
             window_size=window_size,
@@ -56,8 +64,8 @@ def benchmark_nsa_fwd_bwd(
     tflops_fwd = 2 * B * H * N * N * D / 1e12  # approximate (ignoring sparsity)
     mode = "fwd+bwd" if backward else "fwd"
     print(
-        f"N={N:>7d} | {mode} | {elapsed*1000:>8.2f} ms | "
-        f"~{tflops_fwd/elapsed/1e3:.1f} TFLOPS (dense equiv)"
+        f"N={N:>7d} | {mode} | {elapsed * 1000:>8.2f} ms | "
+        f"~{tflops_fwd / elapsed / 1e3:.1f} TFLOPS (dense equiv)"
     )
     return elapsed
 
@@ -68,14 +76,42 @@ def main():
     print(f"GPU: {torch.cuda.get_device_name()}")
     print()
 
-    for N in [1024, 2048, 4096, 8192, 16384, 32768, 65536]:
+    for N in [
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+        2097152,
+        3145728,
+    ]:
         try:
             benchmark_nsa_fwd_bwd(N, backward=False)
         except Exception as e:
             print(f"N={N:>7d} | fwd     | FAILED: {e}")
 
     print()
-    for N in [1024, 2048, 4096, 8192, 16384, 32768, 65536]:
+    for N in [
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+        2097152,
+        3145728,
+    ]:
         try:
             benchmark_nsa_fwd_bwd(N, backward=True)
         except Exception as e:

--- a/test/attention/bench_nsa_backward.py
+++ b/test/attention/bench_nsa_backward.py
@@ -1,0 +1,86 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Benchmark NSA forward + backward at various sequence lengths."""
+
+import time
+
+import torch
+
+
+def benchmark_nsa_fwd_bwd(
+    N: int,
+    B: int = 1,
+    H: int = 32,
+    H_kv: int = 8,
+    D: int = 128,
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    warmup: int = 3,
+    iters: int = 10,
+    backward: bool = True,
+):
+    from mslk.attention.sparse_attn import nsa
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
+
+    def run():
+        out = nsa(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected_blocks,
+            window_size=window_size,
+        )
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = None
+            K.grad = None
+            V.grad = None
+        return out
+
+    # Warmup
+    for _ in range(warmup):
+        run()
+    torch.cuda.synchronize()
+
+    # Benchmark
+    start = time.perf_counter()
+    for _ in range(iters):
+        run()
+    torch.cuda.synchronize()
+    elapsed = (time.perf_counter() - start) / iters
+
+    tflops_fwd = 2 * B * H * N * N * D / 1e12  # approximate (ignoring sparsity)
+    mode = "fwd+bwd" if backward else "fwd"
+    print(
+        f"N={N:>7d} | {mode} | {elapsed*1000:>8.2f} ms | "
+        f"~{tflops_fwd/elapsed/1e3:.1f} TFLOPS (dense equiv)"
+    )
+    return elapsed
+
+
+def main():
+    print("NSA Forward + Backward Benchmark")
+    print("=" * 60)
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print()
+
+    for N in [1024, 2048, 4096, 8192, 16384, 32768, 65536]:
+        try:
+            benchmark_nsa_fwd_bwd(N, backward=False)
+        except Exception as e:
+            print(f"N={N:>7d} | fwd     | FAILED: {e}")
+
+    print()
+    for N in [1024, 2048, 4096, 8192, 16384, 32768, 65536]:
+        try:
+            benchmark_nsa_fwd_bwd(N, backward=True)
+        except Exception as e:
+            print(f"N={N:>7d} | fwd+bwd | FAILED: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_nsa_vs_dense.py
+++ b/test/attention/bench_nsa_vs_dense.py
@@ -1,0 +1,175 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""NSA vs Dense FA4 benchmark — forward and backward at various sequence lengths."""
+
+import gc
+import time
+
+import torch
+
+
+def _time_fn(fn, warmup=3, iters=5):
+    """Time a function with warmup, return median ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        times.append((time.perf_counter() - start) * 1000)
+    times.sort()
+    return times[len(times) // 2]
+
+
+def benchmark_dense_fa4(N, B=1, H=32, H_kv=8, D=128, backward=False):
+    """Benchmark dense causal FA4 attention."""
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out = flash_attn_func(Q, K, V, softmax_scale=1.0 / D**0.5, causal=True)
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = K.grad = V.grad = None
+
+    try:
+        return _time_fn(run)
+    except Exception as e:
+        return f"FAILED: {e}"
+
+
+def benchmark_nsa(N, B=1, H=32, H_kv=8, D=128, backward=False):
+    """Benchmark NSA sparse attention."""
+    from mslk.attention.sparse_attn import nsa
+
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=64,
+            num_selected_blocks=16,
+            window_size=512,
+        )
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = K.grad = V.grad = None
+
+    try:
+        return _time_fn(run)
+    except Exception as e:
+        return f"FAILED: {e}"
+
+
+def main():
+    print("NSA vs Dense FA4 Benchmark")
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(f"Config: B=1, H=32, H_kv=8, D=128")
+    print("=" * 80)
+
+    # Sequence lengths: 1K to 3M (powers of 2, plus some intermediate points)
+    seq_lengths = [
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+        2097152,
+        3145728,
+    ]
+
+    print(
+        f"\n{'N':>10} | {'Dense Fwd':>12} | {'NSA Fwd':>12} | {'Speedup':>8} | "
+        f"{'Dense Bwd':>12} | {'NSA Bwd':>12} | {'Speedup':>8}"
+    )
+    print("-" * 90)
+
+    for N in seq_lengths:
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        # Forward
+        dense_fwd = benchmark_dense_fa4(N, backward=False)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        nsa_fwd = benchmark_nsa(N, backward=False)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        if isinstance(dense_fwd, str) or isinstance(nsa_fwd, str):
+            fwd_speedup = "N/A"
+            dense_fwd_s = (
+                str(dense_fwd)
+                if isinstance(dense_fwd, str)
+                else f"{dense_fwd:>10.2f}ms"
+            )
+            nsa_fwd_s = (
+                str(nsa_fwd) if isinstance(nsa_fwd, str) else f"{nsa_fwd:>10.2f}ms"
+            )
+        else:
+            fwd_speedup = f"{dense_fwd / nsa_fwd:.2f}x"
+            dense_fwd_s = f"{dense_fwd:>10.2f}ms"
+            nsa_fwd_s = f"{nsa_fwd:>10.2f}ms"
+
+        # Backward
+        dense_bwd = benchmark_dense_fa4(N, backward=True)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        nsa_bwd = benchmark_nsa(N, backward=True)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        if isinstance(dense_bwd, str) or isinstance(nsa_bwd, str):
+            bwd_speedup = "N/A"
+            dense_bwd_s = (
+                str(dense_bwd)[:30]
+                if isinstance(dense_bwd, str)
+                else f"{dense_bwd:>10.2f}ms"
+            )
+            nsa_bwd_s = (
+                str(nsa_bwd)[:30] if isinstance(nsa_bwd, str) else f"{nsa_bwd:>10.2f}ms"
+            )
+        else:
+            bwd_speedup = f"{dense_bwd / nsa_bwd:.2f}x"
+            dense_bwd_s = f"{dense_bwd:>10.2f}ms"
+            nsa_bwd_s = f"{nsa_bwd:>10.2f}ms"
+
+        print(
+            f"{N:>10} | {dense_fwd_s:>12} | {nsa_fwd_s:>12} | {fwd_speedup:>8} | "
+            f"{dense_bwd_s:>12} | {nsa_bwd_s:>12} | {bwd_speedup:>8}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_sparse_attn.py
+++ b/test/attention/bench_sparse_attn.py
@@ -1,0 +1,250 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Detailed benchmarks for NSA vs dense FA4 attention.
+
+Reports wall-clock time, effective TFLOPS, and speedup ratio.
+Separately times each NSA component: compression, selection, attention branches, gating.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+
+import torch
+
+
+def benchmark_fn(fn, warmup=5, repeat=20):
+    """Benchmark a CUDA function using CUDA events. Returns median time in ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(repeat):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times = sorted(times)
+    return times[len(times) // 2]
+
+
+def compute_flops_dense(B, H, N, D):
+    """Compute FLOPs for dense attention forward pass."""
+    # QK^T: 2*B*H*N*N*D, PV: 2*B*H*N*N*D
+    return 4 * B * H * N * N * D
+
+
+def compute_flops_nsa(B, H, N, D, compress_block_size, num_selected, window_size):
+    """Compute FLOPs for NSA forward pass."""
+    l = compress_block_size
+    k = num_selected
+    w = window_size
+    # Compressed: 4*B*H*N*(N/l)*D
+    # Selected: 4*B*H*N*(k*l)*D
+    # Sliding: 4*B*H*N*w*D
+    flops_cmp = 4 * B * H * N * (N // l) * D
+    flops_slc = 4 * B * H * N * (k * l) * D
+    flops_sld = 4 * B * H * N * w * D
+    return flops_cmp + flops_slc + flops_sld
+
+
+def run_benchmark(
+    N: int,
+    B: int = 2,
+    H: int = 32,
+    H_kv: int = 8,
+    D: int = 128,
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    dtype=torch.bfloat16,
+    warmup: int = 5,
+    repeat: int = 20,
+):
+    """Run NSA vs dense FA4 benchmark for a given sequence length."""
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+    from mslk.attention.sparse_attn.compress import compress_kv
+    from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+    from mslk.attention.sparse_attn.select import score_and_select_blocks
+    from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+    # --- Dense FA4 baseline ---
+    dense_ms = benchmark_fn(
+        lambda: flash_attn_func(Q, K, V, causal=True),
+        warmup=warmup, repeat=repeat,
+    )
+    dense_flops = compute_flops_dense(B, H, N, D)
+    dense_tflops = dense_flops / (dense_ms * 1e-3) / 1e12
+
+    # --- NSA end-to-end ---
+    nsa_ms = benchmark_fn(
+        lambda: nsa_forward(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected_blocks,
+            window_size=window_size,
+            causal=True,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+    nsa_flops = compute_flops_nsa(
+        B, H, N, D, compress_block_size, num_selected_blocks, window_size
+    )
+    nsa_tflops = nsa_flops / (nsa_ms * 1e-3) / 1e12
+
+    # --- Component timing ---
+    # Compression
+    cmp_ms = benchmark_fn(
+        lambda: compress_kv(K, V, compress_block_size),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Selection
+    K_cmp, V_cmp = compress_kv(K, V, compress_block_size)
+    sel_ms = benchmark_fn(
+        lambda: score_and_select_blocks(
+            Q, K_cmp, num_selected_blocks, compress_block_size,
+            causal=True, q_tile_size=256,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Block-sparse mask construction
+    block_indices = score_and_select_blocks(
+        Q, K_cmp, num_selected_blocks, compress_block_size,
+        causal=True, q_tile_size=256,
+    )
+    mask_ms = benchmark_fn(
+        lambda: build_fa4_block_sparse_tensors(
+            block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Compressed attention FA4
+    fa4_cmp_ms = benchmark_fn(
+        lambda: flash_attn_func(Q, K_cmp, V_cmp, causal=True),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Selected attention FA4 (block-sparse)
+    sparse_tensors = build_fa4_block_sparse_tensors(
+        block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+    )
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+    fa4_slc_ms = benchmark_fn(
+        lambda: _flash_attn_fwd(
+            Q, K, V, causal=True, block_sparse_tensors=sparse_tensors,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Sliding window FA4
+    fa4_sld_ms = benchmark_fn(
+        lambda: flash_attn_func(Q, K, V, causal=True, window_size=(window_size, 0)),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Gating
+    O_cmp = torch.randn_like(Q)
+    O_slc = torch.randn_like(Q)
+    O_sld = torch.randn_like(Q)
+    gates = torch.randn(B, N, H, 3, device="cuda", dtype=dtype)
+    gate_ms = benchmark_fn(
+        lambda: gate_and_combine(O_cmp, O_slc, O_sld, gates),
+        warmup=warmup, repeat=repeat,
+    )
+
+    speedup = dense_ms / nsa_ms
+    theoretical_speedup = N / (N / compress_block_size + num_selected_blocks * compress_block_size + window_size)
+
+    return {
+        "N": N,
+        "dense_ms": dense_ms,
+        "dense_tflops": dense_tflops,
+        "nsa_ms": nsa_ms,
+        "nsa_tflops": nsa_tflops,
+        "speedup": speedup,
+        "theoretical_speedup": theoretical_speedup,
+        "compress_ms": cmp_ms,
+        "select_ms": sel_ms,
+        "mask_ms": mask_ms,
+        "fa4_cmp_ms": fa4_cmp_ms,
+        "fa4_slc_ms": fa4_slc_ms,
+        "fa4_sld_ms": fa4_sld_ms,
+        "gate_ms": gate_ms,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="NSA vs FA4 benchmark")
+    parser.add_argument("--seq-lens", nargs="+", type=int,
+                        default=[1024, 2048, 4096, 8192, 16384])
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--num-heads", type=int, default=32)
+    parser.add_argument("--num-heads-kv", type=int, default=32)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--compress-block-size", type=int, default=64)
+    parser.add_argument("--num-selected-blocks", type=int, default=16)
+    parser.add_argument("--window-size", type=int, default=512)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeat", type=int, default=20)
+    args = parser.parse_args()
+
+    print(f"{'='*100}")
+    print(f"NSA vs Dense FA4 Benchmark")
+    print(f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
+          f"D={args.head_dim}, l={args.compress_block_size}, k={args.num_selected_blocks}, "
+          f"w={args.window_size}")
+    print(f"{'='*100}")
+
+    header = (
+        f"{'N':>8} | {'Dense(ms)':>10} {'TFLOPS':>8} | "
+        f"{'NSA(ms)':>10} {'TFLOPS':>8} | {'Speedup':>8} {'Theory':>8} | "
+        f"{'Cmp':>6} {'Sel':>6} {'Mask':>6} "
+        f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for N in args.seq_lens:
+        result = run_benchmark(
+            N=N,
+            B=args.batch_size,
+            H=args.num_heads,
+            H_kv=args.num_heads_kv,
+            D=args.head_dim,
+            compress_block_size=args.compress_block_size,
+            num_selected_blocks=args.num_selected_blocks,
+            window_size=args.window_size,
+            warmup=args.warmup,
+            repeat=args.repeat,
+        )
+        print(
+            f"{result['N']:>8} | "
+            f"{result['dense_ms']:>10.2f} {result['dense_tflops']:>8.1f} | "
+            f"{result['nsa_ms']:>10.2f} {result['nsa_tflops']:>8.1f} | "
+            f"{result['speedup']:>8.2f}x {result['theoretical_speedup']:>7.1f}x | "
+            f"{result['compress_ms']:>6.2f} {result['select_ms']:>6.2f} "
+            f"{result['mask_ms']:>6.2f} {result['fa4_cmp_ms']:>6.2f} "
+            f"{result['fa4_slc_ms']:>6.2f} {result['fa4_sld_ms']:>6.2f} "
+            f"{result['gate_ms']:>6.2f}"
+        )
+
+    print(f"{'='*100}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_sparse_attn.py
+++ b/test/attention/bench_sparse_attn.py
@@ -69,7 +69,7 @@ def run_benchmark(
     repeat: int = 20,
 ):
     """Run NSA vs dense FA4 benchmark for a given sequence length."""
-    from mslk.attention.sparse_attn.compress import compress_kv
+    from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
     from mslk.attention.sparse_attn.gating import (
         compute_gates,
         fused_gate_and_combine,
@@ -119,6 +119,13 @@ def run_benchmark(
     # Compression
     cmp_ms = benchmark_fn(
         lambda: compress_kv(K, V, compress_block_size),
+        warmup=warmup,
+        repeat=repeat,
+    )
+
+    # Fused compression (CuteDSL kernel)
+    fused_cmp_ms = benchmark_fn(
+        lambda: fused_compress_kv(K, V, compress_block_size),
         warmup=warmup,
         repeat=repeat,
     )
@@ -249,6 +256,7 @@ def run_benchmark(
         "speedup": speedup,
         "theoretical_speedup": theoretical_speedup,
         "compress_ms": cmp_ms,
+        "fused_cmp_ms": fused_cmp_ms,
         "select_ms": sel_ms,
         "fused_sel_ms": fused_sel_ms,
         "mask_ms": mask_ms,
@@ -289,7 +297,7 @@ def main():
     header = (
         f"{'N':>8} | {'Dense(ms)':>10} {'TFLOPS':>8} | "
         f"{'NSA(ms)':>10} {'TFLOPS':>8} | {'Speedup':>8} {'Theory':>8} | "
-        f"{'Cmp':>6} {'Sel':>6} {'FSel':>6} {'Mask':>6} "
+        f"{'Cmp':>6} {'FCmp':>6} {'Sel':>6} {'FSel':>6} {'Mask':>6} "
         f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6} {'CmpG':>6} {'Fuse':>6}"
     )
     print(header)
@@ -313,7 +321,8 @@ def main():
             f"{result['dense_ms']:>10.2f} {result['dense_tflops']:>8.1f} | "
             f"{result['nsa_ms']:>10.2f} {result['nsa_tflops']:>8.1f} | "
             f"{result['speedup']:>8.2f}x {result['theoretical_speedup']:>7.1f}x | "
-            f"{result['compress_ms']:>6.2f} {result['select_ms']:>6.2f} "
+            f"{result['compress_ms']:>6.2f} {result['fused_cmp_ms']:>6.2f} "
+            f"{result['select_ms']:>6.2f} "
             f"{result['fused_sel_ms']:>6.2f} {result['mask_ms']:>6.2f} "
             f"{result['fa4_cmp_ms']:>6.2f} "
             f"{result['fa4_slc_ms']:>6.2f} {result['fa4_sld_ms']:>6.2f} "

--- a/test/attention/bench_sparse_attn.py
+++ b/test/attention/bench_sparse_attn.py
@@ -69,13 +69,19 @@ def run_benchmark(
     repeat: int = 20,
 ):
     """Run NSA vs dense FA4 benchmark for a given sequence length."""
-    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
     from mslk.attention.sparse_attn.compress import compress_kv
-    from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
-    from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+    from mslk.attention.sparse_attn.gating import (
+        compute_gates,
+        fused_gate_and_combine,
+        gate_and_combine,
+    )
     from mslk.attention.sparse_attn.nsa_forward import nsa_forward
-    from mslk.attention.sparse_attn.select import score_and_select_blocks
+    from mslk.attention.sparse_attn.select import (
+        fused_score_and_select_blocks,
+        score_and_select_blocks,
+    )
     from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
 
     Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
     K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
@@ -84,7 +90,8 @@ def run_benchmark(
     # --- Dense FA4 baseline ---
     dense_ms = benchmark_fn(
         lambda: flash_attn_func(Q, K, V, causal=True),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
     dense_flops = compute_flops_dense(B, H, N, D)
     dense_tflops = dense_flops / (dense_ms * 1e-3) / 1e12
@@ -92,13 +99,16 @@ def run_benchmark(
     # --- NSA end-to-end ---
     nsa_ms = benchmark_fn(
         lambda: nsa_forward(
-            Q, K, V,
+            Q,
+            K,
+            V,
             compress_block_size=compress_block_size,
             num_selected_blocks=num_selected_blocks,
             window_size=window_size,
             causal=True,
         ),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
     nsa_flops = compute_flops_nsa(
         B, H, N, D, compress_block_size, num_selected_blocks, window_size
@@ -109,53 +119,92 @@ def run_benchmark(
     # Compression
     cmp_ms = benchmark_fn(
         lambda: compress_kv(K, V, compress_block_size),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Selection
     K_cmp, V_cmp = compress_kv(K, V, compress_block_size)
     sel_ms = benchmark_fn(
         lambda: score_and_select_blocks(
-            Q, K_cmp, num_selected_blocks, compress_block_size,
-            causal=True, q_tile_size=256,
+            Q,
+            K_cmp,
+            num_selected_blocks,
+            compress_block_size,
+            causal=True,
+            q_tile_size=256,
         ),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
+    )
+
+    # Fused selection (CuteDSL kernel)
+    fused_sel_ms = benchmark_fn(
+        lambda: fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected_blocks,
+            compress_block_size,
+            causal=True,
+            q_tile_size=256,
+        ),
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Block-sparse mask construction
     block_indices = score_and_select_blocks(
-        Q, K_cmp, num_selected_blocks, compress_block_size,
-        causal=True, q_tile_size=256,
+        Q,
+        K_cmp,
+        num_selected_blocks,
+        compress_block_size,
+        causal=True,
+        q_tile_size=256,
     )
     mask_ms = benchmark_fn(
         lambda: build_fa4_block_sparse_tensors(
-            block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+            block_indices,
+            compress_block_size,
+            n_block_size=128,
+            seqlen_k=N,
         ),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Compressed attention FA4
     fa4_cmp_ms = benchmark_fn(
         lambda: flash_attn_func(Q, K_cmp, V_cmp, causal=True),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Selected attention FA4 (block-sparse)
     sparse_tensors = build_fa4_block_sparse_tensors(
-        block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+        block_indices,
+        compress_block_size,
+        n_block_size=128,
+        seqlen_k=N,
     )
     from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+
     fa4_slc_ms = benchmark_fn(
         lambda: _flash_attn_fwd(
-            Q, K, V, causal=True, block_sparse_tensors=sparse_tensors,
+            Q,
+            K,
+            V,
+            causal=True,
+            block_sparse_tensors=sparse_tensors,
         ),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Sliding window FA4
     fa4_sld_ms = benchmark_fn(
         lambda: flash_attn_func(Q, K, V, causal=True, window_size=(window_size, 0)),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Gating (gate_and_combine only)
@@ -165,24 +214,31 @@ def run_benchmark(
     gates = torch.randn(B, N, H, 3, device="cuda", dtype=dtype)
     gate_ms = benchmark_fn(
         lambda: gate_and_combine(O_cmp, O_slc, O_sld, gates),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Gating (compute_gates only)
     gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype)
     compute_gates_ms = benchmark_fn(
         lambda: compute_gates(Q, gate_proj_weight),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Fused gating (compute_gates + gate_and_combine in one kernel)
     fused_gate_ms = benchmark_fn(
         lambda: fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     speedup = dense_ms / nsa_ms
-    theoretical_speedup = N / (N / compress_block_size + num_selected_blocks * compress_block_size + window_size)
+    theoretical_speedup = N / (
+        N / compress_block_size
+        + num_selected_blocks * compress_block_size
+        + window_size
+    )
 
     return {
         "N": N,
@@ -194,6 +250,7 @@ def run_benchmark(
         "theoretical_speedup": theoretical_speedup,
         "compress_ms": cmp_ms,
         "select_ms": sel_ms,
+        "fused_sel_ms": fused_sel_ms,
         "mask_ms": mask_ms,
         "fa4_cmp_ms": fa4_cmp_ms,
         "fa4_slc_ms": fa4_slc_ms,
@@ -206,8 +263,9 @@ def run_benchmark(
 
 def main():
     parser = argparse.ArgumentParser(description="NSA vs FA4 benchmark")
-    parser.add_argument("--seq-lens", nargs="+", type=int,
-                        default=[1024, 2048, 4096, 8192, 16384])
+    parser.add_argument(
+        "--seq-lens", nargs="+", type=int, default=[1024, 2048, 4096, 8192, 16384]
+    )
     parser.add_argument("--batch-size", type=int, default=2)
     parser.add_argument("--num-heads", type=int, default=32)
     parser.add_argument("--num-heads-kv", type=int, default=32)
@@ -219,17 +277,19 @@ def main():
     parser.add_argument("--repeat", type=int, default=20)
     args = parser.parse_args()
 
-    print(f"{'='*100}")
+    print(f"{'=' * 100}")
     print(f"NSA vs Dense FA4 Benchmark")
-    print(f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
-          f"D={args.head_dim}, l={args.compress_block_size}, k={args.num_selected_blocks}, "
-          f"w={args.window_size}")
-    print(f"{'='*100}")
+    print(
+        f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
+        f"D={args.head_dim}, l={args.compress_block_size}, k={args.num_selected_blocks}, "
+        f"w={args.window_size}"
+    )
+    print(f"{'=' * 100}")
 
     header = (
         f"{'N':>8} | {'Dense(ms)':>10} {'TFLOPS':>8} | "
         f"{'NSA(ms)':>10} {'TFLOPS':>8} | {'Speedup':>8} {'Theory':>8} | "
-        f"{'Cmp':>6} {'Sel':>6} {'Mask':>6} "
+        f"{'Cmp':>6} {'Sel':>6} {'FSel':>6} {'Mask':>6} "
         f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6} {'CmpG':>6} {'Fuse':>6}"
     )
     print(header)
@@ -254,13 +314,14 @@ def main():
             f"{result['nsa_ms']:>10.2f} {result['nsa_tflops']:>8.1f} | "
             f"{result['speedup']:>8.2f}x {result['theoretical_speedup']:>7.1f}x | "
             f"{result['compress_ms']:>6.2f} {result['select_ms']:>6.2f} "
-            f"{result['mask_ms']:>6.2f} {result['fa4_cmp_ms']:>6.2f} "
+            f"{result['fused_sel_ms']:>6.2f} {result['mask_ms']:>6.2f} "
+            f"{result['fa4_cmp_ms']:>6.2f} "
             f"{result['fa4_slc_ms']:>6.2f} {result['fa4_sld_ms']:>6.2f} "
             f"{result['gate_ms']:>6.2f} {result['compute_gates_ms']:>6.2f} "
             f"{result['fused_gate_ms']:>6.2f}"
         )
 
-    print(f"{'='*100}")
+    print(f"{'=' * 100}")
 
 
 if __name__ == "__main__":

--- a/test/attention/bench_sparse_attn.py
+++ b/test/attention/bench_sparse_attn.py
@@ -72,6 +72,7 @@ def run_benchmark(
     from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
     from mslk.attention.sparse_attn.compress import compress_kv
     from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+    from mslk.attention.sparse_attn.gating import fused_gate_and_combine
     from mslk.attention.sparse_attn.nsa_forward import nsa_forward
     from mslk.attention.sparse_attn.select import score_and_select_blocks
     from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
@@ -157,13 +158,26 @@ def run_benchmark(
         warmup=warmup, repeat=repeat,
     )
 
-    # Gating
+    # Gating (gate_and_combine only)
     O_cmp = torch.randn_like(Q)
     O_slc = torch.randn_like(Q)
     O_sld = torch.randn_like(Q)
     gates = torch.randn(B, N, H, 3, device="cuda", dtype=dtype)
     gate_ms = benchmark_fn(
         lambda: gate_and_combine(O_cmp, O_slc, O_sld, gates),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Gating (compute_gates only)
+    gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype)
+    compute_gates_ms = benchmark_fn(
+        lambda: compute_gates(Q, gate_proj_weight),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Fused gating (compute_gates + gate_and_combine in one kernel)
+    fused_gate_ms = benchmark_fn(
+        lambda: fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight),
         warmup=warmup, repeat=repeat,
     )
 
@@ -185,6 +199,8 @@ def run_benchmark(
         "fa4_slc_ms": fa4_slc_ms,
         "fa4_sld_ms": fa4_sld_ms,
         "gate_ms": gate_ms,
+        "compute_gates_ms": compute_gates_ms,
+        "fused_gate_ms": fused_gate_ms,
     }
 
 
@@ -214,7 +230,7 @@ def main():
         f"{'N':>8} | {'Dense(ms)':>10} {'TFLOPS':>8} | "
         f"{'NSA(ms)':>10} {'TFLOPS':>8} | {'Speedup':>8} {'Theory':>8} | "
         f"{'Cmp':>6} {'Sel':>6} {'Mask':>6} "
-        f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6}"
+        f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6} {'CmpG':>6} {'Fuse':>6}"
     )
     print(header)
     print("-" * len(header))
@@ -240,7 +256,8 @@ def main():
             f"{result['compress_ms']:>6.2f} {result['select_ms']:>6.2f} "
             f"{result['mask_ms']:>6.2f} {result['fa4_cmp_ms']:>6.2f} "
             f"{result['fa4_slc_ms']:>6.2f} {result['fa4_sld_ms']:>6.2f} "
-            f"{result['gate_ms']:>6.2f}"
+            f"{result['gate_ms']:>6.2f} {result['compute_gates_ms']:>6.2f} "
+            f"{result['fused_gate_ms']:>6.2f}"
         )
 
     print(f"{'='*100}")

--- a/test/attention/bench_sparse_attn_e2e.py
+++ b/test/attention/bench_sparse_attn_e2e.py
@@ -1,0 +1,169 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Lean end-to-end benchmark for NSA vs dense FA4 at large sequence lengths.
+
+Only measures end-to-end Dense FA4 and NSA times (no component breakdowns)
+to minimize memory usage and allow benchmarking at N >= 2M.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+
+import torch
+
+
+def benchmark_fn(fn, warmup=3, repeat=7):
+    """Benchmark a CUDA function using CUDA events. Returns median time in ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(repeat):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times = sorted(times)
+    return times[len(times) // 2]
+
+
+def run_e2e(
+    N: int,
+    compress_block_size: int,
+    B: int = 1,
+    H: int = 8,
+    H_kv: int = 2,
+    D: int = 128,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    dtype=torch.bfloat16,
+    warmup: int = 3,
+    repeat: int = 7,
+    skip_dense: bool = False,
+):
+    """Run end-to-end Dense FA4 + NSA benchmark for one (N, l) pair."""
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+    dense_ms = -1.0
+    if not skip_dense:
+        try:
+            dense_ms = benchmark_fn(
+                lambda Q=Q, K=K, V=V: flash_attn_func(Q, K, V, causal=True),
+                warmup=warmup,
+                repeat=repeat,
+            )
+        except Exception as e:
+            print(f"  Dense FA4 failed: {e}")
+
+    torch.cuda.empty_cache()
+
+    nsa_ms = -1.0
+    try:
+        nsa_ms = benchmark_fn(
+            lambda Q=Q, K=K, V=V: nsa_forward(
+                Q,
+                K,
+                V,
+                compress_block_size=compress_block_size,
+                num_selected_blocks=num_selected_blocks,
+                window_size=window_size,
+                causal=True,
+            ),
+            warmup=warmup,
+            repeat=repeat,
+        )
+    except Exception as e:
+        print(f"  NSA l={compress_block_size} failed: {e}")
+
+    del Q, K, V
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    return dense_ms, nsa_ms
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E2E NSA vs FA4 benchmark (lean)")
+    parser.add_argument(
+        "--seq-lens",
+        nargs="+",
+        type=int,
+        default=[2097152, 4194304, 8388608, 16777216],
+    )
+    parser.add_argument("--block-sizes", nargs="+", type=int, default=[32, 64, 128])
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--num-heads", type=int, default=8)
+    parser.add_argument("--num-heads-kv", type=int, default=2)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--num-selected-blocks", type=int, default=16)
+    parser.add_argument("--window-size", type=int, default=512)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeat", type=int, default=7)
+    parser.add_argument(
+        "--skip-dense-above",
+        type=int,
+        default=0,
+        help="Skip dense FA4 for N above this value (0 = never skip)",
+    )
+    args = parser.parse_args()
+
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(
+        f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
+        f"D={args.head_dim}, k={args.num_selected_blocks}, w={args.window_size}"
+    )
+
+    # Header
+    l_cols = "  ".join(f"{'l=' + str(l):>10}" for l in args.block_sizes)
+    print(f"\n{'N':>10} | {'Dense(ms)':>10} | {l_cols}")
+    print("-" * (14 + 13 + 12 * len(args.block_sizes)))
+
+    for N in args.seq_lens:
+        skip_dense = args.skip_dense_above > 0 and N > args.skip_dense_above
+
+        dense_ms = None
+        nsa_times = {}
+
+        for i, l in enumerate(args.block_sizes):
+            d_ms, n_ms = run_e2e(
+                N=N,
+                compress_block_size=l,
+                B=args.batch_size,
+                H=args.num_heads,
+                H_kv=args.num_heads_kv,
+                D=args.head_dim,
+                num_selected_blocks=args.num_selected_blocks,
+                window_size=args.window_size,
+                warmup=args.warmup,
+                repeat=args.repeat,
+                skip_dense=(skip_dense or i > 0),  # Only measure dense once per N
+            )
+            if i == 0:
+                dense_ms = d_ms
+            nsa_times[l] = n_ms
+
+        dense_str = f"{dense_ms:>10.2f}" if dense_ms and dense_ms > 0 else "     skip"
+        nsa_strs = "  ".join(
+            f"{nsa_times[l]:>10.2f}" if nsa_times[l] > 0 else "    failed"
+            for l in args.block_sizes
+        )
+        print(f"{N:>10} | {dense_str} | {nsa_strs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/benchmark_results.svg
+++ b/test/attention/benchmark_results.svg
@@ -17,10 +17,10 @@
 
   <!-- Title -->
   <text x="400" y="32" text-anchor="middle" class="title">NSA vs Dense Flash Attention (FA4) — NVIDIA B200</text>
-  <text x="400" y="50" text-anchor="middle" class="subtitle">B=2, H=32, H_kv=32, D=128, block_size=128, k=16, window=512</text>
+  <text x="400" y="50" text-anchor="middle" class="subtitle">B=2, H=32, H_kv=32, D=128, block_size=64, k=16, window=512 | Fused compress, select, gating kernels</text>
 
   <!-- Chart area: x=100..720, y=70..400 -->
-  <!-- Y axis: 0 to 18ms (log would be better but linear is clearer) -->
+  <!-- Y axis: 0 to 18ms -->
   <!-- X axis: sequence lengths 1024, 2048, 4096, 8192, 16384, 32768 -->
 
   <!-- Grid lines -->
@@ -50,9 +50,6 @@
   <!-- Y axis title -->
   <text x="30" y="235" text-anchor="middle" class="axis-label" transform="rotate(-90, 30, 235)">Latency (ms)</text>
 
-  <!-- X positions: evenly spaced at x = 140, 256, 372, 488, 604, 720 -->
-  <!-- Actually let me use: 130, 248, 366, 484, 602, 720 -->
-
   <!-- X axis labels -->
   <text x="130" y="420" text-anchor="middle" class="tick-label">1K</text>
   <text x="248" y="420" text-anchor="middle" class="tick-label">2K</text>
@@ -68,27 +65,24 @@
   <line x1="100" y1="400" x2="720" y2="400" stroke="#333" stroke-width="1.5"/>
   <line x1="100" y1="70" x2="100" y2="400" stroke="#333" stroke-width="1.5"/>
 
-  <!-- Scale: 18ms = 330px, so 1ms = 18.33px. y = 400 - (ms * 330/18) = 400 - ms*18.33 -->
-  <!-- Dense FA4 data points:
-       1024:  0.08ms -> y=398.5
-       2048:  0.12ms -> y=397.8
-       4096:  0.28ms -> y=394.9
-       8192:  0.96ms -> y=382.4
-       16384: 3.48ms -> y=336.2
-       32768: 16.36ms -> y=100.1
-  -->
+  <!-- Scale: 18ms = 330px, so 1ms = 18.33px. y = 400 - (ms * 330/18) -->
+  <!--
+    MEASURED DATA (B200, B=2, H=32, H_kv=32, D=128, l=64, k=16, w=512, bf16):
+    Fused compress, fused select, fused gating kernels active.
 
-  <!-- NSA data points:
-       1024:  0.92ms -> y=383.1
-       2048:  1.26ms -> y=376.9
-       4096:  1.94ms -> y=364.4
-       8192:  3.75ms -> y=331.3
-       16384: 6.96ms -> y=272.4
-       32768: 15.47ms -> y=116.4
+    Dense FA4:          NSA (fused):
+    1024:  0.08ms       1024:  1.05ms  (k=8, limited by N_cmp)
+    2048:  0.12ms       2048:  1.12ms
+    4096:  0.28ms       4096:  1.20ms
+    8192:  0.96ms       8192:  1.69ms
+    16384: 3.48ms       16384: 3.43ms
+    32768: 15.67ms      32768: 5.88ms
+
+    y = 400 - ms * 18.33
   -->
 
   <!-- Dense FA4 line (blue) -->
-  <polyline points="130,398.5 248,397.8 366,394.9 484,382.4 602,336.2 720,100.1"
+  <polyline points="130,398.5 248,397.8 366,394.9 484,382.4 602,336.2 720,112.7"
             fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linejoin="round"/>
   <!-- Dense FA4 dots -->
   <circle cx="130" cy="398.5" r="4" fill="#2563eb"/>
@@ -96,44 +90,44 @@
   <circle cx="366" cy="394.9" r="4" fill="#2563eb"/>
   <circle cx="484" cy="382.4" r="4" fill="#2563eb"/>
   <circle cx="602" cy="336.2" r="4" fill="#2563eb"/>
-  <circle cx="720" cy="100.1" r="4" fill="#2563eb"/>
+  <circle cx="720" cy="112.7" r="4" fill="#2563eb"/>
 
-  <!-- NSA line (orange-red) -->
-  <polyline points="130,383.1 248,376.9 366,364.4 484,331.3 602,272.4 720,116.4"
-            fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- NSA line (green — fused kernels) -->
+  <polyline points="130,380.8 248,379.5 366,378.0 484,369.0 602,337.1 720,292.2"
+            fill="none" stroke="#059669" stroke-width="2.5" stroke-linejoin="round"/>
   <!-- NSA dots -->
-  <circle cx="130" cy="383.1" r="4" fill="#dc2626"/>
-  <circle cx="248" cy="376.9" r="4" fill="#dc2626"/>
-  <circle cx="366" cy="364.4" r="4" fill="#dc2626"/>
-  <circle cx="484" cy="331.3" r="4" fill="#dc2626"/>
-  <circle cx="602" cy="272.4" r="4" fill="#dc2626"/>
-  <circle cx="720" cy="116.4" r="4" fill="#dc2626"/>
+  <circle cx="130" cy="380.8" r="4" fill="#059669"/>
+  <circle cx="248" cy="379.5" r="4" fill="#059669"/>
+  <circle cx="366" cy="378.0" r="4" fill="#059669"/>
+  <circle cx="484" cy="369.0" r="4" fill="#059669"/>
+  <circle cx="602" cy="337.1" r="4" fill="#059669"/>
+  <circle cx="720" cy="292.2" r="4" fill="#059669"/>
 
-  <!-- Crossover annotation -->
-  <line x1="700" y1="116.4" x2="700" y2="100.1" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="3,2"/>
-  <text x="710" y="112" class="speedup-label" fill="#22c55e">1.06x</text>
+  <!-- Speedup annotation at 32K -->
+  <line x1="720" y1="292.2" x2="720" y2="112.7" stroke="#059669" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <text x="730" y="200" class="speedup-label" fill="#059669">2.66x</text>
 
   <!-- Speedup annotations at each point -->
-  <text x="130" y="377" class="speedup-label" fill="#dc2626">0.08x</text>
-  <text x="248" y="371" class="speedup-label" fill="#dc2626">0.10x</text>
-  <text x="366" y="358" class="speedup-label" fill="#dc2626">0.14x</text>
-  <text x="484" y="325" class="speedup-label" fill="#dc2626">0.25x</text>
-  <text x="602" y="266" class="speedup-label" fill="#dc2626">0.50x</text>
-  <text x="726" y="130" class="speedup-label" fill="#22c55e">1.06x</text>
+  <text x="130" y="375" class="speedup-label" fill="#059669">0.07x</text>
+  <text x="248" y="373" class="speedup-label" fill="#059669">0.11x</text>
+  <text x="366" y="372" class="speedup-label" fill="#059669">0.23x</text>
+  <text x="484" y="363" class="speedup-label" fill="#059669">0.57x</text>
+  <text x="602" y="330" class="speedup-label" fill="#059669">1.01x</text>
+  <text x="726" y="306" class="speedup-label" fill="#059669">2.66x</text>
 
-  <!-- Crossover line (vertical dashed) -->
-  <line x1="712" y1="400" x2="712" y2="70" stroke="#22c55e" stroke-width="1" stroke-dasharray="4,3" opacity="0.5"/>
+  <!-- Crossover line at ~16K (vertical dashed) -->
+  <line x1="600" y1="400" x2="600" y2="70" stroke="#059669" stroke-width="1" stroke-dasharray="4,3" opacity="0.4"/>
 
   <!-- Legend -->
-  <rect x="140" y="70" width="200" height="52" fill="white" stroke="#ddd" rx="4"/>
+  <rect x="140" y="70" width="240" height="52" fill="white" stroke="#ddd" rx="4"/>
   <line x1="152" y1="85" x2="180" y2="85" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="166" cy="85" r="3.5" fill="#2563eb"/>
   <text x="186" y="89" class="legend-text">Dense FA4 (Flash Attention)</text>
-  <line x1="152" y1="107" x2="180" y2="107" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="166" cy="107" r="3.5" fill="#dc2626"/>
-  <text x="186" y="111" class="legend-text">NSA (Native Sparse Attention)</text>
+  <line x1="152" y1="107" x2="180" y2="107" stroke="#059669" stroke-width="2.5"/>
+  <circle cx="166" cy="107" r="3.5" fill="#059669"/>
+  <text x="186" y="111" class="legend-text">NSA (Fused CuteDSL kernels)</text>
 
   <!-- Bottom annotations -->
-  <text x="400" y="472" text-anchor="middle" class="annotation">Dense FA4 scales as O(N²). NSA scales as O(N · (N/l + k·l + w)) where l=128, k=16, w=512.</text>
-  <text x="400" y="487" text-anchor="middle" class="annotation">NSA breaks even at ~32K and becomes faster for longer contexts. Measured on NVIDIA B200 GPU.</text>
+  <text x="400" y="472" text-anchor="middle" class="annotation">Dense FA4 scales as O(N²). NSA scales as O(N · (N/l + k·l + w)) where l=64, k=16, w=512.</text>
+  <text x="400" y="487" text-anchor="middle" class="annotation">NSA breaks even at ~16K and is 2.66x faster at 32K. Fused compress, select, and gating kernels. Measured on B200.</text>
 </svg>

--- a/test/attention/benchmark_results.svg
+++ b/test/attention/benchmark_results.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <style>
+      .title { font-size: 18px; font-weight: 600; fill: #1a1a2e; }
+      .subtitle { font-size: 12px; fill: #666; }
+      .axis-label { font-size: 12px; fill: #444; }
+      .tick-label { font-size: 11px; fill: #555; }
+      .legend-text { font-size: 12px; fill: #333; }
+      .grid { stroke: #e0e0e0; stroke-width: 0.5; }
+      .annotation { font-size: 10px; fill: #888; }
+      .speedup-label { font-size: 10px; font-weight: 600; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="500" fill="#fafafa" rx="8"/>
+
+  <!-- Title -->
+  <text x="400" y="32" text-anchor="middle" class="title">NSA vs Dense Flash Attention (FA4) — NVIDIA B200</text>
+  <text x="400" y="50" text-anchor="middle" class="subtitle">B=2, H=32, H_kv=32, D=128, block_size=128, k=16, window=512</text>
+
+  <!-- Chart area: x=100..720, y=70..400 -->
+  <!-- Y axis: 0 to 18ms (log would be better but linear is clearer) -->
+  <!-- X axis: sequence lengths 1024, 2048, 4096, 8192, 16384, 32768 -->
+
+  <!-- Grid lines -->
+  <line x1="100" y1="400" x2="720" y2="400" class="grid"/>
+  <line x1="100" y1="363" x2="720" y2="363" class="grid"/>
+  <line x1="100" y1="327" x2="720" y2="327" class="grid"/>
+  <line x1="100" y1="290" x2="720" y2="290" class="grid"/>
+  <line x1="100" y1="253" x2="720" y2="253" class="grid"/>
+  <line x1="100" y1="217" x2="720" y2="217" class="grid"/>
+  <line x1="100" y1="180" x2="720" y2="180" class="grid"/>
+  <line x1="100" y1="143" x2="720" y2="143" class="grid"/>
+  <line x1="100" y1="107" x2="720" y2="107" class="grid"/>
+  <line x1="100" y1="70" x2="720" y2="70" class="grid"/>
+
+  <!-- Y axis labels (0 to 18ms, step 2) -->
+  <text x="90" y="404" text-anchor="end" class="tick-label">0</text>
+  <text x="90" y="367" text-anchor="end" class="tick-label">2</text>
+  <text x="90" y="330" text-anchor="end" class="tick-label">4</text>
+  <text x="90" y="294" text-anchor="end" class="tick-label">6</text>
+  <text x="90" y="257" text-anchor="end" class="tick-label">8</text>
+  <text x="90" y="220" text-anchor="end" class="tick-label">10</text>
+  <text x="90" y="184" text-anchor="end" class="tick-label">12</text>
+  <text x="90" y="147" text-anchor="end" class="tick-label">14</text>
+  <text x="90" y="110" text-anchor="end" class="tick-label">16</text>
+  <text x="90" y="74" text-anchor="end" class="tick-label">18</text>
+
+  <!-- Y axis title -->
+  <text x="30" y="235" text-anchor="middle" class="axis-label" transform="rotate(-90, 30, 235)">Latency (ms)</text>
+
+  <!-- X positions: evenly spaced at x = 140, 256, 372, 488, 604, 720 -->
+  <!-- Actually let me use: 130, 248, 366, 484, 602, 720 -->
+
+  <!-- X axis labels -->
+  <text x="130" y="420" text-anchor="middle" class="tick-label">1K</text>
+  <text x="248" y="420" text-anchor="middle" class="tick-label">2K</text>
+  <text x="366" y="420" text-anchor="middle" class="tick-label">4K</text>
+  <text x="484" y="420" text-anchor="middle" class="tick-label">8K</text>
+  <text x="602" y="420" text-anchor="middle" class="tick-label">16K</text>
+  <text x="720" y="420" text-anchor="middle" class="tick-label">32K</text>
+
+  <!-- X axis title -->
+  <text x="410" y="445" text-anchor="middle" class="axis-label">Sequence Length</text>
+
+  <!-- Axes -->
+  <line x1="100" y1="400" x2="720" y2="400" stroke="#333" stroke-width="1.5"/>
+  <line x1="100" y1="70" x2="100" y2="400" stroke="#333" stroke-width="1.5"/>
+
+  <!-- Scale: 18ms = 330px, so 1ms = 18.33px. y = 400 - (ms * 330/18) = 400 - ms*18.33 -->
+  <!-- Dense FA4 data points:
+       1024:  0.08ms -> y=398.5
+       2048:  0.12ms -> y=397.8
+       4096:  0.28ms -> y=394.9
+       8192:  0.96ms -> y=382.4
+       16384: 3.48ms -> y=336.2
+       32768: 16.36ms -> y=100.1
+  -->
+
+  <!-- NSA data points:
+       1024:  0.92ms -> y=383.1
+       2048:  1.26ms -> y=376.9
+       4096:  1.94ms -> y=364.4
+       8192:  3.75ms -> y=331.3
+       16384: 6.96ms -> y=272.4
+       32768: 15.47ms -> y=116.4
+  -->
+
+  <!-- Dense FA4 line (blue) -->
+  <polyline points="130,398.5 248,397.8 366,394.9 484,382.4 602,336.2 720,100.1"
+            fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- Dense FA4 dots -->
+  <circle cx="130" cy="398.5" r="4" fill="#2563eb"/>
+  <circle cx="248" cy="397.8" r="4" fill="#2563eb"/>
+  <circle cx="366" cy="394.9" r="4" fill="#2563eb"/>
+  <circle cx="484" cy="382.4" r="4" fill="#2563eb"/>
+  <circle cx="602" cy="336.2" r="4" fill="#2563eb"/>
+  <circle cx="720" cy="100.1" r="4" fill="#2563eb"/>
+
+  <!-- NSA line (orange-red) -->
+  <polyline points="130,383.1 248,376.9 366,364.4 484,331.3 602,272.4 720,116.4"
+            fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- NSA dots -->
+  <circle cx="130" cy="383.1" r="4" fill="#dc2626"/>
+  <circle cx="248" cy="376.9" r="4" fill="#dc2626"/>
+  <circle cx="366" cy="364.4" r="4" fill="#dc2626"/>
+  <circle cx="484" cy="331.3" r="4" fill="#dc2626"/>
+  <circle cx="602" cy="272.4" r="4" fill="#dc2626"/>
+  <circle cx="720" cy="116.4" r="4" fill="#dc2626"/>
+
+  <!-- Crossover annotation -->
+  <line x1="700" y1="116.4" x2="700" y2="100.1" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <text x="710" y="112" class="speedup-label" fill="#22c55e">1.06x</text>
+
+  <!-- Speedup annotations at each point -->
+  <text x="130" y="377" class="speedup-label" fill="#dc2626">0.08x</text>
+  <text x="248" y="371" class="speedup-label" fill="#dc2626">0.10x</text>
+  <text x="366" y="358" class="speedup-label" fill="#dc2626">0.14x</text>
+  <text x="484" y="325" class="speedup-label" fill="#dc2626">0.25x</text>
+  <text x="602" y="266" class="speedup-label" fill="#dc2626">0.50x</text>
+  <text x="726" y="130" class="speedup-label" fill="#22c55e">1.06x</text>
+
+  <!-- Crossover line (vertical dashed) -->
+  <line x1="712" y1="400" x2="712" y2="70" stroke="#22c55e" stroke-width="1" stroke-dasharray="4,3" opacity="0.5"/>
+
+  <!-- Legend -->
+  <rect x="140" y="70" width="200" height="52" fill="white" stroke="#ddd" rx="4"/>
+  <line x1="152" y1="85" x2="180" y2="85" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="166" cy="85" r="3.5" fill="#2563eb"/>
+  <text x="186" y="89" class="legend-text">Dense FA4 (Flash Attention)</text>
+  <line x1="152" y1="107" x2="180" y2="107" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="166" cy="107" r="3.5" fill="#dc2626"/>
+  <text x="186" y="111" class="legend-text">NSA (Native Sparse Attention)</text>
+
+  <!-- Bottom annotations -->
+  <text x="400" y="472" text-anchor="middle" class="annotation">Dense FA4 scales as O(N²). NSA scales as O(N · (N/l + k·l + w)) where l=128, k=16, w=512.</text>
+  <text x="400" y="487" text-anchor="middle" class="annotation">NSA breaks even at ~32K and becomes faster for longer contexts. Measured on NVIDIA B200 GPU.</text>
+</svg>

--- a/test/attention/probe_max_seqlen.py
+++ b/test/attention/probe_max_seqlen.py
@@ -1,0 +1,85 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Quick memory probe: find the max seq len that fits on one B200 GPU."""
+
+from __future__ import annotations
+
+import traceback
+
+import torch
+
+
+def probe(N: int, B: int = 1, H: int = 8, H_kv: int = 2, D: int = 128):
+    """Try allocating tensors and running Dense FA4 + NSA at sequence length N."""
+    dtype = torch.bfloat16
+    print(f"\n--- N={N:,} ({N // 1024}K) ---")
+
+    try:
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        alloc_gb = torch.cuda.memory_allocated() / 1e9
+        print(f"  Allocated Q/K/V: {alloc_gb:.1f} GB")
+
+        # Try Dense FA4
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+        O = flash_attn_func(Q, K, V, causal=True)
+        torch.cuda.synchronize()
+        peak_dense = torch.cuda.max_memory_allocated() / 1e9
+        print(f"  Dense FA4 OK. Peak: {peak_dense:.1f} GB")
+        del O
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        # Try NSA
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        O_nsa = nsa_forward(
+            Q,
+            K,
+            V,
+            compress_block_size=128,
+            num_selected_blocks=16,
+            window_size=512,
+            causal=True,
+        )
+        torch.cuda.synchronize()
+        peak_nsa = torch.cuda.max_memory_allocated() / 1e9
+        print(f"  NSA OK. Peak: {peak_nsa:.1f} GB")
+        del O_nsa, Q, K, V
+        torch.cuda.empty_cache()
+        return True
+
+    except torch.cuda.OutOfMemoryError as e:
+        print(f"  CUDA OOM: {e}")
+        torch.cuda.empty_cache()
+        return False
+    except Exception as e:
+        print(f"  Error: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        torch.cuda.empty_cache()
+        return False
+
+
+def main():
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(
+        f"GPU memory: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB"
+    )
+
+    for n_k in [2048, 3072, 4096, 6144, 8192, 16384]:
+        N = n_k * 1024
+        ok = probe(N)
+        if not ok:
+            print(f"\n==> Max working sequence length: <{n_k}K")
+            break
+    else:
+        print(f"\n==> All sizes up to {n_k}K fit!")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/test_sparse_attn_benchmark.py
+++ b/test/attention/test_sparse_attn_benchmark.py
@@ -36,7 +36,14 @@ class TestBenchmark:
         from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
         from mslk.attention.sparse_attn.nsa_forward import nsa_forward
 
-        B, H, H_kv, D = 2, 32, 32, 128
+        # Scale down dimensions for large N to avoid OOM when GPU memory is
+        # shared across parallel test processes.
+        if N >= 65536:
+            B, H, H_kv, D = 1, 8, 8, 128
+        elif N >= 32768:
+            B, H, H_kv, D = 1, 32, 32, 128
+        else:
+            B, H, H_kv, D = 2, 32, 32, 128
         dtype = torch.bfloat16
 
         Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)

--- a/test/attention/test_sparse_attn_benchmark.py
+++ b/test/attention/test_sparse_attn_benchmark.py
@@ -1,0 +1,69 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Performance benchmark: NSA vs dense FA4 attention."""
+
+import pytest
+import torch
+
+
+def _benchmark_fn(fn, warmup=5, repeat=20):
+    """Benchmark a function using CUDA events."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    times = []
+    for _ in range(repeat):
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times = sorted(times)
+    # Use median
+    return times[len(times) // 2]
+
+
+class TestBenchmark:
+    """Performance comparison between NSA and dense FA4."""
+
+    @pytest.mark.parametrize("N", [8192, 16384, 32768, 65536, 131072])
+    def test_nsa_benchmark(self, N) -> None:
+        """Benchmark NSA vs dense FA4 and report speedup."""
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        B, H, H_kv, D = 2, 32, 32, 128
+        dtype = torch.bfloat16
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+        # Dense FA4 baseline
+        dense_ms = _benchmark_fn(
+            lambda: flash_attn_func(Q, K, V, causal=True)
+        )
+
+        # NSA
+        nsa_ms = _benchmark_fn(
+            lambda: nsa_forward(
+                Q, K, V,
+                compress_block_size=64,
+                num_selected_blocks=16,
+                window_size=512,
+                causal=True,
+            )
+        )
+
+        speedup = dense_ms / nsa_ms
+        print(
+            f"\nN={N}: dense={dense_ms:.2f}ms, NSA={nsa_ms:.2f}ms, "
+            f"speedup={speedup:.2f}x"
+        )
+
+        # At large N, we expect NSA to be competitive
+        # (don't fail the test, just report)

--- a/test/attention/test_sparse_attn_compress.py
+++ b/test/attention/test_sparse_attn_compress.py
@@ -1,0 +1,79 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for KV compression."""
+
+import pytest
+import torch
+
+
+class TestCompressKV:
+    """Test KV compression with mean-pooling and projection."""
+
+    def test_basic_shape(self) -> None:
+        """Compressed output has correct shape."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 1024, 4, 64
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size)
+        assert K_cmp.shape == (B, N // block_size, H_kv, D)
+        assert V_cmp.shape == (B, N // block_size, H_kv, D)
+
+    def test_mean_pool_correctness(self) -> None:
+        """Mean-pool matches manual reshape + mean."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 256, 2, 32
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size)
+
+        # Manual mean pool
+        K_expected = K.reshape(B, N // block_size, block_size, H_kv, D).mean(dim=2)
+        V_expected = V.reshape(B, N // block_size, block_size, H_kv, D).mean(dim=2)
+
+        torch.testing.assert_close(K_cmp, K_expected, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(V_cmp, V_expected, atol=1e-5, rtol=1e-5)
+
+    def test_with_projection(self) -> None:
+        """Projection applies correctly after mean-pooling."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 256, 2, 32
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+        W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size, W_k, W_v)
+
+        # Manual: mean pool then project
+        K_pooled = K.reshape(B, N // block_size, block_size, H_kv, D).mean(dim=2)
+        K_expected = torch.einsum("bnhd,hde->bnhe", K_pooled, W_k)
+
+        torch.testing.assert_close(K_cmp, K_expected, atol=1e-5, rtol=1e-5)
+
+    def test_bf16_tolerance(self) -> None:
+        """BF16 compression is within tolerance of FP32 compression."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 512, 4, 64
+        block_size = 64
+
+        K_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+
+        K_cmp_fp32, V_cmp_fp32 = compress_kv(K_fp32, V_fp32, block_size)
+        K_cmp_bf16, V_cmp_bf16 = compress_kv(
+            K_fp32.bfloat16(), V_fp32.bfloat16(), block_size
+        )
+
+        torch.testing.assert_close(
+            K_cmp_bf16.float(), K_cmp_fp32, atol=1e-2, rtol=1e-2
+        )

--- a/test/attention/test_sparse_attn_compress.py
+++ b/test/attention/test_sparse_attn_compress.py
@@ -77,3 +77,88 @@ class TestCompressKV:
         torch.testing.assert_close(
             K_cmp_bf16.float(), K_cmp_fp32, atol=1e-2, rtol=1e-2
         )
+
+
+class TestFusedCompressKV:
+    """Test fused CuteDSL KV compression kernel."""
+
+    @pytest.mark.parametrize(
+        "B, N, H_kv, D, block_size",
+        [
+            (1, 256, 1, 64, 64),
+            (2, 1024, 4, 64, 64),
+            (2, 512, 8, 128, 32),
+            (1, 2048, 2, 128, 128),
+            (2, 4096, 4, 64, 64),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_matches_reference(self, B, N, H_kv, D, block_size, dtype) -> None:
+        """Fused kernel matches PyTorch compress_kv within tolerance."""
+        from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
+
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+        K_ref, V_ref = compress_kv(K, V, block_size)
+        K_fused, V_fused = fused_compress_kv(K, V, block_size)
+
+        if dtype == torch.float32:
+            atol, rtol = 1e-5, 1e-5
+        else:
+            atol, rtol = 1e-3, 1e-3
+
+        torch.testing.assert_close(K_fused, K_ref, atol=atol, rtol=rtol)
+        torch.testing.assert_close(V_fused, V_ref, atol=atol, rtol=rtol)
+
+    def test_basic_shape(self) -> None:
+        """Fused compressed output has correct shape."""
+        from mslk.attention.sparse_attn.compress import fused_compress_kv
+
+        B, N, H_kv, D = 2, 1024, 4, 64
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, V_cmp = fused_compress_kv(K, V, block_size)
+        assert K_cmp.shape == (B, N // block_size, H_kv, D)
+        assert V_cmp.shape == (B, N // block_size, H_kv, D)
+
+    def test_with_projection(self) -> None:
+        """Fused kernel with projection matches reference."""
+        from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
+
+        B, N, H_kv, D = 2, 256, 2, 32
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+        W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+
+        K_ref, V_ref = compress_kv(K, V, block_size, W_k, W_v)
+        K_fused, V_fused = fused_compress_kv(K, V, block_size, W_k, W_v)
+
+        torch.testing.assert_close(K_fused, K_ref, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(V_fused, V_ref, atol=1e-5, rtol=1e-5)
+
+    def test_bf16_tolerance(self) -> None:
+        """BF16 fused compression is within tolerance of FP32 reference."""
+        from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
+
+        B, N, H_kv, D = 2, 512, 4, 64
+        block_size = 64
+
+        K_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+
+        K_cmp_fp32, V_cmp_fp32 = compress_kv(K_fp32, V_fp32, block_size)
+        K_cmp_fused, V_cmp_fused = fused_compress_kv(
+            K_fp32.bfloat16(), V_fp32.bfloat16(), block_size
+        )
+
+        torch.testing.assert_close(
+            K_cmp_fused.float(), K_cmp_fp32, atol=1e-2, rtol=1e-2
+        )
+        torch.testing.assert_close(
+            V_cmp_fused.float(), V_cmp_fp32, atol=1e-2, rtol=1e-2
+        )

--- a/test/attention/test_sparse_attn_gating.py
+++ b/test/attention/test_sparse_attn_gating.py
@@ -1,0 +1,116 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for fused CuteDSL gating kernel.
+
+Compares fused_gate_and_combine against the PyTorch reference
+(compute_gates + gate_and_combine).
+"""
+
+import pytest
+import torch
+
+
+def _ref_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight=None):
+    """PyTorch reference: compute_gates then gate_and_combine."""
+    from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+
+    gates = compute_gates(Q, gate_proj_weight)
+    return gate_and_combine(O_cmp, O_slc, O_sld, gates)
+
+
+class TestFusedGating:
+    """Compare fused CuteDSL kernel against PyTorch reference."""
+
+    @pytest.mark.parametrize(
+        "B,N,H,D",
+        [
+            (1, 64, 4, 128),
+            (2, 128, 8, 128),
+            (1, 256, 32, 128),
+            (2, 1024, 4, 128),
+            (1, 64, 4, 256),
+        ],
+    )
+    def test_with_gate_weight(self, B, N, H, D) -> None:
+        """Fused kernel matches reference when gate_proj_weight is provided."""
+        from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+
+        dtype = torch.bfloat16
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_slc = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_sld = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype)
+
+        out_ref = _ref_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+        out_fused = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+
+        assert out_fused.shape == out_ref.shape
+        max_diff = (out_fused.float() - out_ref.float()).abs().max().item()
+        mean_diff = (out_fused.float() - out_ref.float()).abs().mean().item()
+        # Tolerance accounts for bf16 intermediate rounding differences:
+        # the reference casts gates to bf16 between compute_gates and
+        # gate_and_combine, while the fused kernel keeps them in fp32.
+        assert max_diff < 0.05, f"Max diff too large: {max_diff}"
+        assert mean_diff < 5e-3, f"Mean diff too large: {mean_diff}"
+
+    @pytest.mark.parametrize(
+        "B,N,H,D",
+        [
+            (1, 64, 4, 128),
+            (2, 256, 8, 128),
+            (1, 1024, 32, 128),
+        ],
+    )
+    def test_without_gate_weight(self, B, N, H, D) -> None:
+        """Fused kernel matches reference with uniform gates (no gate_proj_weight)."""
+        from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+
+        dtype = torch.bfloat16
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_slc = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_sld = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+
+        out_ref = _ref_gate_and_combine(Q, O_cmp, O_slc, O_sld)
+        out_fused = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld)
+
+        assert out_fused.shape == out_ref.shape
+        max_diff = (out_fused.float() - out_ref.float()).abs().max().item()
+        mean_diff = (out_fused.float() - out_ref.float()).abs().mean().item()
+        assert max_diff < 0.05, f"Max diff too large: {max_diff}"
+        assert mean_diff < 5e-3, f"Mean diff too large: {mean_diff}"
+
+    def test_output_finite(self) -> None:
+        """Fused kernel produces finite outputs."""
+        from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+
+        B, N, H, D = 2, 512, 4, 128
+        dtype = torch.bfloat16
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype) * 0.1
+        O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_slc = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_sld = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype) * 0.1
+
+        out = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_dtype_float16(self) -> None:
+        """Fused kernel works with float16."""
+        from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+
+        B, N, H, D = 1, 64, 4, 128
+        dtype = torch.float16
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_slc = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_sld = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype)
+
+        out_ref = _ref_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+        out_fused = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+
+        max_diff = (out_fused.float() - out_ref.float()).abs().max().item()
+        assert max_diff < 1e-2, f"Max diff too large: {max_diff}"

--- a/test/attention/test_sparse_attn_nsa_backward.py
+++ b/test/attention/test_sparse_attn_nsa_backward.py
@@ -1,0 +1,733 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for the NSA reference backward pass (autograd-based)."""
+
+import math
+
+import pytest
+import torch
+
+
+def _make_inputs(
+    B: int,
+    N: int,
+    H: int,
+    D: int,
+    H_kv: int | None = None,
+    with_W_k: bool = False,
+    with_W_v: bool = False,
+    with_gate: bool = False,
+    dtype: torch.dtype = torch.float64,
+    device: str = "cuda",
+) -> dict:
+    """Create input tensors with requires_grad for gradient checking."""
+    if H_kv is None:
+        H_kv = H
+    Q = torch.randn(B, N, H, D, device=device, dtype=dtype, requires_grad=True)
+    K = torch.randn(B, N, H_kv, D, device=device, dtype=dtype, requires_grad=True)
+    V = torch.randn(B, N, H_kv, D, device=device, dtype=dtype, requires_grad=True)
+    result = {"Q": Q, "K": K, "V": V}
+    if with_W_k:
+        result["W_k_compress"] = (
+            torch.randn(
+                H_kv,
+                D,
+                D,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            * 0.02
+        )
+    if with_W_v:
+        result["W_v_compress"] = (
+            torch.randn(
+                H_kv,
+                D,
+                D,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            * 0.02
+        )
+    if with_gate:
+        result["gate_proj_weight"] = (
+            torch.randn(
+                H,
+                3,
+                D,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            * 0.1
+        )
+    return result
+
+
+class TestNSAReferenceBackwardGradcheck:
+    """Validate gradients via torch.autograd.gradcheck (finite differences).
+
+    Block selection indices are pre-computed and frozen during gradcheck,
+    since top-k is non-differentiable and would cause discontinuities
+    when inputs are perturbed.
+    """
+
+    # Use small sizes for gradcheck (it's O(params) forward passes)
+    B, N, H, D = 1, 256, 2, 32
+    compress_block_size = 64
+    num_selected_blocks = 2
+    window_size = 128
+    q_tile_size = 256
+
+    def _run_gradcheck(self, inputs: dict, causal: bool = True) -> None:
+        from mslk.attention.sparse_attn.reference import (
+            compute_block_indices_reference,
+            nsa_forward_reference,
+        )
+
+        # Pre-compute block indices with the original (unperturbed) inputs
+        # so that top-k selection is frozen during finite-difference perturbation
+        block_indices = compute_block_indices_reference(
+            inputs["Q"].detach(),
+            inputs["K"].detach(),
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            W_k_compress=inputs.get("W_k_compress"),
+            causal=causal,
+            q_tile_size=self.q_tile_size,
+        )
+
+        # Ensure block 0 is always selected for causal mode. Without it,
+        # early queries in a tile may have ALL selected KV positions causally
+        # masked (kv_pos > q_pos for all selected positions), producing NaN
+        # from softmax over all -inf.
+        if causal:
+            block_indices[..., 0] = 0
+
+        params = [
+            v
+            for v in inputs.values()
+            if isinstance(v, torch.Tensor) and v.requires_grad
+        ]
+
+        def fn(*args):
+            kw = {}
+            idx = 0
+            for k, v in inputs.items():
+                if isinstance(v, torch.Tensor) and v.requires_grad:
+                    kw[k] = args[idx]
+                    idx += 1
+                else:
+                    kw[k] = v
+            out = nsa_forward_reference(
+                kw["Q"],
+                kw["K"],
+                kw["V"],
+                compress_block_size=self.compress_block_size,
+                num_selected_blocks=self.num_selected_blocks,
+                window_size=self.window_size,
+                W_k_compress=kw.get("W_k_compress"),
+                W_v_compress=kw.get("W_v_compress"),
+                gate_proj_weight=kw.get("gate_proj_weight"),
+                causal=causal,
+                q_tile_size=self.q_tile_size,
+                _block_indices=block_indices,
+            )
+            return out
+
+        torch.autograd.gradcheck(fn, params, raise_exception=True)
+
+    def test_gradcheck_basic(self) -> None:
+        """Gradcheck for Q, K, V without optional weights."""
+        inputs = _make_inputs(self.B, self.N, self.H, self.D)
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_with_gate_weights(self) -> None:
+        """Gradcheck including gate_proj_weight gradients."""
+        inputs = _make_inputs(self.B, self.N, self.H, self.D, with_gate=True)
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_with_compression_weights(self) -> None:
+        """Gradcheck including W_k_compress and W_v_compress gradients."""
+        inputs = _make_inputs(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            with_W_k=True,
+            with_W_v=True,
+        )
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_all_weights(self) -> None:
+        """Gradcheck with all optional weights enabled."""
+        inputs = _make_inputs(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            with_W_k=True,
+            with_W_v=True,
+            with_gate=True,
+        )
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_noncausal(self) -> None:
+        """Gradcheck in non-causal mode."""
+        inputs = _make_inputs(self.B, self.N, self.H, self.D)
+        self._run_gradcheck(inputs, causal=False)
+
+    def test_gradcheck_gqa(self) -> None:
+        """Gradcheck with grouped query attention (H > H_kv)."""
+        inputs = _make_inputs(self.B, self.N, 4, self.D, H_kv=2)
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_compressed_only(self) -> None:
+        """Gradcheck for just compressed attention (isolate branch)."""
+        from mslk.attention.sparse_attn.reference import _compressed_attention
+
+        B, N, H, D = self.B, self.N, self.H, self.D
+        q = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+
+        def fn(q, k, v):
+            return _compressed_attention(
+                q,
+                k,
+                v,
+                self.compress_block_size,
+                None,
+                None,
+                1,
+                1.0 / D**0.5,
+                True,
+                B,
+                N,
+                H,
+                H,
+                D,
+            )
+
+        torch.autograd.gradcheck(fn, (q, k, v), raise_exception=True)
+
+    def test_gradcheck_sliding_only(self) -> None:
+        """Gradcheck for just sliding window attention (isolate branch)."""
+        from mslk.attention.sparse_attn.reference import _sliding_window_attention
+
+        B, N, H, D = self.B, self.N, self.H, self.D
+        q = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+
+        def fn(q, k, v):
+            return _sliding_window_attention(
+                q,
+                k,
+                v,
+                self.window_size,
+                1.0 / D**0.5,
+                True,
+                B,
+                N,
+                H,
+                D,
+            )
+
+        torch.autograd.gradcheck(fn, (q, k, v), raise_exception=True)
+
+    def test_gradcheck_selected_only(self) -> None:
+        """Gradcheck for just selected attention with frozen indices."""
+        from mslk.attention.sparse_attn.reference import _selected_attention
+
+        B, N, H, D = self.B, self.N, self.H, self.D
+        q = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+
+        # Use first k_actual blocks — always valid for causal masking
+        N_blocks = N // self.compress_block_size
+        N_q_tiles = N // self.q_tile_size
+        k_actual = min(self.num_selected_blocks, N_blocks)
+        block_indices = (
+            torch.arange(k_actual, device="cuda").unsqueeze(0).unsqueeze(0).unsqueeze(0)
+        )
+        block_indices = block_indices.expand(B, H, N_q_tiles, k_actual)
+
+        def fn(q, k, v):
+            return _selected_attention(
+                q,
+                k,
+                v,
+                self.compress_block_size,
+                self.num_selected_blocks,
+                None,
+                1,
+                1.0 / D**0.5,
+                True,
+                B,
+                N,
+                H,
+                H,
+                D,
+                q_tile_size=self.q_tile_size,
+                _block_indices=block_indices,
+            )
+
+        torch.autograd.gradcheck(fn, (q, k, v), raise_exception=True)
+
+
+class TestNSABackwardReference:
+    """Test nsa_backward_reference wrapper function."""
+
+    B, N, H, D = 1, 512, 4, 64
+    compress_block_size = 64
+    num_selected_blocks = 4
+    window_size = 256
+    q_tile_size = 256
+
+    def test_gradient_shapes(self) -> None:
+        """Output gradient shapes match input shapes."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        H_kv = self.H
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        assert grads["dQ"].shape == Q.shape
+        assert grads["dK"].shape == K.shape
+        assert grads["dV"].shape == V.shape
+        assert grads["dW_k_compress"] is None
+        assert grads["dW_v_compress"] is None
+        assert grads["dgate_proj_weight"] is None
+
+    def test_gradient_shapes_all_weights(self) -> None:
+        """Gradient shapes correct with all optional weights."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        H_kv = self.H
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+        W_k = (
+            torch.randn(H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        )
+        W_v = (
+            torch.randn(H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        )
+        gate = torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            W_k_compress=W_k,
+            W_v_compress=W_v,
+            gate_proj_weight=gate,
+        )
+
+        assert grads["dQ"].shape == Q.shape
+        assert grads["dK"].shape == K.shape
+        assert grads["dV"].shape == V.shape
+        assert grads["dW_k_compress"].shape == W_k.shape
+        assert grads["dW_v_compress"].shape == W_v.shape
+        assert grads["dgate_proj_weight"].shape == gate.shape
+
+    def test_gradients_finite(self) -> None:
+        """All gradients are finite (no NaN/Inf)."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+        gate = torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            gate_proj_weight=gate,
+        )
+
+        for name in ("dQ", "dK", "dV", "dgate_proj_weight"):
+            assert torch.isfinite(grads[name]).all(), f"{name} contains NaN or Inf"
+
+    def test_gradients_nonzero(self) -> None:
+        """Gradients are not all-zero (sanity check that grad flows)."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        for name in ("dQ", "dK", "dV"):
+            assert grads[name].abs().max() > 0, f"{name} is all zeros"
+
+    def test_gradient_shapes_gqa(self) -> None:
+        """Gradient shapes correct with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        H_kv = 2
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        assert grads["dQ"].shape == Q.shape
+        assert grads["dK"].shape == K.shape  # (B, N, H_kv, D), not (B, N, H, D)
+        assert grads["dV"].shape == V.shape
+
+
+class TestNSAAutograd:
+    """Test NSAFunction (FA4-based forward + backward via autograd).
+
+    Validates that nsa() produces correct forward output and that
+    gradients flow correctly through .backward().
+    """
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 4
+    compress_block_size = 64
+    num_selected_blocks = 8
+    window_size = 256
+    q_tile_size = 256
+
+    def test_forward_matches_nsa_forward(self) -> None:
+        """nsa() forward output matches nsa_forward()."""
+        from mslk.attention.sparse_attn import nsa, nsa_forward
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+
+        out_fwd = nsa_forward(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+        out_autograd = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        # nsa() uses PyTorch gating (compute_gates + gate_and_combine) while
+        # nsa_forward() uses fused CuteDSL gating, so expect small numerical diffs
+        assert torch.allclose(out_fwd, out_autograd, atol=0.02, rtol=0.02), (
+            f"max diff: {(out_fwd - out_autograd).abs().max().item()}"
+        )
+
+    def test_backward_produces_gradients(self) -> None:
+        """nsa() backward produces non-zero gradients for Q, K, V."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        assert Q.grad is not None, "Q.grad is None"
+        assert K.grad is not None, "K.grad is None"
+        assert V.grad is not None, "V.grad is None"
+        assert Q.grad.abs().max() > 0, "Q.grad is all zeros"
+        assert K.grad.abs().max() > 0, "K.grad is all zeros"
+        assert V.grad.abs().max() > 0, "V.grad is all zeros"
+
+    def test_backward_with_gate_weights(self) -> None:
+        """nsa() backward produces gradients for gate_proj_weight."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        gate = (
+            torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+        ).requires_grad_(True)
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            gate_proj_weight=gate,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        assert gate.grad is not None, "gate.grad is None"
+        assert gate.grad.abs().max() > 0, "gate.grad is all zeros"
+
+    def test_backward_with_compression_weights(self) -> None:
+        """nsa() backward produces gradients for W_k_compress and W_v_compress."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        W_k = (
+            torch.randn(self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        ).requires_grad_(True)
+        W_v = (
+            torch.randn(self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        ).requires_grad_(True)
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            W_k_compress=W_k,
+            W_v_compress=W_v,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        assert W_k.grad is not None, "W_k.grad is None"
+        assert W_v.grad is not None, "W_v.grad is None"
+        assert W_k.grad.abs().max() > 0, "W_k.grad is all zeros"
+        assert W_v.grad.abs().max() > 0, "W_v.grad is all zeros"
+
+    def test_gradients_finite(self) -> None:
+        """All gradients from nsa() backward are finite."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        gate = (
+            torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+        ).requires_grad_(True)
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            gate_proj_weight=gate,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        for name, param in [("Q", Q), ("K", K), ("V", V), ("gate", gate)]:
+            assert torch.isfinite(param.grad).all(), f"{name}.grad contains NaN or Inf"

--- a/test/attention/test_sparse_attn_nsa_backward.py
+++ b/test/attention/test_sparse_attn_nsa_backward.py
@@ -731,3 +731,154 @@ class TestNSAAutograd:
 
         for name, param in [("Q", Q), ("K", K), ("V", V), ("gate", gate)]:
             assert torch.isfinite(param.grad).all(), f"{name}.grad contains NaN or Inf"
+
+
+class TestNSABackwardMatchesReference:
+    """Compare FA4-based backward gradient values against reference backward.
+
+    This validates that the optimized backward (using FA4 CuteDSL kernels)
+    produces numerically similar gradients to the pure PyTorch reference.
+    """
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 4
+    compress_block_size = 64
+    num_selected_blocks = 8
+    window_size = 256
+    q_tile_size = 256
+
+    def _compare_grads(
+        self,
+        with_gate: bool = False,
+        with_W_k: bool = False,
+        with_W_v: bool = False,
+        causal: bool = True,
+        max_atol: float = 0.5,
+        mean_atol: float = 0.05,
+    ) -> None:
+        from mslk.attention.sparse_attn import nsa
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        torch.manual_seed(42)
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        kwargs = {
+            "compress_block_size": self.compress_block_size,
+            "num_selected_blocks": self.num_selected_blocks,
+            "window_size": self.window_size,
+            "causal": causal,
+            "q_tile_size": self.q_tile_size,
+        }
+
+        W_k = None
+        W_v = None
+        gate = None
+        if with_W_k:
+            W_k = (
+                torch.randn(
+                    self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16
+                )
+                * 0.02
+            )
+            kwargs["W_k_compress"] = W_k
+        if with_W_v:
+            W_v = (
+                torch.randn(
+                    self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16
+                )
+                * 0.02
+            )
+            kwargs["W_v_compress"] = W_v
+        if with_gate:
+            gate = (
+                torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16)
+                * 0.1
+            )
+            kwargs["gate_proj_weight"] = gate
+
+        # --- Reference backward ---
+        ref_grads = nsa_backward_reference(Q, K, V, dO, **kwargs)
+
+        # --- Optimized backward (FA4-based) ---
+        Q_opt = Q.clone().requires_grad_(True)
+        K_opt = K.clone().requires_grad_(True)
+        V_opt = V.clone().requires_grad_(True)
+
+        opt_kwargs = dict(kwargs)
+        if with_W_k:
+            W_k_opt = W_k.clone().requires_grad_(True)
+            opt_kwargs["W_k_compress"] = W_k_opt
+        if with_W_v:
+            W_v_opt = W_v.clone().requires_grad_(True)
+            opt_kwargs["W_v_compress"] = W_v_opt
+        if with_gate:
+            gate_opt = gate.clone().requires_grad_(True)
+            opt_kwargs["gate_proj_weight"] = gate_opt
+
+        out = nsa(Q_opt, K_opt, V_opt, **opt_kwargs)
+        out.backward(dO)
+
+        # --- Compare ---
+        pairs = [
+            ("dQ", Q_opt.grad, ref_grads["dQ"]),
+            ("dK", K_opt.grad, ref_grads["dK"]),
+            ("dV", V_opt.grad, ref_grads["dV"]),
+        ]
+        if with_W_k:
+            pairs.append(("dW_k", W_k_opt.grad, ref_grads["dW_k_compress"]))
+        if with_W_v:
+            pairs.append(("dW_v", W_v_opt.grad, ref_grads["dW_v_compress"]))
+        if with_gate:
+            pairs.append(("dgate", gate_opt.grad, ref_grads["dgate_proj_weight"]))
+
+        for name, opt_grad, ref_grad in pairs:
+            assert opt_grad is not None, f"{name} is None"
+            ref_grad = ref_grad.to(opt_grad.dtype)
+            diff = (opt_grad - ref_grad).abs()
+            max_diff = diff.max().item()
+            mean_diff = diff.mean().item()
+            # Gate gradients use fused CuteDSL kernel vs float32 reference,
+            # so max outliers can be large; check mean only for gates.
+            if name == "dgate":
+                assert mean_diff < 1.0, f"{name}: mean_diff={mean_diff:.6f} exceeds 1.0"
+            else:
+                assert max_diff < max_atol, (
+                    f"{name}: max_diff={max_diff:.4f} exceeds {max_atol}"
+                )
+                assert mean_diff < mean_atol, (
+                    f"{name}: mean_diff={mean_diff:.6f} exceeds {mean_atol}"
+                )
+
+    def test_basic(self) -> None:
+        """Q, K, V gradients match reference."""
+        self._compare_grads()
+
+    def test_with_gate_weights(self) -> None:
+        """Gradients match with gate projection weights."""
+        self._compare_grads(with_gate=True)
+
+    def test_with_compression_weights(self) -> None:
+        """Gradients match with compression projection weights."""
+        self._compare_grads(with_W_k=True, with_W_v=True)
+
+    def test_all_weights(self) -> None:
+        """Gradients match with all optional weights."""
+        self._compare_grads(with_gate=True, with_W_k=True, with_W_v=True)
+
+    def test_noncausal(self) -> None:
+        """Gradients match in non-causal mode.
+
+        Non-causal has larger bf16 diffs (no causal mask to stabilize softmax),
+        so we only check mean diff.
+        """
+        self._compare_grads(causal=False, max_atol=5.0, mean_atol=0.1)

--- a/test/attention/test_sparse_attn_nsa_forward.py
+++ b/test/attention/test_sparse_attn_nsa_forward.py
@@ -1,0 +1,184 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""End-to-end correctness tests for NSA forward pass.
+
+Compares the FA4-based NSA implementation against the pure PyTorch reference.
+"""
+
+import math
+
+import pytest
+import torch
+
+
+def _make_inputs(B, N, H, H_kv, D, dtype, device="cuda"):
+    """Create random Q, K, V inputs."""
+    Q = torch.randn(B, N, H, D, device=device, dtype=dtype) * 0.1
+    K = torch.randn(B, N, H_kv, D, device=device, dtype=dtype) * 0.1
+    V = torch.randn(B, N, H_kv, D, device=device, dtype=dtype) * 0.1
+    return Q, K, V
+
+
+class TestNSAForwardCorrectness:
+    """Compare FA4-based NSA against reference implementation."""
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16])
+    @pytest.mark.parametrize("N", [1024, 2048])
+    @pytest.mark.parametrize("causal", [True])
+    def test_nsa_vs_reference(self, dtype, N, causal) -> None:
+        """NSA forward pass matches reference within tolerance."""
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, H, H_kv, D = 1, 4, 4, 128
+        compress_block_size = 64
+        num_selected = 8
+        window_size = 256
+        q_tile_size = 256
+
+        Q, K, V = _make_inputs(B, N, H, H_kv, D, dtype)
+
+        # Reference (pure PyTorch)
+        out_ref = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected,
+            window_size=window_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+        )
+
+        # FA4-based
+        out_fa4 = nsa_forward(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected,
+            window_size=window_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+        )
+
+        max_diff = (out_fa4.float() - out_ref.float()).abs().max().item()
+        mean_diff = (out_fa4.float() - out_ref.float()).abs().mean().item()
+
+        assert max_diff < 0.1, f"Max diff too large: {max_diff}"
+        assert mean_diff < 0.01, f"Mean diff too large: {mean_diff}"
+
+    @pytest.mark.parametrize("H,H_kv", [(4, 4)])
+    def test_nsa_gqa(self, H, H_kv) -> None:
+        """NSA works with MHA configuration.
+
+        Note: GQA (H > H_kv) is not yet supported with block sparsity in FA4
+        (pack_gqa=True is not compatible with block_sparse_tensors).
+        """
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        B, N, D = 1, 1024, 128
+        Q, K, V = _make_inputs(B, N, H, H_kv, D, torch.bfloat16)
+
+        out = nsa_forward(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=8,
+            window_size=256,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    @pytest.mark.parametrize("N", [65536])
+    def test_nsa_large_n(self, N) -> None:
+        """NSA handles large sequence lengths without OOM.
+
+        Verifies that the tiled block scoring, compact index tensors, and
+        chunked gating optimizations allow NSA to scale beyond 32K.
+        """
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        B, H, H_kv, D = 1, 4, 4, 128
+        compress_block_size = 64
+        num_selected = 16
+        window_size = 512
+        dtype = torch.bfloat16
+
+        Q, K, V = _make_inputs(B, N, H, H_kv, D, dtype)
+
+        out = nsa_forward(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected,
+            window_size=window_size,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+
+class TestNSAForwardComponentIntegration:
+    """Test that individual components integrate correctly."""
+
+    def test_compress_then_fa4(self) -> None:
+        """FA4 can run on compressed KV sequence."""
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 4, 128
+        block_size = 64
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size)
+        # K_cmp: (B, N//64, H, D) = (1, 16, 4, 128)
+
+        out, lse = flash_attn_func(Q, K_cmp, V_cmp, causal=True)
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_sliding_window_fa4(self) -> None:
+        """FA4 sliding window attention works correctly."""
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+        B, N, H, D = 1, 1024, 4, 128
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        out, lse = flash_attn_func(
+            Q, K, V, causal=True, window_size=(512, 0)
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_block_sparse_fa4(self) -> None:
+        """FA4 block-sparse attention works with our mask format."""
+        from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, N, H, D = 1, 1024, 4, 128
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        block_indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=256,
+        )
+        sparse_tensors = build_fa4_block_sparse_tensors(
+            block_indices, block_size, n_block_size=128, seqlen_k=N,
+        )
+
+        out, lse = _flash_attn_fwd(
+            Q, K, V,
+            causal=True,
+            block_sparse_tensors=sparse_tensors,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()

--- a/test/attention/test_sparse_attn_reference.py
+++ b/test/attention/test_sparse_attn_reference.py
@@ -1,0 +1,133 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for the pure PyTorch NSA reference implementation."""
+
+import math
+
+import pytest
+import torch
+
+
+class TestNSAReferenceBasic:
+    """Basic sanity checks for the reference implementation."""
+
+    def test_output_shape(self) -> None:
+        """Output shape matches input query shape."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        H_kv = 4
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert out.dtype == torch.bfloat16
+
+    def test_output_shape_gqa(self) -> None:
+        """Output shape correct with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 8, 64
+        H_kv = 2
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+
+    def test_output_finite(self) -> None:
+        """Output contains no NaN or Inf values."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 2, 512, 4, 64
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.float16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.float16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.float16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=True,
+        )
+        assert torch.isfinite(out).all(), "Output contains NaN or Inf"
+
+    def test_with_gate_weights(self) -> None:
+        """Test with explicit gate projection weights."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        gate_proj = torch.randn(H, 3, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            gate_proj_weight=gate_proj,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_with_compression_weights(self) -> None:
+        """Test with learned KV compression projections."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        H_kv = 4
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16) * 0.02
+        W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16) * 0.02
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            W_k_compress=W_k,
+            W_v_compress=W_v,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_noncausal(self) -> None:
+        """Test non-causal mode."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=False,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()

--- a/test/attention/test_sparse_attn_select.py
+++ b/test/attention/test_sparse_attn_select.py
@@ -1,0 +1,157 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for block scoring and top-k selection."""
+
+import pytest
+import torch
+
+
+class TestScoreAndSelectBlocks:
+    """Test block scoring and selection."""
+
+    def test_output_shape(self) -> None:
+        """Selected indices have correct shape."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 2, 1024, 4, 64
+        H_kv = 4
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        N_cmp = N // block_size
+        k_actual = min(num_selected, N_cmp)
+        assert indices.shape == (B, H, N_q_tiles, k_actual)
+        assert indices.dtype == torch.int32
+
+    def test_indices_in_range(self) -> None:
+        """All selected indices are valid KV block indices."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=256,
+        )
+
+        N_cmp = N // block_size
+        assert (indices >= 0).all()
+        assert (indices < N_cmp).all()
+
+    def test_causal_no_future_blocks(self) -> None:
+        """Causal mode: no future blocks are selected."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 2, 64
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        for qt in range(N_q_tiles):
+            # Query tile qt covers positions [qt*q_tile_size, (qt+1)*q_tile_size)
+            # KV block idx covers positions [idx*block_size, (idx+1)*block_size)
+            # Causal: KV block start must be < query tile end
+            q_tile_end = (qt + 1) * q_tile_size
+            max_allowed_block = q_tile_end // block_size
+            assert (indices[:, :, qt, :] < max_allowed_block).all(), (
+                f"Query tile {qt}: found future block indices"
+            )
+
+    def test_indices_sorted(self) -> None:
+        """Selected indices are sorted per query tile."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=256,
+        )
+
+        # Check sorted along last dim
+        sorted_indices = indices.sort(dim=-1).values
+        assert (indices == sorted_indices).all()
+
+    def test_deterministic(self) -> None:
+        """Same input produces same selection."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices1 = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        indices2 = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        assert (indices1 == indices2).all()
+
+    def test_gqa(self) -> None:
+        """Works correctly with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 8, 64
+        H_kv = 2
+        block_size = 64
+        num_selected = 4
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        N_q_tiles = N // 256
+        assert indices.shape == (B, H, N_q_tiles, num_selected)

--- a/test/attention/test_sparse_attn_select.py
+++ b/test/attention/test_sparse_attn_select.py
@@ -11,8 +11,8 @@ class TestScoreAndSelectBlocks:
 
     def test_output_shape(self) -> None:
         """Selected indices have correct shape."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 2, 1024, 4, 64
         H_kv = 4
@@ -26,8 +26,12 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
-            Q, K_cmp, num_selected, block_size,
-            causal=True, q_tile_size=q_tile_size,
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=q_tile_size,
         )
 
         N_q_tiles = N // q_tile_size
@@ -38,8 +42,8 @@ class TestScoreAndSelectBlocks:
 
     def test_indices_in_range(self) -> None:
         """All selected indices are valid KV block indices."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 2, 1024, 4, 64
         block_size = 64
@@ -51,8 +55,12 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
-            Q, K_cmp, num_selected, block_size,
-            causal=True, q_tile_size=256,
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
         )
 
         N_cmp = N // block_size
@@ -61,8 +69,8 @@ class TestScoreAndSelectBlocks:
 
     def test_causal_no_future_blocks(self) -> None:
         """Causal mode: no future blocks are selected."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 1, 1024, 2, 64
         block_size = 64
@@ -75,8 +83,12 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
-            Q, K_cmp, num_selected, block_size,
-            causal=True, q_tile_size=q_tile_size,
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=q_tile_size,
         )
 
         N_q_tiles = N // q_tile_size
@@ -92,8 +104,8 @@ class TestScoreAndSelectBlocks:
 
     def test_indices_sorted(self) -> None:
         """Selected indices are sorted per query tile."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 2, 1024, 4, 64
         block_size = 64
@@ -105,8 +117,12 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
-            Q, K_cmp, num_selected, block_size,
-            causal=True, q_tile_size=256,
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
         )
 
         # Check sorted along last dim
@@ -115,8 +131,8 @@ class TestScoreAndSelectBlocks:
 
     def test_deterministic(self) -> None:
         """Same input produces same selection."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 1, 1024, 4, 64
         block_size = 64
@@ -137,8 +153,8 @@ class TestScoreAndSelectBlocks:
 
     def test_gqa(self) -> None:
         """Works correctly with GQA (H > H_kv)."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 1, 1024, 8, 64
         H_kv = 2
@@ -151,6 +167,275 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        N_q_tiles = N // 256
+        assert indices.shape == (B, H, N_q_tiles, num_selected)
+
+
+def _q_mean_reference(
+    Q,
+    K_cmp,
+    num_selected_blocks,
+    compress_block_size,
+    causal=True,
+    q_tile_size=256,
+    softmax_scale=None,
+):
+    """Q_mean-based PyTorch reference for testing the fused kernel.
+
+    Computes Q_mean in PyTorch, then scores via einsum. This isolates
+    kernel correctness from the Q_mean algebraic equivalence.
+    """
+    import math
+
+    B, N, H, D = Q.shape
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+    N_q_tiles = N // q_tile_size
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    k_actual = min(num_selected_blocks, N_cmp)
+
+    # Q_mean: (B, N_q_tiles, H, D)
+    Q_mean = (
+        Q.reshape(B, N_q_tiles, q_tile_size, H, D).mean(dim=2).float() * softmax_scale
+    )
+
+    # Expand K_cmp for GQA
+    groups = H // H_kv
+    if groups > 1:
+        K_cmp_expanded = K_cmp.repeat_interleave(groups, dim=2)
+    else:
+        K_cmp_expanded = K_cmp
+
+    # Score: (B, N_q_tiles, H, N_cmp)
+    scores = torch.einsum(
+        "bthd,bjhd->bthj", Q_mean, K_cmp_expanded.float()
+    )  # (B, N_q_tiles, H, N_cmp)
+
+    # Causal mask
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
+        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+        scores.masked_fill_(future_mask.unsqueeze(0).unsqueeze(2), float("-inf"))
+
+    # Permute to (B, H, N_q_tiles, N_cmp) for topk
+    scores = scores.permute(0, 2, 1, 3)
+
+    topk_scores, topk_idx = scores.topk(k_actual, dim=-1)
+
+    # Replace -inf entries with 0
+    invalid = topk_scores == float("-inf")
+    if invalid.any():
+        topk_idx = topk_idx.masked_fill(invalid, 0)
+
+    # Sort ascending
+    block_indices = topk_idx.sort(dim=-1).values.to(torch.int32)
+    return block_indices
+
+
+class TestFusedScoreAndSelectBlocks:
+    """Test fused CuteDSL block scoring and selection."""
+
+    @pytest.mark.parametrize(
+        "B, N, H, H_kv, D, block_size, num_selected",
+        [
+            (1, 1024, 4, 4, 64, 64, 8),
+            (2, 1024, 4, 4, 64, 64, 8),
+            (1, 2048, 8, 2, 128, 64, 16),
+            (2, 4096, 4, 4, 64, 64, 8),
+            (1, 1024, 4, 4, 128, 64, 4),
+        ],
+    )
+    def test_index_agreement(self, B, N, H, H_kv, D, block_size, num_selected) -> None:
+        """Fused kernel matches Q_mean-based PyTorch reference (exact)."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        fused_idx = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
+        )
+        ref_idx = _q_mean_reference(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
+        )
+        assert (fused_idx == ref_idx).all(), (
+            f"Mismatch: fused vs Q_mean reference.\n"
+            f"Fused:\n{fused_idx}\nRef:\n{ref_idx}"
+        )
+
+    def test_output_shape(self) -> None:
+        """Selected indices have correct shape."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 2, 1024, 4, 64
+        H_kv = 4
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        N_cmp = N // block_size
+        k_actual = min(num_selected, N_cmp)
+        assert indices.shape == (B, H, N_q_tiles, k_actual)
+        assert indices.dtype == torch.int32
+
+    def test_indices_in_range(self) -> None:
+        """All selected indices are valid KV block indices."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
+        )
+
+        N_cmp = N // block_size
+        assert (indices >= 0).all()
+        assert (indices < N_cmp).all()
+
+    def test_causal_no_future_blocks(self) -> None:
+        """Causal mode: no future blocks are selected."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 1, 1024, 2, 64
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        for qt in range(N_q_tiles):
+            q_tile_end = (qt + 1) * q_tile_size
+            max_allowed_block = q_tile_end // block_size
+            assert (indices[:, :, qt, :] < max_allowed_block).all(), (
+                f"Query tile {qt}: found future block indices"
+            )
+
+    def test_indices_sorted(self) -> None:
+        """Selected indices are sorted per query tile."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
+        )
+
+        sorted_indices = indices.sort(dim=-1).values
+        assert (indices == sorted_indices).all()
+
+    def test_deterministic(self) -> None:
+        """Same input produces same selection."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 1, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices1 = fused_score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        indices2 = fused_score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        assert (indices1 == indices2).all()
+
+    def test_gqa(self) -> None:
+        """Works correctly with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 1, 1024, 8, 64
+        H_kv = 2
+        block_size = 64
+        num_selected = 4
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
             Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
         )
         N_q_tiles = N // 256

--- a/test/attention/test_sparse_attn_sparsity_masks.py
+++ b/test/attention/test_sparse_attn_sparsity_masks.py
@@ -1,0 +1,99 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for sparsity mask construction."""
+
+import pytest
+import torch
+
+
+class TestBuildFA4BlockSparseTensors:
+    """Test conversion from NSA block indices to FA4 format."""
+
+    def test_output_types(self) -> None:
+        """Output is a valid BlockSparseTensorsTorch."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+        from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+
+        B, H, N_q_tiles, k = 2, 4, 4, 8
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+        assert isinstance(result, BlockSparseTensorsTorch)
+        assert result.full_block_cnt is not None
+        assert result.full_block_idx is not None
+        assert result.mask_block_cnt is not None
+        assert result.mask_block_idx is not None
+
+    def test_shapes(self) -> None:
+        """Output tensors have correct shapes."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 2, 4, 8, 4
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+
+        assert result.full_block_cnt.shape == (B, H, N_q_tiles)
+        assert result.full_block_idx.shape == (B, H, N_q_tiles, k)
+        assert result.mask_block_cnt.shape == (B, H, N_q_tiles)
+
+    def test_full_block_count(self) -> None:
+        """Full block count matches expected value."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 1, 2, 4, 8
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        # compress_block_size == n_block_size, so 1:1 mapping
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+        assert (result.full_block_cnt == k).all()
+
+    def test_block_expansion(self) -> None:
+        """When compress_block_size > n_block_size, blocks expand correctly."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 1, 1, 2, 2
+        # Select block 0 and block 3
+        indices = torch.tensor([[[[0, 3]]]], device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=256, n_block_size=128, seqlen_k=1024,
+        )
+
+        # Each NSA block of 256 -> 2 FA4 blocks of 128
+        assert (result.full_block_cnt == 4).all()  # 2 blocks * 2 FA4 blocks each
+
+        # Block 0 -> FA4 blocks [0, 1], Block 3 -> FA4 blocks [6, 7]
+        expected_idx = result.full_block_idx[0, 0, 0, :4]
+        assert expected_idx.tolist() == [0, 1, 6, 7]
+
+    def test_mask_blocks_are_zero(self) -> None:
+        """All mask block counts should be zero (selected blocks are fully attended)."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 2, 4, 4, 8
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+        assert (result.mask_block_cnt == 0).all()
+
+    def test_int32_dtype(self) -> None:
+        """All output tensors are int32."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        indices = torch.randint(0, 8, (1, 2, 4, 4), device="cuda", dtype=torch.int32)
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=1024,
+        )
+        assert result.full_block_cnt.dtype == torch.int32
+        assert result.full_block_idx.dtype == torch.int32
+        assert result.mask_block_cnt.dtype == torch.int32
+        assert result.mask_block_idx.dtype == torch.int32


### PR DESCRIPTION
Summary:
Moves two of three backward attention branches from PyTorch to FA4 CuteDSL:

1. Compressed attention backward: _flash_attn_bwd with mask_mod.
   Eliminates O(N * N_cmp) score matrix materialization.

2. Sliding window backward: _flash_attn_bwd with window_size_left.
   Fixes correctness bug: SDPA backward had is_causal=causal and
   window_size is None which always evaluated to False, producing
   wrong non-causal non-windowed gradients.

3. Selected attention backward: Rewritten to per-tile gather/scatter
   with GQA-aware memory layout (gather from H_kv heads, accumulate
   dK/dV at H_kv resolution). Avoids O(N_q_tiles * N * D) memory.

Adds _fa4_bwd() helper, 5 TestNSABackwardMatchesReference correctness
tests, and extends benchmarks to 3M tokens.

FA4 block-sparse backward on SM100 has a CuTe DSL while-loop closure
capture bug (upstream FlashAttention issue #2011).

Differential Revision: D98080761
