### PR TITLE
Add NSA backward performance chart

### DIFF
--- a/docs/gen_nsa_perf_chart.py
+++ b/docs/gen_nsa_perf_chart.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""Generate NSA performance chart from benchmark data."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def main():
+    # Benchmark data from GB200 (B=1, H=32, H_kv=8, D=128)
+    seq_lengths = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576]
+
+    # Forward: Dense FA4 vs NSA
+    dense_fwd_ms = [0.12, 0.26, 0.26, 0.53, 1.54, 5.47, 24.02, 100.17, 400.45, 1589.36, 6356.49]
+    nsa_fwd_ms = [1.54, 2.54, 2.48, 2.57, 4.09, 6.09, 10.31, 23.89, 62.83, 187.37, 623.98]
+
+    # NSA fwd+bwd
+    nsa_bwd_seq = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288]
+    nsa_fwdbwd_ms = [5.77, 7.98, 12.60, 22.25, 40.29, 77.73, 156.98, 327.90, 722.12, 1661.73]
+    nsa_bwd_only_ms = [fb - f for f, fb in zip(nsa_fwd_ms[: len(nsa_bwd_seq)], nsa_fwdbwd_ms)]
+
+    fwd_speedup = [d / n for d, n in zip(dense_fwd_ms, nsa_fwd_ms)]
+
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5.5))
+
+    ax = axes[0]
+    ax.loglog(seq_lengths, dense_fwd_ms, "o-", color="#d62728", label="Dense FA4", linewidth=2, markersize=6)
+    ax.loglog(seq_lengths, nsa_fwd_ms, "s-", color="#2ca02c", label="NSA Sparse", linewidth=2, markersize=6)
+    ax.set_xlabel("Sequence Length", fontsize=12)
+    ax.set_ylabel("Latency (ms)", fontsize=12)
+    ax.set_title("Forward Pass Latency", fontsize=13, fontweight="bold")
+    ax.legend(fontsize=11)
+    ax.grid(True, alpha=0.3, which="both")
+    ax.set_xticks([1024, 4096, 16384, 65536, 262144, 1048576])
+    ax.set_xticklabels(["1K", "4K", "16K", "64K", "256K", "1M"], fontsize=10)
+    ax.axvline(x=32768, color="gray", linestyle="--", alpha=0.5)
+    ax.annotate("NSA wins\n(>32K)", xy=(65536, 8), fontsize=9, color="gray", ha="center")
+
+    ax = axes[1]
+    ax.semilogx(seq_lengths, fwd_speedup, "D-", color="#1f77b4", linewidth=2, markersize=6)
+    ax.axhline(y=1.0, color="gray", linestyle="--", alpha=0.5)
+    ax.fill_between(seq_lengths, 1.0, fwd_speedup, alpha=0.15, color="#1f77b4")
+    ax.set_xlabel("Sequence Length", fontsize=12)
+    ax.set_ylabel("Speedup (Dense / NSA)", fontsize=12)
+    ax.set_title("NSA Forward Speedup vs Dense", fontsize=13, fontweight="bold")
+    ax.grid(True, alpha=0.3, which="both")
+    ax.set_xticks([1024, 4096, 16384, 65536, 262144, 1048576])
+    ax.set_xticklabels(["1K", "4K", "16K", "64K", "256K", "1M"], fontsize=10)
+    ax.annotate("10.2x", xy=(1048576, 10.19), xytext=(300000, 8.5), fontsize=11, fontweight="bold",
+                arrowprops=dict(arrowstyle="->", color="black"))
+
+    ax = axes[2]
+    bar_labels = ["1K", "2K", "4K", "8K", "16K", "32K", "64K", "128K", "256K", "512K"]
+    x = np.arange(len(bar_labels))
+    fwd_vals = nsa_fwd_ms[: len(nsa_bwd_seq)]
+    ax.bar(x, fwd_vals, 0.4, label="Forward", color="#2ca02c", alpha=0.8)
+    ax.bar(x, nsa_bwd_only_ms, 0.4, bottom=fwd_vals, label="Backward", color="#ff7f0e", alpha=0.8)
+    ax.set_xlabel("Sequence Length", fontsize=12)
+    ax.set_ylabel("Latency (ms)", fontsize=12)
+    ax.set_title("NSA Fwd + Bwd Breakdown", fontsize=13, fontweight="bold")
+    ax.set_xticks(x)
+    ax.set_xticklabels(bar_labels, fontsize=9, rotation=45)
+    ax.legend(fontsize=11)
+    ax.set_yscale("log")
+    ax.grid(True, alpha=0.3, which="both", axis="y")
+    ax.annotate("OOM at 1M\n(FA4 block-sparse\nbwd needed)", xy=(9.5, 1500), fontsize=9, color="#d62728",
+                ha="center", style="italic")
+
+    plt.suptitle("NSA Sparse Attention Performance — GB200 (B=1, H=32, H_kv=8, D=128)",
+                 fontsize=14, fontweight="bold", y=1.02)
+    plt.tight_layout()
+    plt.savefig("docs/nsa_bwd_perf.svg", format="svg", bbox_inches="tight", dpi=150)
+    print("Saved docs/nsa_bwd_perf.svg")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/nsa_bwd_perf.svg
+++ b/docs/nsa_bwd_perf.svg
@@ -1,0 +1,5283 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1285.990226pt" height="405.806828pt" viewBox="0 0 1285.990226 405.806828" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-03-24T22:18:15.467891</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 405.806828 
+L 1285.990226 405.806828 
+L 1285.990226 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 53.31375 353.51338 
+L 415.221898 353.51338 
+L 415.221898 67.2 
+L 53.31375 67.2 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 69.76412 353.51338 
+L 69.76412 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m111aaaac20" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m111aaaac20" x="69.76412" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 1K -->
+      <g transform="translate(63.303964 368.111817) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 135.565602 353.51338 
+L 135.565602 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m111aaaac20" x="135.565602" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 4K -->
+      <g transform="translate(129.105446 368.111817) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 201.367083 353.51338 
+L 201.367083 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m111aaaac20" x="201.367083" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 16K -->
+      <g transform="translate(191.725677 368.111817) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 267.168565 353.51338 
+L 267.168565 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m111aaaac20" x="267.168565" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 64K -->
+      <g transform="translate(257.527158 368.111817) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 332.970046 353.51338 
+L 332.970046 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m111aaaac20" x="332.970046" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 256K -->
+      <g transform="translate(320.14739 368.111817) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 398.771527 353.51338 
+L 398.771527 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m111aaaac20" x="398.771527" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1M -->
+      <g transform="translate(391.276215 368.111817) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-4d" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 58.046725 353.51338 
+L 58.046725 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <defs>
+       <path id="m44898be1c2" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m44898be1c2" x="58.046725" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 63.637384 353.51338 
+L 63.637384 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m44898be1c2" x="63.637384" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 101.539139 353.51338 
+L 101.539139 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m44898be1c2" x="101.539139" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 120.784838 353.51338 
+L 120.784838 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m44898be1c2" x="120.784838" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 134.439879 353.51338 
+L 134.439879 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m44898be1c2" x="134.439879" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 145.031552 353.51338 
+L 145.031552 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m44898be1c2" x="145.031552" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 153.685579 353.51338 
+L 153.685579 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m44898be1c2" x="153.685579" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 161.002454 353.51338 
+L 161.002454 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m44898be1c2" x="161.002454" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 167.34062 353.51338 
+L 167.34062 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m44898be1c2" x="167.34062" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 172.931278 353.51338 
+L 172.931278 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m44898be1c2" x="172.931278" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 210.833034 353.51338 
+L 210.833034 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m44898be1c2" x="210.833034" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 230.078733 353.51338 
+L 230.078733 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m44898be1c2" x="230.078733" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 243.733774 353.51338 
+L 243.733774 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m44898be1c2" x="243.733774" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 254.325447 353.51338 
+L 254.325447 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m44898be1c2" x="254.325447" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 262.979474 353.51338 
+L 262.979474 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m44898be1c2" x="262.979474" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 270.296349 353.51338 
+L 270.296349 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m44898be1c2" x="270.296349" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 276.634515 353.51338 
+L 276.634515 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m44898be1c2" x="276.634515" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 282.225173 353.51338 
+L 282.225173 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m44898be1c2" x="282.225173" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 320.126928 353.51338 
+L 320.126928 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m44898be1c2" x="320.126928" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 339.372628 353.51338 
+L 339.372628 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m44898be1c2" x="339.372628" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 353.027669 353.51338 
+L 353.027669 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m44898be1c2" x="353.027669" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 363.619342 353.51338 
+L 363.619342 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m44898be1c2" x="363.619342" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 372.273369 353.51338 
+L 372.273369 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m44898be1c2" x="372.273369" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_59">
+      <path d="M 379.590244 353.51338 
+L 379.590244 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m44898be1c2" x="379.590244" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_61">
+      <path d="M 385.92841 353.51338 
+L 385.92841 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m44898be1c2" x="385.92841" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_63">
+      <path d="M 391.519068 353.51338 
+L 391.519068 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m44898be1c2" x="391.519068" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- Sequence Length -->
+     <g transform="translate(182.066886 383.30963) scale(0.12 -0.12)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(188.476562 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(251.855469 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(313.378906 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(376.757812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(431.738281 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(493.261719 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(525.048828 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(579.011719 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(640.535156 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(703.914062 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(767.390625 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(806.599609 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_65">
+      <path d="M 53.31375 344.861863 
+L 415.221898 344.861863 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <defs>
+       <path id="m1246d31e4b" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1246d31e4b" x="53.31375" y="344.861863" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g transform="translate(22.81375 348.661082) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_67">
+      <path d="M 53.31375 289.763874 
+L 415.221898 289.763874 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="53.31375" y="289.763874" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(28.71375 293.563092) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_69">
+      <path d="M 53.31375 234.665885 
+L 415.221898 234.665885 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="53.31375" y="234.665885" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(28.71375 238.465103) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_71">
+      <path d="M 53.31375 179.567895 
+L 415.221898 179.567895 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="53.31375" y="179.567895" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(28.71375 183.367114) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_73">
+      <path d="M 53.31375 124.469906 
+L 415.221898 124.469906 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="53.31375" y="124.469906" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(28.71375 128.269125) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_75">
+      <path d="M 53.31375 69.371917 
+L 415.221898 69.371917 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="53.31375" y="69.371917" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(28.71375 73.171136) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_77">
+      <path d="M 53.31375 353.396649 
+L 415.221898 353.396649 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_78">
+      <defs>
+       <path id="m5f5cffa55d" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="353.396649" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_79">
+      <path d="M 53.31375 350.20141 
+L 415.221898 350.20141 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="350.20141" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_81">
+      <path d="M 53.31375 347.383009 
+L 415.221898 347.383009 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="347.383009" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_83">
+      <path d="M 53.31375 328.275715 
+L 415.221898 328.275715 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="328.275715" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_85">
+      <path d="M 53.31375 318.573441 
+L 415.221898 318.573441 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="318.573441" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_87">
+      <path d="M 53.31375 311.689568 
+L 415.221898 311.689568 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="311.689568" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_89">
+      <path d="M 53.31375 306.350021 
+L 415.221898 306.350021 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="306.350021" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_91">
+      <path d="M 53.31375 301.987294 
+L 415.221898 301.987294 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="301.987294" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_93">
+      <path d="M 53.31375 298.29866 
+L 415.221898 298.29866 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="298.29866" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_95">
+      <path d="M 53.31375 295.103421 
+L 415.221898 295.103421 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="295.103421" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_97">
+      <path d="M 53.31375 292.285019 
+L 415.221898 292.285019 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="292.285019" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_99">
+      <path d="M 53.31375 273.177726 
+L 415.221898 273.177726 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="273.177726" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_101">
+      <path d="M 53.31375 263.475452 
+L 415.221898 263.475452 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="263.475452" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_103">
+      <path d="M 53.31375 256.591579 
+L 415.221898 256.591579 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="256.591579" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_105">
+      <path d="M 53.31375 251.252032 
+L 415.221898 251.252032 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="251.252032" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_107">
+      <path d="M 53.31375 246.889305 
+L 415.221898 246.889305 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="246.889305" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_109">
+      <path d="M 53.31375 243.200671 
+L 415.221898 243.200671 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="243.200671" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_111">
+      <path d="M 53.31375 240.005431 
+L 415.221898 240.005431 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="240.005431" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_113">
+      <path d="M 53.31375 237.18703 
+L 415.221898 237.18703 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="237.18703" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_115">
+      <path d="M 53.31375 218.079737 
+L 415.221898 218.079737 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="218.079737" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_117">
+      <path d="M 53.31375 208.377463 
+L 415.221898 208.377463 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="208.377463" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_119">
+      <path d="M 53.31375 201.49359 
+L 415.221898 201.49359 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="201.49359" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_121">
+      <path d="M 53.31375 196.154043 
+L 415.221898 196.154043 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_122">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="196.154043" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_123">
+      <path d="M 53.31375 191.791315 
+L 415.221898 191.791315 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_124">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="191.791315" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_125">
+      <path d="M 53.31375 188.102682 
+L 415.221898 188.102682 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_126">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="188.102682" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_127">
+      <path d="M 53.31375 184.907442 
+L 415.221898 184.907442 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_128">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="184.907442" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_129">
+      <path d="M 53.31375 182.089041 
+L 415.221898 182.089041 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_130">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="182.089041" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_131">
+      <path d="M 53.31375 162.981748 
+L 415.221898 162.981748 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_132">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="162.981748" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_133">
+      <path d="M 53.31375 153.279474 
+L 415.221898 153.279474 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_134">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="153.279474" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_135">
+      <path d="M 53.31375 146.395601 
+L 415.221898 146.395601 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_136">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="146.395601" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_137">
+      <path d="M 53.31375 141.056054 
+L 415.221898 141.056054 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_138">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="141.056054" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_139">
+      <path d="M 53.31375 136.693326 
+L 415.221898 136.693326 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_140">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="136.693326" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_141">
+      <path d="M 53.31375 133.004693 
+L 415.221898 133.004693 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_142">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="133.004693" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_143">
+      <path d="M 53.31375 129.809453 
+L 415.221898 129.809453 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_144">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="129.809453" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_145">
+      <path d="M 53.31375 126.991052 
+L 415.221898 126.991052 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_146">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="126.991052" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_147">
+      <path d="M 53.31375 107.883759 
+L 415.221898 107.883759 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_148">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="107.883759" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_149">
+      <path d="M 53.31375 98.181485 
+L 415.221898 98.181485 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_150">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="98.181485" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_151">
+      <path d="M 53.31375 91.297611 
+L 415.221898 91.297611 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_152">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="91.297611" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_153">
+      <path d="M 53.31375 85.958065 
+L 415.221898 85.958065 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_154">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="85.958065" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_155">
+      <path d="M 53.31375 81.595337 
+L 415.221898 81.595337 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_156">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="81.595337" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_157">
+      <path d="M 53.31375 77.906704 
+L 415.221898 77.906704 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_158">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="77.906704" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_159">
+      <path d="M 53.31375 74.711464 
+L 415.221898 74.711464 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_160">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="74.711464" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_49">
+     <g id="line2d_161">
+      <path d="M 53.31375 71.893063 
+L 415.221898 71.893063 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_162">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="53.31375" y="71.893063" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Latency (ms) -->
+     <g transform="translate(16.318125 249.632315) rotate(-90) scale(0.12 -0.12)">
+      <defs>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(55.712891 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(116.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(156.201172 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(217.724609 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(281.103516 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(336.083984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(395.263672 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(427.050781 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(466.064453 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(563.476562 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(615.576172 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_163">
+    <path d="M 69.76412 340.499135 
+L 102.664861 321.997666 
+L 135.565602 321.997666 
+L 168.466342 304.955719 
+L 201.367083 279.431859 
+L 234.267824 249.102256 
+L 267.168565 213.697077 
+L 300.069305 179.527251 
+L 332.970046 146.368696 
+L 365.870787 113.382963 
+L 398.771527 80.214245 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="mf018c223b7" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #d62728"/>
+    </defs>
+    <g clip-path="url(#p5113ef4ef7)">
+     <use xlink:href="#mf018c223b7" x="69.76412" y="340.499135" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="102.664861" y="321.997666" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="135.565602" y="321.997666" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="168.466342" y="304.955719" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="201.367083" y="279.431859" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="234.267824" y="249.102256" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="267.168565" y="213.697077" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="300.069305" y="179.527251" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="332.970046" y="146.368696" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="365.870787" y="113.382963" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf018c223b7" x="398.771527" y="80.214245" style="fill: #d62728; stroke: #d62728"/>
+    </g>
+   </g>
+   <g id="line2d_164">
+    <path d="M 69.76412 279.431859 
+L 102.664861 267.45835 
+L 135.565602 268.030379 
+L 168.466342 267.177383 
+L 201.367083 256.05915 
+L 234.267824 246.533039 
+L 267.168565 233.935359 
+L 300.069305 213.826935 
+L 332.970046 190.688485 
+L 365.870787 164.542671 
+L 398.771527 135.755591 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="m4de3804703" d="M -3 3 
+L 3 3 
+L 3 -3 
+L -3 -3 
+z
+" style="stroke: #2ca02c; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p5113ef4ef7)">
+     <use xlink:href="#m4de3804703" x="69.76412" y="279.431859" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="102.664861" y="267.45835" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="135.565602" y="268.030379" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="168.466342" y="267.177383" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="201.367083" y="256.05915" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="234.267824" y="246.533039" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="267.168565" y="233.935359" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="300.069305" y="213.826935" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="332.970046" y="190.688485" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="365.870787" y="164.542671" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de3804703" x="398.771527" y="135.755591" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_165">
+    <path d="M 234.267824 353.51338 
+L 234.267824 67.2 
+" clip-path="url(#p5113ef4ef7)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #808080; stroke-opacity: 0.5; stroke-width: 1.5"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 53.31375 353.51338 
+L 53.31375 67.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 415.221898 353.51338 
+L 415.221898 67.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 53.31375 353.51338 
+L 415.221898 353.51338 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 53.31375 67.2 
+L 415.221898 67.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- NSA wins -->
+    <g style="fill: #808080" transform="translate(246.225986 229.9274) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(74.804688 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(140.15625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(208.564453 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(240.351562 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(322.138672 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(349.921875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(413.300781 0)"/>
+    </g>
+    <!-- (&gt;32K) -->
+    <g style="fill: #808080" transform="translate(251.209033 240.005431) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-3e" d="M 678 3150 
+L 678 3719 
+L 4684 2266 
+L 4684 1747 
+L 678 294 
+L 678 863 
+L 3897 2003 
+L 678 3150 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-28"/>
+     <use xlink:href="#DejaVuSans-3e" transform="translate(39.013672 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(186.425781 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(250.048828 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(315.625 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- Forward Pass Latency -->
+    <g transform="translate(154.162433 61.2) scale(0.13 -0.13)">
+     <defs>
+      <path id="DejaVuSans-Bold-46" d="M 588 4666 
+L 3834 4666 
+L 3834 3756 
+L 1791 3756 
+L 1791 2888 
+L 3713 2888 
+L 3713 1978 
+L 1791 1978 
+L 1791 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-77" d="M 225 3500 
+L 1313 3500 
+L 1900 1088 
+L 2491 3500 
+L 3425 3500 
+L 4013 1113 
+L 4603 3500 
+L 5691 3500 
+L 4769 0 
+L 3547 0 
+L 2956 2406 
+L 2369 0 
+L 1147 0 
+L 225 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-50" d="M 588 4666 
+L 2584 4666 
+Q 3475 4666 3951 4270 
+Q 4428 3875 4428 3144 
+Q 4428 2409 3951 2014 
+Q 3475 1619 2584 1619 
+L 1791 1619 
+L 1791 0 
+L 588 0 
+L 588 4666 
+z
+M 1791 3794 
+L 1791 2491 
+L 2456 2491 
+Q 2806 2491 2997 2661 
+Q 3188 2831 3188 3144 
+Q 3188 3456 2997 3625 
+Q 2806 3794 2456 3794 
+L 1791 3794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4c" d="M 588 4666 
+L 1791 4666 
+L 1791 909 
+L 3903 909 
+L 3903 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-79" d="M 78 3500 
+L 1197 3500 
+L 2138 1125 
+L 2938 3500 
+L 4056 3500 
+L 2584 -331 
+Q 2363 -916 2067 -1148 
+Q 1772 -1381 1288 -1381 
+L 641 -1381 
+L 641 -647 
+L 991 -647 
+Q 1275 -647 1404 -556 
+Q 1534 -466 1606 -231 
+L 1638 -134 
+L 78 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-46"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(64.310547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(133.011719 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-77" transform="translate(182.328125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(274.710938 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(342.191406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(391.507812 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(463.089844 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-50" transform="translate(497.904297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(568.570312 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(636.050781 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(695.572266 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(755.09375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4c" transform="translate(789.908203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(853.628906 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(921.109375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(968.912109 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1036.734375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(1107.925781 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-79" transform="translate(1167.203125 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 61.01375 108.291875 
+L 160.381563 108.291875 
+Q 162.581562 108.291875 162.581562 106.091875 
+L 162.581562 74.9 
+Q 162.581562 72.7 160.381563 72.7 
+L 61.01375 72.7 
+Q 58.81375 72.7 58.81375 74.9 
+L 58.81375 106.091875 
+Q 58.81375 108.291875 61.01375 108.291875 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_166">
+     <path d="M 63.21375 81.608281 
+L 74.21375 81.608281 
+L 85.21375 81.608281 
+" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#mf018c223b7" x="74.21375" y="81.608281" style="fill: #d62728; stroke: #d62728"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- Dense FA4 -->
+     <g transform="translate(94.01375 85.458281) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(77.001953 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(138.525391 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(201.904297 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(254.003906 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(315.527344 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(347.314453 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(395.708984 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(464.117188 0)"/>
+     </g>
+    </g>
+    <g id="line2d_167">
+     <path d="M 63.21375 97.754219 
+L 74.21375 97.754219 
+L 85.21375 97.754219 
+" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m4de3804703" x="74.21375" y="97.754219" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- NSA Sparse -->
+     <g transform="translate(94.01375 101.604219) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4e"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(74.804688 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(140.15625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(208.564453 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(240.351562 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(303.828125 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(367.304688 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(428.583984 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(469.697266 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(521.796875 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_8">
+    <path d="M 468.104582 353.51338 
+L 830.01273 353.51338 
+L 830.01273 67.2 
+L 468.104582 67.2 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="FillBetweenPolyCollection_1">
+    <defs>
+     <path id="m0a7944421f" d="M 484.554953 -65.307693 
+L 484.554953 -89.049001 
+L 517.455694 -89.049001 
+L 550.356434 -89.049001 
+L 583.257175 -89.049001 
+L 616.157916 -89.049001 
+L 649.058656 -89.049001 
+L 681.959397 -89.049001 
+L 714.860138 -89.049001 
+L 747.760878 -89.049001 
+L 780.661619 -89.049001 
+L 813.56236 -89.049001 
+L 813.56236 -325.592583 
+L 813.56236 -325.592583 
+L 780.661619 -281.704707 
+L 747.760878 -227.405041 
+L 714.860138 -171.260308 
+L 681.959397 -123.287586 
+L 649.058656 -86.427733 
+L 616.157916 -72.996086 
+L 583.257175 -68.611204 
+L 550.356434 -66.000732 
+L 517.455694 -65.936968 
+L 484.554953 -65.307693 
+z
+" style="stroke: #1f77b4; stroke-opacity: 0.15"/>
+    </defs>
+    <g clip-path="url(#p54977825d1)">
+     <use xlink:href="#m0a7944421f" x="0" y="405.806828" style="fill: #1f77b4; fill-opacity: 0.15; stroke: #1f77b4; stroke-opacity: 0.15"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_33">
+     <g id="line2d_168">
+      <path d="M 484.554953 353.51338 
+L 484.554953 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_169">
+      <g>
+       <use xlink:href="#m111aaaac20" x="484.554953" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 1K -->
+      <g transform="translate(478.094797 368.111817) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_170">
+      <path d="M 550.356434 353.51338 
+L 550.356434 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_171">
+      <g>
+       <use xlink:href="#m111aaaac20" x="550.356434" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 4K -->
+      <g transform="translate(543.896278 368.111817) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_172">
+      <path d="M 616.157916 353.51338 
+L 616.157916 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_173">
+      <g>
+       <use xlink:href="#m111aaaac20" x="616.157916" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 16K -->
+      <g transform="translate(606.516509 368.111817) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_174">
+      <path d="M 681.959397 353.51338 
+L 681.959397 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_175">
+      <g>
+       <use xlink:href="#m111aaaac20" x="681.959397" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 64K -->
+      <g transform="translate(672.317991 368.111817) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_176">
+      <path d="M 747.760878 353.51338 
+L 747.760878 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_177">
+      <g>
+       <use xlink:href="#m111aaaac20" x="747.760878" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 256K -->
+      <g transform="translate(734.938222 368.111817) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_178">
+      <path d="M 813.56236 353.51338 
+L 813.56236 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_179">
+      <g>
+       <use xlink:href="#m111aaaac20" x="813.56236" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 1M -->
+      <g transform="translate(806.067047 368.111817) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-4d" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_180">
+      <path d="M 472.837558 353.51338 
+L 472.837558 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_181">
+      <g>
+       <use xlink:href="#m44898be1c2" x="472.837558" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_182">
+      <path d="M 478.428216 353.51338 
+L 478.428216 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_183">
+      <g>
+       <use xlink:href="#m44898be1c2" x="478.428216" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_184">
+      <path d="M 516.329971 353.51338 
+L 516.329971 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_185">
+      <g>
+       <use xlink:href="#m44898be1c2" x="516.329971" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_186">
+      <path d="M 535.575671 353.51338 
+L 535.575671 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_187">
+      <g>
+       <use xlink:href="#m44898be1c2" x="535.575671" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_188">
+      <path d="M 549.230712 353.51338 
+L 549.230712 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_189">
+      <g>
+       <use xlink:href="#m44898be1c2" x="549.230712" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_190">
+      <path d="M 559.822385 353.51338 
+L 559.822385 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_191">
+      <g>
+       <use xlink:href="#m44898be1c2" x="559.822385" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_192">
+      <path d="M 568.476411 353.51338 
+L 568.476411 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_193">
+      <g>
+       <use xlink:href="#m44898be1c2" x="568.476411" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_194">
+      <path d="M 575.793287 353.51338 
+L 575.793287 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_195">
+      <g>
+       <use xlink:href="#m44898be1c2" x="575.793287" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_196">
+      <path d="M 582.131453 353.51338 
+L 582.131453 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_197">
+      <g>
+       <use xlink:href="#m44898be1c2" x="582.131453" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_198">
+      <path d="M 587.722111 353.51338 
+L 587.722111 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_199">
+      <g>
+       <use xlink:href="#m44898be1c2" x="587.722111" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_200">
+      <path d="M 625.623866 353.51338 
+L 625.623866 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_201">
+      <g>
+       <use xlink:href="#m44898be1c2" x="625.623866" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_202">
+      <path d="M 644.869566 353.51338 
+L 644.869566 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_203">
+      <g>
+       <use xlink:href="#m44898be1c2" x="644.869566" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_51">
+     <g id="line2d_204">
+      <path d="M 658.524607 353.51338 
+L 658.524607 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_205">
+      <g>
+       <use xlink:href="#m44898be1c2" x="658.524607" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_52">
+     <g id="line2d_206">
+      <path d="M 669.116279 353.51338 
+L 669.116279 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_207">
+      <g>
+       <use xlink:href="#m44898be1c2" x="669.116279" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_53">
+     <g id="line2d_208">
+      <path d="M 677.770306 353.51338 
+L 677.770306 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_209">
+      <g>
+       <use xlink:href="#m44898be1c2" x="677.770306" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_54">
+     <g id="line2d_210">
+      <path d="M 685.087182 353.51338 
+L 685.087182 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_211">
+      <g>
+       <use xlink:href="#m44898be1c2" x="685.087182" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_55">
+     <g id="line2d_212">
+      <path d="M 691.425347 353.51338 
+L 691.425347 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_213">
+      <g>
+       <use xlink:href="#m44898be1c2" x="691.425347" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_56">
+     <g id="line2d_214">
+      <path d="M 697.016006 353.51338 
+L 697.016006 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_215">
+      <g>
+       <use xlink:href="#m44898be1c2" x="697.016006" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_57">
+     <g id="line2d_216">
+      <path d="M 734.917761 353.51338 
+L 734.917761 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_217">
+      <g>
+       <use xlink:href="#m44898be1c2" x="734.917761" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_58">
+     <g id="line2d_218">
+      <path d="M 754.16346 353.51338 
+L 754.16346 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_219">
+      <g>
+       <use xlink:href="#m44898be1c2" x="754.16346" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_59">
+     <g id="line2d_220">
+      <path d="M 767.818502 353.51338 
+L 767.818502 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_221">
+      <g>
+       <use xlink:href="#m44898be1c2" x="767.818502" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_60">
+     <g id="line2d_222">
+      <path d="M 778.410174 353.51338 
+L 778.410174 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_223">
+      <g>
+       <use xlink:href="#m44898be1c2" x="778.410174" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_61">
+     <g id="line2d_224">
+      <path d="M 787.064201 353.51338 
+L 787.064201 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_225">
+      <g>
+       <use xlink:href="#m44898be1c2" x="787.064201" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_62">
+     <g id="line2d_226">
+      <path d="M 794.381077 353.51338 
+L 794.381077 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_227">
+      <g>
+       <use xlink:href="#m44898be1c2" x="794.381077" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_63">
+     <g id="line2d_228">
+      <path d="M 800.719242 353.51338 
+L 800.719242 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_229">
+      <g>
+       <use xlink:href="#m44898be1c2" x="800.719242" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_64">
+     <g id="line2d_230">
+      <path d="M 806.309901 353.51338 
+L 806.309901 67.2 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_231">
+      <g>
+       <use xlink:href="#m44898be1c2" x="806.309901" y="353.51338" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_25">
+     <!-- Sequence Length -->
+     <g transform="translate(596.857719 383.30963) scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(188.476562 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(251.855469 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(313.378906 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(376.757812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(431.738281 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(493.261719 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(525.048828 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(579.011719 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(640.535156 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(703.914062 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(767.390625 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(806.599609 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_50">
+     <g id="line2d_232">
+      <path d="M 468.104582 342.505443 
+L 830.01273 342.505443 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_233">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="468.104582" y="342.505443" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 0 -->
+      <g transform="translate(454.742082 346.304662) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_234">
+      <path d="M 468.104582 291.010212 
+L 830.01273 291.010212 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_235">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="468.104582" y="291.010212" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 2 -->
+      <g transform="translate(454.742082 294.80943) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_236">
+      <path d="M 468.104582 239.51498 
+L 830.01273 239.51498 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_237">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="468.104582" y="239.51498" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 4 -->
+      <g transform="translate(454.742082 243.314199) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_238">
+      <path d="M 468.104582 188.019749 
+L 830.01273 188.019749 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_239">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="468.104582" y="188.019749" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 6 -->
+      <g transform="translate(454.742082 191.818967) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_240">
+      <path d="M 468.104582 136.524517 
+L 830.01273 136.524517 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_241">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="468.104582" y="136.524517" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 8 -->
+      <g transform="translate(454.742082 140.323736) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_55">
+     <g id="line2d_242">
+      <path d="M 468.104582 85.029286 
+L 830.01273 85.029286 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_243">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="468.104582" y="85.029286" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 10 -->
+      <g transform="translate(448.379582 88.828504) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_32">
+     <!-- Speedup (Dense / NSA) -->
+     <g transform="translate(441.883957 280.649502) rotate(-90) scale(0.12 -0.12)">
+      <defs>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(126.953125 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(188.476562 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(250 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(313.476562 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(376.855469 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(440.332031 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(472.119141 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(511.132812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(588.134766 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(649.658203 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(713.037109 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(765.136719 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(826.660156 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(858.447266 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(892.138672 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(923.925781 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(998.730469 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1064.082031 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1132.490234 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_244">
+    <path d="M 484.554953 340.499135 
+L 517.455694 339.86986 
+L 550.356434 339.806096 
+L 583.257175 337.195623 
+L 616.157916 332.810742 
+L 649.058656 319.379095 
+L 681.959397 282.519242 
+L 714.860138 234.54652 
+L 747.760878 178.401787 
+L 780.661619 124.10212 
+L 813.56236 80.214245 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="m99ad5f279d" d="M -0 4.242641 
+L 4.242641 0 
+L 0 -4.242641 
+L -4.242641 -0 
+z
+" style="stroke: #1f77b4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p54977825d1)">
+     <use xlink:href="#m99ad5f279d" x="484.554953" y="340.499135" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="517.455694" y="339.86986" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="550.356434" y="339.806096" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="583.257175" y="337.195623" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="616.157916" y="332.810742" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="649.058656" y="319.379095" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="681.959397" y="282.519242" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="714.860138" y="234.54652" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="747.760878" y="178.401787" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="780.661619" y="124.10212" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m99ad5f279d" x="813.56236" y="80.214245" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_245">
+    <path d="M 468.104582 316.757827 
+L 830.01273 316.757827 
+" clip-path="url(#p54977825d1)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #808080; stroke-opacity: 0.5; stroke-width: 1.5"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 468.104582 353.51338 
+L 468.104582 67.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 830.01273 353.51338 
+L 830.01273 67.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 468.104582 353.51338 
+L 830.01273 353.51338 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 468.104582 67.2 
+L 830.01273 67.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 780.375837 111.908052 
+Q 796.246992 96.713947 811.310539 82.292999 
+" style="fill: none; stroke: #000000; stroke-linecap: round"/>
+    <path d="M 806.610846 83.746576 
+L 811.310539 82.292999 
+L 809.653585 86.924899 
+" style="fill: none; stroke: #000000; stroke-linecap: round"/>
+   </g>
+   <g id="text_33">
+    <!-- 10.2x -->
+    <g transform="translate(754.16346 123.650709) scale(0.11 -0.11)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2e" d="M 653 1209 
+L 1778 1209 
+L 1778 0 
+L 653 0 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-78" d="M 1422 1791 
+L 159 3500 
+L 1344 3500 
+L 2059 2463 
+L 2784 3500 
+L 3969 3500 
+L 2706 1797 
+L 4031 0 
+L 2847 0 
+L 2059 1106 
+L 1281 0 
+L 97 0 
+L 1422 1791 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-78" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- NSA Forward Speedup vs Dense -->
+    <g transform="translate(531.856547 61.2) scale(0.13 -0.13)">
+     <defs>
+      <path id="DejaVuSans-Bold-4e" d="M 588 4666 
+L 1931 4666 
+L 3628 1466 
+L 3628 4666 
+L 4769 4666 
+L 4769 0 
+L 3425 0 
+L 1728 3200 
+L 1728 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-53" d="M 3834 4519 
+L 3834 3531 
+Q 3450 3703 3084 3790 
+Q 2719 3878 2394 3878 
+Q 1963 3878 1756 3759 
+Q 1550 3641 1550 3391 
+Q 1550 3203 1689 3098 
+Q 1828 2994 2194 2919 
+L 2706 2816 
+Q 3484 2659 3812 2340 
+Q 4141 2022 4141 1434 
+Q 4141 663 3683 286 
+Q 3225 -91 2284 -91 
+Q 1841 -91 1394 -6 
+Q 947 78 500 244 
+L 500 1259 
+Q 947 1022 1364 901 
+Q 1781 781 2169 781 
+Q 2563 781 2772 912 
+Q 2981 1044 2981 1288 
+Q 2981 1506 2839 1625 
+Q 2697 1744 2272 1838 
+L 1806 1941 
+Q 1106 2091 782 2419 
+Q 459 2747 459 3303 
+Q 459 4000 909 4375 
+Q 1359 4750 2203 4750 
+Q 2588 4750 2994 4692 
+Q 3400 4634 3834 4519 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-41" d="M 3419 850 
+L 1538 850 
+L 1241 0 
+L 31 0 
+L 1759 4666 
+L 3194 4666 
+L 4922 0 
+L 3713 0 
+L 3419 850 
+z
+M 1838 1716 
+L 3116 1716 
+L 2478 3572 
+L 1838 1716 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-75" d="M 500 1363 
+L 500 3500 
+L 1625 3500 
+L 1625 3150 
+Q 1625 2866 1622 2436 
+Q 1619 2006 1619 1863 
+Q 1619 1441 1641 1255 
+Q 1663 1069 1716 984 
+Q 1784 875 1895 815 
+Q 2006 756 2150 756 
+Q 2500 756 2700 1025 
+Q 2900 1294 2900 1772 
+L 2900 3500 
+L 4019 3500 
+L 4019 0 
+L 2900 0 
+L 2900 506 
+Q 2647 200 2364 54 
+Q 2081 -91 1741 -91 
+Q 1134 -91 817 281 
+Q 500 653 500 1363 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-44" d="M 1791 3756 
+L 1791 909 
+L 2222 909 
+Q 2959 909 3348 1275 
+Q 3738 1641 3738 2338 
+Q 3738 3031 3350 3393 
+Q 2963 3756 2222 3756 
+L 1791 3756 
+z
+M 588 4666 
+L 1856 4666 
+Q 2919 4666 3439 4514 
+Q 3959 4363 4331 4000 
+Q 4659 3684 4818 3271 
+Q 4978 2859 4978 2338 
+Q 4978 1809 4818 1395 
+Q 4659 981 4331 666 
+Q 3956 303 3431 151 
+Q 2906 0 1856 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-4e"/>
+     <use xlink:href="#DejaVuSans-Bold-53" transform="translate(83.691406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-41" transform="translate(155.712891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(233.105469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(267.919922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(332.230469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(400.931641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-77" transform="translate(450.248047 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(542.630859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(610.111328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(659.427734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(731.009766 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-53" transform="translate(765.824219 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(837.845703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(909.427734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(977.25 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1045.072266 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-75" transform="translate(1116.654297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(1187.845703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1259.427734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1294.242188 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1359.427734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1418.949219 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-44" transform="translate(1453.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1536.771484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1604.59375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1675.785156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1735.306641 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_14">
+    <path d="M 882.895415 353.51338 
+L 1244.803563 353.51338 
+L 1244.803563 67.2 
+L 882.895415 67.2 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 899.345785 90273.384493 
+L 913.3461 90273.384493 
+L 913.3461 353.51338 
+L 899.345785 353.51338 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 934.346573 90273.384493 
+L 948.346888 90273.384493 
+L 948.346888 333.976287 
+L 934.346573 333.976287 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 969.347361 90273.384493 
+L 983.347676 90273.384493 
+L 983.347676 334.909663 
+L 969.347361 334.909663 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 1004.348149 90273.384493 
+L 1018.348464 90273.384493 
+L 1018.348464 333.517835 
+L 1004.348149 333.517835 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 1039.348937 90273.384493 
+L 1053.349252 90273.384493 
+L 1053.349252 315.376289 
+L 1039.348937 315.376289 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 1074.349725 90273.384493 
+L 1088.35004 90273.384493 
+L 1088.35004 299.832599 
+L 1074.349725 299.832599 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 1109.350513 90273.384493 
+L 1123.350828 90273.384493 
+L 1123.350828 279.277051 
+L 1109.350513 279.277051 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 1144.351301 90273.384493 
+L 1158.351616 90273.384493 
+L 1158.351616 246.466274 
+L 1144.351301 246.466274 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 1179.352089 90273.384493 
+L 1193.352404 90273.384493 
+L 1193.352404 208.711422 
+L 1179.352089 208.711422 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 1214.352877 90273.384493 
+L 1228.353192 90273.384493 
+L 1228.353192 166.049476 
+L 1214.352877 166.049476 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #2ca02c; opacity: 0.8"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 899.345785 353.51338 
+L 913.3461 353.51338 
+L 913.3461 301.940059 
+L 899.345785 301.940059 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 934.346573 333.976287 
+L 948.346888 333.976287 
+L 948.346888 289.27928 
+L 934.346573 289.27928 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 969.347361 334.909663 
+L 983.347676 334.909663 
+L 983.347676 271.445431 
+L 969.347361 271.445431 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 1004.348149 333.517835 
+L 1018.348464 333.517835 
+L 1018.348464 249.24303 
+L 1004.348149 249.24303 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 1039.348937 315.376289 
+L 1053.349252 315.376289 
+L 1053.349252 226.059988 
+L 1039.348937 226.059988 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 1074.349725 299.832599 
+L 1088.35004 299.832599 
+L 1088.35004 200.402441 
+L 1074.349725 200.402441 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 1109.350513 279.277051 
+L 1123.350828 279.277051 
+L 1123.350828 172.959038 
+L 1109.350513 172.959038 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 1144.351301 246.466274 
+L 1158.351616 246.466274 
+L 1158.351616 144.199326 
+L 1144.351301 144.199326 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 1179.352089 208.711422 
+L 1193.352404 208.711422 
+L 1193.352404 113.374464 
+L 1179.352089 113.374464 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 1214.352877 166.049476 
+L 1228.353192 166.049476 
+L 1228.353192 80.83397 
+L 1214.352877 80.83397 
+z
+" clip-path="url(#p77670f5f0f)" style="fill: #ff7f0e; opacity: 0.8"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_65">
+     <g id="line2d_246">
+      <g>
+       <use xlink:href="#m111aaaac20" x="906.345943" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 1K -->
+      <g transform="translate(903.99078 373.571432) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_66">
+     <g id="line2d_247">
+      <g>
+       <use xlink:href="#m111aaaac20" x="941.346731" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 2K -->
+      <g transform="translate(938.991568 373.571432) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_67">
+     <g id="line2d_248">
+      <g>
+       <use xlink:href="#m111aaaac20" x="976.347519" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- 4K -->
+      <g transform="translate(973.992356 373.571432) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_68">
+     <g id="line2d_249">
+      <g>
+       <use xlink:href="#m111aaaac20" x="1011.348307" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_38">
+      <!-- 8K -->
+      <g transform="translate(1008.993144 373.571432) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-38"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_69">
+     <g id="line2d_250">
+      <g>
+       <use xlink:href="#m111aaaac20" x="1046.349095" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_39">
+      <!-- 16K -->
+      <g transform="translate(1041.969397 377.620503) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_70">
+     <g id="line2d_251">
+      <g>
+       <use xlink:href="#m111aaaac20" x="1081.349883" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_40">
+      <!-- 32K -->
+      <g transform="translate(1076.970185 377.620503) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_71">
+     <g id="line2d_252">
+      <g>
+       <use xlink:href="#m111aaaac20" x="1116.350671" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_41">
+      <!-- 64K -->
+      <g transform="translate(1111.970973 377.620503) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_72">
+     <g id="line2d_253">
+      <g>
+       <use xlink:href="#m111aaaac20" x="1151.351459" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_42">
+      <!-- 128K -->
+      <g transform="translate(1144.947226 381.669573) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_73">
+     <g id="line2d_254">
+      <g>
+       <use xlink:href="#m111aaaac20" x="1186.352247" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_43">
+      <!-- 256K -->
+      <g transform="translate(1179.948014 381.669573) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_74">
+     <g id="line2d_255">
+      <g>
+       <use xlink:href="#m111aaaac20" x="1221.353035" y="353.51338" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_44">
+      <!-- 512K -->
+      <g transform="translate(1214.948802 381.669573) rotate(-45) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-4b" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_45">
+     <!-- Sequence Length -->
+     <g transform="translate(1011.648551 396.111203) scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(188.476562 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(251.855469 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(313.378906 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(376.757812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(431.738281 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(493.261719 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(525.048828 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(579.011719 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(640.535156 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(703.914062 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(767.390625 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(806.599609 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_56">
+     <g id="line2d_256">
+      <path d="M 882.895415 280.469045 
+L 1244.803563 280.469045 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_257">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="882.895415" y="280.469045" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_46">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(858.295415 284.268264) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_57">
+     <g id="line2d_258">
+      <path d="M 882.895415 190.566033 
+L 1244.803563 190.566033 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_259">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="882.895415" y="190.566033" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_47">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(858.295415 194.365251) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_58">
+     <g id="line2d_260">
+      <path d="M 882.895415 100.66302 
+L 1244.803563 100.66302 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_261">
+      <g>
+       <use xlink:href="#m1246d31e4b" x="882.895415" y="100.66302" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_48">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(858.295415 104.462239) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_59">
+     <g id="line2d_262">
+      <path d="M 882.895415 343.308554 
+L 1244.803563 343.308554 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_263">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="343.308554" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_60">
+     <g id="line2d_264">
+      <path d="M 882.895415 327.47742 
+L 1244.803563 327.47742 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_265">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="327.47742" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_61">
+     <g id="line2d_266">
+      <path d="M 882.895415 316.245051 
+L 1244.803563 316.245051 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_267">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="316.245051" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_62">
+     <g id="line2d_268">
+      <path d="M 882.895415 307.532549 
+L 1244.803563 307.532549 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_269">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="307.532549" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_63">
+     <g id="line2d_270">
+      <path d="M 882.895415 300.413916 
+L 1244.803563 300.413916 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_271">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="300.413916" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_64">
+     <g id="line2d_272">
+      <path d="M 882.895415 294.395198 
+L 1244.803563 294.395198 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_273">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="294.395198" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_65">
+     <g id="line2d_274">
+      <path d="M 882.895415 289.181547 
+L 1244.803563 289.181547 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_275">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="289.181547" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_66">
+     <g id="line2d_276">
+      <path d="M 882.895415 284.582781 
+L 1244.803563 284.582781 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_277">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="284.582781" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_67">
+     <g id="line2d_278">
+      <path d="M 882.895415 253.405542 
+L 1244.803563 253.405542 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_279">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="253.405542" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_68">
+     <g id="line2d_280">
+      <path d="M 882.895415 237.574407 
+L 1244.803563 237.574407 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_281">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="237.574407" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_69">
+     <g id="line2d_282">
+      <path d="M 882.895415 226.342038 
+L 1244.803563 226.342038 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_283">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="226.342038" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_70">
+     <g id="line2d_284">
+      <path d="M 882.895415 217.629536 
+L 1244.803563 217.629536 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_285">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="217.629536" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_71">
+     <g id="line2d_286">
+      <path d="M 882.895415 210.510904 
+L 1244.803563 210.510904 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_287">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="210.510904" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_72">
+     <g id="line2d_288">
+      <path d="M 882.895415 204.492186 
+L 1244.803563 204.492186 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_289">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="204.492186" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_73">
+     <g id="line2d_290">
+      <path d="M 882.895415 199.278535 
+L 1244.803563 199.278535 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_291">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="199.278535" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_74">
+     <g id="line2d_292">
+      <path d="M 882.895415 194.679769 
+L 1244.803563 194.679769 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_293">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="194.679769" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_75">
+     <g id="line2d_294">
+      <path d="M 882.895415 163.502529 
+L 1244.803563 163.502529 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_295">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="163.502529" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_76">
+     <g id="line2d_296">
+      <path d="M 882.895415 147.671395 
+L 1244.803563 147.671395 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_297">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="147.671395" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_77">
+     <g id="line2d_298">
+      <path d="M 882.895415 136.439026 
+L 1244.803563 136.439026 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_299">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="136.439026" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_78">
+     <g id="line2d_300">
+      <path d="M 882.895415 127.726524 
+L 1244.803563 127.726524 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_301">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="127.726524" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_79">
+     <g id="line2d_302">
+      <path d="M 882.895415 120.607891 
+L 1244.803563 120.607891 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_303">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="120.607891" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_80">
+     <g id="line2d_304">
+      <path d="M 882.895415 114.589173 
+L 1244.803563 114.589173 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_305">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="114.589173" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_81">
+     <g id="line2d_306">
+      <path d="M 882.895415 109.375522 
+L 1244.803563 109.375522 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_307">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="109.375522" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_82">
+     <g id="line2d_308">
+      <path d="M 882.895415 104.776757 
+L 1244.803563 104.776757 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_309">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="104.776757" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_83">
+     <g id="line2d_310">
+      <path d="M 882.895415 73.599517 
+L 1244.803563 73.599517 
+" clip-path="url(#p77670f5f0f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_311">
+      <g>
+       <use xlink:href="#m5f5cffa55d" x="882.895415" y="73.599517" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_49">
+     <!-- Latency (ms) -->
+     <g transform="translate(851.79979 249.632315) rotate(-90) scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(55.712891 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(116.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(156.201172 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(217.724609 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(281.103516 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(336.083984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(395.263672 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(427.050781 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(466.064453 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(563.476562 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(615.576172 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_35">
+    <path d="M 882.895415 353.51338 
+L 882.895415 67.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 1244.803563 353.51338 
+L 1244.803563 67.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 882.895415 353.51338 
+L 1244.803563 353.51338 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 882.895415 67.2 
+L 1244.803563 67.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_50">
+    <!-- OOM at 1M -->
+    <g style="fill: #d62728" transform="translate(1213.758194 64.675823) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Oblique-4f" d="M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+M 2100 -91 
+Q 1241 -91 748 418 
+Q 256 928 256 1813 
+Q 256 2319 448 2847 
+Q 641 3375 978 3788 
+Q 1375 4272 1862 4511 
+Q 2350 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 2331 4593 1812 
+Q 4406 1294 4056 872 
+Q 3656 384 3173 146 
+Q 2691 -91 2100 -91 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-4d" d="M 1081 4666 
+L 2028 4666 
+L 2572 1522 
+L 4378 4666 
+L 5350 4666 
+L 4441 0 
+L 3828 0 
+L 4622 4091 
+L 2791 897 
+L 2175 897 
+L 1581 4103 
+L 788 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-61" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-74" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-31" d="M 416 531 
+L 1447 531 
+L 2144 4122 
+L 978 3897 
+L 1088 4441 
+L 2247 4666 
+L 2881 4666 
+L 2075 531 
+L 3103 531 
+L 3003 0 
+L 313 0 
+L 416 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Oblique-4f"/>
+     <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(78.710938 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-4d" transform="translate(157.421875 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(243.701172 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(275.488281 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(336.767578 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(375.976562 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(407.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-4d" transform="translate(471.386719 0)"/>
+    </g>
+    <!-- (FA4 block-sparse -->
+    <g style="fill: #d62728" transform="translate(1198.916632 74.753854) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Oblique-28" d="M 2731 4856 
+Q 1903 3822 1495 2892 
+Q 1088 1963 1088 1100 
+Q 1088 606 1206 120 
+Q 1325 -366 1563 -844 
+L 1063 -844 
+Q 775 -306 634 201 
+Q 494 709 494 1197 
+Q 494 2125 923 3036 
+Q 1353 3947 2222 4856 
+L 2731 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-46" d="M 1081 4666 
+L 3756 4666 
+L 3653 4134 
+L 1606 4134 
+L 1338 2759 
+L 3188 2759 
+L 3084 2228 
+L 1234 2228 
+L 800 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-41" d="M 2356 4666 
+L 3072 4666 
+L 3938 0 
+L 3278 0 
+L 3084 1197 
+L 984 1197 
+L 325 0 
+L -341 0 
+L 2356 4666 
+z
+M 2584 4044 
+L 1275 1722 
+L 2988 1722 
+L 2584 4044 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-34" d="M 2753 4666 
+L 3547 4666 
+L 2950 1625 
+L 3616 1625 
+L 3513 1100 
+L 2847 1100 
+L 2638 0 
+L 2009 0 
+L 2222 1100 
+L 116 1100 
+L 238 1709 
+L 2753 4666 
+z
+M 2809 4116 
+L 728 1625 
+L 2322 1625 
+L 2809 4116 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-62" d="M 3169 2138 
+Q 3169 2591 2961 2847 
+Q 2753 3103 2388 3103 
+Q 2122 3103 1889 2973 
+Q 1656 2844 1484 2597 
+Q 1303 2338 1198 1995 
+Q 1094 1653 1094 1313 
+Q 1094 881 1298 636 
+Q 1503 391 1863 391 
+Q 2134 391 2365 517 
+Q 2597 644 2772 891 
+Q 2950 1147 3059 1487 
+Q 3169 1828 3169 2138 
+z
+M 1381 2969 
+Q 1594 3256 1914 3420 
+Q 2234 3584 2584 3584 
+Q 3122 3584 3439 3221 
+Q 3756 2859 3756 2241 
+Q 3756 1734 3570 1259 
+Q 3384 784 3041 416 
+Q 2816 172 2522 40 
+Q 2228 -91 1906 -91 
+Q 1566 -91 1316 65 
+Q 1066 222 909 531 
+L 806 0 
+L 231 0 
+L 1178 4863 
+L 1753 4863 
+L 1381 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6c" d="M 1172 4863 
+L 1747 4863 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6f" d="M 1625 -91 
+Q 1009 -91 651 289 
+Q 294 669 294 1325 
+Q 294 1706 417 2101 
+Q 541 2497 738 2766 
+Q 1047 3184 1428 3384 
+Q 1809 3584 2291 3584 
+Q 2888 3584 3255 3212 
+Q 3622 2841 3622 2241 
+Q 3622 1825 3500 1412 
+Q 3378 1000 3181 728 
+Q 2875 309 2494 109 
+Q 2113 -91 1625 -91 
+z
+M 891 1344 
+Q 891 869 1089 633 
+Q 1288 397 1691 397 
+Q 2269 397 2648 901 
+Q 3028 1406 3028 2181 
+Q 3028 2634 2825 2865 
+Q 2622 3097 2228 3097 
+Q 1903 3097 1650 2945 
+Q 1397 2794 1197 2484 
+Q 1050 2253 970 1956 
+Q 891 1659 891 1344 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-63" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6b" d="M 1172 4863 
+L 1747 4863 
+L 1197 2028 
+L 3169 3500 
+L 3916 3500 
+L 1716 1825 
+L 3322 0 
+L 2625 0 
+L 1131 1709 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-2d" d="M 391 2009 
+L 2075 2009 
+L 1978 1497 
+L 288 1497 
+L 391 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-73" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-70" d="M 3175 2156 
+Q 3175 2616 2975 2859 
+Q 2775 3103 2400 3103 
+Q 2144 3103 1911 2972 
+Q 1678 2841 1497 2591 
+Q 1319 2344 1212 1994 
+Q 1106 1644 1106 1300 
+Q 1106 863 1306 627 
+Q 1506 391 1875 391 
+Q 2147 391 2380 519 
+Q 2613 647 2778 891 
+Q 2956 1147 3065 1494 
+Q 3175 1841 3175 2156 
+z
+M 1394 2969 
+Q 1625 3272 1939 3428 
+Q 2253 3584 2638 3584 
+Q 3175 3584 3472 3232 
+Q 3769 2881 3769 2247 
+Q 3769 1728 3584 1258 
+Q 3400 788 3053 416 
+Q 2822 169 2531 39 
+Q 2241 -91 1919 -91 
+Q 1547 -91 1294 64 
+Q 1041 219 916 525 
+L 556 -1331 
+L -19 -1331 
+L 922 3500 
+L 1497 3500 
+L 1394 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-72" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-65" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Oblique-28"/>
+     <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(39.013672 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-41" transform="translate(90.658203 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-34" transform="translate(159.066406 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(222.689453 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(254.476562 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(317.953125 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(345.736328 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(406.917969 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(461.898438 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(519.808594 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(555.892578 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(607.992188 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(671.46875 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(732.748047 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(773.861328 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(825.960938 0)"/>
+    </g>
+    <!-- bwd needed) -->
+    <g style="fill: #d62728" transform="translate(1209.401632 84.831886) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Oblique-77" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-64" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6e" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-29" d="M -397 -844 
+Q 434 191 840 1120 
+Q 1247 2050 1247 2913 
+Q 1247 3406 1130 3892 
+Q 1013 4378 775 4856 
+L 1275 4856 
+Q 1563 4316 1703 3812 
+Q 1844 3309 1844 2822 
+Q 1844 1891 1411 973 
+Q 978 56 116 -844 
+L -397 -844 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Oblique-62"/>
+     <use xlink:href="#DejaVuSans-Oblique-77" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(145.263672 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(208.740234 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(240.527344 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(303.90625 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(365.429688 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(426.953125 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(490.429688 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(551.953125 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-29" transform="translate(615.429688 0)"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- NSA Fwd + Bwd Breakdown -->
+    <g transform="translate(962.461676 61.2) scale(0.13 -0.13)">
+     <defs>
+      <path id="DejaVuSans-Bold-2b" d="M 3053 4013 
+L 3053 2375 
+L 4684 2375 
+L 4684 1638 
+L 3053 1638 
+L 3053 0 
+L 2309 0 
+L 2309 1638 
+L 678 1638 
+L 678 2375 
+L 2309 2375 
+L 2309 4013 
+L 3053 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-42" d="M 2456 2859 
+Q 2741 2859 2887 2984 
+Q 3034 3109 3034 3353 
+Q 3034 3594 2887 3720 
+Q 2741 3847 2456 3847 
+L 1791 3847 
+L 1791 2859 
+L 2456 2859 
+z
+M 2497 819 
+Q 2859 819 3042 972 
+Q 3225 1125 3225 1434 
+Q 3225 1738 3044 1889 
+Q 2863 2041 2497 2041 
+L 1791 2041 
+L 1791 819 
+L 2497 819 
+z
+M 3616 2497 
+Q 4003 2384 4215 2081 
+Q 4428 1778 4428 1338 
+Q 4428 663 3972 331 
+Q 3516 0 2584 0 
+L 588 0 
+L 588 4666 
+L 2394 4666 
+Q 3366 4666 3802 4372 
+Q 4238 4078 4238 3431 
+Q 4238 3091 4078 2852 
+Q 3919 2613 3616 2497 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-4e"/>
+     <use xlink:href="#DejaVuSans-Bold-53" transform="translate(83.691406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-41" transform="translate(155.712891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(233.105469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(267.919922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-77" transform="translate(336.230469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(428.613281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(500.195312 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2b" transform="translate(535.009766 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(618.798828 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-42" transform="translate(653.613281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-77" transform="translate(729.833984 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(822.216797 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(893.798828 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-42" transform="translate(928.613281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1004.833984 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1054.150391 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1121.972656 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" transform="translate(1189.453125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1255.957031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1327.539062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-77" transform="translate(1396.240234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1488.623047 0)"/>
+    </g>
+   </g>
+   <g id="legend_2">
+    <g id="patch_39">
+     <path d="M 890.595415 108.291875 
+L 979.55104 108.291875 
+Q 981.75104 108.291875 981.75104 106.091875 
+L 981.75104 74.9 
+Q 981.75104 72.7 979.55104 72.7 
+L 890.595415 72.7 
+Q 888.395415 72.7 888.395415 74.9 
+L 888.395415 106.091875 
+Q 888.395415 108.291875 890.595415 108.291875 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_40">
+     <path d="M 892.795415 85.458281 
+L 914.795415 85.458281 
+L 914.795415 77.758281 
+L 892.795415 77.758281 
+z
+" style="fill: #2ca02c; opacity: 0.8"/>
+    </g>
+    <g id="text_52">
+     <!-- Forward -->
+     <g transform="translate(923.595415 85.458281) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-46"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(53.894531 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(115.076172 0)"/>
+      <use xlink:href="#DejaVuSans-77" transform="translate(156.189453 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(237.976562 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(299.255859 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(338.619141 0)"/>
+     </g>
+    </g>
+    <g id="patch_41">
+     <path d="M 892.795415 101.604219 
+L 914.795415 101.604219 
+L 914.795415 93.904219 
+L 892.795415 93.904219 
+z
+" style="fill: #ff7f0e; opacity: 0.8"/>
+    </g>
+    <g id="text_53">
+     <!-- Backward -->
+     <g transform="translate(923.595415 101.604219) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(68.603516 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(129.882812 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(184.863281 0)"/>
+      <use xlink:href="#DejaVuSans-77" transform="translate(242.773438 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(324.560547 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(385.839844 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(425.203125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_54">
+   <!-- NSA Sparse Attention Performance — GB200 (B=1, H=32, H_kv=8, D=128) -->
+   <g transform="translate(349.153884 17.837812) scale(0.14 -0.14)">
+    <defs>
+     <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-66" d="M 2841 4863 
+L 2841 4128 
+L 2222 4128 
+Q 1984 4128 1890 4042 
+Q 1797 3956 1797 3744 
+L 1797 3500 
+L 2753 3500 
+L 2753 2700 
+L 1797 2700 
+L 1797 0 
+L 678 0 
+L 678 2700 
+L 122 2700 
+L 122 3500 
+L 678 3500 
+L 678 3744 
+Q 678 4316 997 4589 
+Q 1316 4863 1984 4863 
+L 2841 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2014" d="M 344 2156 
+L 6056 2156 
+L 6056 1350 
+L 344 1350 
+L 344 2156 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-47" d="M 4781 347 
+Q 4331 128 3847 18 
+Q 3363 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3456 1012 4103 
+Q 1706 4750 2913 4750 
+Q 3378 4750 3804 4662 
+Q 4231 4575 4609 4403 
+L 4609 3438 
+Q 4219 3659 3833 3768 
+Q 3447 3878 3059 3878 
+Q 2341 3878 1952 3476 
+Q 1563 3075 1563 2328 
+Q 1563 1588 1938 1184 
+Q 2313 781 3003 781 
+Q 3191 781 3352 804 
+Q 3513 828 3641 878 
+L 3641 1784 
+L 2906 1784 
+L 2906 2591 
+L 4781 2591 
+L 4781 347 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-3d" d="M 678 3084 
+L 4684 3084 
+L 4684 2350 
+L 678 2350 
+L 678 3084 
+z
+M 678 1663 
+L 4684 1663 
+L 4684 922 
+L 678 922 
+L 678 1663 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2c" d="M 653 1209 
+L 1778 1209 
+L 1778 256 
+L 1006 -909 
+L 341 -909 
+L 653 256 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-48" d="M 588 4666 
+L 1791 4666 
+L 1791 2888 
+L 3566 2888 
+L 3566 4666 
+L 4769 4666 
+L 4769 0 
+L 3566 0 
+L 3566 1978 
+L 1791 1978 
+L 1791 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-5f" d="M 3200 -916 
+L 3200 -1509 
+L 0 -1509 
+L 0 -916 
+L 3200 -916 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-4e"/>
+    <use xlink:href="#DejaVuSans-Bold-53" transform="translate(83.691406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-41" transform="translate(155.712891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(233.105469 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-53" transform="translate(267.919922 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(339.941406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(411.523438 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(479.003906 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(528.320312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(587.841797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(655.664062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-41" transform="translate(690.478516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(767.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(815.673828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(863.476562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(931.298828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1002.490234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1050.292969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1084.570312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1153.271484 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1224.462891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-50" transform="translate(1259.277344 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1332.568359 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1400.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-66" transform="translate(1449.707031 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1493.212891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1561.914062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(1611.230469 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1715.429688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1782.910156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(1854.101562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1913.378906 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1981.201172 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2014" transform="translate(2016.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2116.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-47" transform="translate(2150.830078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-42" transform="translate(2232.910156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(2309.130859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-30" transform="translate(2378.710938 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-30" transform="translate(2448.291016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2517.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-28" transform="translate(2552.685547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-42" transform="translate(2598.388672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(2674.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-31" transform="translate(2758.398438 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(2827.978516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2865.966797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-48" transform="translate(2900.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(2984.472656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-33" transform="translate(3068.261719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(3137.841797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(3207.421875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3245.410156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-48" transform="translate(3280.224609 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-5f" transform="translate(3363.916016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6b" transform="translate(3413.916016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(3480.419922 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(3545.605469 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-38" transform="translate(3629.394531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(3698.974609 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3736.962891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-44" transform="translate(3771.777344 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(3854.785156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-31" transform="translate(3938.574219 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(4008.154297 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-38" transform="translate(4077.734375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(4147.314453 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p5113ef4ef7">
+   <rect x="53.31375" y="67.2" width="361.908148" height="286.31338"/>
+  </clipPath>
+  <clipPath id="p54977825d1">
+   <rect x="468.104582" y="67.2" width="361.908148" height="286.31338"/>
+  </clipPath>
+  <clipPath id="p77670f5f0f">
+   <rect x="882.895415" y="67.2" width="361.908148" height="286.31338"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/nsa_vs_dense_perf.svg
+++ b/docs/nsa_vs_dense_perf.svg
@@ -16,12 +16,13 @@
   <rect width="900" height="560" rx="12" fill="url(#bg)" stroke="#dde1e6" stroke-width="1"/>
 
   <!-- Title -->
-  <text x="450" y="36" text-anchor="middle" font-size="18" font-weight="700" fill="#1a1a2e">Dense FA4 vs NSA Sparse Attention — Fused Selection Kernel</text>
-  <text x="450" y="56" text-anchor="middle" font-size="12" fill="#6b7280">B=1, H=8, H_kv=2, D=128 | k=16 selected blocks, w=512 window | bf16 on B200</text>
+  <text x="450" y="36" text-anchor="middle" font-size="18" font-weight="700" fill="#1a1a2e">Dense FA4 vs NSA Sparse Attention — NVIDIA B200</text>
+  <text x="450" y="56" text-anchor="middle" font-size="12" fill="#6b7280">B=1, H=8, H_kv=2, D=128 | k=16 selected blocks, w=512 | bf16 | Fused CuteDSL kernels</text>
 
   <!-- Chart area: x=100..820, y=80..440 (log-log) -->
-  <!-- X: 2^10..2^20 (1K..1M), 72px per octave -->
+  <!-- X: 2^10..2^22 (1K..4M), 60px per octave -->
   <!-- Y: 0.1ms..100s, 6 decades, 60px per decade -->
+  <!-- x = 100 + 60 * (log2(N) - 10) -->
   <!-- y = 440 - 60 * (log10(t_ms) + 1) -->
 
   <!-- Horizontal grid -->
@@ -50,31 +51,35 @@
   <!-- Vertical grid -->
   <g stroke="#e5e7eb" stroke-width="0.7" stroke-dasharray="4,3">
     <line x1="100" y1="80" x2="100" y2="440"/>
-    <line x1="172" y1="80" x2="172" y2="440"/>
-    <line x1="244" y1="80" x2="244" y2="440"/>
-    <line x1="316" y1="80" x2="316" y2="440"/>
-    <line x1="388" y1="80" x2="388" y2="440"/>
+    <line x1="160" y1="80" x2="160" y2="440"/>
+    <line x1="220" y1="80" x2="220" y2="440"/>
+    <line x1="280" y1="80" x2="280" y2="440"/>
+    <line x1="340" y1="80" x2="340" y2="440"/>
+    <line x1="400" y1="80" x2="400" y2="440"/>
     <line x1="460" y1="80" x2="460" y2="440"/>
-    <line x1="532" y1="80" x2="532" y2="440"/>
-    <line x1="604" y1="80" x2="604" y2="440"/>
-    <line x1="676" y1="80" x2="676" y2="440"/>
-    <line x1="748" y1="80" x2="748" y2="440"/>
+    <line x1="520" y1="80" x2="520" y2="440"/>
+    <line x1="580" y1="80" x2="580" y2="440"/>
+    <line x1="640" y1="80" x2="640" y2="440"/>
+    <line x1="700" y1="80" x2="700" y2="440"/>
+    <line x1="760" y1="80" x2="760" y2="440"/>
     <line x1="820" y1="80" x2="820" y2="440"/>
   </g>
 
   <!-- X axis labels -->
   <g font-size="10" fill="#6b7280" text-anchor="middle">
     <text x="100" y="458">1K</text>
-    <text x="172" y="458">2K</text>
-    <text x="244" y="458">4K</text>
-    <text x="316" y="458">8K</text>
-    <text x="388" y="458">16K</text>
-    <text x="460" y="458">32K</text>
-    <text x="532" y="458">64K</text>
-    <text x="604" y="458">128K</text>
-    <text x="676" y="458">256K</text>
-    <text x="748" y="458">512K</text>
-    <text x="820" y="458">1M</text>
+    <text x="160" y="458">2K</text>
+    <text x="220" y="458">4K</text>
+    <text x="280" y="458">8K</text>
+    <text x="340" y="458">16K</text>
+    <text x="400" y="458">32K</text>
+    <text x="460" y="458">64K</text>
+    <text x="520" y="458">128K</text>
+    <text x="580" y="458">256K</text>
+    <text x="640" y="458">512K</text>
+    <text x="700" y="458">1M</text>
+    <text x="760" y="458">2M</text>
+    <text x="820" y="458">4M</text>
   </g>
   <text x="460" y="480" text-anchor="middle" font-size="13" font-weight="600" fill="#374151">Sequence length (tokens)</text>
 
@@ -83,141 +88,138 @@
   <line x1="100" y1="80" x2="100" y2="440" stroke="#9ca3af" stroke-width="1.5"/>
 
   <!--
-    MEASURED DATA (B200, B=1, H=8, H_kv=2, D=128, k=16, w=512, bf16):
+    MEASURED DATA (B200, bf16, CUDA_VISIBLE_DEVICES isolated per run):
+    Config: B=1, H=8, H_kv=2, D=128, k=16, w=512
+    Fused compress, fused select, fused gating kernels active.
+    All data measured end-to-end, no interpolation or scaling.
 
-    N       Dense    NSA-old   NSA l=32  NSA l=64  NSA l=128
-            (ms)     l=64(ms)  new(ms)   new(ms)   new(ms)
-    4K      0.18     1.13      1.08      1.06      0.91      measured
-    8K      0.15     1.21      0.95      0.93      0.78      measured
-    16K     0.43     1.69      0.94      0.95      0.79      measured
-    32K     1.62     4.39      1.15      1.09      1.04      measured
-    64K     7.61     8.14      2.15      1.73      1.47      measured
-    128K    29.71    24.08     5.76      4.11      3.11      measured
-    256K    118.63   81.37     18.29     11.79     8.12      measured
-    512K    474.50   302.66    66.55     37.90     23.76     measured
-    1M      1944     1190      251       133       73        measured (H=4,H_kv=1 scaled 2x)
+    Dense FA4 (from l=64 run, GPU 1):
+    4K:   0.19ms    8K:   0.15ms    16K:  0.44ms    32K:  1.67ms
+    64K:  8.17ms    128K: 32.03ms   256K: 126.72ms  512K: 506.70ms
+    1M:   2026.53ms 2M:   7626.38ms 3M:   18150.16ms
 
-    1M measured with H=4,H_kv=1 (half heads to fit 12GB GPU), times scaled 2x
-    to H=8 equivalent. Dense at 1M validates: 972*2=1944 vs 474.5*4=1898 (2.4% err).
+    NSA l=32 (GPU 3):
+    4K:   1.36ms    8K:   1.09ms    16K:  1.09ms    32K:  1.28ms
+    64K:  2.30ms    128K: 5.90ms    256K: 18.67ms   512K: 66.43ms
+    1M:   254.07ms  (7.97x vs dense)
 
+    NSA l=64 (GPU 1):
+    4K:   1.18ms    8K:   1.07ms    16K:  1.07ms    32K:  1.46ms
+    64K:  1.87ms    128K: 4.11ms    256K: 11.51ms   512K: 37.54ms
+    1M:   139.90ms  2M:   503.71ms  3M:   1117.56ms (16.24x vs dense)
+
+    NSA l=128 (GPU 4):
+    4K:   1.06ms    8K:   0.95ms    16K:  0.94ms    32K:  1.31ms
+    64K:  2.03ms    128K: 3.16ms    256K: 8.05ms    512K: 23.94ms
+    1M:   76.85ms   2M:   282.68ms  3M:   616.48ms  (29.44x vs dense)
+
+    x = 100 + 60 * (log2(N) - 10)
     y = 440 - 60 * (log10(t_ms) + 1)
   -->
 
   <!-- ===== Dense FA4 ===== -->
   <polyline
-    points="244,424.7 316,429.4 388,402.0 460,367.4 532,327.1 604,291.6 676,255.6 748,219.4 820,182.7"
+    points="220,423.3 280,429.4 340,401.4 400,366.6 460,325.3 520,289.7 580,253.8 640,217.7 700,181.6 760,147.1 795,124.5"
     fill="none" stroke="#e74c3c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
     filter="url(#lineShadow)"/>
   <g fill="#e74c3c">
-    <circle cx="244" cy="424.7" r="3"/>
-    <circle cx="316" cy="429.4" r="3"/>
-    <circle cx="388" cy="402.0" r="3"/>
-    <circle cx="460" cy="367.4" r="3"/>
-    <circle cx="532" cy="327.1" r="3"/>
-    <circle cx="604" cy="291.6" r="3"/>
-    <circle cx="676" cy="255.6" r="3"/>
-    <circle cx="748" cy="219.4" r="3"/>
-    <circle cx="820" cy="182.7" r="3"/>
+    <circle cx="220" cy="423.3" r="3"/>
+    <circle cx="280" cy="429.4" r="3"/>
+    <circle cx="340" cy="401.4" r="3"/>
+    <circle cx="400" cy="366.6" r="3"/>
+    <circle cx="460" cy="325.3" r="3"/>
+    <circle cx="520" cy="289.7" r="3"/>
+    <circle cx="580" cy="253.8" r="3"/>
+    <circle cx="640" cy="217.7" r="3"/>
+    <circle cx="700" cy="181.6" r="3"/>
+    <circle cx="760" cy="147.1" r="3"/>
+    <circle cx="795" cy="124.5" r="3"/>
   </g>
 
-  <!-- ===== NSA-old l=64 (PyTorch selection — the bottleneck we fixed) ===== -->
+  <!-- ===== NSA l=32 (fused CuteDSL) ===== -->
   <polyline
-    points="244,376.8 316,375.0 388,366.3 460,341.5 532,325.3 604,297.1 676,265.3 748,231.1 820,195.4"
-    fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-    stroke-dasharray="6,4"
-    filter="url(#lineShadow)"/>
-  <g fill="#f59e0b">
-    <circle cx="460" cy="341.5" r="2.5"/>
-    <circle cx="532" cy="325.3" r="2.5"/>
-    <circle cx="604" cy="297.1" r="2.5"/>
-    <circle cx="676" cy="265.3" r="2.5"/>
-    <circle cx="748" cy="231.1" r="2.5"/>
-  </g>
-
-  <!-- ===== NSA-new l=32 (fused CuteDSL) ===== -->
-  <polyline
-    points="244,378.0 316,381.3 388,381.6 460,376.3 532,360.1 604,334.4 676,304.3 748,270.6 820,236.0"
+    points="220,372.0 280,377.8 340,377.8 400,373.6 460,358.3 520,333.7 580,303.7 640,270.7 700,235.7"
     fill="none" stroke="#a3e635" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
     stroke-dasharray="8,4"
     filter="url(#lineShadow)"/>
   <g fill="#a3e635">
-    <circle cx="460" cy="376.3" r="2.5"/>
-    <circle cx="532" cy="360.1" r="2.5"/>
-    <circle cx="604" cy="334.4" r="2.5"/>
-    <circle cx="676" cy="304.3" r="2.5"/>
-    <circle cx="748" cy="270.6" r="2.5"/>
-    <circle cx="820" cy="236.0" r="2.5"/>
+    <circle cx="220" cy="372.0" r="2.5"/>
+    <circle cx="280" cy="377.8" r="2.5"/>
+    <circle cx="340" cy="377.8" r="2.5"/>
+    <circle cx="400" cy="373.6" r="2.5"/>
+    <circle cx="460" cy="358.3" r="2.5"/>
+    <circle cx="520" cy="333.7" r="2.5"/>
+    <circle cx="580" cy="303.7" r="2.5"/>
+    <circle cx="640" cy="270.7" r="2.5"/>
+    <circle cx="700" cy="235.7" r="2.5"/>
   </g>
 
-  <!-- ===== NSA-new l=64 (fused CuteDSL) ===== -->
+  <!-- ===== NSA l=64 (fused CuteDSL) ===== -->
   <polyline
-    points="244,378.5 316,381.9 388,381.3 460,377.8 532,365.7 604,343.2 676,315.7 748,285.3 820,252.6"
+    points="220,375.7 280,378.2 340,378.2 400,370.1 460,363.7 520,343.2 580,316.3 640,285.5 700,251.3 760,217.9 795,197.1"
     fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
     filter="url(#lineShadow)"/>
   <g fill="#22c55e">
-    <circle cx="244" cy="378.5" r="3"/>
-    <circle cx="316" cy="381.9" r="3"/>
-    <circle cx="388" cy="381.3" r="3"/>
-    <circle cx="460" cy="377.8" r="3"/>
-    <circle cx="532" cy="365.7" r="3"/>
-    <circle cx="604" cy="343.2" r="3"/>
-    <circle cx="676" cy="315.7" r="3"/>
-    <circle cx="748" cy="285.3" r="3"/>
-    <circle cx="820" cy="252.6" r="3"/>
+    <circle cx="220" cy="375.7" r="3"/>
+    <circle cx="280" cy="378.2" r="3"/>
+    <circle cx="340" cy="378.2" r="3"/>
+    <circle cx="400" cy="370.1" r="3"/>
+    <circle cx="460" cy="363.7" r="3"/>
+    <circle cx="520" cy="343.2" r="3"/>
+    <circle cx="580" cy="316.3" r="3"/>
+    <circle cx="640" cy="285.5" r="3"/>
+    <circle cx="700" cy="251.3" r="3"/>
+    <circle cx="760" cy="217.9" r="3"/>
+    <circle cx="795" cy="197.1" r="3"/>
   </g>
 
-  <!-- ===== NSA-new l=128 (fused CuteDSL) ===== -->
+  <!-- ===== NSA l=128 (fused CuteDSL) ===== -->
   <polyline
-    points="244,382.5 316,386.5 388,386.1 460,379.0 532,370.0 604,350.4 676,325.4 748,297.4 820,268.2"
+    points="220,378.5 280,381.3 340,381.6 400,373.0 460,361.6 520,350.0 580,325.7 640,297.3 700,266.9 760,232.9 795,212.6"
     fill="none" stroke="#059669" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
     filter="url(#lineShadow)"/>
   <g fill="#059669">
-    <circle cx="244" cy="382.5" r="3.5"/>
-    <circle cx="316" cy="386.5" r="3.5"/>
-    <circle cx="388" cy="386.1" r="3.5"/>
-    <circle cx="460" cy="379.0" r="3.5"/>
-    <circle cx="532" cy="370.0" r="3.5"/>
-    <circle cx="604" cy="350.4" r="3.5"/>
-    <circle cx="676" cy="325.4" r="3.5"/>
-    <circle cx="748" cy="297.4" r="3.5"/>
-    <circle cx="820" cy="268.2" r="3.5"/>
+    <circle cx="220" cy="378.5" r="3.5"/>
+    <circle cx="280" cy="381.3" r="3.5"/>
+    <circle cx="340" cy="381.6" r="3.5"/>
+    <circle cx="400" cy="373.0" r="3.5"/>
+    <circle cx="460" cy="361.6" r="3.5"/>
+    <circle cx="520" cy="350.0" r="3.5"/>
+    <circle cx="580" cy="325.7" r="3.5"/>
+    <circle cx="640" cy="297.3" r="3.5"/>
+    <circle cx="700" cy="266.9" r="3.5"/>
+    <circle cx="760" cy="232.9" r="3.5"/>
+    <circle cx="795" cy="212.6" r="3.5"/>
   </g>
 
-  <!-- Speedup annotation: old l=64 vs new l=64 at N=1M -->
-  <line x1="820" y1="197" x2="820" y2="250" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="807" y="222" font-size="9" font-weight="600" fill="#7c3aed" text-anchor="end">8.9x</text>
-  <text x="807" y="232" font-size="8" fill="#7c3aed" text-anchor="end">faster</text>
+  <!-- Speedup bracket: Dense vs NSA l=128 at N=3M -->
+  <line x1="795" y1="127" x2="795" y2="210" stroke="#7c3aed" stroke-width="1.5"/>
+  <line x1="791" y1="127" x2="799" y2="127" stroke="#7c3aed" stroke-width="1.5"/>
+  <line x1="791" y1="210" x2="799" y2="210" stroke="#7c3aed" stroke-width="1.5"/>
 
-  <!-- Speedup labels at N=1M (measured) -->
+  <!-- Speedup labels at N=3M (vs dense) -->
   <g font-size="9" font-weight="600">
-    <text x="835" y="234" fill="#a3e635">7.7x</text>
-    <text x="835" y="250" fill="#22c55e">14.6x</text>
-    <text x="835" y="266" fill="#059669">26.5x</text>
+    <text x="808" y="193" fill="#a3e635">8.0x</text>
+    <text x="808" y="203" fill="#22c55e">16.2x</text>
+    <text x="808" y="213" fill="#059669">29.4x</text>
   </g>
 
   <!-- Scaling annotations -->
   <g font-size="9" fill="#6b7280" font-style="italic">
-    <text x="800" y="170" text-anchor="end">O(N²)</text>
+    <text x="775" y="115" text-anchor="end">O(N&#xB2;)</text>
   </g>
 
   <!-- "l" labels at right side of each NSA curve -->
   <g font-size="10" font-weight="600">
-    <text x="828" y="242" fill="#a3e635">l=32</text>
-    <text x="828" y="258" fill="#22c55e">l=64</text>
-    <text x="828" y="274" fill="#059669">l=128</text>
+    <text x="708" y="232" fill="#a3e635">l=32</text>
+    <text x="808" y="200" fill="#22c55e">l=64</text>
+    <text x="808" y="218" fill="#059669">l=128</text>
   </g>
 
-  <!-- NSA-old label -->
-  <text x="828" y="200" font-size="9" font-weight="500" fill="#f59e0b">old l=64</text>
-
   <!-- Crossover annotation -->
-  <text x="445" y="395" text-anchor="middle" font-size="8" fill="#7c3aed" font-weight="500">NSA faster than dense</text>
-  <text x="445" y="404" text-anchor="middle" font-size="8" fill="#7c3aed">above N ~24K</text>
-  <line x1="445" y1="375" x2="445" y2="387" stroke="#7c3aed" stroke-width="0.8" stroke-dasharray="2,2"/>
-
-  <!-- Old crossover annotation -->
-  <text x="610" y="302" text-anchor="start" font-size="7" fill="#f59e0b">old: barely faster</text>
-  <text x="610" y="310" text-anchor="start" font-size="7" fill="#f59e0b">than dense at 128K</text>
+  <text x="380" y="395" text-anchor="middle" font-size="8" fill="#7c3aed" font-weight="500">NSA faster than dense</text>
+  <text x="380" y="404" text-anchor="middle" font-size="8" fill="#7c3aed">above N ~24K</text>
+  <line x1="380" y1="375" x2="380" y2="387" stroke="#7c3aed" stroke-width="0.8" stroke-dasharray="2,2"/>
 
   <!-- Legend -->
   <g transform="translate(110, 495)" filter="url(#shadow)">
@@ -227,20 +229,18 @@
     <circle cx="24" cy="16" r="3" fill="#e74c3c"/>
     <text x="40" y="20" font-size="10" fill="#374151" font-weight="500">Dense FA4</text>
 
-    <line x1="115" y1="16" x2="135" y2="16" stroke="#f59e0b" stroke-width="2" stroke-dasharray="6,4"/>
-    <text x="141" y="20" font-size="10" fill="#374151" font-weight="500">NSA old l=64 (PyTorch select)</text>
+    <line x1="115" y1="16" x2="135" y2="16" stroke="#a3e635" stroke-width="2" stroke-dasharray="8,4"/>
+    <circle cx="125" cy="16" r="2.5" fill="#a3e635"/>
+    <text x="141" y="20" font-size="10" fill="#374151" font-weight="500">NSA l=32</text>
 
-    <line x1="350" y1="16" x2="370" y2="16" stroke="#a3e635" stroke-width="2" stroke-dasharray="8,4"/>
-    <text x="376" y="20" font-size="10" fill="#374151" font-weight="500">l=32</text>
+    <line x1="230" y1="16" x2="250" y2="16" stroke="#22c55e" stroke-width="2.5"/>
+    <circle cx="240" cy="16" r="3" fill="#22c55e"/>
+    <text x="256" y="20" font-size="10" fill="#374151" font-weight="500">NSA l=64</text>
 
-    <line x1="14" y1="40" x2="34" y2="40" stroke="#22c55e" stroke-width="2.5"/>
-    <circle cx="24" cy="40" r="3" fill="#22c55e"/>
-    <text x="40" y="44" font-size="10" fill="#374151" font-weight="500">NSA fused l=64</text>
+    <line x1="340" y1="16" x2="360" y2="16" stroke="#059669" stroke-width="2.5"/>
+    <circle cx="350" cy="16" r="3.5" fill="#059669"/>
+    <text x="366" y="20" font-size="10" fill="#374151" font-weight="500">NSA l=128</text>
 
-    <line x1="155" y1="40" x2="175" y2="40" stroke="#059669" stroke-width="2.5"/>
-    <circle cx="165" cy="40" r="3" fill="#059669"/>
-    <text x="181" y="44" font-size="10" fill="#374151" font-weight="500">l=128</text>
-
-    <text x="260" y="44" font-size="9" fill="#9ca3af">Measured on B200, 4K&#x2013;512K at H=8, 1M at H=4 (scaled)</text>
+    <text x="14" y="44" font-size="9" fill="#9ca3af">All data measured on B200 (180GB). B=1, H=8, H_kv=2, D=128. Fused compress, select, gating kernels. No interpolated points.</text>
   </g>
 </svg>

--- a/docs/nsa_vs_dense_perf.svg
+++ b/docs/nsa_vs_dense_perf.svg
@@ -1,0 +1,246 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Inter, -apple-system, system-ui, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fafbfc"/>
+      <stop offset="100%" stop-color="#f0f2f5"/>
+    </linearGradient>
+    <filter id="shadow" x="-2%" y="-2%" width="104%" height="104%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.08"/>
+    </filter>
+    <filter id="lineShadow">
+      <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="560" rx="12" fill="url(#bg)" stroke="#dde1e6" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="450" y="36" text-anchor="middle" font-size="18" font-weight="700" fill="#1a1a2e">Dense FA4 vs NSA Sparse Attention — Fused Selection Kernel</text>
+  <text x="450" y="56" text-anchor="middle" font-size="12" fill="#6b7280">B=1, H=8, H_kv=2, D=128 | k=16 selected blocks, w=512 window | bf16 on B200</text>
+
+  <!-- Chart area: x=100..820, y=80..440 (log-log) -->
+  <!-- X: 2^10..2^20 (1K..1M), 72px per octave -->
+  <!-- Y: 0.1ms..100s, 6 decades, 60px per decade -->
+  <!-- y = 440 - 60 * (log10(t_ms) + 1) -->
+
+  <!-- Horizontal grid -->
+  <g stroke="#e5e7eb" stroke-width="0.7" stroke-dasharray="4,3">
+    <line x1="100" y1="80" x2="820" y2="80"/>
+    <line x1="100" y1="140" x2="820" y2="140"/>
+    <line x1="100" y1="200" x2="820" y2="200"/>
+    <line x1="100" y1="260" x2="820" y2="260"/>
+    <line x1="100" y1="320" x2="820" y2="320"/>
+    <line x1="100" y1="380" x2="820" y2="380"/>
+    <line x1="100" y1="440" x2="820" y2="440"/>
+  </g>
+
+  <!-- Y axis labels -->
+  <g font-size="11" fill="#6b7280" text-anchor="end">
+    <text x="92" y="84">100s</text>
+    <text x="92" y="144">10s</text>
+    <text x="92" y="204">1s</text>
+    <text x="92" y="264">100ms</text>
+    <text x="92" y="324">10ms</text>
+    <text x="92" y="384">1ms</text>
+    <text x="92" y="444">0.1ms</text>
+  </g>
+  <text x="20" y="260" text-anchor="middle" font-size="13" font-weight="600" fill="#374151" transform="rotate(-90, 20, 260)">Wall-clock time</text>
+
+  <!-- Vertical grid -->
+  <g stroke="#e5e7eb" stroke-width="0.7" stroke-dasharray="4,3">
+    <line x1="100" y1="80" x2="100" y2="440"/>
+    <line x1="172" y1="80" x2="172" y2="440"/>
+    <line x1="244" y1="80" x2="244" y2="440"/>
+    <line x1="316" y1="80" x2="316" y2="440"/>
+    <line x1="388" y1="80" x2="388" y2="440"/>
+    <line x1="460" y1="80" x2="460" y2="440"/>
+    <line x1="532" y1="80" x2="532" y2="440"/>
+    <line x1="604" y1="80" x2="604" y2="440"/>
+    <line x1="676" y1="80" x2="676" y2="440"/>
+    <line x1="748" y1="80" x2="748" y2="440"/>
+    <line x1="820" y1="80" x2="820" y2="440"/>
+  </g>
+
+  <!-- X axis labels -->
+  <g font-size="10" fill="#6b7280" text-anchor="middle">
+    <text x="100" y="458">1K</text>
+    <text x="172" y="458">2K</text>
+    <text x="244" y="458">4K</text>
+    <text x="316" y="458">8K</text>
+    <text x="388" y="458">16K</text>
+    <text x="460" y="458">32K</text>
+    <text x="532" y="458">64K</text>
+    <text x="604" y="458">128K</text>
+    <text x="676" y="458">256K</text>
+    <text x="748" y="458">512K</text>
+    <text x="820" y="458">1M</text>
+  </g>
+  <text x="460" y="480" text-anchor="middle" font-size="13" font-weight="600" fill="#374151">Sequence length (tokens)</text>
+
+  <!-- Axes -->
+  <line x1="100" y1="440" x2="820" y2="440" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="100" y1="80" x2="100" y2="440" stroke="#9ca3af" stroke-width="1.5"/>
+
+  <!--
+    MEASURED DATA (B200, B=1, H=8, H_kv=2, D=128, k=16, w=512, bf16):
+
+    N       Dense    NSA-old   NSA l=32  NSA l=64  NSA l=128
+            (ms)     l=64(ms)  new(ms)   new(ms)   new(ms)
+    4K      0.18     1.13      1.08      1.06      0.91      measured
+    8K      0.15     1.21      0.95      0.93      0.78      measured
+    16K     0.43     1.69      0.94      0.95      0.79      measured
+    32K     1.62     4.39      1.15      1.09      1.04      measured
+    64K     7.61     8.14      2.15      1.73      1.47      measured
+    128K    29.71    24.08     5.76      4.11      3.11      measured
+    256K    118.63   81.37     18.29     11.79     8.12      measured
+    512K    474.50   302.66    66.55     37.90     23.76     measured
+    1M      1944     1190      251       133       73        measured (H=4,H_kv=1 scaled 2x)
+
+    1M measured with H=4,H_kv=1 (half heads to fit 12GB GPU), times scaled 2x
+    to H=8 equivalent. Dense at 1M validates: 972*2=1944 vs 474.5*4=1898 (2.4% err).
+
+    y = 440 - 60 * (log10(t_ms) + 1)
+  -->
+
+  <!-- ===== Dense FA4 ===== -->
+  <polyline
+    points="244,424.7 316,429.4 388,402.0 460,367.4 532,327.1 604,291.6 676,255.6 748,219.4 820,182.7"
+    fill="none" stroke="#e74c3c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+    filter="url(#lineShadow)"/>
+  <g fill="#e74c3c">
+    <circle cx="244" cy="424.7" r="3"/>
+    <circle cx="316" cy="429.4" r="3"/>
+    <circle cx="388" cy="402.0" r="3"/>
+    <circle cx="460" cy="367.4" r="3"/>
+    <circle cx="532" cy="327.1" r="3"/>
+    <circle cx="604" cy="291.6" r="3"/>
+    <circle cx="676" cy="255.6" r="3"/>
+    <circle cx="748" cy="219.4" r="3"/>
+    <circle cx="820" cy="182.7" r="3"/>
+  </g>
+
+  <!-- ===== NSA-old l=64 (PyTorch selection — the bottleneck we fixed) ===== -->
+  <polyline
+    points="244,376.8 316,375.0 388,366.3 460,341.5 532,325.3 604,297.1 676,265.3 748,231.1 820,195.4"
+    fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+    stroke-dasharray="6,4"
+    filter="url(#lineShadow)"/>
+  <g fill="#f59e0b">
+    <circle cx="460" cy="341.5" r="2.5"/>
+    <circle cx="532" cy="325.3" r="2.5"/>
+    <circle cx="604" cy="297.1" r="2.5"/>
+    <circle cx="676" cy="265.3" r="2.5"/>
+    <circle cx="748" cy="231.1" r="2.5"/>
+  </g>
+
+  <!-- ===== NSA-new l=32 (fused CuteDSL) ===== -->
+  <polyline
+    points="244,378.0 316,381.3 388,381.6 460,376.3 532,360.1 604,334.4 676,304.3 748,270.6 820,236.0"
+    fill="none" stroke="#a3e635" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+    stroke-dasharray="8,4"
+    filter="url(#lineShadow)"/>
+  <g fill="#a3e635">
+    <circle cx="460" cy="376.3" r="2.5"/>
+    <circle cx="532" cy="360.1" r="2.5"/>
+    <circle cx="604" cy="334.4" r="2.5"/>
+    <circle cx="676" cy="304.3" r="2.5"/>
+    <circle cx="748" cy="270.6" r="2.5"/>
+    <circle cx="820" cy="236.0" r="2.5"/>
+  </g>
+
+  <!-- ===== NSA-new l=64 (fused CuteDSL) ===== -->
+  <polyline
+    points="244,378.5 316,381.9 388,381.3 460,377.8 532,365.7 604,343.2 676,315.7 748,285.3 820,252.6"
+    fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+    filter="url(#lineShadow)"/>
+  <g fill="#22c55e">
+    <circle cx="244" cy="378.5" r="3"/>
+    <circle cx="316" cy="381.9" r="3"/>
+    <circle cx="388" cy="381.3" r="3"/>
+    <circle cx="460" cy="377.8" r="3"/>
+    <circle cx="532" cy="365.7" r="3"/>
+    <circle cx="604" cy="343.2" r="3"/>
+    <circle cx="676" cy="315.7" r="3"/>
+    <circle cx="748" cy="285.3" r="3"/>
+    <circle cx="820" cy="252.6" r="3"/>
+  </g>
+
+  <!-- ===== NSA-new l=128 (fused CuteDSL) ===== -->
+  <polyline
+    points="244,382.5 316,386.5 388,386.1 460,379.0 532,370.0 604,350.4 676,325.4 748,297.4 820,268.2"
+    fill="none" stroke="#059669" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+    filter="url(#lineShadow)"/>
+  <g fill="#059669">
+    <circle cx="244" cy="382.5" r="3.5"/>
+    <circle cx="316" cy="386.5" r="3.5"/>
+    <circle cx="388" cy="386.1" r="3.5"/>
+    <circle cx="460" cy="379.0" r="3.5"/>
+    <circle cx="532" cy="370.0" r="3.5"/>
+    <circle cx="604" cy="350.4" r="3.5"/>
+    <circle cx="676" cy="325.4" r="3.5"/>
+    <circle cx="748" cy="297.4" r="3.5"/>
+    <circle cx="820" cy="268.2" r="3.5"/>
+  </g>
+
+  <!-- Speedup annotation: old l=64 vs new l=64 at N=1M -->
+  <line x1="820" y1="197" x2="820" y2="250" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="807" y="222" font-size="9" font-weight="600" fill="#7c3aed" text-anchor="end">8.9x</text>
+  <text x="807" y="232" font-size="8" fill="#7c3aed" text-anchor="end">faster</text>
+
+  <!-- Speedup labels at N=1M (measured) -->
+  <g font-size="9" font-weight="600">
+    <text x="835" y="234" fill="#a3e635">7.7x</text>
+    <text x="835" y="250" fill="#22c55e">14.6x</text>
+    <text x="835" y="266" fill="#059669">26.5x</text>
+  </g>
+
+  <!-- Scaling annotations -->
+  <g font-size="9" fill="#6b7280" font-style="italic">
+    <text x="800" y="170" text-anchor="end">O(N²)</text>
+  </g>
+
+  <!-- "l" labels at right side of each NSA curve -->
+  <g font-size="10" font-weight="600">
+    <text x="828" y="242" fill="#a3e635">l=32</text>
+    <text x="828" y="258" fill="#22c55e">l=64</text>
+    <text x="828" y="274" fill="#059669">l=128</text>
+  </g>
+
+  <!-- NSA-old label -->
+  <text x="828" y="200" font-size="9" font-weight="500" fill="#f59e0b">old l=64</text>
+
+  <!-- Crossover annotation -->
+  <text x="445" y="395" text-anchor="middle" font-size="8" fill="#7c3aed" font-weight="500">NSA faster than dense</text>
+  <text x="445" y="404" text-anchor="middle" font-size="8" fill="#7c3aed">above N ~24K</text>
+  <line x1="445" y1="375" x2="445" y2="387" stroke="#7c3aed" stroke-width="0.8" stroke-dasharray="2,2"/>
+
+  <!-- Old crossover annotation -->
+  <text x="610" y="302" text-anchor="start" font-size="7" fill="#f59e0b">old: barely faster</text>
+  <text x="610" y="310" text-anchor="start" font-size="7" fill="#f59e0b">than dense at 128K</text>
+
+  <!-- Legend -->
+  <g transform="translate(110, 495)" filter="url(#shadow)">
+    <rect x="0" y="0" width="700" height="52" rx="8" fill="white" stroke="#e5e7eb" stroke-width="1"/>
+
+    <line x1="14" y1="16" x2="34" y2="16" stroke="#e74c3c" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="24" cy="16" r="3" fill="#e74c3c"/>
+    <text x="40" y="20" font-size="10" fill="#374151" font-weight="500">Dense FA4</text>
+
+    <line x1="115" y1="16" x2="135" y2="16" stroke="#f59e0b" stroke-width="2" stroke-dasharray="6,4"/>
+    <text x="141" y="20" font-size="10" fill="#374151" font-weight="500">NSA old l=64 (PyTorch select)</text>
+
+    <line x1="350" y1="16" x2="370" y2="16" stroke="#a3e635" stroke-width="2" stroke-dasharray="8,4"/>
+    <text x="376" y="20" font-size="10" fill="#374151" font-weight="500">l=32</text>
+
+    <line x1="14" y1="40" x2="34" y2="40" stroke="#22c55e" stroke-width="2.5"/>
+    <circle cx="24" cy="40" r="3" fill="#22c55e"/>
+    <text x="40" y="44" font-size="10" fill="#374151" font-weight="500">NSA fused l=64</text>
+
+    <line x1="155" y1="40" x2="175" y2="40" stroke="#059669" stroke-width="2.5"/>
+    <circle cx="165" cy="40" r="3" fill="#059669"/>
+    <text x="181" y="44" font-size="10" fill="#374151" font-weight="500">l=128</text>
+
+    <text x="260" y="44" font-size="9" fill="#9ca3af">Measured on B200, 4K&#x2013;512K at H=8, 1M at H=4 (scaled)</text>
+  </g>
+</svg>

--- a/mslk/attention/flash_attn/block_sparsity.py
+++ b/mslk/attention/flash_attn/block_sparsity.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+try:
+    from mslk.fb.mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+except ImportError:
+    from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
+
+__all__ = ["BlockSparseTensorsTorch"]

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -6,8 +6,12 @@ from mslk.attention.sparse_attn.gating import (
     fused_gate_and_combine,
     gate_and_combine,
 )
+from mslk.attention.sparse_attn.nsa_autograd import nsa
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward
-from mslk.attention.sparse_attn.reference import nsa_forward_reference
+from mslk.attention.sparse_attn.reference import (
+    nsa_backward_reference,
+    nsa_forward_reference,
+)
 from mslk.attention.sparse_attn.select import (
     fused_score_and_select_blocks,
     score_and_select_blocks,
@@ -15,8 +19,10 @@ from mslk.attention.sparse_attn.select import (
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 
 __all__ = [
+    "nsa",
     "nsa_forward",
     "nsa_forward_reference",
+    "nsa_backward_reference",
     "compress_kv",
     "fused_compress_kv",
     "score_and_select_blocks",

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -8,7 +8,10 @@ from mslk.attention.sparse_attn.gating import (
 )
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward
 from mslk.attention.sparse_attn.reference import nsa_forward_reference
-from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.select import (
+    fused_score_and_select_blocks,
+    score_and_select_blocks,
+)
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 
 __all__ = [
@@ -16,6 +19,7 @@ __all__ = [
     "nsa_forward_reference",
     "compress_kv",
     "score_and_select_blocks",
+    "fused_score_and_select_blocks",
     "build_fa4_block_sparse_tensors",
     "compute_gates",
     "fused_gate_and_combine",

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,6 +1,6 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
 from mslk.attention.sparse_attn.gating import (
     compute_gates,
     fused_gate_and_combine,
@@ -18,6 +18,7 @@ __all__ = [
     "nsa_forward",
     "nsa_forward_reference",
     "compress_kv",
+    "fused_compress_kv",
     "score_and_select_blocks",
     "fused_score_and_select_blocks",
     "build_fa4_block_sparse_tensors",

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,0 +1,18 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+from mslk.attention.sparse_attn.reference import nsa_forward_reference
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+__all__ = [
+    "nsa_forward",
+    "nsa_forward_reference",
+    "compress_kv",
+    "score_and_select_blocks",
+    "build_fa4_block_sparse_tensors",
+    "compute_gates",
+    "gate_and_combine",
+]

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,7 +1,11 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 from mslk.attention.sparse_attn.compress import compress_kv
-from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.gating import (
+    compute_gates,
+    fused_gate_and_combine,
+    gate_and_combine,
+)
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward
 from mslk.attention.sparse_attn.reference import nsa_forward_reference
 from mslk.attention.sparse_attn.select import score_and_select_blocks
@@ -14,5 +18,6 @@ __all__ = [
     "score_and_select_blocks",
     "build_fa4_block_sparse_tensors",
     "compute_gates",
+    "fused_gate_and_combine",
     "gate_and_combine",
 ]

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -37,7 +37,9 @@ def compress_kv(
         V_cmp: Compressed values, shape (B, N // block_size, H_kv, D).
     """
     B, N, H_kv, D = K.shape
-    assert N % block_size == 0, f"Sequence length {N} must be divisible by block_size {block_size}"
+    assert N % block_size == 0, (
+        f"Sequence length {N} must be divisible by block_size {block_size}"
+    )
 
     N_cmp = N // block_size
 
@@ -84,9 +86,7 @@ def _make_fused_compress_kernel(cute_dtype: Type, D: int, block_size: int):
 
     class _Kernel:
         @cute.jit
-        def __call__(
-            self, mK, mV, mK_out, mV_out, N_cmp, H_kv, N, stream
-        ):
+        def __call__(self, mK, mV, mK_out, mV_out, N_cmp, H_kv, N, stream):
             grid_x = mK_out.shape[0]  # B * N_cmp * H_kv
             self.kernel(mK, mV, mK_out, mV_out, N_cmp, H_kv, N).launch(
                 grid=[grid_x, 1, 1],
@@ -113,11 +113,15 @@ def _make_fused_compress_kernel(cute_dtype: Type, D: int, block_size: int):
                     acc_v = Float32(0.0)
 
                     for t in cutlass.range_constexpr(block_size):
-                        input_row = b * N * H_kv + (j * const_expr(block_size) + const_expr(t)) * H_kv + h
+                        input_row = cutlass.Int64(
+                            b * N * H_kv
+                            + (j * const_expr(block_size) + const_expr(t)) * H_kv
+                            + h
+                        )
                         acc_k += Float32(mK[input_row, d])
                         acc_v += Float32(mV[input_row, d])
 
-                    output_row = b * N_cmp * H_kv + j * H_kv + h
+                    output_row = cutlass.Int64(b * N_cmp * H_kv + j * H_kv + h)
                     mK_out[output_row, d] = cute_dtype(acc_k * inv_block_size)
                     mV_out[output_row, d] = cute_dtype(acc_v * inv_block_size)
 
@@ -156,7 +160,9 @@ def fused_compress_kv(
     from cutlass.cute.runtime import from_dlpack
 
     B, N, H_kv, D = K.shape
-    assert N % block_size == 0, f"Sequence length {N} must be divisible by block_size {block_size}"
+    assert N % block_size == 0, (
+        f"Sequence length {N} must be divisible by block_size {block_size}"
+    )
 
     N_cmp = N // block_size
 

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -213,3 +213,151 @@ def fused_compress_kv(
         V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
 
     return K_cmp, V_cmp
+
+
+# ---------------------------------------------------------------------------
+# CuteDSL fused compression backward kernel (mean-pool scatter)
+# ---------------------------------------------------------------------------
+
+_fused_compress_bwd_compile_cache: dict = {}
+
+
+def _make_fused_compress_bwd_kernel(cute_dtype: Type, D: int, block_size: int):
+    """Create CuteDSL kernel for compression backward (mean-pool scatter).
+
+    Each thread block handles one output position (b, pos, h).
+    Reads dK_cmp[b, pos//block_size, h, :] and writes
+    dK[b, pos, h, :] = dK_cmp[b, block, h, :] / block_size.
+    Processes both K and V simultaneously.
+
+    Grid: B * N * H_kv
+    Block: 128 threads
+    """
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass import const_expr, Float32
+
+    THREADS_PER_BLOCK = 128
+    D_PER_THREAD = math.ceil(D / THREADS_PER_BLOCK)
+
+    class _Kernel:
+        @cute.jit
+        def __call__(self, mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv, stream):
+            grid_x = mDK.shape[0]
+            self.kernel(mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv):
+            tidx = cute.arch.thread_idx()[0]
+            bidx = cute.arch.block_idx()[0]
+
+            b = bidx // (N * H_kv)
+            pos = (bidx % (N * H_kv)) // H_kv
+            h = bidx % H_kv
+
+            block_idx = pos // const_expr(block_size)
+            inv_block_size = const_expr(1.0 / block_size)
+
+            N_cmp = N // const_expr(block_size)
+            input_row = cutlass.Int64(b * N_cmp * H_kv + block_idx * H_kv + h)
+
+            for e in cutlass.range_constexpr(D_PER_THREAD):
+                d = tidx + const_expr(e * THREADS_PER_BLOCK)
+                if d < const_expr(D):
+                    dk = Float32(mDK_cmp[input_row, d]) * inv_block_size
+                    dv = Float32(mDV_cmp[input_row, d]) * inv_block_size
+                    mDK[bidx, d] = cute_dtype(dk)
+                    mDV[bidx, d] = cute_dtype(dv)
+
+    return _Kernel()
+
+
+def fused_compress_kv_backward(
+    dK_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    dV_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None = None,
+    W_v: Tensor | None = None,
+) -> tuple[Tensor, Tensor, Tensor | None, Tensor | None]:
+    """Backward through KV compression: CuteDSL scatter + PyTorch projection.
+
+    Returns (dK, dV, dW_k, dW_v).
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H_kv, D = K.shape
+    N_cmp = N // block_size
+
+    dW_k = None
+    dW_v = None
+
+    # Projection backward (PyTorch)
+    if W_k is not None:
+        K_cmp_mean = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+        dW_k = torch.einsum("bnhd,bnhe->hde", K_cmp_mean.float(), dK_cmp.float()).to(
+            W_k.dtype
+        )
+        dK_cmp = torch.einsum("bnhe,hde->bnhd", dK_cmp.float(), W_k.float()).to(
+            dK_cmp.dtype
+        )
+
+    if W_v is not None:
+        V_cmp_mean = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+        dW_v = torch.einsum("bnhd,bnhe->hde", V_cmp_mean.float(), dV_cmp.float()).to(
+            W_v.dtype
+        )
+        dV_cmp = torch.einsum("bnhe,hde->bnhd", dV_cmp.float(), W_v.float()).to(
+            dV_cmp.dtype
+        )
+
+    # Mean-pool backward via CuteDSL scatter kernel
+    dK = torch.empty(B, N, H_kv, D, device=K.device, dtype=K.dtype)
+    dV = torch.empty(B, N, H_kv, D, device=V.device, dtype=V.dtype)
+
+    M_out = B * N * H_kv
+    M_in = B * N_cmp * H_kv
+
+    dK_cmp_2d = dK_cmp.reshape(M_in, D).contiguous()
+    dV_cmp_2d = dV_cmp.reshape(M_in, D).contiguous()
+    dK_2d = dK.reshape(M_out, D)
+    dV_2d = dV.reshape(M_out, D)
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[K.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mDK_cmp = to_cute(dK_cmp_2d)
+    mDV_cmp = to_cute(dV_cmp_2d)
+    mDK = to_cute(dK_2d)
+    mDV = to_cute(dV_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, block_size)
+    if compile_key not in _fused_compress_bwd_compile_cache:
+        kernel_op = _make_fused_compress_bwd_kernel(cute_dtype, D, block_size)
+        _fused_compress_bwd_compile_cache[compile_key] = cute.compile(
+            kernel_op, mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv, current_stream
+        )
+    _fused_compress_bwd_compile_cache[compile_key](
+        mDK_cmp, mDV_cmp, mDK, mDV, N, H_kv, current_stream
+    )
+
+    return dK, dV, dW_k, dW_v

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -1,0 +1,50 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""KV compression for NSA: mean-pool KV into blocks and apply learned projection."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def compress_kv(
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None = None,  # (H_kv, D, D) or None
+    W_v: Tensor | None = None,  # (H_kv, D, D) or None
+) -> tuple[Tensor, Tensor]:
+    """Compress K, V by mean-pooling over blocks and applying optional linear projection.
+
+    Args:
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        block_size: Number of positions to pool together.
+        W_k: Optional per-head projection weight for keys.
+        W_v: Optional per-head projection weight for values.
+
+    Returns:
+        K_cmp: Compressed keys, shape (B, N // block_size, H_kv, D).
+        V_cmp: Compressed values, shape (B, N // block_size, H_kv, D).
+    """
+    B, N, H_kv, D = K.shape
+    assert N % block_size == 0, f"Sequence length {N} must be divisible by block_size {block_size}"
+
+    N_cmp = N // block_size
+
+    # Reshape into blocks and mean-pool
+    K_cmp = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)  # (B, N_cmp, H_kv, D)
+    V_cmp = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+
+    # Apply per-head linear projection if provided
+    if W_k is not None:
+        # W_k: (H_kv, D, D)
+        # K_cmp: (B, N_cmp, H_kv, D) -> einsum over D
+        K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
+
+    if W_v is not None:
+        V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
+
+    return K_cmp, V_cmp

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -1,11 +1,18 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-ignore-all-errors
 
-"""KV compression for NSA: mean-pool KV into blocks and apply learned projection."""
+"""KV compression for NSA: mean-pool KV into blocks and apply learned projection.
+
+Includes both a PyTorch reference (compress_kv) and a fused CuteDSL kernel
+(fused_compress_kv) that processes both K and V in a single kernel launch.
+"""
 
 from __future__ import annotations
 
+import math
+from typing import Type
+
 import torch
-import torch.nn.functional as F
 from torch import Tensor
 
 
@@ -42,6 +49,158 @@ def compress_kv(
     if W_k is not None:
         # W_k: (H_kv, D, D)
         # K_cmp: (B, N_cmp, H_kv, D) -> einsum over D
+        K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
+
+    if W_v is not None:
+        V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
+
+    return K_cmp, V_cmp
+
+
+# ---------------------------------------------------------------------------
+# CuteDSL fused compression kernel
+# ---------------------------------------------------------------------------
+
+_fused_compress_compile_cache: dict = {}
+
+
+def _make_fused_compress_kernel(cute_dtype: Type, D: int, block_size: int):
+    """Create and return a compiled CuteDSL kernel for fused KV compression.
+
+    Each thread block handles one output element (b, j, h) — one compressed
+    block for one KV head. It reads block_size input positions for both K and V,
+    accumulates in float32, divides by block_size, and writes the mean.
+
+    Grid: B * N_cmp * H_kv (one block per output row)
+    Block: 128 threads
+    Each thread handles elements d = tidx, tidx+128, ... of the D dimension.
+    """
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass import const_expr, Float32
+
+    THREADS_PER_BLOCK = 128
+    D_PER_THREAD = math.ceil(D / THREADS_PER_BLOCK)
+
+    class _Kernel:
+        @cute.jit
+        def __call__(
+            self, mK, mV, mK_out, mV_out, N_cmp, H_kv, N, stream
+        ):
+            grid_x = mK_out.shape[0]  # B * N_cmp * H_kv
+            self.kernel(mK, mV, mK_out, mV_out, N_cmp, H_kv, N).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, mK, mV, mK_out, mV_out, N_cmp, H_kv, N):
+            tidx = cute.arch.thread_idx()[0]
+            bidx = cute.arch.block_idx()[0]
+
+            # Decompose block index into (b, j, h)
+            b = bidx // (N_cmp * H_kv)
+            j = (bidx % (N_cmp * H_kv)) // H_kv
+            h = bidx % H_kv
+
+            inv_block_size = const_expr(1.0 / block_size)
+
+            for e in cutlass.range_constexpr(D_PER_THREAD):
+                d = tidx + const_expr(e * THREADS_PER_BLOCK)
+                if d < const_expr(D):
+                    acc_k = Float32(0.0)
+                    acc_v = Float32(0.0)
+
+                    for t in cutlass.range_constexpr(block_size):
+                        input_row = b * N * H_kv + (j * const_expr(block_size) + const_expr(t)) * H_kv + h
+                        acc_k += Float32(mK[input_row, d])
+                        acc_v += Float32(mV[input_row, d])
+
+                    output_row = b * N_cmp * H_kv + j * H_kv + h
+                    mK_out[output_row, d] = cute_dtype(acc_k * inv_block_size)
+                    mV_out[output_row, d] = cute_dtype(acc_v * inv_block_size)
+
+    return _Kernel()
+
+
+def fused_compress_kv(
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None = None,  # (H_kv, D, D) or None
+    W_v: Tensor | None = None,  # (H_kv, D, D) or None
+) -> tuple[Tensor, Tensor]:
+    """Fused KV compression using a CuteDSL kernel.
+
+    Replaces compress_kv's two PyTorch mean-reduction calls with a single
+    fused kernel launch that processes both K and V simultaneously.
+
+    The optional W_k/W_v projections remain in PyTorch since they're rarely
+    used and would require a separate, more complex kernel.
+
+    Args:
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        block_size: Number of positions to pool together.
+        W_k: Optional per-head projection weight for keys.
+        W_v: Optional per-head projection weight for values.
+
+    Returns:
+        K_cmp: Compressed keys, shape (B, N // block_size, H_kv, D).
+        V_cmp: Compressed values, shape (B, N // block_size, H_kv, D).
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H_kv, D = K.shape
+    assert N % block_size == 0, f"Sequence length {N} must be divisible by block_size {block_size}"
+
+    N_cmp = N // block_size
+
+    # Allocate outputs
+    K_cmp = torch.empty(B, N_cmp, H_kv, D, device=K.device, dtype=K.dtype)
+    V_cmp = torch.empty(B, N_cmp, H_kv, D, device=V.device, dtype=V.dtype)
+
+    # Reshape to 2D: (B*N*H_kv, D) and (B*N_cmp*H_kv, D)
+    K_2d = K.reshape(B * N * H_kv, D).contiguous()
+    V_2d = V.reshape(B * N * H_kv, D).contiguous()
+    K_out_2d = K_cmp.reshape(B * N_cmp * H_kv, D)
+    V_out_2d = V_cmp.reshape(B * N_cmp * H_kv, D)
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[K.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mK = to_cute(K_2d)
+    mV = to_cute(V_2d)
+    mK_out = to_cute(K_out_2d)
+    mV_out = to_cute(V_out_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, block_size)
+    if compile_key not in _fused_compress_compile_cache:
+        kernel_op = _make_fused_compress_kernel(cute_dtype, D, block_size)
+        _fused_compress_compile_cache[compile_key] = cute.compile(
+            kernel_op, mK, mV, mK_out, mV_out, N_cmp, H_kv, N, current_stream
+        )
+    _fused_compress_compile_cache[compile_key](
+        mK, mV, mK_out, mV_out, N_cmp, H_kv, N, current_stream
+    )
+
+    # Apply optional projections in PyTorch (rare path)
+    if W_k is not None:
         K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
 
     if W_v is not None:

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -54,7 +54,7 @@ def _make_fused_gating_kernel(cute_dtype: Type, D: int, has_gate_weight: bool):
             warp_id = cute.arch.warp_idx()
             bidx = cute.arch.block_idx()[0]
 
-            row = bidx * WARPS_PER_BLOCK + warp_id
+            row = cutlass.Int64(bidx * WARPS_PER_BLOCK + warp_id)
             num_rows = mQ.shape[0]
 
             if row < num_rows:

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -1,0 +1,88 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Output gating and combination for NSA's three attention branches."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def compute_gates(
+    Q: Tensor,  # (B, N, H, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Compute per-head sigmoid gates for the three NSA branches.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        gate_proj_weight: Learned gate projection, shape (H, 3, D).
+            If None, returns uniform gates (1/3 each).
+        chunk_size: If set, process the sequence dimension in chunks to
+            reduce peak float32 memory usage. Recommended for N > 32K.
+
+    Returns:
+        gates: Sigmoid gates, shape (B, N, H, 3).
+    """
+    if gate_proj_weight is None:
+        B, N, H, D = Q.shape
+        return torch.ones(B, N, H, 3, device=Q.device, dtype=Q.dtype) / 3.0
+
+    if chunk_size is None:
+        # Original path for short sequences
+        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        return gate_logits.sigmoid().to(Q.dtype)
+
+    # Chunked path: process sequence in chunks to bound float32 intermediates
+    B, N, H, D = Q.shape
+    gates = torch.empty(B, N, H, 3, device=Q.device, dtype=Q.dtype)
+    w = gate_proj_weight.float()
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q[:, start:end].float(), w)
+        gates[:, start:end] = gate_logits.sigmoid().to(Q.dtype)
+    return gates
+
+
+def gate_and_combine(
+    O_cmp: Tensor,  # (B, N, H, D)
+    O_slc: Tensor,  # (B, N, H, D)
+    O_sld: Tensor,  # (B, N, H, D)
+    gates: Tensor,  # (B, N, H, 3)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Combine three attention branch outputs with sigmoid gates.
+
+    Args:
+        O_cmp: Compressed attention output, shape (B, N, H, D).
+        O_slc: Selected attention output, shape (B, N, H, D).
+        O_sld: Sliding window attention output, shape (B, N, H, D).
+        gates: Sigmoid gates, shape (B, N, H, 3).
+        chunk_size: If set, process the sequence dimension in chunks to
+            reduce peak float32 memory usage. Recommended for N > 32K.
+
+    Returns:
+        Combined output, shape (B, N, H, D).
+    """
+    if chunk_size is None:
+        # Original path for short sequences
+        g = gates.float()
+        return (
+            g[..., 0:1] * O_cmp.float()
+            + g[..., 1:2] * O_slc.float()
+            + g[..., 2:3] * O_sld.float()
+        ).to(O_cmp.dtype)
+
+    # Chunked path: avoid materializing 3 full (B,N,H,D) float32 tensors at once
+    B, N, H, D = O_cmp.shape
+    out = torch.empty(B, N, H, D, dtype=O_cmp.dtype, device=O_cmp.device)
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        g = gates[:, start:end].float()
+        out[:, start:end] = (
+            g[..., 0:1] * O_cmp[:, start:end].float()
+            + g[..., 1:2] * O_slc[:, start:end].float()
+            + g[..., 2:3] * O_sld[:, start:end].float()
+        ).to(O_cmp.dtype)
+    return out

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -182,6 +182,272 @@ def fused_gate_and_combine(
 
 
 # ---------------------------------------------------------------------------
+# CuteDSL fused gating backward kernel
+# ---------------------------------------------------------------------------
+
+_fused_gating_bwd_compile_cache: dict = {}
+
+
+def _make_fused_gating_bwd_kernel(cute_dtype: Type, D: int):
+    """Create CuteDSL kernel for fused gating backward.
+
+    Computes per-row:
+    - dO_cmp = g0 * dO, dO_slc = g1 * dO, dO_sld = g2 * dO
+    - dot_i = sum_d(dO[d] * O_i[d]) for each branch i
+    - d_logit_i = dot_i * gi * (1 - gi)
+    - dQ_gate[d] = sum_i(d_logit_i * W_i[d])
+
+    Does NOT compute dW_gate (requires cross-row reduction, done in PyTorch).
+    """
+    import cutlass
+    import cutlass.cute as cute
+
+    WARPS_PER_BLOCK = 4
+    THREADS_PER_BLOCK = WARPS_PER_BLOCK * 32
+    elems_per_thread = D // 32
+
+    class _Kernel:
+        @cute.jit
+        def __call__(
+            self,
+            mQ,
+            mdO,
+            mO_cmp,
+            mO_slc,
+            mO_sld,
+            mW,
+            mGates,
+            mdO_cmp,
+            mdO_slc,
+            mdO_sld,
+            mdQ_gate,
+            H,
+            stream,
+        ):
+            num_rows = mQ.shape[0]
+            grid_x = cute.ceil_div(num_rows, WARPS_PER_BLOCK)
+            self.kernel(
+                mQ,
+                mdO,
+                mO_cmp,
+                mO_slc,
+                mO_sld,
+                mW,
+                mGates,
+                mdO_cmp,
+                mdO_slc,
+                mdO_sld,
+                mdQ_gate,
+                H,
+            ).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(
+            self,
+            mQ,
+            mdO,
+            mO_cmp,
+            mO_slc,
+            mO_sld,
+            mW,
+            mGates,
+            mdO_cmp,
+            mdO_slc,
+            mdO_sld,
+            mdQ_gate,
+            H,
+        ):
+            lane_id = cute.arch.lane_idx()
+            warp_id = cute.arch.warp_idx()
+            bidx = cute.arch.block_idx()[0]
+
+            row = cutlass.Int64(bidx * WARPS_PER_BLOCK + warp_id)
+            num_rows = mQ.shape[0]
+
+            if row < num_rows:
+                ept = cutlass.const_expr(elems_per_thread)
+                head_idx = row % H
+
+                # Read gates for this row
+                g0 = cutlass.Float32(mGates[row, 0])
+                g1 = cutlass.Float32(mGates[row, 1])
+                g2 = cutlass.Float32(mGates[row, 2])
+
+                # Phase 1: Compute dot products dO·O_i via warp reduction
+                dot0 = cutlass.Float32(0.0)
+                dot1 = cutlass.Float32(0.0)
+                dot2 = cutlass.Float32(0.0)
+                for e in cutlass.range_constexpr(ept):
+                    d = lane_id * ept + e
+                    dO_val = cutlass.Float32(mdO[row, d])
+                    dot0 += dO_val * cutlass.Float32(mO_cmp[row, d])
+                    dot1 += dO_val * cutlass.Float32(mO_slc[row, d])
+                    dot2 += dO_val * cutlass.Float32(mO_sld[row, d])
+
+                for i in cutlass.range_constexpr(5):
+                    dot0 += cute.arch.shuffle_sync_bfly(dot0, offset=1 << i)
+                    dot1 += cute.arch.shuffle_sync_bfly(dot1, offset=1 << i)
+                    dot2 += cute.arch.shuffle_sync_bfly(dot2, offset=1 << i)
+
+                # Phase 2: Sigmoid derivative and d_logit
+                d_logit0 = dot0 * g0 * (1.0 - g0)
+                d_logit1 = dot1 * g1 * (1.0 - g1)
+                d_logit2 = dot2 * g2 * (1.0 - g2)
+
+                # Phase 3: Write outputs per element
+                for e in cutlass.range_constexpr(ept):
+                    d = lane_id * ept + e
+                    dO_val = cutlass.Float32(mdO[row, d])
+
+                    # dO_i = gi * dO
+                    mdO_cmp[row, d] = cute_dtype(g0 * dO_val)
+                    mdO_slc[row, d] = cute_dtype(g1 * dO_val)
+                    mdO_sld[row, d] = cute_dtype(g2 * dO_val)
+
+                    # dQ_gate = sum_i(d_logit_i * W_i[d])
+                    dq = (
+                        d_logit0 * cutlass.Float32(mW[head_idx, d])
+                        + d_logit1 * cutlass.Float32(mW[head_idx, D + d])
+                        + d_logit2 * cutlass.Float32(mW[head_idx, 2 * D + d])
+                    )
+                    mdQ_gate[row, d] = cute_dtype(dq)
+
+    return _Kernel()
+
+
+def fused_gating_backward(
+    Q: Tensor,  # (B, N, H, D)
+    dO: Tensor,  # (B, N, H, D)
+    O_cmp: Tensor,  # (B, N, H, D)
+    O_slc: Tensor,  # (B, N, H, D)
+    O_sld: Tensor,  # (B, N, H, D)
+    gates: Tensor,  # (B, N, H, 3)
+    gate_proj_weight: Tensor,  # (H, 3, D)
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+    """Fused gating backward using CuteDSL kernel + PyTorch for dW_gate.
+
+    The CuteDSL kernel computes dO_cmp, dO_slc, dO_sld, dQ_gate in one launch.
+    dW_gate is computed via PyTorch einsum (cross-row reduction).
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        dO: Upstream gradient, shape (B, N, H, D).
+        O_cmp, O_slc, O_sld: Branch outputs, shape (B, N, H, D).
+        gates: Sigmoid gate values, shape (B, N, H, 3).
+        gate_proj_weight: Gate weights, shape (H, 3, D).
+
+    Returns:
+        (dO_cmp, dO_slc, dO_sld, dQ_gate, dW_gate)
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H, D = Q.shape
+    assert D % 32 == 0, f"D={D} must be divisible by 32"
+
+    M = B * N * H
+
+    # Allocate outputs
+    dO_cmp = torch.empty_like(dO)
+    dO_slc = torch.empty_like(dO)
+    dO_sld = torch.empty_like(dO)
+    dQ_gate = torch.empty_like(Q)
+
+    # Reshape to 2D
+    Q_2d = Q.reshape(M, D).contiguous()
+    dO_2d = dO.reshape(M, D).contiguous()
+    O_cmp_2d = O_cmp.reshape(M, D).contiguous()
+    O_slc_2d = O_slc.reshape(M, D).contiguous()
+    O_sld_2d = O_sld.reshape(M, D).contiguous()
+    gates_2d = gates.reshape(M, 3).contiguous()
+    W_2d = gate_proj_weight.reshape(H, 3 * D).contiguous()
+    dO_cmp_2d = dO_cmp.reshape(M, D)
+    dO_slc_2d = dO_slc.reshape(M, D)
+    dO_sld_2d = dO_sld.reshape(M, D)
+    dQ_gate_2d = dQ_gate.reshape(M, D)
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[Q.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mQ = to_cute(Q_2d)
+    mdO = to_cute(dO_2d)
+    mO_cmp = to_cute(O_cmp_2d)
+    mO_slc = to_cute(O_slc_2d)
+    mO_sld = to_cute(O_sld_2d)
+    mW = to_cute(W_2d)
+    mGates = to_cute(gates_2d)
+    m_dO_cmp = to_cute(dO_cmp_2d)
+    m_dO_slc = to_cute(dO_slc_2d)
+    m_dO_sld = to_cute(dO_sld_2d)
+    m_dQ_gate = to_cute(dQ_gate_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D)
+    if compile_key not in _fused_gating_bwd_compile_cache:
+        kernel_op = _make_fused_gating_bwd_kernel(cute_dtype, D)
+        _fused_gating_bwd_compile_cache[compile_key] = cute.compile(
+            kernel_op,
+            mQ,
+            mdO,
+            mO_cmp,
+            mO_slc,
+            mO_sld,
+            mW,
+            mGates,
+            m_dO_cmp,
+            m_dO_slc,
+            m_dO_sld,
+            m_dQ_gate,
+            H,
+            current_stream,
+        )
+    _fused_gating_bwd_compile_cache[compile_key](
+        mQ,
+        mdO,
+        mO_cmp,
+        mO_slc,
+        mO_sld,
+        mW,
+        mGates,
+        m_dO_cmp,
+        m_dO_slc,
+        m_dO_sld,
+        m_dQ_gate,
+        H,
+        current_stream,
+    )
+
+    # dW_gate via PyTorch einsum: d_logit (B,N,H,3) @ Q (B,N,H,D) -> (H,3,D)
+    # Recompute d_logit from gates and dO·O products
+    g = gates.float()
+    dO_f = dO.float()
+    O_branches = torch.stack([O_cmp.float(), O_slc.float(), O_sld.float()], dim=-1)
+    dg = (dO_f.unsqueeze(-1) * O_branches).sum(dim=-2)  # (B, N, H, 3)
+    d_logit = dg * g * (1 - g)
+    dW_gate = torch.einsum("bnhg,bnhd->hgd", d_logit, Q.float()).to(
+        gate_proj_weight.dtype
+    )
+
+    return dO_cmp, dO_slc, dO_sld, dQ_gate, dW_gate
+
+
+# ---------------------------------------------------------------------------
 # PyTorch reference implementations (kept for testing and fallback)
 # ---------------------------------------------------------------------------
 

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -1,11 +1,189 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-ignore-all-errors
 
-"""Output gating and combination for NSA's three attention branches."""
+"""Output gating and combination for NSA's three attention branches.
+
+Includes both PyTorch reference implementations (compute_gates, gate_and_combine)
+and a fused CuteDSL kernel (fused_gate_and_combine) that computes gates from Q
+and combines the three branch outputs in a single kernel launch.
+"""
 
 from __future__ import annotations
 
+import math
+from typing import Type
+
 import torch
 from torch import Tensor
+
+
+# ---------------------------------------------------------------------------
+# CuteDSL fused gating kernel
+# ---------------------------------------------------------------------------
+
+_fused_gating_compile_cache: dict = {}
+
+
+def _make_fused_gating_kernel(cute_dtype: Type, D: int, has_gate_weight: bool):
+    """Create and return a compiled CuteDSL kernel for fused gating.
+
+    Defined as a factory function so CuteDSL imports happen lazily,
+    keeping the module importable without GPU/CuteDSL availability.
+    """
+    import cutlass
+    import cutlass.cute as cute
+
+    WARPS_PER_BLOCK = 4
+    THREADS_PER_BLOCK = WARPS_PER_BLOCK * 32
+    elems_per_thread = D // 32
+
+    class _Kernel:
+        @cute.jit
+        def __call__(self, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, stream):
+            num_rows = mQ.shape[0]
+            grid_x = cute.ceil_div(num_rows, WARPS_PER_BLOCK)
+            self.kernel(mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H):
+            lane_id = cute.arch.lane_idx()
+            warp_id = cute.arch.warp_idx()
+            bidx = cute.arch.block_idx()[0]
+
+            row = bidx * WARPS_PER_BLOCK + warp_id
+            num_rows = mQ.shape[0]
+
+            if row < num_rows:
+                ept = cutlass.const_expr(elems_per_thread)
+
+                if cutlass.const_expr(has_gate_weight):
+                    head_idx = row % H
+                    g0 = cutlass.Float32(0.0)
+                    g1 = cutlass.Float32(0.0)
+                    g2 = cutlass.Float32(0.0)
+                    for e in cutlass.range_constexpr(ept):
+                        d = lane_id * ept + e
+                        q_val = cutlass.Float32(mQ[row, d])
+                        g0 += q_val * cutlass.Float32(mW[head_idx, d])
+                        g1 += q_val * cutlass.Float32(mW[head_idx, D + d])
+                        g2 += q_val * cutlass.Float32(mW[head_idx, 2 * D + d])
+
+                    for i in cutlass.range_constexpr(5):
+                        g0 += cute.arch.shuffle_sync_bfly(g0, offset=1 << i)
+                        g1 += cute.arch.shuffle_sync_bfly(g1, offset=1 << i)
+                        g2 += cute.arch.shuffle_sync_bfly(g2, offset=1 << i)
+
+                    log2_e = cutlass.const_expr(math.log2(math.e))
+                    g0 = 1.0 / (1.0 + cute.math.exp2(-g0 * log2_e))
+                    g1 = 1.0 / (1.0 + cute.math.exp2(-g1 * log2_e))
+                    g2 = 1.0 / (1.0 + cute.math.exp2(-g2 * log2_e))
+                else:
+                    g0 = cutlass.Float32(1.0 / 3.0)
+                    g1 = cutlass.Float32(1.0 / 3.0)
+                    g2 = cutlass.Float32(1.0 / 3.0)
+
+                for e in cutlass.range_constexpr(ept):
+                    d = lane_id * ept + e
+                    o = (
+                        g0 * cutlass.Float32(mO_cmp[row, d])
+                        + g1 * cutlass.Float32(mO_slc[row, d])
+                        + g2 * cutlass.Float32(mO_sld[row, d])
+                    )
+                    mOut[row, d] = cute_dtype(o)
+
+    return _Kernel()
+
+
+def fused_gate_and_combine(
+    Q: Tensor,  # (B, N, H, D)
+    O_cmp: Tensor,  # (B, N, H, D)
+    O_slc: Tensor,  # (B, N, H, D)
+    O_sld: Tensor,  # (B, N, H, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+) -> Tensor:
+    """Fused gate computation and branch combination using a CuteDSL kernel.
+
+    Replaces the two-step compute_gates() + gate_and_combine() with a single
+    kernel launch. Eliminates the intermediate gates tensor and reduces memory
+    traffic by fusing the dot-product gate computation with the weighted sum.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        O_cmp: Compressed attention output, shape (B, N, H, D).
+        O_slc: Selected attention output, shape (B, N, H, D).
+        O_sld: Sliding window attention output, shape (B, N, H, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+            If None, uses uniform gates (1/3 each).
+
+    Returns:
+        Combined output, shape (B, N, H, D).
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H, D = Q.shape
+    assert D % 32 == 0, f"D={D} must be divisible by 32"
+
+    out = torch.empty_like(O_cmp)
+    has_gate_weight = gate_proj_weight is not None
+
+    # Reshape to 2D: (B*N*H, D)
+    M = B * N * H
+    Q_2d = Q.reshape(M, D)
+    O_cmp_2d = O_cmp.reshape(M, D)
+    O_slc_2d = O_slc.reshape(M, D)
+    O_sld_2d = O_sld.reshape(M, D)
+    out_2d = out.reshape(M, D)
+
+    # Gate weights: (H, 3, D) -> (H, 3*D)
+    if has_gate_weight:
+        W_2d = gate_proj_weight.reshape(H, 3 * D).contiguous()
+    else:
+        W_2d = torch.empty(1, 1, device=Q.device, dtype=Q.dtype)
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[Q.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mQ = to_cute(Q_2d)
+    mO_cmp = to_cute(O_cmp_2d)
+    mO_slc = to_cute(O_slc_2d)
+    mO_sld = to_cute(O_sld_2d)
+    mW = to_cute(W_2d)
+    mOut = to_cute(out_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, has_gate_weight)
+    if compile_key not in _fused_gating_compile_cache:
+        kernel_op = _make_fused_gating_kernel(cute_dtype, D, has_gate_weight)
+        _fused_gating_compile_cache[compile_key] = cute.compile(
+            kernel_op, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, current_stream
+        )
+    _fused_gating_compile_cache[compile_key](
+        mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, current_stream
+    )
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# PyTorch reference implementations (kept for testing and fallback)
+# ---------------------------------------------------------------------------
 
 
 def compute_gates(
@@ -31,7 +209,9 @@ def compute_gates(
 
     if chunk_size is None:
         # Original path for short sequences
-        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        gate_logits = torch.einsum(
+            "bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float()
+        )
         return gate_logits.sigmoid().to(Q.dtype)
 
     # Chunked path: process sequence in chunks to bound float32 intermediates

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -101,7 +101,7 @@ def _transpose_block_sparse_for_bwd(
     )
 
 
-def _fa4_bwd(
+def _attn_bwd_pytorch(
     q: Tensor,
     k: Tensor,
     v: Tensor,
@@ -112,44 +112,93 @@ def _fa4_bwd(
     causal: bool = False,
     window_size_left: int | None = None,
     window_size_right: int | None = None,
-    block_sparse_tensors=None,
-    mask_mod: Callable | None = None,
-    aux_tensors: list[Tensor] | None = None,
+    mask: Tensor | None = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
-    """Call FA4's backward pass (low-level, supports block sparsity and mask_mod).
+    """Attention backward using PyTorch ops (torch.matmul + cuBLAS). No CUTLASS JIT.
 
     All inputs are (B, N, H, D) layout.
     Returns (dq, dk, dv).
+
+    Uses the saved output and log-sum-exp to recompute attention weights
+    without materializing the full N×N score matrix where possible.
     """
-    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_bwd
+    B, N_q, H, D = q.shape
+    H_kv = k.shape[2]
+    N_kv = k.shape[1]
+    groups = H // H_kv
 
-    # Workaround: FA4 backward doesn't disable 2-CTA for block sparsity,
-    # but does for mask_mod. Pass a trivial mask to force 1-CTA mode.
-    if block_sparse_tensors is not None and mask_mod is None:
-        import cutlass.cute as cute
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
 
-        @cute.jit
-        def _trivial_mask(batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
-            return True
+    # Transpose to (B, H, N, D) for matmul
+    q_t = q.transpose(1, 2).float()  # (B, H, N_q, D)
+    k_t = k.transpose(1, 2).float()  # (B, H_kv, N_kv, D)
+    v_t = v.transpose(1, 2).float()  # (B, H_kv, N_kv, D)
+    dout_t = dout.transpose(1, 2).float()  # (B, H, N_q, D)
 
-        mask_mod = _trivial_mask
+    # Expand K, V for GQA
+    if groups > 1:
+        k_t = k_t.repeat_interleave(groups, dim=1)  # (B, H, N_kv, D)
+        v_t = v_t.repeat_interleave(groups, dim=1)
 
-    dq, dk, dv = _flash_attn_bwd(
-        q,
-        k,
-        v,
-        out,
-        dout,
-        lse,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
-        block_sparse_tensors=block_sparse_tensors,
-        mask_mod=mask_mod,
-        aux_tensors=aux_tensors,
+    # Recompute attention scores and weights from LSE
+    scores = (
+        torch.matmul(q_t, k_t.transpose(-2, -1)) * softmax_scale
+    )  # (B, H, N_q, N_kv)
+
+    # Apply masks
+    if causal and N_q == N_kv:
+        q_pos = torch.arange(N_q, device=q.device).unsqueeze(1)
+        kv_pos = torch.arange(N_kv, device=q.device).unsqueeze(0)
+        causal_mask = kv_pos > q_pos
+        if window_size_left is not None:
+            causal_mask = causal_mask | (kv_pos < q_pos - window_size_left + 1)
+        scores = scores.masked_fill(
+            causal_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+    elif window_size_left is not None and N_q == N_kv:
+        q_pos = torch.arange(N_q, device=q.device).unsqueeze(1)
+        kv_pos = torch.arange(N_kv, device=q.device).unsqueeze(0)
+        window_mask = (kv_pos > q_pos) | (kv_pos < q_pos - window_size_left + 1)
+        scores = scores.masked_fill(
+            window_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+
+    if mask is not None:
+        scores = scores.masked_fill(mask, float("-inf"))
+
+    # Softmax (recompute from scores, not from LSE, for simplicity)
+    attn = torch.softmax(scores, dim=-1)
+
+    # Standard attention backward:
+    # dV = P^T @ dO
+    dv_t = torch.matmul(attn.transpose(-2, -1), dout_t)  # (B, H, N_kv, D)
+
+    # dP = dO @ V^T
+    dp = torch.matmul(dout_t, v_t.transpose(-2, -1))  # (B, H, N_q, N_kv)
+
+    # dS = P * (dP - (dP * P).sum(-1, keepdim=True))
+    # Equivalently: dS = P * (dP - rowsum), where rowsum = (dO * O).sum(D)
+    rowsum = (dout_t * (torch.matmul(attn, v_t))).sum(dim=-1, keepdim=True)
+    ds = attn * (dp - rowsum) * softmax_scale
+
+    # dQ = dS @ K
+    dq_t = torch.matmul(ds, k_t)  # (B, H, N_q, D)
+
+    # dK = dS^T @ Q
+    dk_t = torch.matmul(ds.transpose(-2, -1), q_t)  # (B, H, N_kv, D)
+
+    # Handle GQA: sum dK, dV across head groups
+    if groups > 1:
+        dk_t = dk_t.reshape(B, H_kv, groups, N_kv, D).sum(dim=2)
+        dv_t = dv_t.reshape(B, H_kv, groups, N_kv, D).sum(dim=2)
+
+    # Transpose back to (B, N, H, D)
+    return (
+        dq_t.transpose(1, 2).to(q.dtype),
+        dk_t.transpose(1, 2).to(k.dtype),
+        dv_t.transpose(1, 2).to(v.dtype),
     )
-    return dq, dk, dv
 
 
 class NSAFunction(torch.autograd.Function):
@@ -356,8 +405,19 @@ class NSAFunction(torch.autograd.Function):
             dO_slc = (g[..., 1:2] * dO_f).to(dO.dtype)
             dO_sld = (g[..., 2:3] * dO_f).to(dO.dtype)
 
-        # --- Stage 2: Three FA4 backward passes ---
-        dQ_cmp, dK_cmp, dV_cmp = _fa4_bwd(
+        # --- Stage 2: Three attention backward passes (PyTorch/cuBLAS, no CUTLASS JIT) ---
+
+        # Branch 1: Compressed attention backward
+        # Build compressed causal mask: kv_block_start > q_pos
+        B_size, N_size, H_size = Q.shape[:3]
+        N_cmp = K_cmp.shape[1]
+        cmp_mask = None
+        if causal:
+            q_pos = torch.arange(N_size, device=Q.device).unsqueeze(1)
+            kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
+            cmp_mask = (kv_block_start.unsqueeze(0) > q_pos).unsqueeze(0).unsqueeze(0)
+
+        dQ_cmp, dK_cmp, dV_cmp = _attn_bwd_pytorch(
             Q,
             K_cmp,
             V_cmp,
@@ -365,73 +425,113 @@ class NSAFunction(torch.autograd.Function):
             dO_cmp,
             lse_cmp,
             softmax_scale=softmax_scale,
-            causal=False,
-            mask_mod=compressed_mask,
+            mask=cmp_mask,
         )
 
-        # For the selected branch backward, transpose block sparse tensors
-        # to Q-direction format for FA4 backward. Falls back to mask_mod if
-        # block sparsity backward fails.
-        B_size, N_size = Q.shape[:2]
-        bwd_sparse_tensors = _transpose_block_sparse_for_bwd(
-            sparse_tensors,
-            seqlen_q=N_size,
-            seqlen_k=N_size,
-            n_block_size=ctx.n_block_size,
-            q_tile_size=ctx.q_tile_size,
+        # Branch 2: Selected attention backward via gather/scatter
+        # Gather selected K/V blocks, run attention backward on gathered subset,
+        # then scatter dK/dV gradients back to full KV positions.
+        block_indices = ctx.block_indices
+        q_tile_size = ctx.q_tile_size
+        num_sel = ctx.num_selected_blocks
+        block_size = compress_block_size
+
+        N_blocks = N_size // block_size
+        N_q_tiles = N_size // q_tile_size
+        k_actual = min(num_sel, N_blocks)
+
+        # Expand block indices to position indices
+        offsets = torch.arange(block_size, device=Q.device)
+        pos_indices = block_indices.unsqueeze(-1) * block_size + offsets
+        kv_len = k_actual * block_size
+        pos_indices = pos_indices.reshape(B_size, H_size, N_q_tiles, kv_len)
+
+        # Gather K, V at selected positions: (B, H, N_q_tiles, kv_len, D)
+        H_kv = K.shape[2]
+        groups = H_size // H_kv
+        k_t = K.transpose(1, 2).float()
+        v_t = V.transpose(1, 2).float()
+        if groups > 1:
+            k_t = k_t.repeat_interleave(groups, dim=1)
+            v_t = v_t.repeat_interleave(groups, dim=1)
+
+        D = Q.shape[-1]
+        gather_idx = pos_indices.unsqueeze(-1).expand(
+            B_size, H_size, N_q_tiles, kv_len, D
+        )
+        k_exp = k_t.unsqueeze(2).expand(B_size, H_size, N_q_tiles, N_size, D)
+        v_exp = v_t.unsqueeze(2).expand(B_size, H_size, N_q_tiles, N_size, D)
+        sel_k = torch.gather(k_exp, 3, gather_idx)
+        sel_v = torch.gather(v_exp, 3, gather_idx)
+
+        # Reshape Q and dO into tiles
+        q_tiles = (
+            Q.transpose(1, 2).float().reshape(B_size, H_size, N_q_tiles, q_tile_size, D)
+        )
+        dO_slc_tiles = (
+            dO_slc.transpose(1, 2)
+            .float()
+            .reshape(B_size, H_size, N_q_tiles, q_tile_size, D)
         )
 
-        try:
-            dQ_slc, dK_slc, dV_slc = _fa4_bwd(
-                Q,
-                K,
-                V,
-                O_slc,
-                dO_slc,
-                lse_slc,
-                softmax_scale=softmax_scale,
-                causal=causal,
-                block_sparse_tensors=bwd_sparse_tensors,
+        # Attention scores on gathered KV
+        scores_slc = torch.matmul(q_tiles, sel_k.transpose(-2, -1)) * softmax_scale
+
+        # Causal mask on gathered positions
+        if causal:
+            q_tile_starts = torch.arange(N_q_tiles, device=Q.device) * q_tile_size
+            q_offsets_t = torch.arange(q_tile_size, device=Q.device)
+            q_positions = q_tile_starts.unsqueeze(1) + q_offsets_t.unsqueeze(0)
+            c_mask = pos_indices.unsqueeze(3) > q_positions.reshape(
+                1, 1, N_q_tiles, q_tile_size, 1
             )
-        except Exception:
-            # Fallback: use mask_mod with aux_tensors for block selection
-            block_indices = ctx.block_indices
-            q_tile_size = ctx.q_tile_size
-            num_sel = ctx.num_selected_blocks
+            scores_slc = scores_slc.masked_fill(c_mask, float("-inf"))
 
-            import cutlass
-            import cutlass.cute as cute
+        attn_slc = torch.softmax(scores_slc, dim=-1)
 
-            @cute.jit
-            def _selected_block_mask(
-                batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
-            ):
-                indices = aux_tensors[0]
-                q_tile = q_idx[0] // cutlass.const_expr(q_tile_size)
-                kv_block = kv_idx[0] // cutlass.const_expr(compress_block_size)
+        # dV_sel = attn^T @ dO_slc_tiles
+        dv_sel = torch.matmul(attn_slc.transpose(-2, -1), dO_slc_tiles)
 
-                found = cutlass.Boolean(False)
-                for i in cutlass.range_constexpr(num_sel):
-                    sel_block = indices[batch_idx[0], head_idx[0], q_tile, i]
-                    found = found | (sel_block == kv_block)
-                if cutlass.const_expr(causal):
-                    found = found & (kv_idx <= q_idx)
-                return found
+        # dP = dO @ V^T
+        dp_slc = torch.matmul(dO_slc_tiles, sel_v.transpose(-2, -1))
+        rowsum_slc = (dO_slc_tiles * torch.matmul(attn_slc, sel_v)).sum(
+            dim=-1, keepdim=True
+        )
+        ds_slc = attn_slc * (dp_slc - rowsum_slc) * softmax_scale
 
-            dQ_slc, dK_slc, dV_slc = _fa4_bwd(
-                Q,
-                K,
-                V,
-                O_slc,
-                dO_slc,
-                lse_slc,
-                softmax_scale=softmax_scale,
-                causal=False,
-                mask_mod=_selected_block_mask,
-                aux_tensors=[block_indices],
+        # dQ_slc_tiles = dS @ sel_K
+        dq_slc_tiles = torch.matmul(ds_slc, sel_k)
+        dQ_slc = (
+            dq_slc_tiles.reshape(B_size, H_size, N_size, D).transpose(1, 2).to(Q.dtype)
+        )
+
+        # dK_sel = dS^T @ Q_tiles
+        dk_sel = torch.matmul(ds_slc.transpose(-2, -1), q_tiles)
+
+        # Scatter dK_sel and dV_sel back to full KV
+        dK_slc_full = torch.zeros(
+            B_size, H_size, N_size, D, device=Q.device, dtype=torch.float32
+        )
+        dV_slc_full = torch.zeros_like(dK_slc_full)
+        scatter_idx = gather_idx  # (B, H, N_q_tiles, kv_len, D)
+        # Sum across query tiles that share the same KV position
+        for qt in range(N_q_tiles):
+            dK_slc_full.scatter_add_(2, gather_idx[:, :, qt], dk_sel[:, :, qt])
+            dV_slc_full.scatter_add_(2, gather_idx[:, :, qt], dv_sel[:, :, qt])
+
+        # Handle GQA: sum across head groups
+        if groups > 1:
+            dK_slc_full = dK_slc_full.reshape(B_size, H_kv, groups, N_size, D).sum(
+                dim=2
             )
+            dV_slc_full = dV_slc_full.reshape(B_size, H_kv, groups, N_size, D).sum(
+                dim=2
+            )
+        dK_slc = dK_slc_full.transpose(1, 2).to(K.dtype)
+        dV_slc = dV_slc_full.transpose(1, 2).to(V.dtype)
 
-        dQ_sld, dK_sld, dV_sld = _fa4_bwd(
+        # Branch 3: Sliding window backward
+        dQ_sld, dK_sld, dV_sld = _attn_bwd_pytorch(
             Q,
             K,
             V,
@@ -441,7 +541,6 @@ class NSAFunction(torch.autograd.Function):
             softmax_scale=softmax_scale,
             causal=causal,
             window_size_left=window_size,
-            window_size_right=0,
         )
 
         # --- Stage 3: Compression backward ---

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -1,0 +1,497 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""NSA autograd function: wraps FA4-based forward + backward with activation checkpointing.
+
+Provides NSAFunction(torch.autograd.Function) and a user-facing nsa() function
+that supports training (backward pass).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional, Tuple
+
+import torch
+from mslk.attention.sparse_attn.compress import (
+    compress_kv,
+    fused_compress_kv,
+    fused_compress_kv_backward,
+)
+from mslk.attention.sparse_attn.gating import (
+    compute_gates,
+    fused_gating_backward,
+    gate_and_combine,
+)
+from mslk.attention.sparse_attn.nsa_forward import (
+    _fa4_fwd,
+    _make_compressed_causal_mask,
+)
+from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+from torch import Tensor
+
+
+def _transpose_block_sparse_for_bwd(
+    tensors,
+    seqlen_q: int,
+    seqlen_k: int,
+    n_block_size: int,
+    q_tile_size: int,
+):
+    """Transpose forward block sparse tensors to backward Q-direction format.
+
+    Forward tensors indexed by (m=Q-tiles, n=KV-blocks).
+    Backward tensors indexed by (m=KV-blocks, n=Q-tiles).
+    """
+    from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+
+    n_kv_blocks = (seqlen_k + n_block_size - 1) // n_block_size
+    n_q_tiles = seqlen_q // q_tile_size
+
+    B, H = tensors.full_block_cnt.shape[:2]
+    device = tensors.full_block_cnt.device
+
+    fwd_full_idx = tensors.full_block_idx  # (B, H, n_q_tiles, n_kv_blocks)
+    fwd_full_cnt = tensors.full_block_cnt  # (B, H, n_q_tiles)
+
+    # Build dense boolean attendance: (B, H, n_q_tiles, n_kv_blocks)
+    attendance = torch.zeros(
+        B, H, n_q_tiles, n_kv_blocks, dtype=torch.bool, device=device
+    )
+    for qt in range(n_q_tiles):
+        cnt = fwd_full_cnt[:, :, qt]  # (B, H)
+        for i in range(min(fwd_full_idx.shape[3], n_kv_blocks)):
+            if (i < cnt).any():
+                idx = fwd_full_idx[:, :, qt, i].long().clamp(0, n_kv_blocks - 1)
+                # Set attendance[b, h, qt, idx[b,h]] = True where i < cnt[b,h]
+                valid = i < cnt  # (B, H)
+                for b in range(B):
+                    for h in range(H):
+                        if valid[b, h]:
+                            attendance[b, h, qt, idx[b, h]] = True
+
+    # Transpose: (B, H, n_q_tiles, n_kv_blocks) -> (B, H, n_kv_blocks, n_q_tiles)
+    bwd_attendance = attendance.transpose(2, 3)
+
+    # Convert to cnt/idx: for each KV block, list the Q tiles that attend to it
+    bwd_full_cnt = bwd_attendance.sum(dim=-1).to(torch.int32)  # (B, H, n_kv_blocks)
+
+    # Build index tensor: for each KV block, pack the attending Q tile indices
+    bwd_full_idx = torch.zeros(
+        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device=device
+    )
+    for b in range(B):
+        for h in range(H):
+            for kv in range(n_kv_blocks):
+                qt_indices = bwd_attendance[b, h, kv].nonzero(as_tuple=True)[0]
+                for i, qt in enumerate(qt_indices):
+                    bwd_full_idx[b, h, kv, i] = qt.int()
+
+    bwd_mask_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device=device)
+    bwd_mask_idx = torch.zeros(
+        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device=device
+    )
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=bwd_mask_cnt,
+        mask_block_idx=bwd_mask_idx,
+        full_block_cnt=bwd_full_cnt,
+        full_block_idx=bwd_full_idx,
+        block_size=(q_tile_size, n_block_size),
+    )
+
+
+def _fa4_bwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    dout: Tensor,
+    lse: Tensor,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Call FA4's backward pass (low-level, supports block sparsity and mask_mod).
+
+    All inputs are (B, N, H, D) layout.
+    Returns (dq, dk, dv).
+    """
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_bwd
+
+    # Workaround: FA4 backward doesn't disable 2-CTA for block sparsity,
+    # but does for mask_mod. Pass a trivial mask to force 1-CTA mode.
+    if block_sparse_tensors is not None and mask_mod is None:
+        import cutlass.cute as cute
+
+        @cute.jit
+        def _trivial_mask(batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+            return True
+
+        mask_mod = _trivial_mask
+
+    dq, dk, dv = _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        dout,
+        lse,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        block_sparse_tensors=block_sparse_tensors,
+        mask_mod=mask_mod,
+        # Disable 2-CTA mode for block sparsity compatibility
+        num_threads=128 if block_sparse_tensors is not None else 256,
+    )
+    return dq, dk, dv
+
+
+class NSAFunction(torch.autograd.Function):
+    """Autograd function for NSA with activation checkpointing.
+
+    Forward: runs the FA4-based NSA forward pass.
+    Backward: recomputes FA4 branch outputs (activation checkpointing),
+    then calls _flash_attn_bwd for each branch.
+
+    Saved for backward (small tensors only):
+        - Q, K, V (inputs, already in autograd graph)
+        - K_cmp, V_cmp (compressed KV)
+        - block_indices, sparse_tensors (discrete, small)
+        - gates (B, N, H, 3)
+        - Config scalars
+
+    Recomputed during backward (activation checkpointing):
+        - O_cmp, lse_cmp, O_slc, lse_slc, O_sld, lse_sld
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        Q: Tensor,
+        K: Tensor,
+        V: Tensor,
+        W_k_compress: Tensor | None,
+        W_v_compress: Tensor | None,
+        gate_proj_weight: Tensor | None,
+        compress_block_size: int,
+        num_selected_blocks: int,
+        window_size: int,
+        causal: bool,
+        softmax_scale: float,
+        q_tile_size: int,
+        n_block_size: int,
+    ) -> Tensor:
+        B, N, H, D = Q.shape
+
+        # Step 1: Compress KV
+        K_cmp, V_cmp = fused_compress_kv(
+            K, V, compress_block_size, W_k_compress, W_v_compress
+        )
+
+        # Step 2: Score blocks and select top-k
+        block_indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected_blocks,
+            compress_block_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+            softmax_scale=softmax_scale,
+        )
+
+        # Step 3: Build FA4 sparsity masks
+        sparse_tensors = build_fa4_block_sparse_tensors(
+            block_indices,
+            compress_block_size,
+            n_block_size=n_block_size,
+            seqlen_k=N,
+        )
+
+        # Step 4: Three FA4 branches
+        compressed_mask = (
+            _make_compressed_causal_mask(compress_block_size) if causal else None
+        )
+        O_cmp, lse_cmp = _fa4_fwd(
+            Q,
+            K_cmp,
+            V_cmp,
+            causal=False,
+            softmax_scale=softmax_scale,
+            mask_mod=compressed_mask,
+        )
+
+        O_slc, lse_slc = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            block_sparse_tensors=sparse_tensors,
+        )
+
+        O_sld, lse_sld = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
+
+        # Step 5: Compute gates and combine
+        gates = compute_gates(Q, gate_proj_weight)
+        O = gate_and_combine(O_cmp, O_slc, O_sld, gates)
+
+        # Save for backward — small tensors + inputs only
+        # (activation checkpointing: we do NOT save O_cmp, O_slc, O_sld, lse_*)
+        ctx.save_for_backward(
+            Q,
+            K,
+            V,
+            K_cmp,
+            V_cmp,
+            gates,
+            gate_proj_weight,
+            W_k_compress,
+            W_v_compress,
+        )
+        # Save block sparsity info (non-tensor or small)
+        ctx.block_indices = block_indices
+        ctx.sparse_tensors = sparse_tensors
+        ctx.compress_block_size = compress_block_size
+        ctx.num_selected_blocks = num_selected_blocks
+        ctx.window_size = window_size
+        ctx.causal = causal
+        ctx.softmax_scale = softmax_scale
+        ctx.q_tile_size = q_tile_size
+        ctx.n_block_size = n_block_size
+
+        return O
+
+    @staticmethod
+    def backward(ctx, dO: Tensor):
+        (
+            Q,
+            K,
+            V,
+            K_cmp,
+            V_cmp,
+            gates,
+            gate_proj_weight,
+            W_k_compress,
+            W_v_compress,
+        ) = ctx.saved_tensors
+
+        causal = ctx.causal
+        softmax_scale = ctx.softmax_scale
+        compress_block_size = ctx.compress_block_size
+        window_size = ctx.window_size
+        sparse_tensors = ctx.sparse_tensors
+
+        # --- Stage 1: Gating backward ---
+        # O = g0*O_cmp + g1*O_slc + g2*O_sld
+        # dO_i = gi * dO
+        # dgi = (dO * Oi).sum(dim=-1)  (need Oi, so must recompute)
+
+        # --- Recompute FA4 forward outputs (activation checkpointing) ---
+        compressed_mask = (
+            _make_compressed_causal_mask(compress_block_size) if causal else None
+        )
+
+        O_cmp, lse_cmp = _fa4_fwd(
+            Q,
+            K_cmp,
+            V_cmp,
+            causal=False,
+            softmax_scale=softmax_scale,
+            mask_mod=compressed_mask,
+        )
+
+        O_slc, lse_slc = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            block_sparse_tensors=sparse_tensors,
+        )
+
+        O_sld, lse_sld = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
+
+        # --- Gating backward ---
+        dQ_gate = None
+        dgate_proj_weight = None
+        if gate_proj_weight is not None:
+            # Fused CuteDSL kernel for dO branches + dQ_gate,
+            # PyTorch einsum for dW_gate (cross-row reduction)
+            dO_cmp, dO_slc, dO_sld, dQ_gate, dgate_proj_weight = fused_gating_backward(
+                Q,
+                dO,
+                O_cmp,
+                O_slc,
+                O_sld,
+                gates,
+                gate_proj_weight,
+            )
+        else:
+            # No gate weights — uniform 1/3 gates, simple scaling
+            g = gates.float()
+            dO_f = dO.float()
+            dO_cmp = (g[..., 0:1] * dO_f).to(dO.dtype)
+            dO_slc = (g[..., 1:2] * dO_f).to(dO.dtype)
+            dO_sld = (g[..., 2:3] * dO_f).to(dO.dtype)
+
+        # --- Stage 2: Three FA4 backward passes ---
+        dQ_cmp, dK_cmp, dV_cmp = _fa4_bwd(
+            Q,
+            K_cmp,
+            V_cmp,
+            O_cmp,
+            dO_cmp,
+            lse_cmp,
+            softmax_scale=softmax_scale,
+            causal=False,
+            mask_mod=compressed_mask,
+        )
+
+        # For the selected branch backward, skip block sparsity since FA4's
+        # backward block-sparse path has compatibility issues on SM100.
+        # Using causal-only (no block sparsity) with the forward's LSE is correct
+        # because the LSE already encodes the block selection — non-selected blocks
+        # get near-zero attention weights in the backward.
+        dQ_slc, dK_slc, dV_slc = _fa4_bwd(
+            Q,
+            K,
+            V,
+            O_slc,
+            dO_slc,
+            lse_slc,
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+
+        dQ_sld, dK_sld, dV_sld = _fa4_bwd(
+            Q,
+            K,
+            V,
+            O_sld,
+            dO_sld,
+            lse_sld,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
+
+        # --- Stage 3: Compression backward ---
+        # dK_cmp, dV_cmp are gradients w.r.t. compressed KV
+        # CuteDSL kernel for mean-pool scatter, PyTorch for projection
+        dK_compress, dV_compress, dW_k, dW_v = fused_compress_kv_backward(
+            dK_cmp,
+            dV_cmp,
+            K,
+            V,
+            compress_block_size,
+            W_k_compress,
+            W_v_compress,
+        )
+
+        # --- Stage 4: Gradient accumulation ---
+        dQ = dQ_cmp + dQ_slc + dQ_sld
+        if dQ_gate is not None:
+            dQ = dQ + dQ_gate
+
+        dK = dK_slc + dK_sld + dK_compress
+        dV = dV_slc + dV_sld + dV_compress
+
+        # Return gradients matching forward() args order:
+        # Q, K, V, W_k_compress, W_v_compress, gate_proj_weight, + 7 non-tensor args
+        return (
+            dQ,
+            dK,
+            dV,
+            dW_k,
+            dW_v,
+            dgate_proj_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def nsa(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    n_block_size: int = 128,
+) -> Tensor:
+    """NSA with autograd support (forward + backward).
+
+    Same interface as nsa_forward, but supports training via torch.autograd.
+    Uses FA4 for both forward and backward passes, with activation checkpointing
+    to reduce memory usage (recomputes branch outputs during backward).
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        compress_block_size: Number of KV positions per block for compression.
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        window_size: Sliding window size (left window, causal).
+        W_k_compress: Per-head key compression weights, shape (H_kv, D, D).
+        W_v_compress: Per-head value compression weights, shape (H_kv, D, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        causal: Whether to use causal masking.
+        softmax_scale: Attention scaling factor (default: 1/sqrt(D)).
+        q_tile_size: Query tile size for block selection.
+        n_block_size: FA4 KV block size (128 for SM100).
+
+    Returns:
+        Output tensor, shape (B, N, H, D).
+    """
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(Q.shape[-1])
+
+    return NSAFunction.apply(
+        Q,
+        K,
+        V,
+        W_k_compress,
+        W_v_compress,
+        gate_proj_weight,
+        compress_block_size,
+        num_selected_blocks,
+        window_size,
+        causal,
+        softmax_scale,
+        q_tile_size,
+        n_block_size,
+    )

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -369,47 +369,67 @@ class NSAFunction(torch.autograd.Function):
             mask_mod=compressed_mask,
         )
 
-        # For the selected branch backward, use mask_mod to implement block
-        # selection. This avoids FA4's block_sparse_tensors backward path which
-        # has 2-CTA compatibility issues on SM100. The mask_mod checks if each
-        # (q_idx, kv_idx) pair falls within a selected block, using the block
-        # indices passed as aux_tensors.
-        block_indices = ctx.block_indices
-        q_tile_size = ctx.q_tile_size
-        num_sel = ctx.num_selected_blocks
-
-        import cutlass
-        import cutlass.cute as cute
-
-        @cute.jit
-        def _selected_block_mask(
-            batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
-        ):
-            # aux_tensors[0] = block_indices: (B, H, N_q_tiles, k) int32
-            indices = aux_tensors[0]
-            q_tile = q_idx[0] // cutlass.const_expr(q_tile_size)
-            kv_block = kv_idx[0] // cutlass.const_expr(compress_block_size)
-
-            found = cutlass.Boolean(False)
-            for i in cutlass.range_constexpr(num_sel):
-                sel_block = indices[batch_idx[0], head_idx[0], q_tile, i]
-                found = found | (sel_block == kv_block)
-            if cutlass.const_expr(causal):
-                found = found & (kv_idx <= q_idx)
-            return found
-
-        dQ_slc, dK_slc, dV_slc = _fa4_bwd(
-            Q,
-            K,
-            V,
-            O_slc,
-            dO_slc,
-            lse_slc,
-            softmax_scale=softmax_scale,
-            causal=False,  # causal handled in mask_mod
-            mask_mod=_selected_block_mask,
-            aux_tensors=[block_indices],
+        # For the selected branch backward, transpose block sparse tensors
+        # to Q-direction format for FA4 backward. Falls back to mask_mod if
+        # block sparsity backward fails.
+        B_size, N_size = Q.shape[:2]
+        bwd_sparse_tensors = _transpose_block_sparse_for_bwd(
+            sparse_tensors,
+            seqlen_q=N_size,
+            seqlen_k=N_size,
+            n_block_size=ctx.n_block_size,
+            q_tile_size=ctx.q_tile_size,
         )
+
+        try:
+            dQ_slc, dK_slc, dV_slc = _fa4_bwd(
+                Q,
+                K,
+                V,
+                O_slc,
+                dO_slc,
+                lse_slc,
+                softmax_scale=softmax_scale,
+                causal=causal,
+                block_sparse_tensors=bwd_sparse_tensors,
+            )
+        except Exception:
+            # Fallback: use mask_mod with aux_tensors for block selection
+            block_indices = ctx.block_indices
+            q_tile_size = ctx.q_tile_size
+            num_sel = ctx.num_selected_blocks
+
+            import cutlass
+            import cutlass.cute as cute
+
+            @cute.jit
+            def _selected_block_mask(
+                batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+            ):
+                indices = aux_tensors[0]
+                q_tile = q_idx[0] // cutlass.const_expr(q_tile_size)
+                kv_block = kv_idx[0] // cutlass.const_expr(compress_block_size)
+
+                found = cutlass.Boolean(False)
+                for i in cutlass.range_constexpr(num_sel):
+                    sel_block = indices[batch_idx[0], head_idx[0], q_tile, i]
+                    found = found | (sel_block == kv_block)
+                if cutlass.const_expr(causal):
+                    found = found & (kv_idx <= q_idx)
+                return found
+
+            dQ_slc, dK_slc, dV_slc = _fa4_bwd(
+                Q,
+                K,
+                V,
+                O_slc,
+                dO_slc,
+                lse_slc,
+                softmax_scale=softmax_scale,
+                causal=False,
+                mask_mod=_selected_block_mask,
+                aux_tensors=[block_indices],
+            )
 
         dQ_sld, dK_sld, dV_sld = _fa4_bwd(
             Q,

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -530,18 +530,59 @@ class NSAFunction(torch.autograd.Function):
         dK_slc = dK_slc_full.transpose(1, 2).to(K.dtype)
         dV_slc = dV_slc_full.transpose(1, 2).to(V.dtype)
 
-        # Branch 3: Sliding window backward
-        dQ_sld, dK_sld, dV_sld = _attn_bwd_pytorch(
-            Q,
-            K,
-            V,
-            O_sld,
-            dO_sld,
-            lse_sld,
-            softmax_scale=softmax_scale,
-            causal=causal,
-            window_size_left=window_size,
-        )
+        # Branch 3: Sliding window backward — use PyTorch SDPA which has
+        # built-in memory-efficient backward (no N×N materialization).
+        # We recompute forward + backward together via SDPA's autograd.
+        H_kv_sld = K.shape[2]
+        groups_sld = H_size // H_kv_sld
+        q_sld = Q.float()
+        k_sld = K.float()
+        v_sld = V.float()
+
+        # SDPA needs (B, H, N, D) layout
+        q_sld_t = q_sld.transpose(1, 2)  # (B, H, N, D)
+        k_sld_t = k_sld.transpose(1, 2)  # (B, H_kv, N, D)
+        v_sld_t = v_sld.transpose(1, 2)
+
+        # Expand for GQA
+        if groups_sld > 1:
+            k_sld_t = k_sld_t.repeat_interleave(groups_sld, dim=1)
+            v_sld_t = v_sld_t.repeat_interleave(groups_sld, dim=1)
+
+        # Enable grad for SDPA backward
+        q_sld_t.requires_grad_(True)
+        k_sld_t.requires_grad_(True)
+        v_sld_t.requires_grad_(True)
+
+        # Build causal+window mask via attn_mask
+        # For sliding window: each query attends to [q_pos - window + 1, q_pos]
+        with torch.enable_grad():
+            O_sld_recomputed = torch.nn.functional.scaled_dot_product_attention(
+                q_sld_t,
+                k_sld_t,
+                v_sld_t,
+                is_causal=causal and window_size is None,
+                scale=softmax_scale,
+            )
+            # Get dO in the right layout
+            dO_sld_t = dO_sld.transpose(1, 2).float()
+            O_sld_recomputed.backward(dO_sld_t)
+
+        dQ_sld = q_sld_t.grad.transpose(1, 2).to(Q.dtype)
+        dk_sld_t = k_sld_t.grad
+        dv_sld_t = v_sld_t.grad
+
+        # Handle GQA: sum across head groups for dK, dV
+        if groups_sld > 1:
+            dk_sld_t = dk_sld_t.reshape(B_size, H_kv_sld, groups_sld, N_size, D).sum(
+                dim=2
+            )
+            dv_sld_t = dv_sld_t.reshape(B_size, H_kv_sld, groups_sld, N_size, D).sum(
+                dim=2
+            )
+
+        dK_sld = dk_sld_t.transpose(1, 2).to(K.dtype)
+        dV_sld = dv_sld_t.transpose(1, 2).to(V.dtype)
 
         # --- Stage 3: Compression backward ---
         # dK_cmp, dV_cmp are gradients w.r.t. compressed KV

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -114,6 +114,7 @@ def _fa4_bwd(
     window_size_right: int | None = None,
     block_sparse_tensors=None,
     mask_mod: Callable | None = None,
+    aux_tensors: list[Tensor] | None = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """Call FA4's backward pass (low-level, supports block sparsity and mask_mod).
 
@@ -146,8 +147,7 @@ def _fa4_bwd(
         window_size_right=window_size_right,
         block_sparse_tensors=block_sparse_tensors,
         mask_mod=mask_mod,
-        # Disable 2-CTA mode for block sparsity compatibility
-        num_threads=128 if block_sparse_tensors is not None else 256,
+        aux_tensors=aux_tensors,
     )
     return dq, dk, dv
 
@@ -369,11 +369,35 @@ class NSAFunction(torch.autograd.Function):
             mask_mod=compressed_mask,
         )
 
-        # For the selected branch backward, skip block sparsity since FA4's
-        # backward block-sparse path has compatibility issues on SM100.
-        # Using causal-only (no block sparsity) with the forward's LSE is correct
-        # because the LSE already encodes the block selection — non-selected blocks
-        # get near-zero attention weights in the backward.
+        # For the selected branch backward, use mask_mod to implement block
+        # selection. This avoids FA4's block_sparse_tensors backward path which
+        # has 2-CTA compatibility issues on SM100. The mask_mod checks if each
+        # (q_idx, kv_idx) pair falls within a selected block, using the block
+        # indices passed as aux_tensors.
+        block_indices = ctx.block_indices
+        q_tile_size = ctx.q_tile_size
+        num_sel = ctx.num_selected_blocks
+
+        import cutlass
+        import cutlass.cute as cute
+
+        @cute.jit
+        def _selected_block_mask(
+            batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+        ):
+            # aux_tensors[0] = block_indices: (B, H, N_q_tiles, k) int32
+            indices = aux_tensors[0]
+            q_tile = q_idx[0] // cutlass.const_expr(q_tile_size)
+            kv_block = kv_idx[0] // cutlass.const_expr(compress_block_size)
+
+            found = cutlass.Boolean(False)
+            for i in cutlass.range_constexpr(num_sel):
+                sel_block = indices[batch_idx[0], head_idx[0], q_tile, i]
+                found = found | (sel_block == kv_block)
+            if cutlass.const_expr(causal):
+                found = found & (kv_idx <= q_idx)
+            return found
+
         dQ_slc, dK_slc, dV_slc = _fa4_bwd(
             Q,
             K,
@@ -382,7 +406,9 @@ class NSAFunction(torch.autograd.Function):
             dO_slc,
             lse_slc,
             softmax_scale=softmax_scale,
-            causal=causal,
+            causal=False,  # causal handled in mask_mod
+            mask_mod=_selected_block_mask,
+            aux_tensors=[block_indices],
         )
 
         dQ_sld, dK_sld, dV_sld = _fa4_bwd(

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -9,11 +9,9 @@ that supports training (backward pass).
 from __future__ import annotations
 
 import math
-from typing import Callable, Optional, Tuple
 
 import torch
 from mslk.attention.sparse_attn.compress import (
-    compress_kv,
     fused_compress_kv,
     fused_compress_kv_backward,
 )
@@ -23,182 +21,13 @@ from mslk.attention.sparse_attn.gating import (
     gate_and_combine,
 )
 from mslk.attention.sparse_attn.nsa_forward import (
+    _fa4_bwd,
     _fa4_fwd,
     _make_compressed_causal_mask,
 )
 from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 from torch import Tensor
-
-
-def _transpose_block_sparse_for_bwd(
-    tensors,
-    seqlen_q: int,
-    seqlen_k: int,
-    n_block_size: int,
-    q_tile_size: int,
-):
-    """Transpose forward block sparse tensors to backward Q-direction format.
-
-    Forward tensors indexed by (m=Q-tiles, n=KV-blocks).
-    Backward tensors indexed by (m=KV-blocks, n=Q-tiles).
-    """
-    from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
-
-    n_kv_blocks = (seqlen_k + n_block_size - 1) // n_block_size
-    n_q_tiles = seqlen_q // q_tile_size
-
-    B, H = tensors.full_block_cnt.shape[:2]
-    device = tensors.full_block_cnt.device
-
-    fwd_full_idx = tensors.full_block_idx  # (B, H, n_q_tiles, n_kv_blocks)
-    fwd_full_cnt = tensors.full_block_cnt  # (B, H, n_q_tiles)
-
-    # Build dense boolean attendance: (B, H, n_q_tiles, n_kv_blocks)
-    attendance = torch.zeros(
-        B, H, n_q_tiles, n_kv_blocks, dtype=torch.bool, device=device
-    )
-    for qt in range(n_q_tiles):
-        cnt = fwd_full_cnt[:, :, qt]  # (B, H)
-        for i in range(min(fwd_full_idx.shape[3], n_kv_blocks)):
-            if (i < cnt).any():
-                idx = fwd_full_idx[:, :, qt, i].long().clamp(0, n_kv_blocks - 1)
-                # Set attendance[b, h, qt, idx[b,h]] = True where i < cnt[b,h]
-                valid = i < cnt  # (B, H)
-                for b in range(B):
-                    for h in range(H):
-                        if valid[b, h]:
-                            attendance[b, h, qt, idx[b, h]] = True
-
-    # Transpose: (B, H, n_q_tiles, n_kv_blocks) -> (B, H, n_kv_blocks, n_q_tiles)
-    bwd_attendance = attendance.transpose(2, 3)
-
-    # Convert to cnt/idx: for each KV block, list the Q tiles that attend to it
-    bwd_full_cnt = bwd_attendance.sum(dim=-1).to(torch.int32)  # (B, H, n_kv_blocks)
-
-    # Build index tensor: for each KV block, pack the attending Q tile indices
-    bwd_full_idx = torch.zeros(
-        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device=device
-    )
-    for b in range(B):
-        for h in range(H):
-            for kv in range(n_kv_blocks):
-                qt_indices = bwd_attendance[b, h, kv].nonzero(as_tuple=True)[0]
-                for i, qt in enumerate(qt_indices):
-                    bwd_full_idx[b, h, kv, i] = qt.int()
-
-    bwd_mask_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device=device)
-    bwd_mask_idx = torch.zeros(
-        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device=device
-    )
-
-    return BlockSparseTensorsTorch(
-        mask_block_cnt=bwd_mask_cnt,
-        mask_block_idx=bwd_mask_idx,
-        full_block_cnt=bwd_full_cnt,
-        full_block_idx=bwd_full_idx,
-        block_size=(q_tile_size, n_block_size),
-    )
-
-
-def _attn_bwd_pytorch(
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    out: Tensor,
-    dout: Tensor,
-    lse: Tensor,
-    softmax_scale: float | None = None,
-    causal: bool = False,
-    window_size_left: int | None = None,
-    window_size_right: int | None = None,
-    mask: Tensor | None = None,
-) -> Tuple[Tensor, Tensor, Tensor]:
-    """Attention backward using PyTorch ops (torch.matmul + cuBLAS). No CUTLASS JIT.
-
-    All inputs are (B, N, H, D) layout.
-    Returns (dq, dk, dv).
-
-    Uses the saved output and log-sum-exp to recompute attention weights
-    without materializing the full N×N score matrix where possible.
-    """
-    B, N_q, H, D = q.shape
-    H_kv = k.shape[2]
-    N_kv = k.shape[1]
-    groups = H // H_kv
-
-    if softmax_scale is None:
-        softmax_scale = 1.0 / math.sqrt(D)
-
-    # Transpose to (B, H, N, D) for matmul
-    q_t = q.transpose(1, 2).float()  # (B, H, N_q, D)
-    k_t = k.transpose(1, 2).float()  # (B, H_kv, N_kv, D)
-    v_t = v.transpose(1, 2).float()  # (B, H_kv, N_kv, D)
-    dout_t = dout.transpose(1, 2).float()  # (B, H, N_q, D)
-
-    # Expand K, V for GQA
-    if groups > 1:
-        k_t = k_t.repeat_interleave(groups, dim=1)  # (B, H, N_kv, D)
-        v_t = v_t.repeat_interleave(groups, dim=1)
-
-    # Recompute attention scores and weights from LSE
-    scores = (
-        torch.matmul(q_t, k_t.transpose(-2, -1)) * softmax_scale
-    )  # (B, H, N_q, N_kv)
-
-    # Apply masks
-    if causal and N_q == N_kv:
-        q_pos = torch.arange(N_q, device=q.device).unsqueeze(1)
-        kv_pos = torch.arange(N_kv, device=q.device).unsqueeze(0)
-        causal_mask = kv_pos > q_pos
-        if window_size_left is not None:
-            causal_mask = causal_mask | (kv_pos < q_pos - window_size_left + 1)
-        scores = scores.masked_fill(
-            causal_mask.unsqueeze(0).unsqueeze(0), float("-inf")
-        )
-    elif window_size_left is not None and N_q == N_kv:
-        q_pos = torch.arange(N_q, device=q.device).unsqueeze(1)
-        kv_pos = torch.arange(N_kv, device=q.device).unsqueeze(0)
-        window_mask = (kv_pos > q_pos) | (kv_pos < q_pos - window_size_left + 1)
-        scores = scores.masked_fill(
-            window_mask.unsqueeze(0).unsqueeze(0), float("-inf")
-        )
-
-    if mask is not None:
-        scores = scores.masked_fill(mask, float("-inf"))
-
-    # Softmax (recompute from scores, not from LSE, for simplicity)
-    attn = torch.softmax(scores, dim=-1)
-
-    # Standard attention backward:
-    # dV = P^T @ dO
-    dv_t = torch.matmul(attn.transpose(-2, -1), dout_t)  # (B, H, N_kv, D)
-
-    # dP = dO @ V^T
-    dp = torch.matmul(dout_t, v_t.transpose(-2, -1))  # (B, H, N_q, N_kv)
-
-    # dS = P * (dP - (dP * P).sum(-1, keepdim=True))
-    # Equivalently: dS = P * (dP - rowsum), where rowsum = (dO * O).sum(D)
-    rowsum = (dout_t * (torch.matmul(attn, v_t))).sum(dim=-1, keepdim=True)
-    ds = attn * (dp - rowsum) * softmax_scale
-
-    # dQ = dS @ K
-    dq_t = torch.matmul(ds, k_t)  # (B, H, N_q, D)
-
-    # dK = dS^T @ Q
-    dk_t = torch.matmul(ds.transpose(-2, -1), q_t)  # (B, H, N_kv, D)
-
-    # Handle GQA: sum dK, dV across head groups
-    if groups > 1:
-        dk_t = dk_t.reshape(B, H_kv, groups, N_kv, D).sum(dim=2)
-        dv_t = dv_t.reshape(B, H_kv, groups, N_kv, D).sum(dim=2)
-
-    # Transpose back to (B, N, H, D)
-    return (
-        dq_t.transpose(1, 2).to(q.dtype),
-        dk_t.transpose(1, 2).to(k.dtype),
-        dv_t.transpose(1, 2).to(v.dtype),
-    )
 
 
 class NSAFunction(torch.autograd.Function):
@@ -405,19 +234,10 @@ class NSAFunction(torch.autograd.Function):
             dO_slc = (g[..., 1:2] * dO_f).to(dO.dtype)
             dO_sld = (g[..., 2:3] * dO_f).to(dO.dtype)
 
-        # --- Stage 2: Three attention backward passes (PyTorch/cuBLAS, no CUTLASS JIT) ---
+        # --- Stage 2: Three attention backward passes (FA4 CuteDSL) ---
 
         # Branch 1: Compressed attention backward
-        # Build compressed causal mask: kv_block_start > q_pos
-        B_size, N_size, H_size = Q.shape[:3]
-        N_cmp = K_cmp.shape[1]
-        cmp_mask = None
-        if causal:
-            q_pos = torch.arange(N_size, device=Q.device).unsqueeze(1)
-            kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
-            cmp_mask = (kv_block_start.unsqueeze(0) > q_pos).unsqueeze(0).unsqueeze(0)
-
-        dQ_cmp, dK_cmp, dV_cmp = _attn_bwd_pytorch(
+        dQ_cmp, dK_cmp, dV_cmp = _fa4_bwd(
             Q,
             K_cmp,
             V_cmp,
@@ -425,164 +245,130 @@ class NSAFunction(torch.autograd.Function):
             dO_cmp,
             lse_cmp,
             softmax_scale=softmax_scale,
-            mask=cmp_mask,
+            causal=False,
+            mask_mod=compressed_mask,
         )
 
-        # Branch 2: Selected attention backward via gather/scatter
-        # Gather selected K/V blocks, run attention backward on gathered subset,
-        # then scatter dK/dV gradients back to full KV positions.
+        # Branch 2: Selected attention backward via gather/scatter (per-tile)
+        # FA4 block-sparse backward is not yet supported on SM100, so we use
+        # a PyTorch-based approach: for each query tile, gather selected K/V,
+        # compute attention backward, then scatter dK/dV gradients back.
+        # Processing one tile at a time avoids O(N_q_tiles * N * D) memory.
+        # GQA is handled inside the loop to avoid expanding K/V to H heads.
         block_indices = ctx.block_indices
         q_tile_size = ctx.q_tile_size
         num_sel = ctx.num_selected_blocks
         block_size = compress_block_size
 
+        B_size, N_size, H_size, D = Q.shape
+        H_kv = K.shape[2]
+        groups = H_size // H_kv
+
         N_blocks = N_size // block_size
         N_q_tiles = N_size // q_tile_size
         k_actual = min(num_sel, N_blocks)
-
-        # Expand block indices to position indices
-        offsets = torch.arange(block_size, device=Q.device)
-        pos_indices = block_indices.unsqueeze(-1) * block_size + offsets
         kv_len = k_actual * block_size
-        pos_indices = pos_indices.reshape(B_size, H_size, N_q_tiles, kv_len)
 
-        # Gather K, V at selected positions: (B, H, N_q_tiles, kv_len, D)
-        H_kv = K.shape[2]
-        groups = H_size // H_kv
-        k_t = K.transpose(1, 2).float()
-        v_t = V.transpose(1, 2).float()
-        if groups > 1:
-            k_t = k_t.repeat_interleave(groups, dim=1)
-            v_t = v_t.repeat_interleave(groups, dim=1)
-
-        D = Q.shape[-1]
-        gather_idx = pos_indices.unsqueeze(-1).expand(
-            B_size, H_size, N_q_tiles, kv_len, D
-        )
-        k_exp = k_t.unsqueeze(2).expand(B_size, H_size, N_q_tiles, N_size, D)
-        v_exp = v_t.unsqueeze(2).expand(B_size, H_size, N_q_tiles, N_size, D)
-        sel_k = torch.gather(k_exp, 3, gather_idx)
-        sel_v = torch.gather(v_exp, 3, gather_idx)
-
-        # Reshape Q and dO into tiles
-        q_tiles = (
-            Q.transpose(1, 2).float().reshape(B_size, H_size, N_q_tiles, q_tile_size, D)
-        )
-        dO_slc_tiles = (
-            dO_slc.transpose(1, 2)
-            .float()
-            .reshape(B_size, H_size, N_q_tiles, q_tile_size, D)
+        # Expand block indices to position indices: (B, H, N_q_tiles, kv_len)
+        offsets = torch.arange(block_size, device=Q.device)
+        pos_indices = (block_indices.unsqueeze(-1) * block_size + offsets).reshape(
+            B_size, H_size, N_q_tiles, kv_len
         )
 
-        # Attention scores on gathered KV
-        scores_slc = torch.matmul(q_tiles, sel_k.transpose(-2, -1)) * softmax_scale
+        # Keep K, V at H_kv heads — no GQA expansion
+        k_t = K.transpose(1, 2).float()  # (B, H_kv, N, D)
+        v_t = V.transpose(1, 2).float()  # (B, H_kv, N, D)
 
-        # Causal mask on gathered positions
-        if causal:
-            q_tile_starts = torch.arange(N_q_tiles, device=Q.device) * q_tile_size
-            q_offsets_t = torch.arange(q_tile_size, device=Q.device)
-            q_positions = q_tile_starts.unsqueeze(1) + q_offsets_t.unsqueeze(0)
-            c_mask = pos_indices.unsqueeze(3) > q_positions.reshape(
-                1, 1, N_q_tiles, q_tile_size, 1
-            )
-            scores_slc = scores_slc.masked_fill(c_mask, float("-inf"))
-
-        attn_slc = torch.softmax(scores_slc, dim=-1)
-
-        # dV_sel = attn^T @ dO_slc_tiles
-        dv_sel = torch.matmul(attn_slc.transpose(-2, -1), dO_slc_tiles)
-
-        # dP = dO @ V^T
-        dp_slc = torch.matmul(dO_slc_tiles, sel_v.transpose(-2, -1))
-        rowsum_slc = (dO_slc_tiles * torch.matmul(attn_slc, sel_v)).sum(
-            dim=-1, keepdim=True
-        )
-        ds_slc = attn_slc * (dp_slc - rowsum_slc) * softmax_scale
-
-        # dQ_slc_tiles = dS @ sel_K
-        dq_slc_tiles = torch.matmul(ds_slc, sel_k)
-        dQ_slc = (
-            dq_slc_tiles.reshape(B_size, H_size, N_size, D).transpose(1, 2).to(Q.dtype)
-        )
-
-        # dK_sel = dS^T @ Q_tiles
-        dk_sel = torch.matmul(ds_slc.transpose(-2, -1), q_tiles)
-
-        # Scatter dK_sel and dV_sel back to full KV
-        dK_slc_full = torch.zeros(
+        # Accumulate dQ at H heads, dK/dV at H_kv heads
+        dQ_slc = torch.zeros(
             B_size, H_size, N_size, D, device=Q.device, dtype=torch.float32
         )
+        dK_slc_full = torch.zeros(
+            B_size, H_kv, N_size, D, device=Q.device, dtype=torch.float32
+        )
         dV_slc_full = torch.zeros_like(dK_slc_full)
-        scatter_idx = gather_idx  # (B, H, N_q_tiles, kv_len, D)
-        # Sum across query tiles that share the same KV position
-        for qt in range(N_q_tiles):
-            dK_slc_full.scatter_add_(2, gather_idx[:, :, qt], dk_sel[:, :, qt])
-            dV_slc_full.scatter_add_(2, gather_idx[:, :, qt], dv_sel[:, :, qt])
 
-        # Handle GQA: sum across head groups
-        if groups > 1:
-            dK_slc_full = dK_slc_full.reshape(B_size, H_kv, groups, N_size, D).sum(
-                dim=2
-            )
-            dV_slc_full = dV_slc_full.reshape(B_size, H_kv, groups, N_size, D).sum(
-                dim=2
-            )
+        q_t = Q.transpose(1, 2).float()  # (B, H, N, D)
+        dO_slc_t = dO_slc.transpose(1, 2).float()
+
+        for qt in range(N_q_tiles):
+            q_start = qt * q_tile_size
+            q_end = q_start + q_tile_size
+
+            # Block indices for this tile: (B, H, kv_len)
+            idx_qt = pos_indices[:, :, qt]
+
+            # Gather K, V from H_kv heads, then expand for GQA
+            # idx_qt is (B, H, kv_len) but K is (B, H_kv, N, D)
+            # Map H→H_kv: idx_kv_qt = idx_qt[:, ::groups] (same indices per group)
+            idx_kv_qt = idx_qt[:, ::groups]  # (B, H_kv, kv_len)
+            gather_kv = idx_kv_qt.unsqueeze(-1).expand(B_size, H_kv, kv_len, D)
+            sel_k_kv = torch.gather(k_t, 2, gather_kv)  # (B, H_kv, kv_len, D)
+            sel_v_kv = torch.gather(v_t, 2, gather_kv)
+
+            # Expand gathered K, V to H heads for attention
+            if groups > 1:
+                sel_k = sel_k_kv.repeat_interleave(groups, dim=1)  # (B, H, kv_len, D)
+                sel_v = sel_v_kv.repeat_interleave(groups, dim=1)
+            else:
+                sel_k = sel_k_kv
+                sel_v = sel_v_kv
+
+            # Q and dO for this tile: (B, H, q_tile_size, D)
+            q_tile = q_t[:, :, q_start:q_end]
+            dO_tile = dO_slc_t[:, :, q_start:q_end]
+
+            # Attention scores: (B, H, q_tile_size, kv_len)
+            scores = torch.matmul(q_tile, sel_k.transpose(-2, -1)) * softmax_scale
+
+            if causal:
+                q_positions = torch.arange(q_start, q_end, device=Q.device).unsqueeze(1)
+                kv_positions = idx_qt.unsqueeze(2)  # (B, H, 1, kv_len)
+                c_mask = kv_positions > q_positions.reshape(1, 1, q_tile_size, 1)
+                scores = scores.masked_fill(c_mask, float("-inf"))
+
+            attn = torch.softmax(scores, dim=-1)
+
+            # dV = attn^T @ dO
+            dv_qt = torch.matmul(attn.transpose(-2, -1), dO_tile)  # (B, H, kv_len, D)
+
+            # dP = dO @ V^T, dS = P * (dP - rowsum) * scale
+            dp = torch.matmul(dO_tile, sel_v.transpose(-2, -1))
+            rowsum = (dO_tile * torch.matmul(attn, sel_v)).sum(dim=-1, keepdim=True)
+            ds = attn * (dp - rowsum) * softmax_scale
+
+            # dQ = dS @ K
+            dQ_slc[:, :, q_start:q_end] = torch.matmul(ds, sel_k)
+
+            # dK = dS^T @ Q
+            dk_qt = torch.matmul(ds.transpose(-2, -1), q_tile)  # (B, H, kv_len, D)
+
+            # Reduce dK, dV from H heads to H_kv heads before scatter
+            if groups > 1:
+                dk_qt = dk_qt.reshape(B_size, H_kv, groups, kv_len, D).sum(dim=2)
+                dv_qt = dv_qt.reshape(B_size, H_kv, groups, kv_len, D).sum(dim=2)
+
+            # Scatter dK, dV back at H_kv resolution
+            dK_slc_full.scatter_add_(2, gather_kv, dk_qt)
+            dV_slc_full.scatter_add_(2, gather_kv, dv_qt)
+
+        dQ_slc = dQ_slc.transpose(1, 2).to(Q.dtype)
         dK_slc = dK_slc_full.transpose(1, 2).to(K.dtype)
         dV_slc = dV_slc_full.transpose(1, 2).to(V.dtype)
 
-        # Branch 3: Sliding window backward — use PyTorch SDPA which has
-        # built-in memory-efficient backward (no N×N materialization).
-        # We recompute forward + backward together via SDPA's autograd.
-        H_kv_sld = K.shape[2]
-        groups_sld = H_size // H_kv_sld
-        q_sld = Q.float()
-        k_sld = K.float()
-        v_sld = V.float()
-
-        # SDPA needs (B, H, N, D) layout
-        q_sld_t = q_sld.transpose(1, 2)  # (B, H, N, D)
-        k_sld_t = k_sld.transpose(1, 2)  # (B, H_kv, N, D)
-        v_sld_t = v_sld.transpose(1, 2)
-
-        # Expand for GQA
-        if groups_sld > 1:
-            k_sld_t = k_sld_t.repeat_interleave(groups_sld, dim=1)
-            v_sld_t = v_sld_t.repeat_interleave(groups_sld, dim=1)
-
-        # Enable grad for SDPA backward
-        q_sld_t.requires_grad_(True)
-        k_sld_t.requires_grad_(True)
-        v_sld_t.requires_grad_(True)
-
-        # Build causal+window mask via attn_mask
-        # For sliding window: each query attends to [q_pos - window + 1, q_pos]
-        with torch.enable_grad():
-            O_sld_recomputed = torch.nn.functional.scaled_dot_product_attention(
-                q_sld_t,
-                k_sld_t,
-                v_sld_t,
-                is_causal=causal and window_size is None,
-                scale=softmax_scale,
-            )
-            # Get dO in the right layout
-            dO_sld_t = dO_sld.transpose(1, 2).float()
-            O_sld_recomputed.backward(dO_sld_t)
-
-        dQ_sld = q_sld_t.grad.transpose(1, 2).to(Q.dtype)
-        dk_sld_t = k_sld_t.grad
-        dv_sld_t = v_sld_t.grad
-
-        # Handle GQA: sum across head groups for dK, dV
-        if groups_sld > 1:
-            dk_sld_t = dk_sld_t.reshape(B_size, H_kv_sld, groups_sld, N_size, D).sum(
-                dim=2
-            )
-            dv_sld_t = dv_sld_t.reshape(B_size, H_kv_sld, groups_sld, N_size, D).sum(
-                dim=2
-            )
-
-        dK_sld = dk_sld_t.transpose(1, 2).to(K.dtype)
-        dV_sld = dv_sld_t.transpose(1, 2).to(V.dtype)
+        # Branch 3: Sliding window attention backward
+        dQ_sld, dK_sld, dV_sld = _fa4_bwd(
+            Q,
+            K,
+            V,
+            O_sld,
+            dO_sld,
+            lse_sld,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
 
         # --- Stage 3: Compression backward ---
         # dK_cmp, dV_cmp are gradients w.r.t. compressed KV

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -1,0 +1,200 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""End-to-end NSA (Native Sparse Attention) forward pass using FA4.
+
+Orchestrates the three attention branches:
+1. Compressed attention (FA4 on short KV sequence)
+2. Selected attention (FA4 with block sparsity)
+3. Sliding window attention (FA4 with window_size)
+
+Then gates and combines the outputs.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+
+def _make_compressed_causal_mask(compress_block_size: int) -> Callable:
+    """Create a CuteDSL mask_mod for compressed attention causal masking.
+
+    Block j (at kv_idx=j) represents positions [j*block_size, (j+1)*block_size).
+    Query at position q_idx can attend to block j iff j * block_size <= q_idx.
+    """
+    import cutlass.cute as cute
+
+    @cute.jit
+    def compressed_causal_mask(
+        batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+    ):
+        return kv_idx * compress_block_size <= q_idx
+
+    return compressed_causal_mask
+
+
+def _fa4_fwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+) -> Tuple[Tensor, Tensor]:
+    """Call FA4's forward pass (low-level, supports block sparsity and mask_mod).
+
+    Uses _flash_attn_fwd from the fb interface which supports block_sparse_tensors
+    and mask_mod.
+
+    All inputs are (B, N, H, D) layout.
+    Returns (output, lse).
+    """
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+
+    # mask_mod is not compatible with pack_gqa=True in FA4, so disable it
+    pack_gqa = False if mask_mod is not None else None
+
+    out, lse = _flash_attn_fwd(
+        q, k, v,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        block_sparse_tensors=block_sparse_tensors,
+        mask_mod=mask_mod,
+        pack_gqa=pack_gqa,
+        return_lse=True,
+    )
+    return out, lse
+
+
+def _fa4_fwd_simple(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size: tuple[int, int] | None = None,
+) -> Tuple[Tensor, Tensor]:
+    """Call FA4 via the autograd interface (for branches without block sparsity)."""
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    return flash_attn_func(
+        q, k, v,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+    )
+
+
+def nsa_forward(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    n_block_size: int = 128,
+) -> Tensor:
+    """NSA forward pass using FA4 for all attention branches.
+
+    Orchestrates:
+    1. KV compression (mean-pool + optional projection)
+    2. Block scoring and top-k selection
+    3. Three FA4 calls: compressed, selected (block-sparse), sliding window
+    4. Gating and combination
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        compress_block_size: Number of KV positions per block for compression.
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        window_size: Sliding window size (left window, causal).
+        W_k_compress: Per-head key compression weights, shape (H_kv, D, D).
+        W_v_compress: Per-head value compression weights, shape (H_kv, D, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        causal: Whether to use causal masking.
+        softmax_scale: Attention scaling factor (default: 1/sqrt(D)).
+        q_tile_size: Query tile size for block selection (FA4 CTA tile: 2*128=256).
+        n_block_size: FA4 KV block size (128 for SM100).
+
+    Returns:
+        Output tensor, shape (B, N, H, D).
+    """
+    B, N, H, D = Q.shape
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # Step 1: Compress KV
+    K_cmp, V_cmp = compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+    # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
+
+    # Step 2: Score blocks and select top-k
+    block_indices = score_and_select_blocks(
+        Q, K_cmp, num_selected_blocks, compress_block_size,
+        causal=causal, q_tile_size=q_tile_size, softmax_scale=softmax_scale,
+    )
+    # block_indices: (B, H, N_q_tiles, k) int32
+
+    # Step 3: Build FA4 sparsity masks for selected attention
+    sparse_tensors = build_fa4_block_sparse_tensors(
+        block_indices, compress_block_size,
+        n_block_size=n_block_size, seqlen_k=N,
+    )
+
+    # Step 4: Run three FA4 branches
+
+    # Branch 1: Compressed attention — block-aware causal masking on short KV
+    # Standard causal=True gives wrong masking for compressed KV since N_cmp << N:
+    # it masks based on kv_j > q_i, but we need kv_j * compress_block_size > q_i.
+    compressed_mask = _make_compressed_causal_mask(compress_block_size) if causal else None
+    O_cmp, lse_cmp = _fa4_fwd(
+        Q, K_cmp, V_cmp,
+        causal=False,
+        softmax_scale=softmax_scale,
+        mask_mod=compressed_mask,
+    )
+
+    # Branch 2: Selected attention — block-sparse attention on full KV
+    O_slc, lse_slc = _fa4_fwd(
+        Q, K, V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        block_sparse_tensors=sparse_tensors,
+    )
+
+    # Branch 3: Sliding window attention
+    O_sld, lse_sld = _fa4_fwd_simple(
+        Q, K, V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        window_size=(window_size, 0),  # (left, right=0 for causal)
+    )
+
+    # Step 5: Gate and combine
+    # Use chunked gating for long sequences to avoid materializing
+    # 3 full (B,N,H,D) float32 tensors simultaneously.
+    gate_chunk = 4096 if N > 32768 else None
+    gates = compute_gates(Q, gate_proj_weight, chunk_size=gate_chunk)  # (B, N, H, 3)
+    O = gate_and_combine(O_cmp, O_slc, O_sld, gates, chunk_size=gate_chunk)
+
+    return O

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -80,6 +80,47 @@ def _fa4_fwd(
     return out, lse
 
 
+def _fa4_bwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    dout: Tensor,
+    lse: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Call FA4's backward pass (low-level, supports block sparsity and mask_mod).
+
+    Uses _flash_attn_bwd from the fb interface which supports block_sparse_tensors
+    and mask_mod.
+
+    All inputs are (B, N, H, D) layout.
+    Returns (dq, dk, dv).
+    """
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_bwd
+
+    dq, dk, dv = _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        dout,
+        lse,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        block_sparse_tensors=block_sparse_tensors,
+        mask_mod=mask_mod,
+    )
+    return dq, dk, dv
+
+
 def _fa4_fwd_simple(
     q: Tensor,
     k: Tensor,
@@ -148,7 +189,9 @@ def nsa_forward(
         softmax_scale = 1.0 / math.sqrt(D)
 
     # Step 1: Compress KV
-    K_cmp, V_cmp = fused_compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+    K_cmp, V_cmp = fused_compress_kv(
+        K, V, compress_block_size, W_k_compress, W_v_compress
+    )
     # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
 
     # Step 2: Score blocks and select top-k

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -16,7 +16,7 @@ import math
 from typing import Callable, Optional, Tuple
 
 import torch
-from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.compress import fused_compress_kv
 from mslk.attention.sparse_attn.gating import fused_gate_and_combine
 from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
@@ -148,7 +148,7 @@ def nsa_forward(
         softmax_scale = 1.0 / math.sqrt(D)
 
     # Step 1: Compress KV
-    K_cmp, V_cmp = compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+    K_cmp, V_cmp = fused_compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
     # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
 
     # Step 2: Score blocks and select top-k

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -18,7 +18,7 @@ from typing import Callable, Optional, Tuple
 import torch
 from mslk.attention.sparse_attn.compress import compress_kv
 from mslk.attention.sparse_attn.gating import fused_gate_and_combine
-from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 from torch import Tensor
 
@@ -152,7 +152,7 @@ def nsa_forward(
     # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
 
     # Step 2: Score blocks and select top-k
-    block_indices = score_and_select_blocks(
+    block_indices = fused_score_and_select_blocks(
         Q,
         K_cmp,
         num_selected_blocks,

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -16,12 +16,11 @@ import math
 from typing import Callable, Optional, Tuple
 
 import torch
-from torch import Tensor
-
 from mslk.attention.sparse_attn.compress import compress_kv
-from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.gating import fused_gate_and_combine
 from mslk.attention.sparse_attn.select import score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+from torch import Tensor
 
 
 def _make_compressed_causal_mask(compress_block_size: int) -> Callable:
@@ -66,7 +65,9 @@ def _fa4_fwd(
     pack_gqa = False if mask_mod is not None else None
 
     out, lse = _flash_attn_fwd(
-        q, k, v,
+        q,
+        k,
+        v,
         softmax_scale=softmax_scale,
         causal=causal,
         window_size_left=window_size_left,
@@ -91,7 +92,9 @@ def _fa4_fwd_simple(
     from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
 
     return flash_attn_func(
-        q, k, v,
+        q,
+        k,
+        v,
         softmax_scale=softmax_scale,
         causal=causal,
         window_size=window_size,
@@ -150,15 +153,22 @@ def nsa_forward(
 
     # Step 2: Score blocks and select top-k
     block_indices = score_and_select_blocks(
-        Q, K_cmp, num_selected_blocks, compress_block_size,
-        causal=causal, q_tile_size=q_tile_size, softmax_scale=softmax_scale,
+        Q,
+        K_cmp,
+        num_selected_blocks,
+        compress_block_size,
+        causal=causal,
+        q_tile_size=q_tile_size,
+        softmax_scale=softmax_scale,
     )
     # block_indices: (B, H, N_q_tiles, k) int32
 
     # Step 3: Build FA4 sparsity masks for selected attention
     sparse_tensors = build_fa4_block_sparse_tensors(
-        block_indices, compress_block_size,
-        n_block_size=n_block_size, seqlen_k=N,
+        block_indices,
+        compress_block_size,
+        n_block_size=n_block_size,
+        seqlen_k=N,
     )
 
     # Step 4: Run three FA4 branches
@@ -166,9 +176,13 @@ def nsa_forward(
     # Branch 1: Compressed attention — block-aware causal masking on short KV
     # Standard causal=True gives wrong masking for compressed KV since N_cmp << N:
     # it masks based on kv_j > q_i, but we need kv_j * compress_block_size > q_i.
-    compressed_mask = _make_compressed_causal_mask(compress_block_size) if causal else None
+    compressed_mask = (
+        _make_compressed_causal_mask(compress_block_size) if causal else None
+    )
     O_cmp, lse_cmp = _fa4_fwd(
-        Q, K_cmp, V_cmp,
+        Q,
+        K_cmp,
+        V_cmp,
         causal=False,
         softmax_scale=softmax_scale,
         mask_mod=compressed_mask,
@@ -176,7 +190,9 @@ def nsa_forward(
 
     # Branch 2: Selected attention — block-sparse attention on full KV
     O_slc, lse_slc = _fa4_fwd(
-        Q, K, V,
+        Q,
+        K,
+        V,
         causal=causal,
         softmax_scale=softmax_scale,
         block_sparse_tensors=sparse_tensors,
@@ -184,17 +200,15 @@ def nsa_forward(
 
     # Branch 3: Sliding window attention
     O_sld, lse_sld = _fa4_fwd_simple(
-        Q, K, V,
+        Q,
+        K,
+        V,
         causal=causal,
         softmax_scale=softmax_scale,
         window_size=(window_size, 0),  # (left, right=0 for causal)
     )
 
-    # Step 5: Gate and combine
-    # Use chunked gating for long sequences to avoid materializing
-    # 3 full (B,N,H,D) float32 tensors simultaneously.
-    gate_chunk = 4096 if N > 32768 else None
-    gates = compute_gates(Q, gate_proj_weight, chunk_size=gate_chunk)  # (B, N, H, 3)
-    O = gate_and_combine(O_cmp, O_slc, O_sld, gates, chunk_size=gate_chunk)
+    # Step 5: Fused gate and combine
+    O = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
 
     return O

--- a/mslk/attention/sparse_attn/nsa_scoring.py
+++ b/mslk/attention/sparse_attn/nsa_scoring.py
@@ -1,0 +1,145 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
+
+"""Block score column-reduction utilities for NSA scoring phase.
+
+During the fused scoring + compressed attention phase, the softmax warps
+read QK scores from TMEM and reduce each column (KV block dimension) to
+produce a single block importance score. These scores are accumulated
+across all Q rows within a tile to produce per-block scores.
+
+The column reduction reuses the TMEM read infrastructure from FA4's
+softmax warps, adding a parallel reduction along the M dimension.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+import cutlass.cute.nvgpu.tcgen05 as tcgen05
+
+import mslk.fb.mslk.attention.flash_attn.utils as utils
+
+
+@cute.jit
+def reduce_s_to_block_scores(
+    tSrS_t2r: cute.Tensor,  # Register fragment of S tile loaded from TMEM
+    thr_tmem_load: cute.CopyAtom,
+    thr_mma_qk: cute.core.ThrMma,
+    m_block_size: int,
+    n_block_size: int,
+    block_scores: cute.Tensor,  # (n_blocks_in_tile,) accumulator in registers
+    n_block_offset: Int32,  # Which compressed block this KV tile corresponds to
+    n_blocks_per_tile: int,  # How many compressed blocks fit in one n_block_size tile
+    is_first: bool,
+) -> None:
+    """Reduce S tile columns to block scores and accumulate.
+
+    After QK GEMM produces S in TMEM, the softmax warps load it into
+    registers. This function reduces each column of S (summing across
+    the M dimension, i.e., all Q positions in the tile) to produce a
+    single score per KV block.
+
+    For compressed attention where compress_block_size >= n_block_size,
+    each S tile column already corresponds to one compressed block, so
+    we just sum the column. When compress_block_size < n_block_size,
+    multiple compressed blocks share one S tile — we partition the
+    columns accordingly.
+
+    Args:
+        tSrS_t2r: S scores in registers after TMEM load, shape depends on
+            partition layout from thr_mma_qk.
+        thr_tmem_load: TMEM load copy atom (for layout info).
+        thr_mma_qk: QK MMA partition (for coordinate mapping).
+        m_block_size: M tile size (e.g., 128).
+        n_block_size: N tile size (e.g., 128).
+        block_scores: Accumulator for block scores, shape (n_cmp,).
+        n_block_offset: Starting compressed block index for this tile.
+        n_blocks_per_tile: Number of compressed blocks per N tile.
+        is_first: If True, initialize block_scores; otherwise accumulate.
+    """
+    # The S tile has been loaded into registers with layout from thr_mma_qk.
+    # We need to reduce across the M dimension (rows) for each N position (column).
+    #
+    # tSrS_t2r has shape organized by the MMA partition. We interpret it as
+    # (M_per_thread, N_per_thread) logically.
+    #
+    # For SM100 with 128-thread warp groups doing TMEM loads:
+    # Each thread in the softmax warp group gets one row of the 128x128 S tile.
+    # So each thread has n_block_size values (one full row).
+    # The column reduction = warp-level reduction across threads (rows),
+    # then store into block_scores.
+
+    acc_S_mn = utils.make_acc_tensor_mn_view(tSrS_t2r)
+    n_cols = cute.size(acc_S_mn, mode=[1])
+
+    # Each thread contributes its row's values to the column sum.
+    # We do a warp-level reduction for each column group.
+    # Since each compressed block spans (compress_block_size / n_block_size * n_block_size)
+    # columns within the tile, or if compress_block_size aligns with n_block_size,
+    # just one column per block.
+
+    # For the common case where n_blocks_per_tile == 1 (compress_block_size >= n_block_size),
+    # sum all columns of this thread's row, then warp-reduce.
+    if const_expr(n_blocks_per_tile == 1):
+        row_sum = Float32(0.0)
+        for c in cutlass.range(n_cols, unroll_full=True):
+            row_sum += acc_S_mn[0, c].load()
+
+        # Warp-level reduction: sum across all threads (rows in the tile)
+        col_sum = utils.warp_reduce(row_sum, cute.arch.fadd, width=4)
+
+        if is_first:
+            block_scores[n_block_offset] = col_sum
+        else:
+            block_scores[n_block_offset] += col_sum
+    else:
+        # Multiple compressed blocks per N tile
+        cols_per_block: int = const_expr(n_block_size // n_blocks_per_tile)
+        for blk in cutlass.range_constexpr(n_blocks_per_tile):
+            row_sum = Float32(0.0)
+            for c in cutlass.range_constexpr(cols_per_block):
+                col_idx: int = const_expr(blk * cols_per_block + c)
+                row_sum += acc_S_mn[0, col_idx].load()
+
+            col_sum = utils.warp_reduce(row_sum, cute.arch.fadd, width=4)
+
+            global_blk_idx = n_block_offset + blk
+            if is_first:
+                block_scores[global_blk_idx] = col_sum
+            else:
+                block_scores[global_blk_idx] += col_sum
+
+
+@cute.jit
+def apply_causal_mask_to_block_scores(
+    block_scores: cute.Tensor,  # (n_cmp,) block score accumulator
+    n_cmp: Int32,
+    m_block: Int32,  # Current Q tile index
+    q_tile_size: int,
+    compress_block_size: int,
+) -> None:
+    """Apply causal mask to block scores: future blocks get -inf.
+
+    A compressed block j is "future" for query tile i if:
+        j * compress_block_size >= (i + 1) * q_tile_size
+
+    Args:
+        block_scores: Block score accumulator, shape (n_cmp,).
+        n_cmp: Total number of compressed blocks.
+        m_block: Current Q tile index.
+        q_tile_size: Size of each Q tile.
+        compress_block_size: Size of each compressed block.
+    """
+    q_tile_end = (m_block + 1) * q_tile_size
+    tidx = cute.arch.thread_idx()[0] % 128  # thread in correction warp group
+
+    # Each thread checks its assigned blocks
+    n_per_thread = (n_cmp + 127) // 128
+    for i in cutlass.range(n_per_thread, unroll=1):
+        blk_idx = tidx * n_per_thread + i
+        if blk_idx < n_cmp:
+            blk_start = blk_idx * compress_block_size
+            if blk_start >= q_tile_end:
+                block_scores[blk_idx] = -Float32.inf

--- a/mslk/attention/sparse_attn/nsa_topk.py
+++ b/mslk/attention/sparse_attn/nsa_topk.py
@@ -1,0 +1,272 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
+
+"""In-register parallel top-K selection for NSA block scoring.
+
+Provides CuteDSL @cute.jit utilities for performing top-K selection entirely
+in registers across the correction warp group (128 threads, 4 warps).
+
+Algorithm:
+1. Each thread holds N_cmp/128 block scores in registers.
+2. Local insertion sort: each thread keeps its top-K values + indices.
+3. Warp-level merge: 5 rounds of butterfly shuffle to merge across 32 threads.
+4. Cross-warp merge: 4 warps → final K candidates via shared memory staging.
+
+For 1M tokens with L=64: N_cmp=16384, each thread holds 128 scores.
+With K_SEL=16, total ~240 comparisons per thread — negligible vs MMA time.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+
+
+@cute.jit
+def insertion_sort_topk(
+    scores: cute.Tensor,  # Thread-local scores, shape (local_n,)
+    num_local: Int32,
+    k: int,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Per-thread insertion sort to find top-K from local scores.
+
+    Each thread independently sorts its local scores (descending) and
+    retains the top-K values and their local indices.
+
+    Args:
+        scores: Thread-local block scores, shape (local_n,).
+        num_local: Number of valid scores this thread holds.
+        k: Number of top elements to retain.
+
+    Returns:
+        top_vals: Top-K values (descending), shape (k,).
+        top_idxs: Corresponding local indices, shape (k,).
+    """
+    top_vals = cute.make_fragment(k, Float32)
+    top_idxs = cute.make_fragment(k, Int32)
+
+    # Initialize with -inf
+    top_vals.fill(-Float32.inf)
+    top_idxs.fill(Int32(0))
+
+    # Insertion sort: for each score, insert into sorted top_vals if larger
+    for i in cutlass.range(num_local, unroll=1):
+        val = scores[i]
+        idx = Int32(i)
+        # Find insertion point (linear scan from the end)
+        for j in cutlass.range_constexpr(k - 1, -1, -1):
+            if val > top_vals[j]:
+                if const_expr(j < k - 1):
+                    top_vals[j + 1] = top_vals[j]
+                    top_idxs[j + 1] = top_idxs[j]
+                top_vals[j] = val
+                top_idxs[j] = idx
+                break
+
+    return top_vals, top_idxs
+
+
+@cute.jit
+def merge_sorted_pairs(
+    vals_a: cute.Tensor,  # (k,) descending
+    idxs_a: cute.Tensor,  # (k,)
+    vals_b: cute.Tensor,  # (k,) descending
+    idxs_b: cute.Tensor,  # (k,)
+    k: int,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Merge two sorted top-K lists into one top-K list.
+
+    Standard merge of two sorted (descending) sequences, keeping only
+    the top-K elements from the merged result.
+
+    Args:
+        vals_a, idxs_a: First sorted top-K list.
+        vals_b, idxs_b: Second sorted top-K list.
+        k: Number of elements to keep.
+
+    Returns:
+        merged_vals: Merged top-K values (descending), shape (k,).
+        merged_idxs: Corresponding indices, shape (k,).
+    """
+    merged_vals = cute.make_fragment(k, Float32)
+    merged_idxs = cute.make_fragment(k, Int32)
+
+    ia = Int32(0)
+    ib = Int32(0)
+    for out_idx in cutlass.range_constexpr(k):
+        take_a = (ia < k) & ((ib >= k) | (vals_a[ia] >= vals_b[ib]))
+        if take_a:
+            merged_vals[out_idx] = vals_a[ia]
+            merged_idxs[out_idx] = idxs_a[ia]
+            ia += 1
+        else:
+            merged_vals[out_idx] = vals_b[ib]
+            merged_idxs[out_idx] = idxs_b[ib]
+            ib += 1
+
+    return merged_vals, merged_idxs
+
+
+@cute.jit
+def warp_merge_topk(
+    vals: cute.Tensor,  # (k,) per-thread top-K values
+    idxs: cute.Tensor,  # (k,) per-thread top-K local indices
+    thread_id_in_warp: Int32,
+    k: int,
+    n_per_thread: Int32,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Warp-level butterfly merge of per-thread top-K lists.
+
+    After this, thread 0 in each warp holds the warp-level top-K.
+    Indices are converted from thread-local to warp-global during merging.
+
+    5 rounds of shuffle: distance 1, 2, 4, 8, 16.
+
+    Args:
+        vals: Per-thread top-K values, shape (k,).
+        idxs: Per-thread top-K local indices, shape (k,).
+        thread_id_in_warp: Lane ID (0-31).
+        k: Number of top elements.
+        n_per_thread: Number of scores each thread originally held.
+
+    Returns:
+        vals: Merged top-K values (valid on lane 0).
+        idxs: Merged top-K global indices (valid on lane 0).
+    """
+    # Convert local indices to global: global_idx = thread_id * n_per_thread + local_idx
+    for i in cutlass.range_constexpr(k):
+        idxs[i] = thread_id_in_warp * n_per_thread + idxs[i]
+
+    # Butterfly reduction: 5 rounds
+    for round_idx in cutlass.range_constexpr(5):
+        distance: int = const_expr(1 << round_idx)
+        # Exchange top-K with partner
+        partner_vals = cute.make_fragment(k, Float32)
+        partner_idxs = cute.make_fragment(k, Int32)
+        for i in cutlass.range_constexpr(k):
+            partner_vals[i] = cute.arch.shfl_xor(vals[i], distance)
+            partner_idxs[i] = cute.arch.shfl_xor(idxs[i], distance)
+        # Merge: the lower-ID thread in each pair does the merge
+        if (thread_id_in_warp & distance) == 0:
+            vals, idxs = merge_sorted_pairs(vals, idxs, partner_vals, partner_idxs, k)
+
+    return vals, idxs
+
+
+@cute.jit
+def cross_warp_merge_topk(
+    vals: cute.Tensor,  # (k,) — valid on lane 0 of each warp
+    idxs: cute.Tensor,  # (k,) — valid on lane 0 of each warp
+    thread_id_in_wg: Int32,  # 0..127 within correction warp group
+    warp_id_in_wg: Int32,  # 0..3
+    smem_vals: cute.Tensor,  # shared mem buffer for vals, shape (4, k)
+    smem_idxs: cute.Tensor,  # shared mem buffer for idxs, shape (4, k)
+    k: int,
+    n_per_warp: Int32,
+) -> tuple[cute.Tensor, cute.Tensor]:
+    """Cross-warp merge: reduce 4 warp-level top-K lists to one.
+
+    Lane 0 of each warp writes its top-K to shared memory. Then lane 0 of
+    warp 0 performs a sequential merge of all 4 lists.
+
+    After the merge, the result is broadcast back to all threads via smem.
+
+    Args:
+        vals: Warp-level top-K values (valid on lane 0).
+        idxs: Warp-level top-K global indices (valid on lane 0).
+        thread_id_in_wg: Thread index within correction warp group (0-127).
+        warp_id_in_wg: Warp index within correction warp group (0-3).
+        smem_vals: Shared memory for values exchange, shape (4, k).
+        smem_idxs: Shared memory for indices exchange, shape (4, k).
+        k: Number of top elements.
+        n_per_warp: Scores per warp (for global index offset).
+
+    Returns:
+        vals: Final top-K values (broadcast to all threads).
+        idxs: Final top-K global indices (broadcast to all threads).
+    """
+    lane_id = thread_id_in_wg % 32
+
+    # Lane 0 of each warp writes to shared memory
+    # Offset indices by warp_id * n_per_warp for cross-warp global indexing
+    if lane_id == 0:
+        for i in cutlass.range_constexpr(k):
+            smem_vals[warp_id_in_wg * k + i] = vals[i]
+            smem_idxs[warp_id_in_wg * k + i] = idxs[i] + warp_id_in_wg * n_per_warp
+
+    cute.arch.sync_threads()
+
+    # Lane 0 of warp 0 merges all 4 lists sequentially
+    if thread_id_in_wg == 0:
+        # Start with warp 0's list
+        for w in cutlass.range_constexpr(1, 4):
+            other_vals = cute.make_fragment(k, Float32)
+            other_idxs = cute.make_fragment(k, Int32)
+            for i in cutlass.range_constexpr(k):
+                other_vals[i] = smem_vals[w * k + i]
+                other_idxs[i] = smem_idxs[w * k + i]
+            vals, idxs = merge_sorted_pairs(vals, idxs, other_vals, other_idxs, k)
+
+        # Write merged result back to smem for broadcast
+        for i in cutlass.range_constexpr(k):
+            smem_vals[i] = vals[i]
+            smem_idxs[i] = idxs[i]
+
+    cute.arch.sync_threads()
+
+    # All threads read the final result
+    result_vals = cute.make_fragment(k, Float32)
+    result_idxs = cute.make_fragment(k, Int32)
+    for i in cutlass.range_constexpr(k):
+        result_vals[i] = smem_vals[i]
+        result_idxs[i] = smem_idxs[i]
+
+    return result_vals, result_idxs
+
+
+@cute.jit
+def parallel_topk(
+    scores: cute.Tensor,  # Thread-local scores, shape (local_n,)
+    num_local: Int32,
+    k: int,
+    thread_id_in_wg: Int32,  # 0..127 within correction warp group
+    smem_vals: cute.Tensor,  # shared mem buffer, shape (4 * k,)
+    smem_idxs: cute.Tensor,  # shared mem buffer, shape (4 * k,)
+    n_total: Int32,
+) -> cute.Tensor:
+    """Full parallel top-K pipeline: local sort → warp merge → cross-warp merge.
+
+    Each of 128 threads holds num_local = N_cmp/128 scores. Returns the global
+    top-K indices into the score array.
+
+    Args:
+        scores: Thread-local block scores, shape (local_n,).
+        num_local: Number of valid scores per thread.
+        k: Number of top blocks to select (K_SEL).
+        thread_id_in_wg: Thread index within the correction warp group (0-127).
+        smem_vals: Shared memory for cross-warp merge, shape (4 * k,).
+        smem_idxs: Shared memory for cross-warp merge, shape (4 * k,).
+        n_total: Total number of compressed blocks.
+
+    Returns:
+        top_indices: Top-K global block indices, shape (k,), sorted descending by score.
+    """
+    lane_id = thread_id_in_wg % 32
+    warp_id_in_wg = thread_id_in_wg // 32
+    n_per_thread = num_local
+    n_per_warp = n_per_thread * 32
+
+    # Step 1: Per-thread insertion sort
+    vals, idxs = insertion_sort_topk(scores, num_local, k)
+
+    # Step 2: Warp-level butterfly merge
+    vals, idxs = warp_merge_topk(vals, idxs, lane_id, k, n_per_thread)
+
+    # Step 3: Cross-warp merge (4 warps → 1)
+    vals, idxs = cross_warp_merge_topk(
+        vals, idxs, thread_id_in_wg, warp_id_in_wg,
+        smem_vals, smem_idxs, k, n_per_warp,
+    )
+
+    return idxs

--- a/mslk/attention/sparse_attn/reference.py
+++ b/mslk/attention/sparse_attn/reference.py
@@ -1,0 +1,269 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Pure PyTorch reference implementation of NSA (Native Sparse Attention).
+
+This serves as a correctness reference for the optimized FA4-based implementation.
+All operations are done in PyTorch without custom kernels.
+
+Reference: arxiv 2502.11089
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def nsa_forward_reference(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+) -> Tensor:
+    """Pure PyTorch NSA forward pass.
+
+    Combines three attention branches:
+    1. Compressed attention: Attend over mean-pooled KV blocks with learned projection.
+    2. Selected attention: Block-sparse attention over top-k important KV blocks.
+    3. Sliding window attention: Local attention within a fixed window.
+
+    All inputs/outputs use (B, N, H, D) layout.
+
+    Returns:
+        Output tensor of shape (B, N, H, D).
+    """
+    B, N, H, D = Q.shape
+    H_kv = K.shape[2]
+    assert H % H_kv == 0, "H must be divisible by H_kv for GQA"
+    groups = H // H_kv
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # Transpose to (B, H, N, D) for matmul convenience
+    q = Q.transpose(1, 2).float()  # (B, H, N, D)
+    k = K.transpose(1, 2).float()  # (B, H_kv, N, D)
+    v = V.transpose(1, 2).float()  # (B, H_kv, N, D)
+
+    # Expand K, V for GQA: (B, H_kv, N, D) -> (B, H, N, D)
+    if groups > 1:
+        k = k.repeat_interleave(groups, dim=1)
+        v = v.repeat_interleave(groups, dim=1)
+
+    # --- Branch 1: Compressed Attention ---
+    O_cmp = _compressed_attention(
+        q, k, v, compress_block_size, W_k_compress, W_v_compress,
+        groups, softmax_scale, causal, B, N, H, H_kv, D,
+    )
+
+    # --- Branch 2: Selected (Block-Sparse) Attention ---
+    O_slc = _selected_attention(
+        q, k, v, compress_block_size, num_selected_blocks,
+        W_k_compress, groups, softmax_scale, causal, B, N, H, H_kv, D,
+        q_tile_size=q_tile_size,
+    )
+
+    # --- Branch 3: Sliding Window Attention ---
+    O_sld = _sliding_window_attention(
+        q, k, v, window_size, softmax_scale, causal, B, N, H, D,
+    )
+
+    # --- Gate and Combine ---
+    # All outputs are (B, H, N, D), transpose to (B, N, H, D)
+    O_cmp = O_cmp.transpose(1, 2)
+    O_slc = O_slc.transpose(1, 2)
+    O_sld = O_sld.transpose(1, 2)
+
+    if gate_proj_weight is not None:
+        # gate_proj_weight: (H, 3, D)
+        # Q: (B, N, H, D) -> compute per-head gates
+        gates = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        gates = gates.sigmoid()  # (B, N, H, 3)
+    else:
+        gates = torch.ones(B, N, H, 3, device=Q.device, dtype=torch.float32) / 3.0
+
+    O = (
+        gates[..., 0:1] * O_cmp
+        + gates[..., 1:2] * O_slc
+        + gates[..., 2:3] * O_sld
+    )
+
+    return O.to(Q.dtype)
+
+
+def _compressed_attention(
+    q: Tensor, k: Tensor, v: Tensor,
+    block_size: int,
+    W_k_compress: Tensor | None, W_v_compress: Tensor | None,
+    groups: int, softmax_scale: float, causal: bool,
+    B: int, N: int, H: int, H_kv: int, D: int,
+) -> Tensor:
+    """Compressed attention: attend over mean-pooled KV blocks."""
+    # Use un-expanded K, V for compression
+    k_orig = k[:, ::groups]  # (B, H_kv, N, D)
+    v_orig = v[:, ::groups]
+
+    N_cmp = N // block_size
+    # Reshape into blocks and mean-pool
+    k_blocks = k_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_cmp, D)
+    v_blocks = v_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    v_cmp = v_blocks.mean(dim=3)
+
+    # Apply learned projection if provided
+    if W_k_compress is not None:
+        # W_k_compress: (H_kv, D, D)
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if W_v_compress is not None:
+        v_cmp = torch.einsum("bhnd,hde->bhne", v_cmp, W_v_compress.float())
+
+    # Expand for GQA
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+        v_cmp = v_cmp.repeat_interleave(groups, dim=1)
+
+    # Standard attention on compressed KV: (B, H, N, D) x (B, H, N_cmp, D)
+    scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale  # (B, H, N, N_cmp)
+
+    if causal:
+        # A query at position i can attend to compressed block j if the block
+        # starts at or before position i: j * block_size <= i.
+        q_pos = torch.arange(N, device=q.device).unsqueeze(1)  # (N, 1)
+        kv_block_start = (torch.arange(N_cmp, device=q.device)) * block_size  # (N_cmp,)
+        causal_mask = kv_block_start.unsqueeze(0) > q_pos  # (N, N_cmp)
+        scores = scores.masked_fill(causal_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    attn = torch.softmax(scores, dim=-1)
+    out = torch.matmul(attn, v_cmp)  # (B, H, N, D)
+    return out
+
+
+def _selected_attention(
+    q: Tensor, k: Tensor, v: Tensor,
+    block_size: int, num_selected: int,
+    W_k_compress: Tensor | None,
+    groups: int, softmax_scale: float, causal: bool,
+    B: int, N: int, H: int, H_kv: int, D: int,
+    q_tile_size: int = 256,
+) -> Tensor:
+    """Selected block-sparse attention: attend to top-k important KV blocks.
+
+    Aggregates block scores per q_tile_size (matching FA4's CTA tile) and
+    selects blocks per query tile rather than per query block.
+    """
+    N_blocks = N // block_size
+    N_q_tiles = N // q_tile_size
+
+    # Score blocks using compressed keys
+    k_orig = k[:, ::groups]  # (B, H_kv, N, D)
+    k_blocks = k_orig.reshape(B, H_kv, N_blocks, block_size, D)
+    k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_blocks, D)
+    if W_k_compress is not None:
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+
+    # Compute block importance scores: (B, H, N, N_blocks)
+    block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+
+    # Aggregate per query-tile (mean over queries in the same tile)
+    block_scores_agg = block_scores.reshape(
+        B, H, N_q_tiles, q_tile_size, N_blocks
+    ).mean(dim=3)
+    # (B, H, N_q_tiles, N_blocks)
+
+    if causal:
+        # Match score_and_select_blocks: block j is future if
+        # j * block_size >= (tile_i + 1) * q_tile_size
+        q_tile_end = (torch.arange(N_q_tiles, device=q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_blocks, device=q.device) * block_size
+        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+        block_scores_agg = block_scores_agg.masked_fill(
+            future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+
+    # Select top-k blocks per query tile
+    k_actual = min(num_selected, N_blocks)
+    _, top_indices = block_scores_agg.topk(k_actual, dim=-1)  # (B, H, N_q_tiles, k)
+
+    # Build block-sparse attention output
+    out = torch.zeros(B, H, N, D, device=q.device, dtype=q.dtype)
+
+    for b in range(B):
+        for h in range(H):
+            for qt in range(N_q_tiles):
+                q_start = qt * q_tile_size
+                q_end = (qt + 1) * q_tile_size
+
+                # Gather selected KV blocks
+                selected_k_list = []
+                selected_v_list = []
+                for idx in top_indices[b, h, qt]:
+                    kv_start = idx.item() * block_size
+                    kv_end = kv_start + block_size
+                    selected_k_list.append(k[b, h, kv_start:kv_end])
+                    selected_v_list.append(v[b, h, kv_start:kv_end])
+
+                if not selected_k_list:
+                    continue
+
+                sel_k = torch.cat(selected_k_list, dim=0)  # (k*block_size, D)
+                sel_v = torch.cat(selected_v_list, dim=0)
+
+                # Compute attention for this query tile
+                q_tile = q[b, h, q_start:q_end]  # (q_tile_size, D)
+                scores = torch.matmul(q_tile, sel_k.T) * softmax_scale
+
+                if causal:
+                    q_positions = torch.arange(q_start, q_end, device=q.device).unsqueeze(1)
+                    kv_positions = []
+                    for idx in top_indices[b, h, qt]:
+                        kv_s = idx.item() * block_size
+                        kv_positions.append(
+                            torch.arange(kv_s, kv_s + block_size, device=q.device)
+                        )
+                    kv_positions = torch.cat(kv_positions)
+                    c_mask = kv_positions.unsqueeze(0) > q_positions
+                    scores = scores.masked_fill(c_mask, float("-inf"))
+
+                attn = torch.softmax(scores, dim=-1)
+                out[b, h, q_start:q_end] = torch.matmul(attn, sel_v)
+
+    return out
+
+
+def _sliding_window_attention(
+    q: Tensor, k: Tensor, v: Tensor,
+    window_size: int, softmax_scale: float, causal: bool,
+    B: int, N: int, H: int, D: int,
+) -> Tensor:
+    """Sliding window attention: each query attends to a local window of KV."""
+    scores = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale  # (B, H, N, N)
+
+    # Build sliding window + causal mask
+    q_pos = torch.arange(N, device=q.device).unsqueeze(1)
+    kv_pos = torch.arange(N, device=q.device).unsqueeze(0)
+
+    # Window mask: kv must be within [q_pos - window_size + 1, q_pos] (causal window)
+    # or [q_pos - window_size//2, q_pos + window_size//2] (non-causal)
+    if causal:
+        mask = (kv_pos > q_pos) | (kv_pos < q_pos - window_size + 1)
+    else:
+        half_w = window_size // 2
+        mask = (kv_pos > q_pos + half_w) | (kv_pos < q_pos - half_w)
+
+    scores = scores.masked_fill(mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    attn = torch.softmax(scores, dim=-1)
+    out = torch.matmul(attn, v)
+    return out

--- a/mslk/attention/sparse_attn/reference.py
+++ b/mslk/attention/sparse_attn/reference.py
@@ -5,6 +5,10 @@
 This serves as a correctness reference for the optimized FA4-based implementation.
 All operations are done in PyTorch without custom kernels.
 
+The forward pass is fully differentiable (all tensor ops, no Python loops that
+break autograd), so PyTorch autograd provides the reference backward pass.
+Use nsa_backward_reference() to compute gradients for validation.
+
 Reference: arxiv 2502.11089
 """
 
@@ -30,6 +34,7 @@ def nsa_forward_reference(
     causal: bool = True,
     softmax_scale: float | None = None,
     q_tile_size: int = 256,
+    _block_indices: Tensor | None = None,
 ) -> Tensor:
     """Pure PyTorch NSA forward pass.
 
@@ -52,9 +57,11 @@ def nsa_forward_reference(
         softmax_scale = 1.0 / math.sqrt(D)
 
     # Transpose to (B, H, N, D) for matmul convenience
-    q = Q.transpose(1, 2).float()  # (B, H, N, D)
-    k = K.transpose(1, 2).float()  # (B, H_kv, N, D)
-    v = V.transpose(1, 2).float()  # (B, H_kv, N, D)
+    # Use at least float32 for numerical stability, but preserve float64 for gradcheck
+    compute_dtype = torch.float64 if Q.dtype == torch.float64 else torch.float32
+    q = Q.transpose(1, 2).to(compute_dtype)  # (B, H, N, D)
+    k = K.transpose(1, 2).to(compute_dtype)  # (B, H_kv, N, D)
+    v = V.transpose(1, 2).to(compute_dtype)  # (B, H_kv, N, D)
 
     # Expand K, V for GQA: (B, H_kv, N, D) -> (B, H, N, D)
     if groups > 1:
@@ -63,20 +70,54 @@ def nsa_forward_reference(
 
     # --- Branch 1: Compressed Attention ---
     O_cmp = _compressed_attention(
-        q, k, v, compress_block_size, W_k_compress, W_v_compress,
-        groups, softmax_scale, causal, B, N, H, H_kv, D,
+        q,
+        k,
+        v,
+        compress_block_size,
+        W_k_compress,
+        W_v_compress,
+        groups,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        H_kv,
+        D,
     )
 
     # --- Branch 2: Selected (Block-Sparse) Attention ---
     O_slc = _selected_attention(
-        q, k, v, compress_block_size, num_selected_blocks,
-        W_k_compress, groups, softmax_scale, causal, B, N, H, H_kv, D,
+        q,
+        k,
+        v,
+        compress_block_size,
+        num_selected_blocks,
+        W_k_compress,
+        groups,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        H_kv,
+        D,
         q_tile_size=q_tile_size,
+        _block_indices=_block_indices,
     )
 
     # --- Branch 3: Sliding Window Attention ---
     O_sld = _sliding_window_attention(
-        q, k, v, window_size, softmax_scale, causal, B, N, H, D,
+        q,
+        k,
+        v,
+        window_size,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        D,
     )
 
     # --- Gate and Combine ---
@@ -88,26 +129,33 @@ def nsa_forward_reference(
     if gate_proj_weight is not None:
         # gate_proj_weight: (H, 3, D)
         # Q: (B, N, H, D) -> compute per-head gates
-        gates = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+        gates = torch.einsum(
+            "bnhd,hgd->bnhg", Q.to(compute_dtype), gate_proj_weight.to(compute_dtype)
+        )
         gates = gates.sigmoid()  # (B, N, H, 3)
     else:
-        gates = torch.ones(B, N, H, 3, device=Q.device, dtype=torch.float32) / 3.0
+        gates = torch.ones(B, N, H, 3, device=Q.device, dtype=compute_dtype) / 3.0
 
-    O = (
-        gates[..., 0:1] * O_cmp
-        + gates[..., 1:2] * O_slc
-        + gates[..., 2:3] * O_sld
-    )
+    O = gates[..., 0:1] * O_cmp + gates[..., 1:2] * O_slc + gates[..., 2:3] * O_sld
 
     return O.to(Q.dtype)
 
 
 def _compressed_attention(
-    q: Tensor, k: Tensor, v: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
     block_size: int,
-    W_k_compress: Tensor | None, W_v_compress: Tensor | None,
-    groups: int, softmax_scale: float, causal: bool,
-    B: int, N: int, H: int, H_kv: int, D: int,
+    W_k_compress: Tensor | None,
+    W_v_compress: Tensor | None,
+    groups: int,
+    softmax_scale: float,
+    causal: bool,
+    B: int,
+    N: int,
+    H: int,
+    H_kv: int,
+    D: int,
 ) -> Tensor:
     """Compressed attention: attend over mean-pooled KV blocks."""
     # Use un-expanded K, V for compression
@@ -124,9 +172,9 @@ def _compressed_attention(
     # Apply learned projection if provided
     if W_k_compress is not None:
         # W_k_compress: (H_kv, D, D)
-        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.to(k_cmp.dtype))
     if W_v_compress is not None:
-        v_cmp = torch.einsum("bhnd,hde->bhne", v_cmp, W_v_compress.float())
+        v_cmp = torch.einsum("bhnd,hde->bhne", v_cmp, W_v_compress.to(v_cmp.dtype))
 
     # Expand for GQA
     if groups > 1:
@@ -134,7 +182,9 @@ def _compressed_attention(
         v_cmp = v_cmp.repeat_interleave(groups, dim=1)
 
     # Standard attention on compressed KV: (B, H, N, D) x (B, H, N_cmp, D)
-    scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale  # (B, H, N, N_cmp)
+    scores = (
+        torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+    )  # (B, H, N, N_cmp)
 
     if causal:
         # A query at position i can attend to compressed block j if the block
@@ -142,7 +192,9 @@ def _compressed_attention(
         q_pos = torch.arange(N, device=q.device).unsqueeze(1)  # (N, 1)
         kv_block_start = (torch.arange(N_cmp, device=q.device)) * block_size  # (N_cmp,)
         causal_mask = kv_block_start.unsqueeze(0) > q_pos  # (N, N_cmp)
-        scores = scores.masked_fill(causal_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+        scores = scores.masked_fill(
+            causal_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
 
     attn = torch.softmax(scores, dim=-1)
     out = torch.matmul(attn, v_cmp)  # (B, H, N, D)
@@ -150,103 +202,128 @@ def _compressed_attention(
 
 
 def _selected_attention(
-    q: Tensor, k: Tensor, v: Tensor,
-    block_size: int, num_selected: int,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    block_size: int,
+    num_selected: int,
     W_k_compress: Tensor | None,
-    groups: int, softmax_scale: float, causal: bool,
-    B: int, N: int, H: int, H_kv: int, D: int,
+    groups: int,
+    softmax_scale: float,
+    causal: bool,
+    B: int,
+    N: int,
+    H: int,
+    H_kv: int,
+    D: int,
     q_tile_size: int = 256,
+    _block_indices: Tensor | None = None,
 ) -> Tensor:
     """Selected block-sparse attention: attend to top-k important KV blocks.
 
     Aggregates block scores per q_tile_size (matching FA4's CTA tile) and
     selects blocks per query tile rather than per query block.
+
+    All operations use tensor ops (no Python loops) so autograd can
+    differentiate through this function w.r.t. q, k, v.  The top-k block
+    indices are non-differentiable (stop-gradient) by design.
+
+    Args:
+        _block_indices: If provided, use these pre-computed block indices
+            instead of computing them from scores. Shape (B, H, N_q_tiles, k).
+            Useful for freezing selection during gradcheck.
     """
     N_blocks = N // block_size
     N_q_tiles = N // q_tile_size
+    k_actual = min(num_selected, N_blocks)
 
-    # Score blocks using compressed keys
-    k_orig = k[:, ::groups]  # (B, H_kv, N, D)
-    k_blocks = k_orig.reshape(B, H_kv, N_blocks, block_size, D)
-    k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_blocks, D)
-    if W_k_compress is not None:
-        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
-    if groups > 1:
-        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+    if _block_indices is not None:
+        top_indices = _block_indices
+    else:
+        # Score blocks using compressed keys
+        k_orig = k[:, ::groups]  # (B, H_kv, N, D)
+        k_blocks = k_orig.reshape(B, H_kv, N_blocks, block_size, D)
+        k_cmp = k_blocks.mean(dim=3)  # (B, H_kv, N_blocks, D)
+        if W_k_compress is not None:
+            k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.to(k_cmp.dtype))
+        if groups > 1:
+            k_cmp = k_cmp.repeat_interleave(groups, dim=1)
 
-    # Compute block importance scores: (B, H, N, N_blocks)
-    block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+        # Compute block importance scores: (B, H, N, N_blocks)
+        block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
 
-    # Aggregate per query-tile (mean over queries in the same tile)
-    block_scores_agg = block_scores.reshape(
-        B, H, N_q_tiles, q_tile_size, N_blocks
-    ).mean(dim=3)
-    # (B, H, N_q_tiles, N_blocks)
+        # Aggregate per query-tile (mean over queries in the same tile)
+        block_scores_agg = block_scores.reshape(
+            B, H, N_q_tiles, q_tile_size, N_blocks
+        ).mean(dim=3)
+        # (B, H, N_q_tiles, N_blocks)
+
+        if causal:
+            # Match score_and_select_blocks: block j is future if
+            # j * block_size >= (tile_i + 1) * q_tile_size
+            q_tile_end = (torch.arange(N_q_tiles, device=q.device) + 1) * q_tile_size
+            kv_block_start = torch.arange(N_blocks, device=q.device) * block_size
+            future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+            block_scores_agg = block_scores_agg.masked_fill(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        # Select top-k blocks per query tile (non-differentiable, stop-gradient)
+        _, top_indices = block_scores_agg.topk(k_actual, dim=-1)  # (B, H, N_q_tiles, k)
+
+    # Expand block indices to position-level indices for gather
+    # Each block index i maps to positions [i*block_size, ..., (i+1)*block_size - 1]
+    offsets = torch.arange(block_size, device=q.device)  # (block_size,)
+    # (B, H, N_q_tiles, k, block_size)
+    pos_indices = top_indices.unsqueeze(-1) * block_size + offsets
+    kv_len = k_actual * block_size
+    pos_indices = pos_indices.reshape(B, H, N_q_tiles, kv_len)
+
+    # Gather K and V at selected positions using differentiable gather
+    # k, v: (B, H, N, D) -> gather along N dimension per query tile
+    gather_idx = pos_indices.unsqueeze(-1).expand(
+        B, H, N_q_tiles, kv_len, D
+    )  # (B, H, N_q_tiles, kv_len, D)
+    k_exp = k.unsqueeze(2).expand(B, H, N_q_tiles, N, D)
+    v_exp = v.unsqueeze(2).expand(B, H, N_q_tiles, N, D)
+    sel_k = torch.gather(k_exp, 3, gather_idx)  # (B, H, N_q_tiles, kv_len, D)
+    sel_v = torch.gather(v_exp, 3, gather_idx)
+
+    # Reshape q into tiles and compute attention
+    q_tiles = q.reshape(B, H, N_q_tiles, q_tile_size, D)
+    scores = (
+        torch.matmul(q_tiles, sel_k.transpose(-2, -1)) * softmax_scale
+    )  # (B, H, N_q_tiles, q_tile_size, kv_len)
 
     if causal:
-        # Match score_and_select_blocks: block j is future if
-        # j * block_size >= (tile_i + 1) * q_tile_size
-        q_tile_end = (torch.arange(N_q_tiles, device=q.device) + 1) * q_tile_size
-        kv_block_start = torch.arange(N_blocks, device=q.device) * block_size
-        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
-        block_scores_agg = block_scores_agg.masked_fill(
-            future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        # q positions per tile: (N_q_tiles, q_tile_size)
+        q_tile_starts = torch.arange(N_q_tiles, device=q.device) * q_tile_size
+        q_offsets = torch.arange(q_tile_size, device=q.device)
+        q_positions = q_tile_starts.unsqueeze(1) + q_offsets.unsqueeze(0)
+        # causal mask: kv_pos > q_pos
+        # pos_indices: (B, H, N_q_tiles, kv_len) -> (B, H, N_q_tiles, 1, kv_len)
+        # q_positions: (N_q_tiles, q_tile_size) -> (1, 1, N_q_tiles, q_tile_size, 1)
+        c_mask = pos_indices.unsqueeze(3) > q_positions.reshape(
+            1, 1, N_q_tiles, q_tile_size, 1
         )
+        scores = scores.masked_fill(c_mask, float("-inf"))
 
-    # Select top-k blocks per query tile
-    k_actual = min(num_selected, N_blocks)
-    _, top_indices = block_scores_agg.topk(k_actual, dim=-1)  # (B, H, N_q_tiles, k)
-
-    # Build block-sparse attention output
-    out = torch.zeros(B, H, N, D, device=q.device, dtype=q.dtype)
-
-    for b in range(B):
-        for h in range(H):
-            for qt in range(N_q_tiles):
-                q_start = qt * q_tile_size
-                q_end = (qt + 1) * q_tile_size
-
-                # Gather selected KV blocks
-                selected_k_list = []
-                selected_v_list = []
-                for idx in top_indices[b, h, qt]:
-                    kv_start = idx.item() * block_size
-                    kv_end = kv_start + block_size
-                    selected_k_list.append(k[b, h, kv_start:kv_end])
-                    selected_v_list.append(v[b, h, kv_start:kv_end])
-
-                if not selected_k_list:
-                    continue
-
-                sel_k = torch.cat(selected_k_list, dim=0)  # (k*block_size, D)
-                sel_v = torch.cat(selected_v_list, dim=0)
-
-                # Compute attention for this query tile
-                q_tile = q[b, h, q_start:q_end]  # (q_tile_size, D)
-                scores = torch.matmul(q_tile, sel_k.T) * softmax_scale
-
-                if causal:
-                    q_positions = torch.arange(q_start, q_end, device=q.device).unsqueeze(1)
-                    kv_positions = []
-                    for idx in top_indices[b, h, qt]:
-                        kv_s = idx.item() * block_size
-                        kv_positions.append(
-                            torch.arange(kv_s, kv_s + block_size, device=q.device)
-                        )
-                    kv_positions = torch.cat(kv_positions)
-                    c_mask = kv_positions.unsqueeze(0) > q_positions
-                    scores = scores.masked_fill(c_mask, float("-inf"))
-
-                attn = torch.softmax(scores, dim=-1)
-                out[b, h, q_start:q_end] = torch.matmul(attn, sel_v)
-
-    return out
+    attn = torch.softmax(scores, dim=-1)
+    out_tiles = torch.matmul(attn, sel_v)  # (B, H, N_q_tiles, q_tile_size, D)
+    return out_tiles.reshape(B, H, N, D)
 
 
 def _sliding_window_attention(
-    q: Tensor, k: Tensor, v: Tensor,
-    window_size: int, softmax_scale: float, causal: bool,
-    B: int, N: int, H: int, D: int,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    window_size: int,
+    softmax_scale: float,
+    causal: bool,
+    B: int,
+    N: int,
+    H: int,
+    D: int,
 ) -> Tensor:
     """Sliding window attention: each query attends to a local window of KV."""
     scores = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale  # (B, H, N, N)
@@ -267,3 +344,162 @@ def _sliding_window_attention(
     attn = torch.softmax(scores, dim=-1)
     out = torch.matmul(attn, v)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Reference backward (via autograd on the differentiable forward)
+# ---------------------------------------------------------------------------
+
+
+def compute_block_indices_reference(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    W_k_compress: Tensor | None = None,
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+) -> Tensor:
+    """Pre-compute block selection indices (non-differentiable).
+
+    Returns block indices that can be passed to nsa_forward_reference via
+    _block_indices to freeze the selection during gradient computation.
+
+    Returns:
+        top_indices: (B, H, N_q_tiles, k) int64 tensor of selected block indices.
+    """
+    B, N, H, D = Q.shape
+    H_kv = K.shape[2]
+    groups = H // H_kv
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    q = Q.transpose(1, 2).float()  # (B, H, N, D)
+    k = K.transpose(1, 2).float()  # (B, H_kv, N, D)
+
+    N_blocks = N // compress_block_size
+    N_q_tiles = N // q_tile_size
+
+    # K already has H_kv heads — no need to slice with ::groups
+    k_blocks = k.reshape(B, H_kv, N_blocks, compress_block_size, D)
+    k_cmp = k_blocks.mean(dim=3)
+    if W_k_compress is not None:
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+
+    block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+    block_scores_agg = block_scores.reshape(
+        B, H, N_q_tiles, q_tile_size, N_blocks
+    ).mean(dim=3)
+
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_blocks, device=Q.device) * compress_block_size
+        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+        block_scores_agg = block_scores_agg.masked_fill(
+            future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+
+    k_actual = min(num_selected_blocks, N_blocks)
+    _, top_indices = block_scores_agg.topk(k_actual, dim=-1)
+    return top_indices
+
+
+def nsa_backward_reference(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    dO: Tensor,  # (B, N, H, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    _block_indices: Tensor | None = None,
+) -> dict[str, Tensor | None]:
+    """Compute NSA gradients using autograd on the differentiable reference forward.
+
+    Runs nsa_forward_reference with requires_grad=True inputs, then calls
+    torch.autograd.grad to compute dQ, dK, dV, and optionally dW_k_compress,
+    dW_v_compress, dgate_proj_weight.
+
+    Args:
+        Q, K, V: Input tensors (same as nsa_forward_reference).
+        dO: Upstream gradient, shape (B, N, H, D).
+        Other args: Same as nsa_forward_reference.
+
+    Returns:
+        Dictionary with keys: "dQ", "dK", "dV", "dW_k_compress",
+        "dW_v_compress", "dgate_proj_weight".  Values are None for
+        parameters that were not provided.
+    """
+    # Clone inputs and enable gradients
+    Q_g = Q.detach().float().requires_grad_(True)
+    K_g = K.detach().float().requires_grad_(True)
+    V_g = V.detach().float().requires_grad_(True)
+
+    params = []
+    W_k_g = None
+    if W_k_compress is not None:
+        W_k_g = W_k_compress.detach().float().requires_grad_(True)
+        params.append(W_k_g)
+    W_v_g = None
+    if W_v_compress is not None:
+        W_v_g = W_v_compress.detach().float().requires_grad_(True)
+        params.append(W_v_g)
+    gate_g = None
+    if gate_proj_weight is not None:
+        gate_g = gate_proj_weight.detach().float().requires_grad_(True)
+        params.append(gate_g)
+
+    O = nsa_forward_reference(
+        Q_g,
+        K_g,
+        V_g,
+        compress_block_size=compress_block_size,
+        num_selected_blocks=num_selected_blocks,
+        window_size=window_size,
+        W_k_compress=W_k_g,
+        W_v_compress=W_v_g,
+        gate_proj_weight=gate_g,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        q_tile_size=q_tile_size,
+        _block_indices=_block_indices,
+    )
+
+    grad_inputs = [Q_g, K_g, V_g] + params
+    grads = torch.autograd.grad(
+        O,
+        grad_inputs,
+        grad_outputs=dO.float(),
+        allow_unused=True,
+    )
+
+    result: dict[str, Tensor | None] = {
+        "dQ": grads[0].to(Q.dtype),
+        "dK": grads[1].to(K.dtype),
+        "dV": grads[2].to(V.dtype),
+        "dW_k_compress": None,
+        "dW_v_compress": None,
+        "dgate_proj_weight": None,
+    }
+
+    idx = 3
+    if W_k_compress is not None:
+        result["dW_k_compress"] = grads[idx].to(W_k_compress.dtype)
+        idx += 1
+    if W_v_compress is not None:
+        result["dW_v_compress"] = grads[idx].to(W_v_compress.dtype)
+        idx += 1
+    if gate_proj_weight is not None:
+        result["dgate_proj_weight"] = grads[idx].to(gate_proj_weight.dtype)
+
+    return result

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import math
+from typing import Type
 
 import torch
 from torch import Tensor
@@ -86,21 +87,19 @@ def score_and_select_blocks(
         q_end = chunk_end * q_tile_size
 
         # (B, H, n_tiles * q_tile_size, N_cmp) — bounded, not O(N²)
-        scores_chunk = torch.matmul(
-            Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t
-        ) * softmax_scale
+        scores_chunk = (
+            torch.matmul(Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t)
+            * softmax_scale
+        )
 
         # Average per tile: (B, H, n_tiles, N_cmp)
-        scores_agg = scores_chunk.reshape(
-            B, H, n_tiles, q_tile_size, N_cmp
-        ).mean(dim=3)
+        scores_agg = scores_chunk.reshape(B, H, n_tiles, q_tile_size, N_cmp).mean(dim=3)
 
         # Apply causal mask: block j is future if j * block_size >= (i+1) * q_tile_size
         if causal:
-            future_mask = (
-                kv_block_start.unsqueeze(0)
-                >= q_tile_end[chunk_start:chunk_end].unsqueeze(1)
-            )  # (n_tiles, N_cmp)
+            future_mask = kv_block_start.unsqueeze(0) >= q_tile_end[
+                chunk_start:chunk_end
+            ].unsqueeze(1)  # (n_tiles, N_cmp)
             scores_agg.masked_fill_(
                 future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
             )
@@ -114,8 +113,431 @@ def score_and_select_blocks(
             chunk_idx = chunk_idx.masked_fill(invalid, 0)
 
         # Sort indices for better memory access patterns
-        block_indices[:, :, chunk_start:chunk_end] = (
-            chunk_idx.sort(dim=-1).values.to(torch.int32)
+        block_indices[:, :, chunk_start:chunk_end] = chunk_idx.sort(dim=-1).values.to(
+            torch.int32
         )
 
+    return block_indices
+
+
+# ---------------------------------------------------------------------------
+# CuteDSL fused scoring + top-k selection kernel
+# ---------------------------------------------------------------------------
+
+_fused_select_compile_cache: dict = {}
+
+# Bucket sizes for max_n_per_thread to limit compilations
+_N_PER_THREAD_BUCKETS = [4, 8, 16, 32, 64, 128]
+
+
+def _bucket_n_per_thread(n: int) -> int:
+    """Round up n to the next bucket size."""
+    for b in _N_PER_THREAD_BUCKETS:
+        if n <= b:
+            return b
+    return _N_PER_THREAD_BUCKETS[-1]
+
+
+def _make_fused_select_kernel(
+    cute_dtype: Type, D: int, k: int, max_n_per_thread: int, causal: bool
+):
+    """Create a compiled CuteDSL kernel for fused scoring + top-k selection.
+
+    Each thread block handles one (batch, head, query_tile) triple.
+    128 threads (4 warps) per block:
+      Phase 1: Each thread scores ceil(N_cmp/128) KV blocks via dot product.
+      Phase 2: parallel_topk finds the global top-k across all threads.
+      Phase 3: Thread 0 replaces -inf entries with 0, sorts ascending, writes.
+
+    The topk logic is inlined directly in the kernel to avoid CuteDSL
+    preprocessor issues with 'break' inside range_constexpr in helper
+    functions.
+    """
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass import const_expr, Float32, Int32
+
+    THREADS_PER_BLOCK = 128
+
+    class _Kernel:
+        @cute.jit
+        def __call__(
+            self,
+            mQ_mean,
+            mK_cmp,
+            mOut,
+            N_cmp,
+            N_q_tiles,
+            H,
+            H_kv,
+            compress_block_size,
+            q_tile_size,
+            stream,
+        ):
+            B_val = mQ_mean.shape[0] // (N_q_tiles * H)
+            grid_x = B_val * H * N_q_tiles
+            self.kernel(
+                mQ_mean,
+                mK_cmp,
+                mOut,
+                N_cmp,
+                N_q_tiles,
+                H,
+                H_kv,
+                compress_block_size,
+                q_tile_size,
+                B_val,
+            ).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                smem=const_expr(4 * k * 4 + 16 + 4 * k * 4 + 16),
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(
+            self,
+            mQ_mean,
+            mK_cmp,
+            mOut,
+            N_cmp,
+            N_q_tiles,
+            H,
+            H_kv,
+            compress_block_size,
+            q_tile_size,
+            B_val,
+        ):
+            tidx = cute.arch.thread_idx()[0]
+            bidx = cute.arch.block_idx()[0]
+
+            # Decompose block index into (b, h, tile)
+            b = bidx // (H * N_q_tiles)
+            h = (bidx % (H * N_q_tiles)) // N_q_tiles
+            tile = bidx % N_q_tiles
+
+            # GQA: map query head to KV head
+            h_kv = h // (H // H_kv)
+
+            # Q_mean row index: b * N_q_tiles * H + tile * H + h
+            q_row = b * N_q_tiles * H + tile * H + h
+
+            # --- Phase 1: Score blocks ---
+            n_per_thread = (N_cmp + Int32(THREADS_PER_BLOCK - 1)) // Int32(
+                THREADS_PER_BLOCK
+            )
+            scores = cute.make_fragment(max_n_per_thread, Float32)
+            scores.fill(-Float32.inf)
+
+            # Causal: block j is future if
+            # j * compress_block_size >= (tile+1) * q_tile_size
+            if const_expr(causal):
+                causal_limit = (tile + 1) * q_tile_size
+
+            for i in cutlass.range(n_per_thread, unroll=1):
+                j = tidx * n_per_thread + i
+                if j < N_cmp:
+                    # Causal check
+                    skip = Int32(0)
+                    if const_expr(causal):
+                        if j * compress_block_size >= causal_limit:
+                            skip = Int32(1)
+
+                    if skip == 0:
+                        # Dot product: sum_d Q_mean[q_row, d] * K_cmp[k_row, d]
+                        k_row = b * N_cmp * H_kv + j * H_kv + h_kv
+                        acc = Float32(0.0)
+                        for d in cutlass.range_constexpr(D):
+                            acc += Float32(mQ_mean[q_row, d]) * Float32(
+                                mK_cmp[k_row, d]
+                            )
+                        scores[i] = acc
+
+            # --- Phase 2: TopK ---
+            @cute.struct
+            class TopkSmem:
+                vals: cute.struct.MemRange[Float32, const_expr(4 * k)]
+                idxs: cute.struct.MemRange[Int32, const_expr(4 * k)]
+
+            smem = cutlass.utils.SmemAllocator()
+            storage = smem.allocate(TopkSmem, 16)
+            smem_vals = storage.vals.get_tensor(cute.make_layout(const_expr(4 * k)))
+            smem_idxs = storage.idxs.get_tensor(cute.make_layout(const_expr(4 * k)))
+
+            # Step 2a: Per-thread insertion sort
+            # Maintains top_vals in descending order (largest at index 0).
+            # For each score, scan from bottom (k-1) to top (0). At each
+            # position where val > top_vals[jj], shift top_vals[jj] down
+            # and write val. Without break, val cascades up to its correct
+            # position — earlier writes are overwritten by later shifts.
+            top_vals = cute.make_fragment(k, Float32)
+            top_idxs = cute.make_fragment(k, Int32)
+            top_vals.fill(-Float32.inf)
+            top_idxs.fill(Int32(0))
+
+            for ii in cutlass.range(n_per_thread, unroll=1):
+                val = scores[ii]
+                idx = Int32(ii)
+                for jj in cutlass.range_constexpr(k - 1, -1, -1):
+                    if val > top_vals[jj]:
+                        if const_expr(jj < k - 1):
+                            top_vals[jj + 1] = top_vals[jj]
+                            top_idxs[jj + 1] = top_idxs[jj]
+                        top_vals[jj] = val
+                        top_idxs[jj] = idx
+
+            # Step 2b: Convert local indices to global
+            lane_id = tidx % 32
+            warp_id = tidx // 32
+            for ii in cutlass.range_constexpr(k):
+                top_idxs[ii] = lane_id * n_per_thread + top_idxs[ii]
+
+            # Step 2c: Warp butterfly merge (5 rounds)
+            for round_idx in cutlass.range_constexpr(5):
+                distance: int = const_expr(1 << round_idx)
+                p_vals = cute.make_fragment(k, Float32)
+                p_idxs = cute.make_fragment(k, Int32)
+                for ii in cutlass.range_constexpr(k):
+                    p_vals[ii] = cute.arch.shuffle_sync_bfly(
+                        top_vals[ii], offset=distance
+                    )
+                    p_idxs[ii] = cute.arch.shuffle_sync_bfly(
+                        top_idxs[ii], offset=distance
+                    )
+                if (lane_id & distance) == 0:
+                    # Merge top_vals/idxs with p_vals/p_idxs
+                    m_vals = cute.make_fragment(k, Float32)
+                    m_idxs = cute.make_fragment(k, Int32)
+                    ia = Int32(0)
+                    ib = Int32(0)
+                    for oi in cutlass.range_constexpr(k):
+                        take_a = (ia < k) & ((ib >= k) | (top_vals[ia] >= p_vals[ib]))
+                        if take_a:
+                            m_vals[oi] = top_vals[ia]
+                            m_idxs[oi] = top_idxs[ia]
+                            ia += 1
+                        else:
+                            m_vals[oi] = p_vals[ib]
+                            m_idxs[oi] = p_idxs[ib]
+                            ib += 1
+                    for ii in cutlass.range_constexpr(k):
+                        top_vals[ii] = m_vals[ii]
+                        top_idxs[ii] = m_idxs[ii]
+
+            # Step 2d: Cross-warp merge via shared memory
+            n_per_warp = n_per_thread * 32
+
+            if lane_id == 0:
+                for ii in cutlass.range_constexpr(k):
+                    smem_vals[warp_id * k + ii] = top_vals[ii]
+                    smem_idxs[warp_id * k + ii] = top_idxs[ii] + warp_id * n_per_warp
+
+            cute.arch.sync_threads()
+
+            if tidx == 0:
+                # Start with warp 0's data (already in top_vals/top_idxs)
+                for w in cutlass.range_constexpr(1, 4):
+                    o_vals = cute.make_fragment(k, Float32)
+                    o_idxs = cute.make_fragment(k, Int32)
+                    for ii in cutlass.range_constexpr(k):
+                        o_vals[ii] = smem_vals[w * k + ii]
+                        o_idxs[ii] = smem_idxs[w * k + ii]
+                    # Merge
+                    m_vals = cute.make_fragment(k, Float32)
+                    m_idxs = cute.make_fragment(k, Int32)
+                    ia = Int32(0)
+                    ib = Int32(0)
+                    for oi in cutlass.range_constexpr(k):
+                        take_a = (ia < k) & ((ib >= k) | (top_vals[ia] >= o_vals[ib]))
+                        if take_a:
+                            m_vals[oi] = top_vals[ia]
+                            m_idxs[oi] = top_idxs[ia]
+                            ia += 1
+                        else:
+                            m_vals[oi] = o_vals[ib]
+                            m_idxs[oi] = o_idxs[ib]
+                            ib += 1
+                    for ii in cutlass.range_constexpr(k):
+                        top_vals[ii] = m_vals[ii]
+                        top_idxs[ii] = m_idxs[ii]
+
+                # Write merged result to smem for broadcast
+                for ii in cutlass.range_constexpr(k):
+                    smem_vals[ii] = top_vals[ii]
+                    smem_idxs[ii] = top_idxs[ii]
+
+            cute.arch.sync_threads()
+
+            # All threads read final result
+            result_idxs = cute.make_fragment(k, Int32)
+            for ii in cutlass.range_constexpr(k):
+                result_idxs[ii] = smem_idxs[ii]
+
+            # --- Phase 3: Sort + write (thread 0) ---
+            if tidx == 0:
+                # Replace -inf-scored entries with index 0
+                for ii in cutlass.range_constexpr(k):
+                    if smem_vals[ii] == -Float32.inf:
+                        result_idxs[ii] = Int32(0)
+
+                # Insertion sort indices ascending
+                for ii in cutlass.range_constexpr(1, k):
+                    key = result_idxs[ii]
+                    insert_pos = Int32(ii)
+                    for j_scan in cutlass.range_constexpr(ii):
+                        pos: int = const_expr(ii - 1 - j_scan)
+                        if insert_pos == const_expr(pos + 1):
+                            if result_idxs[pos] > key:
+                                result_idxs[pos + 1] = result_idxs[pos]
+                                insert_pos = Int32(pos)
+                    result_idxs[insert_pos] = key
+
+                # Write output
+                out_row = b * H * N_q_tiles + h * N_q_tiles + tile
+                for ii in cutlass.range_constexpr(k):
+                    mOut[out_row, ii] = result_idxs[ii]
+
+    return _Kernel()
+
+
+def fused_score_and_select_blocks(
+    Q: Tensor,  # (B, N, H, D)
+    K_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    num_selected_blocks: int,
+    compress_block_size: int,
+    causal: bool = True,
+    q_tile_size: int = 256,
+    softmax_scale: float | None = None,
+) -> Tensor:
+    """Fused block scoring and top-k selection using a CuteDSL kernel.
+
+    Replaces score_and_select_blocks with a single kernel launch. Uses the
+    Q_mean optimization: mean(Q @ K) = mean(Q) @ K, reducing scoring from a
+    full GEMM to a GEMV per query tile (256x fewer FLOPs).
+
+    The Q_mean computation is done in PyTorch (single kernel), then the
+    CuteDSL kernel fuses dot products, causal masking, top-k selection, and
+    sorting into one launch.
+
+    Falls back to PyTorch reference for N_cmp > 128 * 128 = 16384 blocks.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K_cmp: Compressed key tensor, shape (B, N_cmp, H_kv, D).
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        compress_block_size: Size of each KV block.
+        causal: Whether to apply causal masking.
+        q_tile_size: Size of each query tile.
+        softmax_scale: Scaling factor for attention scores.
+
+    Returns:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    B, N, H, D = Q.shape
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+
+    N_q_tiles = N // q_tile_size
+    assert N % q_tile_size == 0, (
+        f"Sequence length {N} must be divisible by q_tile_size {q_tile_size}"
+    )
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    k_actual = min(num_selected_blocks, N_cmp)
+
+    THREADS = 128
+    raw_n_per_thread = (N_cmp + THREADS - 1) // THREADS
+    max_n_per_thread = _bucket_n_per_thread(raw_n_per_thread)
+
+    # Fall back to PyTorch reference for very large N_cmp
+    if max_n_per_thread > _N_PER_THREAD_BUCKETS[-1]:
+        return score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected_blocks,
+            compress_block_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+            softmax_scale=softmax_scale,
+        )
+
+    # --- Q_mean in PyTorch ---
+    # Q: (B, N, H, D) -> (B, N_q_tiles, q_tile_size, H, D) -> mean over q_tile_size
+    Q_mean = (
+        Q.reshape(B, N_q_tiles, q_tile_size, H, D)
+        .mean(dim=2)  # (B, N_q_tiles, H, D)
+        .float()
+        * softmax_scale
+    )
+
+    # Reshape Q_mean to 2D: row (b, tile, h) -> b * N_q_tiles * H + tile * H + h
+    Q_mean_2d = Q_mean.reshape(B * N_q_tiles * H, D).contiguous()
+
+    # Reshape K_cmp to 2D: row (b, j, h_kv) -> b * N_cmp * H_kv + j * H_kv + h_kv
+    K_cmp_2d = K_cmp.reshape(B * N_cmp * H_kv, D).contiguous().float()
+
+    # Output: (B * H * N_q_tiles, k_actual) int32
+    out_2d = torch.empty(
+        B * H * N_q_tiles, k_actual, dtype=torch.int32, device=Q.device
+    )
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[Q_mean_2d.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mQ_mean = to_cute(Q_mean_2d)
+    mK_cmp = to_cute(K_cmp_2d)
+    mOut = to_cute(out_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, k_actual, max_n_per_thread, causal)
+    if compile_key not in _fused_select_compile_cache:
+        kernel_op = _make_fused_select_kernel(
+            cute_dtype, D, k_actual, max_n_per_thread, causal
+        )
+        _fused_select_compile_cache[compile_key] = cute.compile(
+            kernel_op,
+            mQ_mean,
+            mK_cmp,
+            mOut,
+            N_cmp,
+            N_q_tiles,
+            H,
+            H_kv,
+            compress_block_size,
+            q_tile_size,
+            current_stream,
+        )
+
+    _fused_select_compile_cache[compile_key](
+        mQ_mean,
+        mK_cmp,
+        mOut,
+        N_cmp,
+        N_q_tiles,
+        H,
+        H_kv,
+        compress_block_size,
+        q_tile_size,
+        current_stream,
+    )
+
+    # Reshape output: (B * H * N_q_tiles, k) -> (B, H, N_q_tiles, k)
+    block_indices = out_2d.reshape(B, H, N_q_tiles, k_actual)
     return block_indices

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -127,7 +127,7 @@ def score_and_select_blocks(
 _fused_select_compile_cache: dict = {}
 
 # Bucket sizes for max_n_per_thread to limit compilations
-_N_PER_THREAD_BUCKETS = [4, 8, 16, 32, 64, 128]
+_N_PER_THREAD_BUCKETS = [4, 8, 16, 32, 64, 128, 256, 512]
 
 
 def _bucket_n_per_thread(n: int) -> int:
@@ -135,7 +135,7 @@ def _bucket_n_per_thread(n: int) -> int:
     for b in _N_PER_THREAD_BUCKETS:
         if n <= b:
             return b
-    return _N_PER_THREAD_BUCKETS[-1]
+    return n
 
 
 def _make_fused_select_kernel(

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -1,0 +1,121 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Block scoring and top-k selection for NSA."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def score_and_select_blocks(
+    Q: Tensor,  # (B, N, H, D)
+    K_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    num_selected_blocks: int,
+    compress_block_size: int,
+    causal: bool = True,
+    q_tile_size: int = 256,
+    softmax_scale: float | None = None,
+) -> Tensor:
+    """Score KV blocks by importance and select top-k for each query tile.
+
+    Uses compressed keys to efficiently compute block importance scores.
+    Each query tile (q_tile_size positions) independently selects its own
+    top-k KV blocks.
+
+    Processes query tiles in chunks to avoid materializing a full (B, H, N, N_cmp)
+    score tensor, reducing peak memory from O(N * N_cmp) to
+    O(chunk_tiles * q_tile_size * N_cmp).
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K_cmp: Compressed key tensor, shape (B, N_cmp, H_kv, D).
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        compress_block_size: Size of each KV block.
+        causal: Whether to apply causal masking (prevent selecting future blocks).
+        q_tile_size: Size of each query tile (should match FA4's CTA tile: 2 * m_block_size = 256).
+        softmax_scale: Scaling factor for attention scores.
+
+    Returns:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+            Each entry is an index into the compressed KV sequence.
+    """
+    B, N, H, D = Q.shape
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+    groups = H // H_kv
+
+    N_q_tiles = N // q_tile_size
+    assert N % q_tile_size == 0, (
+        f"Sequence length {N} must be divisible by q_tile_size {q_tile_size}"
+    )
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    k_actual = min(num_selected_blocks, N_cmp)
+
+    # Expand K_cmp for GQA: (B, N_cmp, H_kv, D) -> (B, N_cmp, H, D)
+    if groups > 1:
+        K_cmp_expanded = K_cmp.repeat_interleave(groups, dim=2)
+    else:
+        K_cmp_expanded = K_cmp
+
+    # Pre-transpose for efficient matmul: (B, H, D, N_cmp)
+    K_cmp_t = K_cmp_expanded.permute(0, 2, 3, 1).float()
+
+    block_indices = torch.empty(
+        B, H, N_q_tiles, k_actual, dtype=torch.int32, device=Q.device
+    )
+
+    # Precompute causal mask data (tiny tensors)
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
+
+    # Process query tiles in chunks to bound peak memory.
+    # Each chunk computes (B, H, chunk_tiles * q_tile_size, N_cmp) scores,
+    # averages per tile, applies causal mask, and runs topk.
+    chunk_tiles = min(16, N_q_tiles)
+    for chunk_start in range(0, N_q_tiles, chunk_tiles):
+        chunk_end = min(chunk_start + chunk_tiles, N_q_tiles)
+        n_tiles = chunk_end - chunk_start
+        q_start = chunk_start * q_tile_size
+        q_end = chunk_end * q_tile_size
+
+        # (B, H, n_tiles * q_tile_size, N_cmp) — bounded, not O(N²)
+        scores_chunk = torch.matmul(
+            Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t
+        ) * softmax_scale
+
+        # Average per tile: (B, H, n_tiles, N_cmp)
+        scores_agg = scores_chunk.reshape(
+            B, H, n_tiles, q_tile_size, N_cmp
+        ).mean(dim=3)
+
+        # Apply causal mask: block j is future if j * block_size >= (i+1) * q_tile_size
+        if causal:
+            future_mask = (
+                kv_block_start.unsqueeze(0)
+                >= q_tile_end[chunk_start:chunk_end].unsqueeze(1)
+            )  # (n_tiles, N_cmp)
+            scores_agg.masked_fill_(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        # Select top-k blocks for this chunk
+        topk_scores, chunk_idx = scores_agg.topk(k_actual, dim=-1)
+
+        # Replace invalid selections (future blocks with -inf score) with block 0
+        invalid = topk_scores == float("-inf")
+        if invalid.any():
+            chunk_idx = chunk_idx.masked_fill(invalid, 0)
+
+        # Sort indices for better memory access patterns
+        block_indices[:, :, chunk_start:chunk_end] = (
+            chunk_idx.sort(dim=-1).values.to(torch.int32)
+        )
+
+    return block_indices

--- a/mslk/attention/sparse_attn/sparsity_masks.py
+++ b/mslk/attention/sparse_attn/sparsity_masks.py
@@ -1,0 +1,117 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Convert top-k block indices into FA4's BlockSparseTensorsTorch format."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+
+
+def build_fa4_block_sparse_tensors(
+    block_indices: Tensor,  # (B, H, N_q_tiles, k) int32
+    compress_block_size: int,
+    n_block_size: int = 128,
+    seqlen_k: int | None = None,
+) -> BlockSparseTensorsTorch:
+    """Convert selected KV block indices into FA4's block sparsity format.
+
+    FA4 block sparsity uses two pairs of tensors:
+    - full_block_cnt/full_block_idx: KV blocks that need NO masking (fully attended).
+    - mask_block_cnt/mask_block_idx: KV blocks that need masking (partially attended).
+
+    Handles two cases:
+    - compress_block_size >= n_block_size: Each NSA block expands to multiple FA4 blocks.
+    - compress_block_size < n_block_size: Multiple NSA blocks contract to one FA4 block
+      (duplicates are removed).
+
+    All selected blocks are "full" blocks (no partial masking needed), since we're
+    attending to entire KV blocks.
+
+    Args:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+            Values are indices into the compressed KV sequence.
+        compress_block_size: Size of each NSA KV block.
+        n_block_size: FA4's KV tile size (default 128 for SM100).
+        seqlen_k: Total KV sequence length (for computing n_blocks_k).
+
+    Returns:
+        BlockSparseTensorsTorch with full_block_cnt, full_block_idx,
+        mask_block_cnt, mask_block_idx.
+    """
+    B, H, N_q_tiles, k = block_indices.shape
+    device = block_indices.device
+
+    if compress_block_size >= n_block_size:
+        # Each NSA block maps to one or more FA4 blocks
+        assert compress_block_size % n_block_size == 0, (
+            f"compress_block_size ({compress_block_size}) must be divisible by "
+            f"n_block_size ({n_block_size})"
+        )
+        fa4_blocks_per_nsa_block = compress_block_size // n_block_size
+
+        # NSA block j maps to FA4 blocks [j*ratio, j*ratio+1, ..., j*ratio+ratio-1]
+        base_indices = block_indices.long() * fa4_blocks_per_nsa_block
+        offsets = torch.arange(fa4_blocks_per_nsa_block, device=device)
+        expanded_indices = base_indices.unsqueeze(-1) + offsets
+        fa4_indices = expanded_indices.reshape(B, H, N_q_tiles, k * fa4_blocks_per_nsa_block)
+        k_fa4 = k * fa4_blocks_per_nsa_block
+    else:
+        # Multiple NSA blocks map to a single FA4 block
+        assert n_block_size % compress_block_size == 0, (
+            f"n_block_size ({n_block_size}) must be divisible by "
+            f"compress_block_size ({compress_block_size})"
+        )
+        # NSA block j maps to FA4 block j * compress_block_size // n_block_size
+        fa4_block_indices = (block_indices.long() * compress_block_size) // n_block_size
+
+        # Remove duplicates per query tile: sort, then unique via consecutive dedup
+        fa4_block_indices = fa4_block_indices.sort(dim=-1).values
+        # Mark duplicates: compare with previous element
+        shifted = torch.roll(fa4_block_indices, 1, dims=-1)
+        is_dup = (fa4_block_indices == shifted) & (torch.arange(k, device=device) > 0)
+        # Replace duplicates with a sentinel (max_n_blocks) that we'll filter out
+        if seqlen_k is not None:
+            sentinel = (seqlen_k + n_block_size - 1) // n_block_size
+        else:
+            sentinel = fa4_block_indices.max().item() + 1
+        fa4_block_indices = fa4_block_indices.masked_fill(is_dup, sentinel)
+        # Re-sort to push sentinels to the end
+        fa4_block_indices = fa4_block_indices.sort(dim=-1).values
+        # Count non-sentinel entries per query tile
+        counts = (fa4_block_indices < sentinel).sum(dim=-1)  # (B, H, N_q_tiles)
+
+        fa4_indices = fa4_block_indices
+        k_fa4 = k  # max possible, actual counts may be smaller
+
+    # full_block_cnt: (B, H, N_q_tiles)
+    if compress_block_size >= n_block_size:
+        full_block_cnt = torch.full(
+            (B, H, N_q_tiles), k_fa4, dtype=torch.int32, device=device
+        )
+    else:
+        full_block_cnt = counts.to(torch.int32)
+
+    # full_block_idx: use compact shape (B, H, N_q_tiles, k_fa4) instead of
+    # (B, H, N_q_tiles, N/n_block_size). FA4 only accesses indices 0..cnt-1,
+    # so the last dimension only needs to be k_fa4. This reduces memory from
+    # O(N²) to O(N * k_fa4) — e.g. 8 MB vs 8.6 GB at N=1M.
+    full_block_idx = fa4_indices[:, :, :, :k_fa4].to(torch.int32)
+
+    # mask_block_cnt/idx: no partial masking needed. Use shape (B,H,N_q_tiles,1)
+    # for mask_block_idx since count is always 0.
+    mask_block_cnt = torch.zeros(
+        (B, H, N_q_tiles), dtype=torch.int32, device=device
+    )
+    mask_block_idx = torch.zeros(
+        (B, H, N_q_tiles, 1), dtype=torch.int32, device=device
+    )
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=mask_block_cnt,
+        mask_block_idx=mask_block_idx,
+        full_block_cnt=full_block_cnt,
+        full_block_idx=full_block_idx,
+    )

--- a/mslk/attention/sparse_attn/sparsity_masks.py
+++ b/mslk/attention/sparse_attn/sparsity_masks.py
@@ -5,9 +5,8 @@
 from __future__ import annotations
 
 import torch
-from torch import Tensor
-
 from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+from torch import Tensor
 
 
 def build_fa4_block_sparse_tensors(
@@ -56,7 +55,9 @@ def build_fa4_block_sparse_tensors(
         base_indices = block_indices.long() * fa4_blocks_per_nsa_block
         offsets = torch.arange(fa4_blocks_per_nsa_block, device=device)
         expanded_indices = base_indices.unsqueeze(-1) + offsets
-        fa4_indices = expanded_indices.reshape(B, H, N_q_tiles, k * fa4_blocks_per_nsa_block)
+        fa4_indices = expanded_indices.reshape(
+            B, H, N_q_tiles, k * fa4_blocks_per_nsa_block
+        )
         k_fa4 = k * fa4_blocks_per_nsa_block
     else:
         # Multiple NSA blocks map to a single FA4 block
@@ -86,6 +87,12 @@ def build_fa4_block_sparse_tensors(
         fa4_indices = fa4_block_indices
         k_fa4 = k  # max possible, actual counts may be smaller
 
+    # Compute the full number of KV blocks for FA4
+    if seqlen_k is not None:
+        n_blocks_k = (seqlen_k + n_block_size - 1) // n_block_size
+    else:
+        n_blocks_k = fa4_indices.max().item() + 1
+
     # full_block_cnt: (B, H, N_q_tiles)
     if compress_block_size >= n_block_size:
         full_block_cnt = torch.full(
@@ -94,24 +101,36 @@ def build_fa4_block_sparse_tensors(
     else:
         full_block_cnt = counts.to(torch.int32)
 
-    # full_block_idx: use compact shape (B, H, N_q_tiles, k_fa4) instead of
-    # (B, H, N_q_tiles, N/n_block_size). FA4 only accesses indices 0..cnt-1,
-    # so the last dimension only needs to be k_fa4. This reduces memory from
-    # O(N²) to O(N * k_fa4) — e.g. 8 MB vs 8.6 GB at N=1M.
-    full_block_idx = fa4_indices[:, :, :, :k_fa4].to(torch.int32)
-
-    # mask_block_cnt/idx: no partial masking needed. Use shape (B,H,N_q_tiles,1)
-    # for mask_block_idx since count is always 0.
-    mask_block_cnt = torch.zeros(
-        (B, H, N_q_tiles), dtype=torch.int32, device=device
+    # full_block_idx: use dense shape (B, H, N_q_tiles, n_blocks_k) so that
+    # FA4's backward can transpose to Q-direction indexing. The compact format
+    # (k_fa4 << n_blocks_k) saves memory but is incompatible with backward.
+    full_block_idx_dense = torch.zeros(
+        (B, H, N_q_tiles, n_blocks_k), dtype=torch.int32, device=device
     )
+    # Copy compact indices into the dense tensor
+    copy_len = min(k_fa4, n_blocks_k)
+    full_block_idx_dense[:, :, :, :copy_len] = fa4_indices[:, :, :, :copy_len].to(
+        torch.int32
+    )
+
+    # mask_block_cnt/idx: no partial masking needed.
+    mask_block_cnt = torch.zeros((B, H, N_q_tiles), dtype=torch.int32, device=device)
     mask_block_idx = torch.zeros(
-        (B, H, N_q_tiles, 1), dtype=torch.int32, device=device
+        (B, H, N_q_tiles, n_blocks_k), dtype=torch.int32, device=device
+    )
+
+    # Determine the Q-direction block size. With q_tile_size positions per query tile
+    # and N_q_tiles tiles, each m-block covers q_tile_size positions.
+    # For the contraction case (compress_block_size < n_block_size), the Q block size
+    # is inferred from the tensor shapes.
+    q_block_size = (
+        seqlen_k // N_q_tiles if seqlen_k is not None else compress_block_size
     )
 
     return BlockSparseTensorsTorch(
         mask_block_cnt=mask_block_cnt,
         mask_block_idx=mask_block_idx,
         full_block_cnt=full_block_cnt,
-        full_block_idx=full_block_idx,
+        full_block_idx=full_block_idx_dense,
+        block_size=(q_block_size, n_block_size),
     )

--- a/test/attention/bench_nsa_backward.py
+++ b/test/attention/bench_nsa_backward.py
@@ -22,13 +22,21 @@ def benchmark_nsa_fwd_bwd(
 ):
     from mslk.attention.sparse_attn import nsa
 
-    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
-    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
-    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
 
     def run():
         out = nsa(
-            Q, K, V,
+            Q,
+            K,
+            V,
             compress_block_size=compress_block_size,
             num_selected_blocks=num_selected_blocks,
             window_size=window_size,
@@ -56,8 +64,8 @@ def benchmark_nsa_fwd_bwd(
     tflops_fwd = 2 * B * H * N * N * D / 1e12  # approximate (ignoring sparsity)
     mode = "fwd+bwd" if backward else "fwd"
     print(
-        f"N={N:>7d} | {mode} | {elapsed*1000:>8.2f} ms | "
-        f"~{tflops_fwd/elapsed/1e3:.1f} TFLOPS (dense equiv)"
+        f"N={N:>7d} | {mode} | {elapsed * 1000:>8.2f} ms | "
+        f"~{tflops_fwd / elapsed / 1e3:.1f} TFLOPS (dense equiv)"
     )
     return elapsed
 
@@ -68,14 +76,42 @@ def main():
     print(f"GPU: {torch.cuda.get_device_name()}")
     print()
 
-    for N in [1024, 2048, 4096, 8192, 16384, 32768, 65536]:
+    for N in [
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+        2097152,
+        3145728,
+    ]:
         try:
             benchmark_nsa_fwd_bwd(N, backward=False)
         except Exception as e:
             print(f"N={N:>7d} | fwd     | FAILED: {e}")
 
     print()
-    for N in [1024, 2048, 4096, 8192, 16384, 32768, 65536]:
+    for N in [
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+        2097152,
+        3145728,
+    ]:
         try:
             benchmark_nsa_fwd_bwd(N, backward=True)
         except Exception as e:

--- a/test/attention/bench_nsa_backward.py
+++ b/test/attention/bench_nsa_backward.py
@@ -1,0 +1,86 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Benchmark NSA forward + backward at various sequence lengths."""
+
+import time
+
+import torch
+
+
+def benchmark_nsa_fwd_bwd(
+    N: int,
+    B: int = 1,
+    H: int = 32,
+    H_kv: int = 8,
+    D: int = 128,
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    warmup: int = 3,
+    iters: int = 10,
+    backward: bool = True,
+):
+    from mslk.attention.sparse_attn import nsa
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward)
+
+    def run():
+        out = nsa(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected_blocks,
+            window_size=window_size,
+        )
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = None
+            K.grad = None
+            V.grad = None
+        return out
+
+    # Warmup
+    for _ in range(warmup):
+        run()
+    torch.cuda.synchronize()
+
+    # Benchmark
+    start = time.perf_counter()
+    for _ in range(iters):
+        run()
+    torch.cuda.synchronize()
+    elapsed = (time.perf_counter() - start) / iters
+
+    tflops_fwd = 2 * B * H * N * N * D / 1e12  # approximate (ignoring sparsity)
+    mode = "fwd+bwd" if backward else "fwd"
+    print(
+        f"N={N:>7d} | {mode} | {elapsed*1000:>8.2f} ms | "
+        f"~{tflops_fwd/elapsed/1e3:.1f} TFLOPS (dense equiv)"
+    )
+    return elapsed
+
+
+def main():
+    print("NSA Forward + Backward Benchmark")
+    print("=" * 60)
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print()
+
+    for N in [1024, 2048, 4096, 8192, 16384, 32768, 65536]:
+        try:
+            benchmark_nsa_fwd_bwd(N, backward=False)
+        except Exception as e:
+            print(f"N={N:>7d} | fwd     | FAILED: {e}")
+
+    print()
+    for N in [1024, 2048, 4096, 8192, 16384, 32768, 65536]:
+        try:
+            benchmark_nsa_fwd_bwd(N, backward=True)
+        except Exception as e:
+            print(f"N={N:>7d} | fwd+bwd | FAILED: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_nsa_vs_dense.py
+++ b/test/attention/bench_nsa_vs_dense.py
@@ -1,0 +1,175 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""NSA vs Dense FA4 benchmark — forward and backward at various sequence lengths."""
+
+import gc
+import time
+
+import torch
+
+
+def _time_fn(fn, warmup=3, iters=5):
+    """Time a function with warmup, return median ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        times.append((time.perf_counter() - start) * 1000)
+    times.sort()
+    return times[len(times) // 2]
+
+
+def benchmark_dense_fa4(N, B=1, H=32, H_kv=8, D=128, backward=False):
+    """Benchmark dense causal FA4 attention."""
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out = flash_attn_func(Q, K, V, softmax_scale=1.0 / D**0.5, causal=True)
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = K.grad = V.grad = None
+
+    try:
+        return _time_fn(run)
+    except Exception as e:
+        return f"FAILED: {e}"
+
+
+def benchmark_nsa(N, B=1, H=32, H_kv=8, D=128, backward=False):
+    """Benchmark NSA sparse attention."""
+    from mslk.attention.sparse_attn import nsa
+
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=64,
+            num_selected_blocks=16,
+            window_size=512,
+        )
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = K.grad = V.grad = None
+
+    try:
+        return _time_fn(run)
+    except Exception as e:
+        return f"FAILED: {e}"
+
+
+def main():
+    print("NSA vs Dense FA4 Benchmark")
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(f"Config: B=1, H=32, H_kv=8, D=128")
+    print("=" * 80)
+
+    # Sequence lengths: 1K to 3M (powers of 2, plus some intermediate points)
+    seq_lengths = [
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+        2097152,
+        3145728,
+    ]
+
+    print(
+        f"\n{'N':>10} | {'Dense Fwd':>12} | {'NSA Fwd':>12} | {'Speedup':>8} | "
+        f"{'Dense Bwd':>12} | {'NSA Bwd':>12} | {'Speedup':>8}"
+    )
+    print("-" * 90)
+
+    for N in seq_lengths:
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        # Forward
+        dense_fwd = benchmark_dense_fa4(N, backward=False)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        nsa_fwd = benchmark_nsa(N, backward=False)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        if isinstance(dense_fwd, str) or isinstance(nsa_fwd, str):
+            fwd_speedup = "N/A"
+            dense_fwd_s = (
+                str(dense_fwd)
+                if isinstance(dense_fwd, str)
+                else f"{dense_fwd:>10.2f}ms"
+            )
+            nsa_fwd_s = (
+                str(nsa_fwd) if isinstance(nsa_fwd, str) else f"{nsa_fwd:>10.2f}ms"
+            )
+        else:
+            fwd_speedup = f"{dense_fwd / nsa_fwd:.2f}x"
+            dense_fwd_s = f"{dense_fwd:>10.2f}ms"
+            nsa_fwd_s = f"{nsa_fwd:>10.2f}ms"
+
+        # Backward
+        dense_bwd = benchmark_dense_fa4(N, backward=True)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        nsa_bwd = benchmark_nsa(N, backward=True)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        if isinstance(dense_bwd, str) or isinstance(nsa_bwd, str):
+            bwd_speedup = "N/A"
+            dense_bwd_s = (
+                str(dense_bwd)[:30]
+                if isinstance(dense_bwd, str)
+                else f"{dense_bwd:>10.2f}ms"
+            )
+            nsa_bwd_s = (
+                str(nsa_bwd)[:30] if isinstance(nsa_bwd, str) else f"{nsa_bwd:>10.2f}ms"
+            )
+        else:
+            bwd_speedup = f"{dense_bwd / nsa_bwd:.2f}x"
+            dense_bwd_s = f"{dense_bwd:>10.2f}ms"
+            nsa_bwd_s = f"{nsa_bwd:>10.2f}ms"
+
+        print(
+            f"{N:>10} | {dense_fwd_s:>12} | {nsa_fwd_s:>12} | {fwd_speedup:>8} | "
+            f"{dense_bwd_s:>12} | {nsa_bwd_s:>12} | {bwd_speedup:>8}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_sparse_attn.py
+++ b/test/attention/bench_sparse_attn.py
@@ -1,0 +1,250 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Detailed benchmarks for NSA vs dense FA4 attention.
+
+Reports wall-clock time, effective TFLOPS, and speedup ratio.
+Separately times each NSA component: compression, selection, attention branches, gating.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+
+import torch
+
+
+def benchmark_fn(fn, warmup=5, repeat=20):
+    """Benchmark a CUDA function using CUDA events. Returns median time in ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(repeat):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times = sorted(times)
+    return times[len(times) // 2]
+
+
+def compute_flops_dense(B, H, N, D):
+    """Compute FLOPs for dense attention forward pass."""
+    # QK^T: 2*B*H*N*N*D, PV: 2*B*H*N*N*D
+    return 4 * B * H * N * N * D
+
+
+def compute_flops_nsa(B, H, N, D, compress_block_size, num_selected, window_size):
+    """Compute FLOPs for NSA forward pass."""
+    l = compress_block_size
+    k = num_selected
+    w = window_size
+    # Compressed: 4*B*H*N*(N/l)*D
+    # Selected: 4*B*H*N*(k*l)*D
+    # Sliding: 4*B*H*N*w*D
+    flops_cmp = 4 * B * H * N * (N // l) * D
+    flops_slc = 4 * B * H * N * (k * l) * D
+    flops_sld = 4 * B * H * N * w * D
+    return flops_cmp + flops_slc + flops_sld
+
+
+def run_benchmark(
+    N: int,
+    B: int = 2,
+    H: int = 32,
+    H_kv: int = 8,
+    D: int = 128,
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    dtype=torch.bfloat16,
+    warmup: int = 5,
+    repeat: int = 20,
+):
+    """Run NSA vs dense FA4 benchmark for a given sequence length."""
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+    from mslk.attention.sparse_attn.compress import compress_kv
+    from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+    from mslk.attention.sparse_attn.select import score_and_select_blocks
+    from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+    # --- Dense FA4 baseline ---
+    dense_ms = benchmark_fn(
+        lambda: flash_attn_func(Q, K, V, causal=True),
+        warmup=warmup, repeat=repeat,
+    )
+    dense_flops = compute_flops_dense(B, H, N, D)
+    dense_tflops = dense_flops / (dense_ms * 1e-3) / 1e12
+
+    # --- NSA end-to-end ---
+    nsa_ms = benchmark_fn(
+        lambda: nsa_forward(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected_blocks,
+            window_size=window_size,
+            causal=True,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+    nsa_flops = compute_flops_nsa(
+        B, H, N, D, compress_block_size, num_selected_blocks, window_size
+    )
+    nsa_tflops = nsa_flops / (nsa_ms * 1e-3) / 1e12
+
+    # --- Component timing ---
+    # Compression
+    cmp_ms = benchmark_fn(
+        lambda: compress_kv(K, V, compress_block_size),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Selection
+    K_cmp, V_cmp = compress_kv(K, V, compress_block_size)
+    sel_ms = benchmark_fn(
+        lambda: score_and_select_blocks(
+            Q, K_cmp, num_selected_blocks, compress_block_size,
+            causal=True, q_tile_size=256,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Block-sparse mask construction
+    block_indices = score_and_select_blocks(
+        Q, K_cmp, num_selected_blocks, compress_block_size,
+        causal=True, q_tile_size=256,
+    )
+    mask_ms = benchmark_fn(
+        lambda: build_fa4_block_sparse_tensors(
+            block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Compressed attention FA4
+    fa4_cmp_ms = benchmark_fn(
+        lambda: flash_attn_func(Q, K_cmp, V_cmp, causal=True),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Selected attention FA4 (block-sparse)
+    sparse_tensors = build_fa4_block_sparse_tensors(
+        block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+    )
+    from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+    fa4_slc_ms = benchmark_fn(
+        lambda: _flash_attn_fwd(
+            Q, K, V, causal=True, block_sparse_tensors=sparse_tensors,
+        ),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Sliding window FA4
+    fa4_sld_ms = benchmark_fn(
+        lambda: flash_attn_func(Q, K, V, causal=True, window_size=(window_size, 0)),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Gating
+    O_cmp = torch.randn_like(Q)
+    O_slc = torch.randn_like(Q)
+    O_sld = torch.randn_like(Q)
+    gates = torch.randn(B, N, H, 3, device="cuda", dtype=dtype)
+    gate_ms = benchmark_fn(
+        lambda: gate_and_combine(O_cmp, O_slc, O_sld, gates),
+        warmup=warmup, repeat=repeat,
+    )
+
+    speedup = dense_ms / nsa_ms
+    theoretical_speedup = N / (N / compress_block_size + num_selected_blocks * compress_block_size + window_size)
+
+    return {
+        "N": N,
+        "dense_ms": dense_ms,
+        "dense_tflops": dense_tflops,
+        "nsa_ms": nsa_ms,
+        "nsa_tflops": nsa_tflops,
+        "speedup": speedup,
+        "theoretical_speedup": theoretical_speedup,
+        "compress_ms": cmp_ms,
+        "select_ms": sel_ms,
+        "mask_ms": mask_ms,
+        "fa4_cmp_ms": fa4_cmp_ms,
+        "fa4_slc_ms": fa4_slc_ms,
+        "fa4_sld_ms": fa4_sld_ms,
+        "gate_ms": gate_ms,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="NSA vs FA4 benchmark")
+    parser.add_argument("--seq-lens", nargs="+", type=int,
+                        default=[1024, 2048, 4096, 8192, 16384])
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--num-heads", type=int, default=32)
+    parser.add_argument("--num-heads-kv", type=int, default=32)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--compress-block-size", type=int, default=64)
+    parser.add_argument("--num-selected-blocks", type=int, default=16)
+    parser.add_argument("--window-size", type=int, default=512)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeat", type=int, default=20)
+    args = parser.parse_args()
+
+    print(f"{'='*100}")
+    print(f"NSA vs Dense FA4 Benchmark")
+    print(f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
+          f"D={args.head_dim}, l={args.compress_block_size}, k={args.num_selected_blocks}, "
+          f"w={args.window_size}")
+    print(f"{'='*100}")
+
+    header = (
+        f"{'N':>8} | {'Dense(ms)':>10} {'TFLOPS':>8} | "
+        f"{'NSA(ms)':>10} {'TFLOPS':>8} | {'Speedup':>8} {'Theory':>8} | "
+        f"{'Cmp':>6} {'Sel':>6} {'Mask':>6} "
+        f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for N in args.seq_lens:
+        result = run_benchmark(
+            N=N,
+            B=args.batch_size,
+            H=args.num_heads,
+            H_kv=args.num_heads_kv,
+            D=args.head_dim,
+            compress_block_size=args.compress_block_size,
+            num_selected_blocks=args.num_selected_blocks,
+            window_size=args.window_size,
+            warmup=args.warmup,
+            repeat=args.repeat,
+        )
+        print(
+            f"{result['N']:>8} | "
+            f"{result['dense_ms']:>10.2f} {result['dense_tflops']:>8.1f} | "
+            f"{result['nsa_ms']:>10.2f} {result['nsa_tflops']:>8.1f} | "
+            f"{result['speedup']:>8.2f}x {result['theoretical_speedup']:>7.1f}x | "
+            f"{result['compress_ms']:>6.2f} {result['select_ms']:>6.2f} "
+            f"{result['mask_ms']:>6.2f} {result['fa4_cmp_ms']:>6.2f} "
+            f"{result['fa4_slc_ms']:>6.2f} {result['fa4_sld_ms']:>6.2f} "
+            f"{result['gate_ms']:>6.2f}"
+        )
+
+    print(f"{'='*100}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_sparse_attn.py
+++ b/test/attention/bench_sparse_attn.py
@@ -69,7 +69,7 @@ def run_benchmark(
     repeat: int = 20,
 ):
     """Run NSA vs dense FA4 benchmark for a given sequence length."""
-    from mslk.attention.sparse_attn.compress import compress_kv
+    from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
     from mslk.attention.sparse_attn.gating import (
         compute_gates,
         fused_gate_and_combine,
@@ -119,6 +119,13 @@ def run_benchmark(
     # Compression
     cmp_ms = benchmark_fn(
         lambda: compress_kv(K, V, compress_block_size),
+        warmup=warmup,
+        repeat=repeat,
+    )
+
+    # Fused compression (CuteDSL kernel)
+    fused_cmp_ms = benchmark_fn(
+        lambda: fused_compress_kv(K, V, compress_block_size),
         warmup=warmup,
         repeat=repeat,
     )
@@ -249,6 +256,7 @@ def run_benchmark(
         "speedup": speedup,
         "theoretical_speedup": theoretical_speedup,
         "compress_ms": cmp_ms,
+        "fused_cmp_ms": fused_cmp_ms,
         "select_ms": sel_ms,
         "fused_sel_ms": fused_sel_ms,
         "mask_ms": mask_ms,
@@ -289,7 +297,7 @@ def main():
     header = (
         f"{'N':>8} | {'Dense(ms)':>10} {'TFLOPS':>8} | "
         f"{'NSA(ms)':>10} {'TFLOPS':>8} | {'Speedup':>8} {'Theory':>8} | "
-        f"{'Cmp':>6} {'Sel':>6} {'FSel':>6} {'Mask':>6} "
+        f"{'Cmp':>6} {'FCmp':>6} {'Sel':>6} {'FSel':>6} {'Mask':>6} "
         f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6} {'CmpG':>6} {'Fuse':>6}"
     )
     print(header)
@@ -313,7 +321,8 @@ def main():
             f"{result['dense_ms']:>10.2f} {result['dense_tflops']:>8.1f} | "
             f"{result['nsa_ms']:>10.2f} {result['nsa_tflops']:>8.1f} | "
             f"{result['speedup']:>8.2f}x {result['theoretical_speedup']:>7.1f}x | "
-            f"{result['compress_ms']:>6.2f} {result['select_ms']:>6.2f} "
+            f"{result['compress_ms']:>6.2f} {result['fused_cmp_ms']:>6.2f} "
+            f"{result['select_ms']:>6.2f} "
             f"{result['fused_sel_ms']:>6.2f} {result['mask_ms']:>6.2f} "
             f"{result['fa4_cmp_ms']:>6.2f} "
             f"{result['fa4_slc_ms']:>6.2f} {result['fa4_sld_ms']:>6.2f} "

--- a/test/attention/bench_sparse_attn.py
+++ b/test/attention/bench_sparse_attn.py
@@ -69,13 +69,19 @@ def run_benchmark(
     repeat: int = 20,
 ):
     """Run NSA vs dense FA4 benchmark for a given sequence length."""
-    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
     from mslk.attention.sparse_attn.compress import compress_kv
-    from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
-    from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+    from mslk.attention.sparse_attn.gating import (
+        compute_gates,
+        fused_gate_and_combine,
+        gate_and_combine,
+    )
     from mslk.attention.sparse_attn.nsa_forward import nsa_forward
-    from mslk.attention.sparse_attn.select import score_and_select_blocks
+    from mslk.attention.sparse_attn.select import (
+        fused_score_and_select_blocks,
+        score_and_select_blocks,
+    )
     from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
 
     Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
     K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
@@ -84,7 +90,8 @@ def run_benchmark(
     # --- Dense FA4 baseline ---
     dense_ms = benchmark_fn(
         lambda: flash_attn_func(Q, K, V, causal=True),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
     dense_flops = compute_flops_dense(B, H, N, D)
     dense_tflops = dense_flops / (dense_ms * 1e-3) / 1e12
@@ -92,13 +99,16 @@ def run_benchmark(
     # --- NSA end-to-end ---
     nsa_ms = benchmark_fn(
         lambda: nsa_forward(
-            Q, K, V,
+            Q,
+            K,
+            V,
             compress_block_size=compress_block_size,
             num_selected_blocks=num_selected_blocks,
             window_size=window_size,
             causal=True,
         ),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
     nsa_flops = compute_flops_nsa(
         B, H, N, D, compress_block_size, num_selected_blocks, window_size
@@ -109,53 +119,92 @@ def run_benchmark(
     # Compression
     cmp_ms = benchmark_fn(
         lambda: compress_kv(K, V, compress_block_size),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Selection
     K_cmp, V_cmp = compress_kv(K, V, compress_block_size)
     sel_ms = benchmark_fn(
         lambda: score_and_select_blocks(
-            Q, K_cmp, num_selected_blocks, compress_block_size,
-            causal=True, q_tile_size=256,
+            Q,
+            K_cmp,
+            num_selected_blocks,
+            compress_block_size,
+            causal=True,
+            q_tile_size=256,
         ),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
+    )
+
+    # Fused selection (CuteDSL kernel)
+    fused_sel_ms = benchmark_fn(
+        lambda: fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected_blocks,
+            compress_block_size,
+            causal=True,
+            q_tile_size=256,
+        ),
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Block-sparse mask construction
     block_indices = score_and_select_blocks(
-        Q, K_cmp, num_selected_blocks, compress_block_size,
-        causal=True, q_tile_size=256,
+        Q,
+        K_cmp,
+        num_selected_blocks,
+        compress_block_size,
+        causal=True,
+        q_tile_size=256,
     )
     mask_ms = benchmark_fn(
         lambda: build_fa4_block_sparse_tensors(
-            block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+            block_indices,
+            compress_block_size,
+            n_block_size=128,
+            seqlen_k=N,
         ),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Compressed attention FA4
     fa4_cmp_ms = benchmark_fn(
         lambda: flash_attn_func(Q, K_cmp, V_cmp, causal=True),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Selected attention FA4 (block-sparse)
     sparse_tensors = build_fa4_block_sparse_tensors(
-        block_indices, compress_block_size, n_block_size=128, seqlen_k=N,
+        block_indices,
+        compress_block_size,
+        n_block_size=128,
+        seqlen_k=N,
     )
     from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+
     fa4_slc_ms = benchmark_fn(
         lambda: _flash_attn_fwd(
-            Q, K, V, causal=True, block_sparse_tensors=sparse_tensors,
+            Q,
+            K,
+            V,
+            causal=True,
+            block_sparse_tensors=sparse_tensors,
         ),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Sliding window FA4
     fa4_sld_ms = benchmark_fn(
         lambda: flash_attn_func(Q, K, V, causal=True, window_size=(window_size, 0)),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Gating (gate_and_combine only)
@@ -165,24 +214,31 @@ def run_benchmark(
     gates = torch.randn(B, N, H, 3, device="cuda", dtype=dtype)
     gate_ms = benchmark_fn(
         lambda: gate_and_combine(O_cmp, O_slc, O_sld, gates),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Gating (compute_gates only)
     gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype)
     compute_gates_ms = benchmark_fn(
         lambda: compute_gates(Q, gate_proj_weight),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     # Fused gating (compute_gates + gate_and_combine in one kernel)
     fused_gate_ms = benchmark_fn(
         lambda: fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight),
-        warmup=warmup, repeat=repeat,
+        warmup=warmup,
+        repeat=repeat,
     )
 
     speedup = dense_ms / nsa_ms
-    theoretical_speedup = N / (N / compress_block_size + num_selected_blocks * compress_block_size + window_size)
+    theoretical_speedup = N / (
+        N / compress_block_size
+        + num_selected_blocks * compress_block_size
+        + window_size
+    )
 
     return {
         "N": N,
@@ -194,6 +250,7 @@ def run_benchmark(
         "theoretical_speedup": theoretical_speedup,
         "compress_ms": cmp_ms,
         "select_ms": sel_ms,
+        "fused_sel_ms": fused_sel_ms,
         "mask_ms": mask_ms,
         "fa4_cmp_ms": fa4_cmp_ms,
         "fa4_slc_ms": fa4_slc_ms,
@@ -206,8 +263,9 @@ def run_benchmark(
 
 def main():
     parser = argparse.ArgumentParser(description="NSA vs FA4 benchmark")
-    parser.add_argument("--seq-lens", nargs="+", type=int,
-                        default=[1024, 2048, 4096, 8192, 16384])
+    parser.add_argument(
+        "--seq-lens", nargs="+", type=int, default=[1024, 2048, 4096, 8192, 16384]
+    )
     parser.add_argument("--batch-size", type=int, default=2)
     parser.add_argument("--num-heads", type=int, default=32)
     parser.add_argument("--num-heads-kv", type=int, default=32)
@@ -219,17 +277,19 @@ def main():
     parser.add_argument("--repeat", type=int, default=20)
     args = parser.parse_args()
 
-    print(f"{'='*100}")
+    print(f"{'=' * 100}")
     print(f"NSA vs Dense FA4 Benchmark")
-    print(f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
-          f"D={args.head_dim}, l={args.compress_block_size}, k={args.num_selected_blocks}, "
-          f"w={args.window_size}")
-    print(f"{'='*100}")
+    print(
+        f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
+        f"D={args.head_dim}, l={args.compress_block_size}, k={args.num_selected_blocks}, "
+        f"w={args.window_size}"
+    )
+    print(f"{'=' * 100}")
 
     header = (
         f"{'N':>8} | {'Dense(ms)':>10} {'TFLOPS':>8} | "
         f"{'NSA(ms)':>10} {'TFLOPS':>8} | {'Speedup':>8} {'Theory':>8} | "
-        f"{'Cmp':>6} {'Sel':>6} {'Mask':>6} "
+        f"{'Cmp':>6} {'Sel':>6} {'FSel':>6} {'Mask':>6} "
         f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6} {'CmpG':>6} {'Fuse':>6}"
     )
     print(header)
@@ -254,13 +314,14 @@ def main():
             f"{result['nsa_ms']:>10.2f} {result['nsa_tflops']:>8.1f} | "
             f"{result['speedup']:>8.2f}x {result['theoretical_speedup']:>7.1f}x | "
             f"{result['compress_ms']:>6.2f} {result['select_ms']:>6.2f} "
-            f"{result['mask_ms']:>6.2f} {result['fa4_cmp_ms']:>6.2f} "
+            f"{result['fused_sel_ms']:>6.2f} {result['mask_ms']:>6.2f} "
+            f"{result['fa4_cmp_ms']:>6.2f} "
             f"{result['fa4_slc_ms']:>6.2f} {result['fa4_sld_ms']:>6.2f} "
             f"{result['gate_ms']:>6.2f} {result['compute_gates_ms']:>6.2f} "
             f"{result['fused_gate_ms']:>6.2f}"
         )
 
-    print(f"{'='*100}")
+    print(f"{'=' * 100}")
 
 
 if __name__ == "__main__":

--- a/test/attention/bench_sparse_attn.py
+++ b/test/attention/bench_sparse_attn.py
@@ -72,6 +72,7 @@ def run_benchmark(
     from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
     from mslk.attention.sparse_attn.compress import compress_kv
     from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+    from mslk.attention.sparse_attn.gating import fused_gate_and_combine
     from mslk.attention.sparse_attn.nsa_forward import nsa_forward
     from mslk.attention.sparse_attn.select import score_and_select_blocks
     from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
@@ -157,13 +158,26 @@ def run_benchmark(
         warmup=warmup, repeat=repeat,
     )
 
-    # Gating
+    # Gating (gate_and_combine only)
     O_cmp = torch.randn_like(Q)
     O_slc = torch.randn_like(Q)
     O_sld = torch.randn_like(Q)
     gates = torch.randn(B, N, H, 3, device="cuda", dtype=dtype)
     gate_ms = benchmark_fn(
         lambda: gate_and_combine(O_cmp, O_slc, O_sld, gates),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Gating (compute_gates only)
+    gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype)
+    compute_gates_ms = benchmark_fn(
+        lambda: compute_gates(Q, gate_proj_weight),
+        warmup=warmup, repeat=repeat,
+    )
+
+    # Fused gating (compute_gates + gate_and_combine in one kernel)
+    fused_gate_ms = benchmark_fn(
+        lambda: fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight),
         warmup=warmup, repeat=repeat,
     )
 
@@ -185,6 +199,8 @@ def run_benchmark(
         "fa4_slc_ms": fa4_slc_ms,
         "fa4_sld_ms": fa4_sld_ms,
         "gate_ms": gate_ms,
+        "compute_gates_ms": compute_gates_ms,
+        "fused_gate_ms": fused_gate_ms,
     }
 
 
@@ -214,7 +230,7 @@ def main():
         f"{'N':>8} | {'Dense(ms)':>10} {'TFLOPS':>8} | "
         f"{'NSA(ms)':>10} {'TFLOPS':>8} | {'Speedup':>8} {'Theory':>8} | "
         f"{'Cmp':>6} {'Sel':>6} {'Mask':>6} "
-        f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6}"
+        f"{'FA4c':>6} {'FA4s':>6} {'FA4w':>6} {'Gate':>6} {'CmpG':>6} {'Fuse':>6}"
     )
     print(header)
     print("-" * len(header))
@@ -240,7 +256,8 @@ def main():
             f"{result['compress_ms']:>6.2f} {result['select_ms']:>6.2f} "
             f"{result['mask_ms']:>6.2f} {result['fa4_cmp_ms']:>6.2f} "
             f"{result['fa4_slc_ms']:>6.2f} {result['fa4_sld_ms']:>6.2f} "
-            f"{result['gate_ms']:>6.2f}"
+            f"{result['gate_ms']:>6.2f} {result['compute_gates_ms']:>6.2f} "
+            f"{result['fused_gate_ms']:>6.2f}"
         )
 
     print(f"{'='*100}")

--- a/test/attention/bench_sparse_attn_e2e.py
+++ b/test/attention/bench_sparse_attn_e2e.py
@@ -1,0 +1,169 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Lean end-to-end benchmark for NSA vs dense FA4 at large sequence lengths.
+
+Only measures end-to-end Dense FA4 and NSA times (no component breakdowns)
+to minimize memory usage and allow benchmarking at N >= 2M.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+
+import torch
+
+
+def benchmark_fn(fn, warmup=3, repeat=7):
+    """Benchmark a CUDA function using CUDA events. Returns median time in ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(repeat):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times = sorted(times)
+    return times[len(times) // 2]
+
+
+def run_e2e(
+    N: int,
+    compress_block_size: int,
+    B: int = 1,
+    H: int = 8,
+    H_kv: int = 2,
+    D: int = 128,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    dtype=torch.bfloat16,
+    warmup: int = 3,
+    repeat: int = 7,
+    skip_dense: bool = False,
+):
+    """Run end-to-end Dense FA4 + NSA benchmark for one (N, l) pair."""
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+    dense_ms = -1.0
+    if not skip_dense:
+        try:
+            dense_ms = benchmark_fn(
+                lambda Q=Q, K=K, V=V: flash_attn_func(Q, K, V, causal=True),
+                warmup=warmup,
+                repeat=repeat,
+            )
+        except Exception as e:
+            print(f"  Dense FA4 failed: {e}")
+
+    torch.cuda.empty_cache()
+
+    nsa_ms = -1.0
+    try:
+        nsa_ms = benchmark_fn(
+            lambda Q=Q, K=K, V=V: nsa_forward(
+                Q,
+                K,
+                V,
+                compress_block_size=compress_block_size,
+                num_selected_blocks=num_selected_blocks,
+                window_size=window_size,
+                causal=True,
+            ),
+            warmup=warmup,
+            repeat=repeat,
+        )
+    except Exception as e:
+        print(f"  NSA l={compress_block_size} failed: {e}")
+
+    del Q, K, V
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    return dense_ms, nsa_ms
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E2E NSA vs FA4 benchmark (lean)")
+    parser.add_argument(
+        "--seq-lens",
+        nargs="+",
+        type=int,
+        default=[2097152, 4194304, 8388608, 16777216],
+    )
+    parser.add_argument("--block-sizes", nargs="+", type=int, default=[32, 64, 128])
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--num-heads", type=int, default=8)
+    parser.add_argument("--num-heads-kv", type=int, default=2)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--num-selected-blocks", type=int, default=16)
+    parser.add_argument("--window-size", type=int, default=512)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeat", type=int, default=7)
+    parser.add_argument(
+        "--skip-dense-above",
+        type=int,
+        default=0,
+        help="Skip dense FA4 for N above this value (0 = never skip)",
+    )
+    args = parser.parse_args()
+
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(
+        f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
+        f"D={args.head_dim}, k={args.num_selected_blocks}, w={args.window_size}"
+    )
+
+    # Header
+    l_cols = "  ".join(f"{'l=' + str(l):>10}" for l in args.block_sizes)
+    print(f"\n{'N':>10} | {'Dense(ms)':>10} | {l_cols}")
+    print("-" * (14 + 13 + 12 * len(args.block_sizes)))
+
+    for N in args.seq_lens:
+        skip_dense = args.skip_dense_above > 0 and N > args.skip_dense_above
+
+        dense_ms = None
+        nsa_times = {}
+
+        for i, l in enumerate(args.block_sizes):
+            d_ms, n_ms = run_e2e(
+                N=N,
+                compress_block_size=l,
+                B=args.batch_size,
+                H=args.num_heads,
+                H_kv=args.num_heads_kv,
+                D=args.head_dim,
+                num_selected_blocks=args.num_selected_blocks,
+                window_size=args.window_size,
+                warmup=args.warmup,
+                repeat=args.repeat,
+                skip_dense=(skip_dense or i > 0),  # Only measure dense once per N
+            )
+            if i == 0:
+                dense_ms = d_ms
+            nsa_times[l] = n_ms
+
+        dense_str = f"{dense_ms:>10.2f}" if dense_ms and dense_ms > 0 else "     skip"
+        nsa_strs = "  ".join(
+            f"{nsa_times[l]:>10.2f}" if nsa_times[l] > 0 else "    failed"
+            for l in args.block_sizes
+        )
+        print(f"{N:>10} | {dense_str} | {nsa_strs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/benchmark_results.svg
+++ b/test/attention/benchmark_results.svg
@@ -17,10 +17,10 @@
 
   <!-- Title -->
   <text x="400" y="32" text-anchor="middle" class="title">NSA vs Dense Flash Attention (FA4) — NVIDIA B200</text>
-  <text x="400" y="50" text-anchor="middle" class="subtitle">B=2, H=32, H_kv=32, D=128, block_size=128, k=16, window=512</text>
+  <text x="400" y="50" text-anchor="middle" class="subtitle">B=2, H=32, H_kv=32, D=128, block_size=64, k=16, window=512 | Fused compress, select, gating kernels</text>
 
   <!-- Chart area: x=100..720, y=70..400 -->
-  <!-- Y axis: 0 to 18ms (log would be better but linear is clearer) -->
+  <!-- Y axis: 0 to 18ms -->
   <!-- X axis: sequence lengths 1024, 2048, 4096, 8192, 16384, 32768 -->
 
   <!-- Grid lines -->
@@ -50,9 +50,6 @@
   <!-- Y axis title -->
   <text x="30" y="235" text-anchor="middle" class="axis-label" transform="rotate(-90, 30, 235)">Latency (ms)</text>
 
-  <!-- X positions: evenly spaced at x = 140, 256, 372, 488, 604, 720 -->
-  <!-- Actually let me use: 130, 248, 366, 484, 602, 720 -->
-
   <!-- X axis labels -->
   <text x="130" y="420" text-anchor="middle" class="tick-label">1K</text>
   <text x="248" y="420" text-anchor="middle" class="tick-label">2K</text>
@@ -68,27 +65,24 @@
   <line x1="100" y1="400" x2="720" y2="400" stroke="#333" stroke-width="1.5"/>
   <line x1="100" y1="70" x2="100" y2="400" stroke="#333" stroke-width="1.5"/>
 
-  <!-- Scale: 18ms = 330px, so 1ms = 18.33px. y = 400 - (ms * 330/18) = 400 - ms*18.33 -->
-  <!-- Dense FA4 data points:
-       1024:  0.08ms -> y=398.5
-       2048:  0.12ms -> y=397.8
-       4096:  0.28ms -> y=394.9
-       8192:  0.96ms -> y=382.4
-       16384: 3.48ms -> y=336.2
-       32768: 16.36ms -> y=100.1
-  -->
+  <!-- Scale: 18ms = 330px, so 1ms = 18.33px. y = 400 - (ms * 330/18) -->
+  <!--
+    MEASURED DATA (B200, B=2, H=32, H_kv=32, D=128, l=64, k=16, w=512, bf16):
+    Fused compress, fused select, fused gating kernels active.
 
-  <!-- NSA data points:
-       1024:  0.92ms -> y=383.1
-       2048:  1.26ms -> y=376.9
-       4096:  1.94ms -> y=364.4
-       8192:  3.75ms -> y=331.3
-       16384: 6.96ms -> y=272.4
-       32768: 15.47ms -> y=116.4
+    Dense FA4:          NSA (fused):
+    1024:  0.08ms       1024:  1.05ms  (k=8, limited by N_cmp)
+    2048:  0.12ms       2048:  1.12ms
+    4096:  0.28ms       4096:  1.20ms
+    8192:  0.96ms       8192:  1.69ms
+    16384: 3.48ms       16384: 3.43ms
+    32768: 15.67ms      32768: 5.88ms
+
+    y = 400 - ms * 18.33
   -->
 
   <!-- Dense FA4 line (blue) -->
-  <polyline points="130,398.5 248,397.8 366,394.9 484,382.4 602,336.2 720,100.1"
+  <polyline points="130,398.5 248,397.8 366,394.9 484,382.4 602,336.2 720,112.7"
             fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linejoin="round"/>
   <!-- Dense FA4 dots -->
   <circle cx="130" cy="398.5" r="4" fill="#2563eb"/>
@@ -96,44 +90,44 @@
   <circle cx="366" cy="394.9" r="4" fill="#2563eb"/>
   <circle cx="484" cy="382.4" r="4" fill="#2563eb"/>
   <circle cx="602" cy="336.2" r="4" fill="#2563eb"/>
-  <circle cx="720" cy="100.1" r="4" fill="#2563eb"/>
+  <circle cx="720" cy="112.7" r="4" fill="#2563eb"/>
 
-  <!-- NSA line (orange-red) -->
-  <polyline points="130,383.1 248,376.9 366,364.4 484,331.3 602,272.4 720,116.4"
-            fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- NSA line (green — fused kernels) -->
+  <polyline points="130,380.8 248,379.5 366,378.0 484,369.0 602,337.1 720,292.2"
+            fill="none" stroke="#059669" stroke-width="2.5" stroke-linejoin="round"/>
   <!-- NSA dots -->
-  <circle cx="130" cy="383.1" r="4" fill="#dc2626"/>
-  <circle cx="248" cy="376.9" r="4" fill="#dc2626"/>
-  <circle cx="366" cy="364.4" r="4" fill="#dc2626"/>
-  <circle cx="484" cy="331.3" r="4" fill="#dc2626"/>
-  <circle cx="602" cy="272.4" r="4" fill="#dc2626"/>
-  <circle cx="720" cy="116.4" r="4" fill="#dc2626"/>
+  <circle cx="130" cy="380.8" r="4" fill="#059669"/>
+  <circle cx="248" cy="379.5" r="4" fill="#059669"/>
+  <circle cx="366" cy="378.0" r="4" fill="#059669"/>
+  <circle cx="484" cy="369.0" r="4" fill="#059669"/>
+  <circle cx="602" cy="337.1" r="4" fill="#059669"/>
+  <circle cx="720" cy="292.2" r="4" fill="#059669"/>
 
-  <!-- Crossover annotation -->
-  <line x1="700" y1="116.4" x2="700" y2="100.1" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="3,2"/>
-  <text x="710" y="112" class="speedup-label" fill="#22c55e">1.06x</text>
+  <!-- Speedup annotation at 32K -->
+  <line x1="720" y1="292.2" x2="720" y2="112.7" stroke="#059669" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <text x="730" y="200" class="speedup-label" fill="#059669">2.66x</text>
 
   <!-- Speedup annotations at each point -->
-  <text x="130" y="377" class="speedup-label" fill="#dc2626">0.08x</text>
-  <text x="248" y="371" class="speedup-label" fill="#dc2626">0.10x</text>
-  <text x="366" y="358" class="speedup-label" fill="#dc2626">0.14x</text>
-  <text x="484" y="325" class="speedup-label" fill="#dc2626">0.25x</text>
-  <text x="602" y="266" class="speedup-label" fill="#dc2626">0.50x</text>
-  <text x="726" y="130" class="speedup-label" fill="#22c55e">1.06x</text>
+  <text x="130" y="375" class="speedup-label" fill="#059669">0.07x</text>
+  <text x="248" y="373" class="speedup-label" fill="#059669">0.11x</text>
+  <text x="366" y="372" class="speedup-label" fill="#059669">0.23x</text>
+  <text x="484" y="363" class="speedup-label" fill="#059669">0.57x</text>
+  <text x="602" y="330" class="speedup-label" fill="#059669">1.01x</text>
+  <text x="726" y="306" class="speedup-label" fill="#059669">2.66x</text>
 
-  <!-- Crossover line (vertical dashed) -->
-  <line x1="712" y1="400" x2="712" y2="70" stroke="#22c55e" stroke-width="1" stroke-dasharray="4,3" opacity="0.5"/>
+  <!-- Crossover line at ~16K (vertical dashed) -->
+  <line x1="600" y1="400" x2="600" y2="70" stroke="#059669" stroke-width="1" stroke-dasharray="4,3" opacity="0.4"/>
 
   <!-- Legend -->
-  <rect x="140" y="70" width="200" height="52" fill="white" stroke="#ddd" rx="4"/>
+  <rect x="140" y="70" width="240" height="52" fill="white" stroke="#ddd" rx="4"/>
   <line x1="152" y1="85" x2="180" y2="85" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="166" cy="85" r="3.5" fill="#2563eb"/>
   <text x="186" y="89" class="legend-text">Dense FA4 (Flash Attention)</text>
-  <line x1="152" y1="107" x2="180" y2="107" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="166" cy="107" r="3.5" fill="#dc2626"/>
-  <text x="186" y="111" class="legend-text">NSA (Native Sparse Attention)</text>
+  <line x1="152" y1="107" x2="180" y2="107" stroke="#059669" stroke-width="2.5"/>
+  <circle cx="166" cy="107" r="3.5" fill="#059669"/>
+  <text x="186" y="111" class="legend-text">NSA (Fused CuteDSL kernels)</text>
 
   <!-- Bottom annotations -->
-  <text x="400" y="472" text-anchor="middle" class="annotation">Dense FA4 scales as O(N²). NSA scales as O(N · (N/l + k·l + w)) where l=128, k=16, w=512.</text>
-  <text x="400" y="487" text-anchor="middle" class="annotation">NSA breaks even at ~32K and becomes faster for longer contexts. Measured on NVIDIA B200 GPU.</text>
+  <text x="400" y="472" text-anchor="middle" class="annotation">Dense FA4 scales as O(N²). NSA scales as O(N · (N/l + k·l + w)) where l=64, k=16, w=512.</text>
+  <text x="400" y="487" text-anchor="middle" class="annotation">NSA breaks even at ~16K and is 2.66x faster at 32K. Fused compress, select, and gating kernels. Measured on B200.</text>
 </svg>

--- a/test/attention/benchmark_results.svg
+++ b/test/attention/benchmark_results.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <style>
+      .title { font-size: 18px; font-weight: 600; fill: #1a1a2e; }
+      .subtitle { font-size: 12px; fill: #666; }
+      .axis-label { font-size: 12px; fill: #444; }
+      .tick-label { font-size: 11px; fill: #555; }
+      .legend-text { font-size: 12px; fill: #333; }
+      .grid { stroke: #e0e0e0; stroke-width: 0.5; }
+      .annotation { font-size: 10px; fill: #888; }
+      .speedup-label { font-size: 10px; font-weight: 600; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="500" fill="#fafafa" rx="8"/>
+
+  <!-- Title -->
+  <text x="400" y="32" text-anchor="middle" class="title">NSA vs Dense Flash Attention (FA4) — NVIDIA B200</text>
+  <text x="400" y="50" text-anchor="middle" class="subtitle">B=2, H=32, H_kv=32, D=128, block_size=128, k=16, window=512</text>
+
+  <!-- Chart area: x=100..720, y=70..400 -->
+  <!-- Y axis: 0 to 18ms (log would be better but linear is clearer) -->
+  <!-- X axis: sequence lengths 1024, 2048, 4096, 8192, 16384, 32768 -->
+
+  <!-- Grid lines -->
+  <line x1="100" y1="400" x2="720" y2="400" class="grid"/>
+  <line x1="100" y1="363" x2="720" y2="363" class="grid"/>
+  <line x1="100" y1="327" x2="720" y2="327" class="grid"/>
+  <line x1="100" y1="290" x2="720" y2="290" class="grid"/>
+  <line x1="100" y1="253" x2="720" y2="253" class="grid"/>
+  <line x1="100" y1="217" x2="720" y2="217" class="grid"/>
+  <line x1="100" y1="180" x2="720" y2="180" class="grid"/>
+  <line x1="100" y1="143" x2="720" y2="143" class="grid"/>
+  <line x1="100" y1="107" x2="720" y2="107" class="grid"/>
+  <line x1="100" y1="70" x2="720" y2="70" class="grid"/>
+
+  <!-- Y axis labels (0 to 18ms, step 2) -->
+  <text x="90" y="404" text-anchor="end" class="tick-label">0</text>
+  <text x="90" y="367" text-anchor="end" class="tick-label">2</text>
+  <text x="90" y="330" text-anchor="end" class="tick-label">4</text>
+  <text x="90" y="294" text-anchor="end" class="tick-label">6</text>
+  <text x="90" y="257" text-anchor="end" class="tick-label">8</text>
+  <text x="90" y="220" text-anchor="end" class="tick-label">10</text>
+  <text x="90" y="184" text-anchor="end" class="tick-label">12</text>
+  <text x="90" y="147" text-anchor="end" class="tick-label">14</text>
+  <text x="90" y="110" text-anchor="end" class="tick-label">16</text>
+  <text x="90" y="74" text-anchor="end" class="tick-label">18</text>
+
+  <!-- Y axis title -->
+  <text x="30" y="235" text-anchor="middle" class="axis-label" transform="rotate(-90, 30, 235)">Latency (ms)</text>
+
+  <!-- X positions: evenly spaced at x = 140, 256, 372, 488, 604, 720 -->
+  <!-- Actually let me use: 130, 248, 366, 484, 602, 720 -->
+
+  <!-- X axis labels -->
+  <text x="130" y="420" text-anchor="middle" class="tick-label">1K</text>
+  <text x="248" y="420" text-anchor="middle" class="tick-label">2K</text>
+  <text x="366" y="420" text-anchor="middle" class="tick-label">4K</text>
+  <text x="484" y="420" text-anchor="middle" class="tick-label">8K</text>
+  <text x="602" y="420" text-anchor="middle" class="tick-label">16K</text>
+  <text x="720" y="420" text-anchor="middle" class="tick-label">32K</text>
+
+  <!-- X axis title -->
+  <text x="410" y="445" text-anchor="middle" class="axis-label">Sequence Length</text>
+
+  <!-- Axes -->
+  <line x1="100" y1="400" x2="720" y2="400" stroke="#333" stroke-width="1.5"/>
+  <line x1="100" y1="70" x2="100" y2="400" stroke="#333" stroke-width="1.5"/>
+
+  <!-- Scale: 18ms = 330px, so 1ms = 18.33px. y = 400 - (ms * 330/18) = 400 - ms*18.33 -->
+  <!-- Dense FA4 data points:
+       1024:  0.08ms -> y=398.5
+       2048:  0.12ms -> y=397.8
+       4096:  0.28ms -> y=394.9
+       8192:  0.96ms -> y=382.4
+       16384: 3.48ms -> y=336.2
+       32768: 16.36ms -> y=100.1
+  -->
+
+  <!-- NSA data points:
+       1024:  0.92ms -> y=383.1
+       2048:  1.26ms -> y=376.9
+       4096:  1.94ms -> y=364.4
+       8192:  3.75ms -> y=331.3
+       16384: 6.96ms -> y=272.4
+       32768: 15.47ms -> y=116.4
+  -->
+
+  <!-- Dense FA4 line (blue) -->
+  <polyline points="130,398.5 248,397.8 366,394.9 484,382.4 602,336.2 720,100.1"
+            fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- Dense FA4 dots -->
+  <circle cx="130" cy="398.5" r="4" fill="#2563eb"/>
+  <circle cx="248" cy="397.8" r="4" fill="#2563eb"/>
+  <circle cx="366" cy="394.9" r="4" fill="#2563eb"/>
+  <circle cx="484" cy="382.4" r="4" fill="#2563eb"/>
+  <circle cx="602" cy="336.2" r="4" fill="#2563eb"/>
+  <circle cx="720" cy="100.1" r="4" fill="#2563eb"/>
+
+  <!-- NSA line (orange-red) -->
+  <polyline points="130,383.1 248,376.9 366,364.4 484,331.3 602,272.4 720,116.4"
+            fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- NSA dots -->
+  <circle cx="130" cy="383.1" r="4" fill="#dc2626"/>
+  <circle cx="248" cy="376.9" r="4" fill="#dc2626"/>
+  <circle cx="366" cy="364.4" r="4" fill="#dc2626"/>
+  <circle cx="484" cy="331.3" r="4" fill="#dc2626"/>
+  <circle cx="602" cy="272.4" r="4" fill="#dc2626"/>
+  <circle cx="720" cy="116.4" r="4" fill="#dc2626"/>
+
+  <!-- Crossover annotation -->
+  <line x1="700" y1="116.4" x2="700" y2="100.1" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <text x="710" y="112" class="speedup-label" fill="#22c55e">1.06x</text>
+
+  <!-- Speedup annotations at each point -->
+  <text x="130" y="377" class="speedup-label" fill="#dc2626">0.08x</text>
+  <text x="248" y="371" class="speedup-label" fill="#dc2626">0.10x</text>
+  <text x="366" y="358" class="speedup-label" fill="#dc2626">0.14x</text>
+  <text x="484" y="325" class="speedup-label" fill="#dc2626">0.25x</text>
+  <text x="602" y="266" class="speedup-label" fill="#dc2626">0.50x</text>
+  <text x="726" y="130" class="speedup-label" fill="#22c55e">1.06x</text>
+
+  <!-- Crossover line (vertical dashed) -->
+  <line x1="712" y1="400" x2="712" y2="70" stroke="#22c55e" stroke-width="1" stroke-dasharray="4,3" opacity="0.5"/>
+
+  <!-- Legend -->
+  <rect x="140" y="70" width="200" height="52" fill="white" stroke="#ddd" rx="4"/>
+  <line x1="152" y1="85" x2="180" y2="85" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="166" cy="85" r="3.5" fill="#2563eb"/>
+  <text x="186" y="89" class="legend-text">Dense FA4 (Flash Attention)</text>
+  <line x1="152" y1="107" x2="180" y2="107" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="166" cy="107" r="3.5" fill="#dc2626"/>
+  <text x="186" y="111" class="legend-text">NSA (Native Sparse Attention)</text>
+
+  <!-- Bottom annotations -->
+  <text x="400" y="472" text-anchor="middle" class="annotation">Dense FA4 scales as O(N²). NSA scales as O(N · (N/l + k·l + w)) where l=128, k=16, w=512.</text>
+  <text x="400" y="487" text-anchor="middle" class="annotation">NSA breaks even at ~32K and becomes faster for longer contexts. Measured on NVIDIA B200 GPU.</text>
+</svg>

--- a/test/attention/probe_max_seqlen.py
+++ b/test/attention/probe_max_seqlen.py
@@ -1,0 +1,85 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Quick memory probe: find the max seq len that fits on one B200 GPU."""
+
+from __future__ import annotations
+
+import traceback
+
+import torch
+
+
+def probe(N: int, B: int = 1, H: int = 8, H_kv: int = 2, D: int = 128):
+    """Try allocating tensors and running Dense FA4 + NSA at sequence length N."""
+    dtype = torch.bfloat16
+    print(f"\n--- N={N:,} ({N // 1024}K) ---")
+
+    try:
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        alloc_gb = torch.cuda.memory_allocated() / 1e9
+        print(f"  Allocated Q/K/V: {alloc_gb:.1f} GB")
+
+        # Try Dense FA4
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+        O = flash_attn_func(Q, K, V, causal=True)
+        torch.cuda.synchronize()
+        peak_dense = torch.cuda.max_memory_allocated() / 1e9
+        print(f"  Dense FA4 OK. Peak: {peak_dense:.1f} GB")
+        del O
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        # Try NSA
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        O_nsa = nsa_forward(
+            Q,
+            K,
+            V,
+            compress_block_size=128,
+            num_selected_blocks=16,
+            window_size=512,
+            causal=True,
+        )
+        torch.cuda.synchronize()
+        peak_nsa = torch.cuda.max_memory_allocated() / 1e9
+        print(f"  NSA OK. Peak: {peak_nsa:.1f} GB")
+        del O_nsa, Q, K, V
+        torch.cuda.empty_cache()
+        return True
+
+    except torch.cuda.OutOfMemoryError as e:
+        print(f"  CUDA OOM: {e}")
+        torch.cuda.empty_cache()
+        return False
+    except Exception as e:
+        print(f"  Error: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        torch.cuda.empty_cache()
+        return False
+
+
+def main():
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(
+        f"GPU memory: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB"
+    )
+
+    for n_k in [2048, 3072, 4096, 6144, 8192, 16384]:
+        N = n_k * 1024
+        ok = probe(N)
+        if not ok:
+            print(f"\n==> Max working sequence length: <{n_k}K")
+            break
+    else:
+        print(f"\n==> All sizes up to {n_k}K fit!")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/test_sparse_attn_benchmark.py
+++ b/test/attention/test_sparse_attn_benchmark.py
@@ -36,7 +36,14 @@ class TestBenchmark:
         from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
         from mslk.attention.sparse_attn.nsa_forward import nsa_forward
 
-        B, H, H_kv, D = 2, 32, 32, 128
+        # Scale down dimensions for large N to avoid OOM when GPU memory is
+        # shared across parallel test processes.
+        if N >= 65536:
+            B, H, H_kv, D = 1, 8, 8, 128
+        elif N >= 32768:
+            B, H, H_kv, D = 1, 32, 32, 128
+        else:
+            B, H, H_kv, D = 2, 32, 32, 128
         dtype = torch.bfloat16
 
         Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)

--- a/test/attention/test_sparse_attn_benchmark.py
+++ b/test/attention/test_sparse_attn_benchmark.py
@@ -1,0 +1,69 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Performance benchmark: NSA vs dense FA4 attention."""
+
+import pytest
+import torch
+
+
+def _benchmark_fn(fn, warmup=5, repeat=20):
+    """Benchmark a function using CUDA events."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    times = []
+    for _ in range(repeat):
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times = sorted(times)
+    # Use median
+    return times[len(times) // 2]
+
+
+class TestBenchmark:
+    """Performance comparison between NSA and dense FA4."""
+
+    @pytest.mark.parametrize("N", [8192, 16384, 32768, 65536, 131072])
+    def test_nsa_benchmark(self, N) -> None:
+        """Benchmark NSA vs dense FA4 and report speedup."""
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        B, H, H_kv, D = 2, 32, 32, 128
+        dtype = torch.bfloat16
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+        # Dense FA4 baseline
+        dense_ms = _benchmark_fn(
+            lambda: flash_attn_func(Q, K, V, causal=True)
+        )
+
+        # NSA
+        nsa_ms = _benchmark_fn(
+            lambda: nsa_forward(
+                Q, K, V,
+                compress_block_size=64,
+                num_selected_blocks=16,
+                window_size=512,
+                causal=True,
+            )
+        )
+
+        speedup = dense_ms / nsa_ms
+        print(
+            f"\nN={N}: dense={dense_ms:.2f}ms, NSA={nsa_ms:.2f}ms, "
+            f"speedup={speedup:.2f}x"
+        )
+
+        # At large N, we expect NSA to be competitive
+        # (don't fail the test, just report)

--- a/test/attention/test_sparse_attn_compress.py
+++ b/test/attention/test_sparse_attn_compress.py
@@ -1,0 +1,79 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for KV compression."""
+
+import pytest
+import torch
+
+
+class TestCompressKV:
+    """Test KV compression with mean-pooling and projection."""
+
+    def test_basic_shape(self) -> None:
+        """Compressed output has correct shape."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 1024, 4, 64
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size)
+        assert K_cmp.shape == (B, N // block_size, H_kv, D)
+        assert V_cmp.shape == (B, N // block_size, H_kv, D)
+
+    def test_mean_pool_correctness(self) -> None:
+        """Mean-pool matches manual reshape + mean."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 256, 2, 32
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size)
+
+        # Manual mean pool
+        K_expected = K.reshape(B, N // block_size, block_size, H_kv, D).mean(dim=2)
+        V_expected = V.reshape(B, N // block_size, block_size, H_kv, D).mean(dim=2)
+
+        torch.testing.assert_close(K_cmp, K_expected, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(V_cmp, V_expected, atol=1e-5, rtol=1e-5)
+
+    def test_with_projection(self) -> None:
+        """Projection applies correctly after mean-pooling."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 256, 2, 32
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+        W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size, W_k, W_v)
+
+        # Manual: mean pool then project
+        K_pooled = K.reshape(B, N // block_size, block_size, H_kv, D).mean(dim=2)
+        K_expected = torch.einsum("bnhd,hde->bnhe", K_pooled, W_k)
+
+        torch.testing.assert_close(K_cmp, K_expected, atol=1e-5, rtol=1e-5)
+
+    def test_bf16_tolerance(self) -> None:
+        """BF16 compression is within tolerance of FP32 compression."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H_kv, D = 2, 512, 4, 64
+        block_size = 64
+
+        K_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+
+        K_cmp_fp32, V_cmp_fp32 = compress_kv(K_fp32, V_fp32, block_size)
+        K_cmp_bf16, V_cmp_bf16 = compress_kv(
+            K_fp32.bfloat16(), V_fp32.bfloat16(), block_size
+        )
+
+        torch.testing.assert_close(
+            K_cmp_bf16.float(), K_cmp_fp32, atol=1e-2, rtol=1e-2
+        )

--- a/test/attention/test_sparse_attn_compress.py
+++ b/test/attention/test_sparse_attn_compress.py
@@ -77,3 +77,88 @@ class TestCompressKV:
         torch.testing.assert_close(
             K_cmp_bf16.float(), K_cmp_fp32, atol=1e-2, rtol=1e-2
         )
+
+
+class TestFusedCompressKV:
+    """Test fused CuteDSL KV compression kernel."""
+
+    @pytest.mark.parametrize(
+        "B, N, H_kv, D, block_size",
+        [
+            (1, 256, 1, 64, 64),
+            (2, 1024, 4, 64, 64),
+            (2, 512, 8, 128, 32),
+            (1, 2048, 2, 128, 128),
+            (2, 4096, 4, 64, 64),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_matches_reference(self, B, N, H_kv, D, block_size, dtype) -> None:
+        """Fused kernel matches PyTorch compress_kv within tolerance."""
+        from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
+
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+        K_ref, V_ref = compress_kv(K, V, block_size)
+        K_fused, V_fused = fused_compress_kv(K, V, block_size)
+
+        if dtype == torch.float32:
+            atol, rtol = 1e-5, 1e-5
+        else:
+            atol, rtol = 1e-3, 1e-3
+
+        torch.testing.assert_close(K_fused, K_ref, atol=atol, rtol=rtol)
+        torch.testing.assert_close(V_fused, V_ref, atol=atol, rtol=rtol)
+
+    def test_basic_shape(self) -> None:
+        """Fused compressed output has correct shape."""
+        from mslk.attention.sparse_attn.compress import fused_compress_kv
+
+        B, N, H_kv, D = 2, 1024, 4, 64
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, V_cmp = fused_compress_kv(K, V, block_size)
+        assert K_cmp.shape == (B, N // block_size, H_kv, D)
+        assert V_cmp.shape == (B, N // block_size, H_kv, D)
+
+    def test_with_projection(self) -> None:
+        """Fused kernel with projection matches reference."""
+        from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
+
+        B, N, H_kv, D = 2, 256, 2, 32
+        block_size = 64
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+        W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+
+        K_ref, V_ref = compress_kv(K, V, block_size, W_k, W_v)
+        K_fused, V_fused = fused_compress_kv(K, V, block_size, W_k, W_v)
+
+        torch.testing.assert_close(K_fused, K_ref, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(V_fused, V_ref, atol=1e-5, rtol=1e-5)
+
+    def test_bf16_tolerance(self) -> None:
+        """BF16 fused compression is within tolerance of FP32 reference."""
+        from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
+
+        B, N, H_kv, D = 2, 512, 4, 64
+        block_size = 64
+
+        K_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+        V_fp32 = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+
+        K_cmp_fp32, V_cmp_fp32 = compress_kv(K_fp32, V_fp32, block_size)
+        K_cmp_fused, V_cmp_fused = fused_compress_kv(
+            K_fp32.bfloat16(), V_fp32.bfloat16(), block_size
+        )
+
+        torch.testing.assert_close(
+            K_cmp_fused.float(), K_cmp_fp32, atol=1e-2, rtol=1e-2
+        )
+        torch.testing.assert_close(
+            V_cmp_fused.float(), V_cmp_fp32, atol=1e-2, rtol=1e-2
+        )

--- a/test/attention/test_sparse_attn_gating.py
+++ b/test/attention/test_sparse_attn_gating.py
@@ -1,0 +1,116 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for fused CuteDSL gating kernel.
+
+Compares fused_gate_and_combine against the PyTorch reference
+(compute_gates + gate_and_combine).
+"""
+
+import pytest
+import torch
+
+
+def _ref_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight=None):
+    """PyTorch reference: compute_gates then gate_and_combine."""
+    from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+
+    gates = compute_gates(Q, gate_proj_weight)
+    return gate_and_combine(O_cmp, O_slc, O_sld, gates)
+
+
+class TestFusedGating:
+    """Compare fused CuteDSL kernel against PyTorch reference."""
+
+    @pytest.mark.parametrize(
+        "B,N,H,D",
+        [
+            (1, 64, 4, 128),
+            (2, 128, 8, 128),
+            (1, 256, 32, 128),
+            (2, 1024, 4, 128),
+            (1, 64, 4, 256),
+        ],
+    )
+    def test_with_gate_weight(self, B, N, H, D) -> None:
+        """Fused kernel matches reference when gate_proj_weight is provided."""
+        from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+
+        dtype = torch.bfloat16
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_slc = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_sld = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype)
+
+        out_ref = _ref_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+        out_fused = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+
+        assert out_fused.shape == out_ref.shape
+        max_diff = (out_fused.float() - out_ref.float()).abs().max().item()
+        mean_diff = (out_fused.float() - out_ref.float()).abs().mean().item()
+        # Tolerance accounts for bf16 intermediate rounding differences:
+        # the reference casts gates to bf16 between compute_gates and
+        # gate_and_combine, while the fused kernel keeps them in fp32.
+        assert max_diff < 0.05, f"Max diff too large: {max_diff}"
+        assert mean_diff < 5e-3, f"Mean diff too large: {mean_diff}"
+
+    @pytest.mark.parametrize(
+        "B,N,H,D",
+        [
+            (1, 64, 4, 128),
+            (2, 256, 8, 128),
+            (1, 1024, 32, 128),
+        ],
+    )
+    def test_without_gate_weight(self, B, N, H, D) -> None:
+        """Fused kernel matches reference with uniform gates (no gate_proj_weight)."""
+        from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+
+        dtype = torch.bfloat16
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_slc = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_sld = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+
+        out_ref = _ref_gate_and_combine(Q, O_cmp, O_slc, O_sld)
+        out_fused = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld)
+
+        assert out_fused.shape == out_ref.shape
+        max_diff = (out_fused.float() - out_ref.float()).abs().max().item()
+        mean_diff = (out_fused.float() - out_ref.float()).abs().mean().item()
+        assert max_diff < 0.05, f"Max diff too large: {max_diff}"
+        assert mean_diff < 5e-3, f"Mean diff too large: {mean_diff}"
+
+    def test_output_finite(self) -> None:
+        """Fused kernel produces finite outputs."""
+        from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+
+        B, N, H, D = 2, 512, 4, 128
+        dtype = torch.bfloat16
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype) * 0.1
+        O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_slc = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_sld = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype) * 0.1
+
+        out = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_dtype_float16(self) -> None:
+        """Fused kernel works with float16."""
+        from mslk.attention.sparse_attn.gating import fused_gate_and_combine
+
+        B, N, H, D = 1, 64, 4, 128
+        dtype = torch.float16
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_slc = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        O_sld = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        gate_proj_weight = torch.randn(H, 3, D, device="cuda", dtype=dtype)
+
+        out_ref = _ref_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+        out_fused = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+
+        max_diff = (out_fused.float() - out_ref.float()).abs().max().item()
+        assert max_diff < 1e-2, f"Max diff too large: {max_diff}"

--- a/test/attention/test_sparse_attn_nsa_backward.py
+++ b/test/attention/test_sparse_attn_nsa_backward.py
@@ -1,0 +1,733 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for the NSA reference backward pass (autograd-based)."""
+
+import math
+
+import pytest
+import torch
+
+
+def _make_inputs(
+    B: int,
+    N: int,
+    H: int,
+    D: int,
+    H_kv: int | None = None,
+    with_W_k: bool = False,
+    with_W_v: bool = False,
+    with_gate: bool = False,
+    dtype: torch.dtype = torch.float64,
+    device: str = "cuda",
+) -> dict:
+    """Create input tensors with requires_grad for gradient checking."""
+    if H_kv is None:
+        H_kv = H
+    Q = torch.randn(B, N, H, D, device=device, dtype=dtype, requires_grad=True)
+    K = torch.randn(B, N, H_kv, D, device=device, dtype=dtype, requires_grad=True)
+    V = torch.randn(B, N, H_kv, D, device=device, dtype=dtype, requires_grad=True)
+    result = {"Q": Q, "K": K, "V": V}
+    if with_W_k:
+        result["W_k_compress"] = (
+            torch.randn(
+                H_kv,
+                D,
+                D,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            * 0.02
+        )
+    if with_W_v:
+        result["W_v_compress"] = (
+            torch.randn(
+                H_kv,
+                D,
+                D,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            * 0.02
+        )
+    if with_gate:
+        result["gate_proj_weight"] = (
+            torch.randn(
+                H,
+                3,
+                D,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            * 0.1
+        )
+    return result
+
+
+class TestNSAReferenceBackwardGradcheck:
+    """Validate gradients via torch.autograd.gradcheck (finite differences).
+
+    Block selection indices are pre-computed and frozen during gradcheck,
+    since top-k is non-differentiable and would cause discontinuities
+    when inputs are perturbed.
+    """
+
+    # Use small sizes for gradcheck (it's O(params) forward passes)
+    B, N, H, D = 1, 256, 2, 32
+    compress_block_size = 64
+    num_selected_blocks = 2
+    window_size = 128
+    q_tile_size = 256
+
+    def _run_gradcheck(self, inputs: dict, causal: bool = True) -> None:
+        from mslk.attention.sparse_attn.reference import (
+            compute_block_indices_reference,
+            nsa_forward_reference,
+        )
+
+        # Pre-compute block indices with the original (unperturbed) inputs
+        # so that top-k selection is frozen during finite-difference perturbation
+        block_indices = compute_block_indices_reference(
+            inputs["Q"].detach(),
+            inputs["K"].detach(),
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            W_k_compress=inputs.get("W_k_compress"),
+            causal=causal,
+            q_tile_size=self.q_tile_size,
+        )
+
+        # Ensure block 0 is always selected for causal mode. Without it,
+        # early queries in a tile may have ALL selected KV positions causally
+        # masked (kv_pos > q_pos for all selected positions), producing NaN
+        # from softmax over all -inf.
+        if causal:
+            block_indices[..., 0] = 0
+
+        params = [
+            v
+            for v in inputs.values()
+            if isinstance(v, torch.Tensor) and v.requires_grad
+        ]
+
+        def fn(*args):
+            kw = {}
+            idx = 0
+            for k, v in inputs.items():
+                if isinstance(v, torch.Tensor) and v.requires_grad:
+                    kw[k] = args[idx]
+                    idx += 1
+                else:
+                    kw[k] = v
+            out = nsa_forward_reference(
+                kw["Q"],
+                kw["K"],
+                kw["V"],
+                compress_block_size=self.compress_block_size,
+                num_selected_blocks=self.num_selected_blocks,
+                window_size=self.window_size,
+                W_k_compress=kw.get("W_k_compress"),
+                W_v_compress=kw.get("W_v_compress"),
+                gate_proj_weight=kw.get("gate_proj_weight"),
+                causal=causal,
+                q_tile_size=self.q_tile_size,
+                _block_indices=block_indices,
+            )
+            return out
+
+        torch.autograd.gradcheck(fn, params, raise_exception=True)
+
+    def test_gradcheck_basic(self) -> None:
+        """Gradcheck for Q, K, V without optional weights."""
+        inputs = _make_inputs(self.B, self.N, self.H, self.D)
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_with_gate_weights(self) -> None:
+        """Gradcheck including gate_proj_weight gradients."""
+        inputs = _make_inputs(self.B, self.N, self.H, self.D, with_gate=True)
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_with_compression_weights(self) -> None:
+        """Gradcheck including W_k_compress and W_v_compress gradients."""
+        inputs = _make_inputs(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            with_W_k=True,
+            with_W_v=True,
+        )
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_all_weights(self) -> None:
+        """Gradcheck with all optional weights enabled."""
+        inputs = _make_inputs(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            with_W_k=True,
+            with_W_v=True,
+            with_gate=True,
+        )
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_noncausal(self) -> None:
+        """Gradcheck in non-causal mode."""
+        inputs = _make_inputs(self.B, self.N, self.H, self.D)
+        self._run_gradcheck(inputs, causal=False)
+
+    def test_gradcheck_gqa(self) -> None:
+        """Gradcheck with grouped query attention (H > H_kv)."""
+        inputs = _make_inputs(self.B, self.N, 4, self.D, H_kv=2)
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_compressed_only(self) -> None:
+        """Gradcheck for just compressed attention (isolate branch)."""
+        from mslk.attention.sparse_attn.reference import _compressed_attention
+
+        B, N, H, D = self.B, self.N, self.H, self.D
+        q = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+
+        def fn(q, k, v):
+            return _compressed_attention(
+                q,
+                k,
+                v,
+                self.compress_block_size,
+                None,
+                None,
+                1,
+                1.0 / D**0.5,
+                True,
+                B,
+                N,
+                H,
+                H,
+                D,
+            )
+
+        torch.autograd.gradcheck(fn, (q, k, v), raise_exception=True)
+
+    def test_gradcheck_sliding_only(self) -> None:
+        """Gradcheck for just sliding window attention (isolate branch)."""
+        from mslk.attention.sparse_attn.reference import _sliding_window_attention
+
+        B, N, H, D = self.B, self.N, self.H, self.D
+        q = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+
+        def fn(q, k, v):
+            return _sliding_window_attention(
+                q,
+                k,
+                v,
+                self.window_size,
+                1.0 / D**0.5,
+                True,
+                B,
+                N,
+                H,
+                D,
+            )
+
+        torch.autograd.gradcheck(fn, (q, k, v), raise_exception=True)
+
+    def test_gradcheck_selected_only(self) -> None:
+        """Gradcheck for just selected attention with frozen indices."""
+        from mslk.attention.sparse_attn.reference import _selected_attention
+
+        B, N, H, D = self.B, self.N, self.H, self.D
+        q = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+
+        # Use first k_actual blocks — always valid for causal masking
+        N_blocks = N // self.compress_block_size
+        N_q_tiles = N // self.q_tile_size
+        k_actual = min(self.num_selected_blocks, N_blocks)
+        block_indices = (
+            torch.arange(k_actual, device="cuda").unsqueeze(0).unsqueeze(0).unsqueeze(0)
+        )
+        block_indices = block_indices.expand(B, H, N_q_tiles, k_actual)
+
+        def fn(q, k, v):
+            return _selected_attention(
+                q,
+                k,
+                v,
+                self.compress_block_size,
+                self.num_selected_blocks,
+                None,
+                1,
+                1.0 / D**0.5,
+                True,
+                B,
+                N,
+                H,
+                H,
+                D,
+                q_tile_size=self.q_tile_size,
+                _block_indices=block_indices,
+            )
+
+        torch.autograd.gradcheck(fn, (q, k, v), raise_exception=True)
+
+
+class TestNSABackwardReference:
+    """Test nsa_backward_reference wrapper function."""
+
+    B, N, H, D = 1, 512, 4, 64
+    compress_block_size = 64
+    num_selected_blocks = 4
+    window_size = 256
+    q_tile_size = 256
+
+    def test_gradient_shapes(self) -> None:
+        """Output gradient shapes match input shapes."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        H_kv = self.H
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        assert grads["dQ"].shape == Q.shape
+        assert grads["dK"].shape == K.shape
+        assert grads["dV"].shape == V.shape
+        assert grads["dW_k_compress"] is None
+        assert grads["dW_v_compress"] is None
+        assert grads["dgate_proj_weight"] is None
+
+    def test_gradient_shapes_all_weights(self) -> None:
+        """Gradient shapes correct with all optional weights."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        H_kv = self.H
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+        W_k = (
+            torch.randn(H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        )
+        W_v = (
+            torch.randn(H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        )
+        gate = torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            W_k_compress=W_k,
+            W_v_compress=W_v,
+            gate_proj_weight=gate,
+        )
+
+        assert grads["dQ"].shape == Q.shape
+        assert grads["dK"].shape == K.shape
+        assert grads["dV"].shape == V.shape
+        assert grads["dW_k_compress"].shape == W_k.shape
+        assert grads["dW_v_compress"].shape == W_v.shape
+        assert grads["dgate_proj_weight"].shape == gate.shape
+
+    def test_gradients_finite(self) -> None:
+        """All gradients are finite (no NaN/Inf)."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+        gate = torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            gate_proj_weight=gate,
+        )
+
+        for name in ("dQ", "dK", "dV", "dgate_proj_weight"):
+            assert torch.isfinite(grads[name]).all(), f"{name} contains NaN or Inf"
+
+    def test_gradients_nonzero(self) -> None:
+        """Gradients are not all-zero (sanity check that grad flows)."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        for name in ("dQ", "dK", "dV"):
+            assert grads[name].abs().max() > 0, f"{name} is all zeros"
+
+    def test_gradient_shapes_gqa(self) -> None:
+        """Gradient shapes correct with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        H_kv = 2
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        assert grads["dQ"].shape == Q.shape
+        assert grads["dK"].shape == K.shape  # (B, N, H_kv, D), not (B, N, H, D)
+        assert grads["dV"].shape == V.shape
+
+
+class TestNSAAutograd:
+    """Test NSAFunction (FA4-based forward + backward via autograd).
+
+    Validates that nsa() produces correct forward output and that
+    gradients flow correctly through .backward().
+    """
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 4
+    compress_block_size = 64
+    num_selected_blocks = 8
+    window_size = 256
+    q_tile_size = 256
+
+    def test_forward_matches_nsa_forward(self) -> None:
+        """nsa() forward output matches nsa_forward()."""
+        from mslk.attention.sparse_attn import nsa, nsa_forward
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+
+        out_fwd = nsa_forward(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+        out_autograd = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        # nsa() uses PyTorch gating (compute_gates + gate_and_combine) while
+        # nsa_forward() uses fused CuteDSL gating, so expect small numerical diffs
+        assert torch.allclose(out_fwd, out_autograd, atol=0.02, rtol=0.02), (
+            f"max diff: {(out_fwd - out_autograd).abs().max().item()}"
+        )
+
+    def test_backward_produces_gradients(self) -> None:
+        """nsa() backward produces non-zero gradients for Q, K, V."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        assert Q.grad is not None, "Q.grad is None"
+        assert K.grad is not None, "K.grad is None"
+        assert V.grad is not None, "V.grad is None"
+        assert Q.grad.abs().max() > 0, "Q.grad is all zeros"
+        assert K.grad.abs().max() > 0, "K.grad is all zeros"
+        assert V.grad.abs().max() > 0, "V.grad is all zeros"
+
+    def test_backward_with_gate_weights(self) -> None:
+        """nsa() backward produces gradients for gate_proj_weight."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        gate = (
+            torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+        ).requires_grad_(True)
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            gate_proj_weight=gate,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        assert gate.grad is not None, "gate.grad is None"
+        assert gate.grad.abs().max() > 0, "gate.grad is all zeros"
+
+    def test_backward_with_compression_weights(self) -> None:
+        """nsa() backward produces gradients for W_k_compress and W_v_compress."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        W_k = (
+            torch.randn(self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        ).requires_grad_(True)
+        W_v = (
+            torch.randn(self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        ).requires_grad_(True)
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            W_k_compress=W_k,
+            W_v_compress=W_v,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        assert W_k.grad is not None, "W_k.grad is None"
+        assert W_v.grad is not None, "W_v.grad is None"
+        assert W_k.grad.abs().max() > 0, "W_k.grad is all zeros"
+        assert W_v.grad.abs().max() > 0, "W_v.grad is all zeros"
+
+    def test_gradients_finite(self) -> None:
+        """All gradients from nsa() backward are finite."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        gate = (
+            torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+        ).requires_grad_(True)
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            gate_proj_weight=gate,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        for name, param in [("Q", Q), ("K", K), ("V", V), ("gate", gate)]:
+            assert torch.isfinite(param.grad).all(), f"{name}.grad contains NaN or Inf"

--- a/test/attention/test_sparse_attn_nsa_backward.py
+++ b/test/attention/test_sparse_attn_nsa_backward.py
@@ -731,3 +731,154 @@ class TestNSAAutograd:
 
         for name, param in [("Q", Q), ("K", K), ("V", V), ("gate", gate)]:
             assert torch.isfinite(param.grad).all(), f"{name}.grad contains NaN or Inf"
+
+
+class TestNSABackwardMatchesReference:
+    """Compare FA4-based backward gradient values against reference backward.
+
+    This validates that the optimized backward (using FA4 CuteDSL kernels)
+    produces numerically similar gradients to the pure PyTorch reference.
+    """
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 4
+    compress_block_size = 64
+    num_selected_blocks = 8
+    window_size = 256
+    q_tile_size = 256
+
+    def _compare_grads(
+        self,
+        with_gate: bool = False,
+        with_W_k: bool = False,
+        with_W_v: bool = False,
+        causal: bool = True,
+        max_atol: float = 0.5,
+        mean_atol: float = 0.05,
+    ) -> None:
+        from mslk.attention.sparse_attn import nsa
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        torch.manual_seed(42)
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        kwargs = {
+            "compress_block_size": self.compress_block_size,
+            "num_selected_blocks": self.num_selected_blocks,
+            "window_size": self.window_size,
+            "causal": causal,
+            "q_tile_size": self.q_tile_size,
+        }
+
+        W_k = None
+        W_v = None
+        gate = None
+        if with_W_k:
+            W_k = (
+                torch.randn(
+                    self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16
+                )
+                * 0.02
+            )
+            kwargs["W_k_compress"] = W_k
+        if with_W_v:
+            W_v = (
+                torch.randn(
+                    self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16
+                )
+                * 0.02
+            )
+            kwargs["W_v_compress"] = W_v
+        if with_gate:
+            gate = (
+                torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16)
+                * 0.1
+            )
+            kwargs["gate_proj_weight"] = gate
+
+        # --- Reference backward ---
+        ref_grads = nsa_backward_reference(Q, K, V, dO, **kwargs)
+
+        # --- Optimized backward (FA4-based) ---
+        Q_opt = Q.clone().requires_grad_(True)
+        K_opt = K.clone().requires_grad_(True)
+        V_opt = V.clone().requires_grad_(True)
+
+        opt_kwargs = dict(kwargs)
+        if with_W_k:
+            W_k_opt = W_k.clone().requires_grad_(True)
+            opt_kwargs["W_k_compress"] = W_k_opt
+        if with_W_v:
+            W_v_opt = W_v.clone().requires_grad_(True)
+            opt_kwargs["W_v_compress"] = W_v_opt
+        if with_gate:
+            gate_opt = gate.clone().requires_grad_(True)
+            opt_kwargs["gate_proj_weight"] = gate_opt
+
+        out = nsa(Q_opt, K_opt, V_opt, **opt_kwargs)
+        out.backward(dO)
+
+        # --- Compare ---
+        pairs = [
+            ("dQ", Q_opt.grad, ref_grads["dQ"]),
+            ("dK", K_opt.grad, ref_grads["dK"]),
+            ("dV", V_opt.grad, ref_grads["dV"]),
+        ]
+        if with_W_k:
+            pairs.append(("dW_k", W_k_opt.grad, ref_grads["dW_k_compress"]))
+        if with_W_v:
+            pairs.append(("dW_v", W_v_opt.grad, ref_grads["dW_v_compress"]))
+        if with_gate:
+            pairs.append(("dgate", gate_opt.grad, ref_grads["dgate_proj_weight"]))
+
+        for name, opt_grad, ref_grad in pairs:
+            assert opt_grad is not None, f"{name} is None"
+            ref_grad = ref_grad.to(opt_grad.dtype)
+            diff = (opt_grad - ref_grad).abs()
+            max_diff = diff.max().item()
+            mean_diff = diff.mean().item()
+            # Gate gradients use fused CuteDSL kernel vs float32 reference,
+            # so max outliers can be large; check mean only for gates.
+            if name == "dgate":
+                assert mean_diff < 1.0, f"{name}: mean_diff={mean_diff:.6f} exceeds 1.0"
+            else:
+                assert max_diff < max_atol, (
+                    f"{name}: max_diff={max_diff:.4f} exceeds {max_atol}"
+                )
+                assert mean_diff < mean_atol, (
+                    f"{name}: mean_diff={mean_diff:.6f} exceeds {mean_atol}"
+                )
+
+    def test_basic(self) -> None:
+        """Q, K, V gradients match reference."""
+        self._compare_grads()
+
+    def test_with_gate_weights(self) -> None:
+        """Gradients match with gate projection weights."""
+        self._compare_grads(with_gate=True)
+
+    def test_with_compression_weights(self) -> None:
+        """Gradients match with compression projection weights."""
+        self._compare_grads(with_W_k=True, with_W_v=True)
+
+    def test_all_weights(self) -> None:
+        """Gradients match with all optional weights."""
+        self._compare_grads(with_gate=True, with_W_k=True, with_W_v=True)
+
+    def test_noncausal(self) -> None:
+        """Gradients match in non-causal mode.
+
+        Non-causal has larger bf16 diffs (no causal mask to stabilize softmax),
+        so we only check mean diff.
+        """
+        self._compare_grads(causal=False, max_atol=5.0, mean_atol=0.1)

--- a/test/attention/test_sparse_attn_nsa_forward.py
+++ b/test/attention/test_sparse_attn_nsa_forward.py
@@ -1,0 +1,184 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""End-to-end correctness tests for NSA forward pass.
+
+Compares the FA4-based NSA implementation against the pure PyTorch reference.
+"""
+
+import math
+
+import pytest
+import torch
+
+
+def _make_inputs(B, N, H, H_kv, D, dtype, device="cuda"):
+    """Create random Q, K, V inputs."""
+    Q = torch.randn(B, N, H, D, device=device, dtype=dtype) * 0.1
+    K = torch.randn(B, N, H_kv, D, device=device, dtype=dtype) * 0.1
+    V = torch.randn(B, N, H_kv, D, device=device, dtype=dtype) * 0.1
+    return Q, K, V
+
+
+class TestNSAForwardCorrectness:
+    """Compare FA4-based NSA against reference implementation."""
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16])
+    @pytest.mark.parametrize("N", [1024, 2048])
+    @pytest.mark.parametrize("causal", [True])
+    def test_nsa_vs_reference(self, dtype, N, causal) -> None:
+        """NSA forward pass matches reference within tolerance."""
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, H, H_kv, D = 1, 4, 4, 128
+        compress_block_size = 64
+        num_selected = 8
+        window_size = 256
+        q_tile_size = 256
+
+        Q, K, V = _make_inputs(B, N, H, H_kv, D, dtype)
+
+        # Reference (pure PyTorch)
+        out_ref = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected,
+            window_size=window_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+        )
+
+        # FA4-based
+        out_fa4 = nsa_forward(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected,
+            window_size=window_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+        )
+
+        max_diff = (out_fa4.float() - out_ref.float()).abs().max().item()
+        mean_diff = (out_fa4.float() - out_ref.float()).abs().mean().item()
+
+        assert max_diff < 0.1, f"Max diff too large: {max_diff}"
+        assert mean_diff < 0.01, f"Mean diff too large: {mean_diff}"
+
+    @pytest.mark.parametrize("H,H_kv", [(4, 4)])
+    def test_nsa_gqa(self, H, H_kv) -> None:
+        """NSA works with MHA configuration.
+
+        Note: GQA (H > H_kv) is not yet supported with block sparsity in FA4
+        (pack_gqa=True is not compatible with block_sparse_tensors).
+        """
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        B, N, D = 1, 1024, 128
+        Q, K, V = _make_inputs(B, N, H, H_kv, D, torch.bfloat16)
+
+        out = nsa_forward(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=8,
+            window_size=256,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    @pytest.mark.parametrize("N", [65536])
+    def test_nsa_large_n(self, N) -> None:
+        """NSA handles large sequence lengths without OOM.
+
+        Verifies that the tiled block scoring, compact index tensors, and
+        chunked gating optimizations allow NSA to scale beyond 32K.
+        """
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        B, H, H_kv, D = 1, 4, 4, 128
+        compress_block_size = 64
+        num_selected = 16
+        window_size = 512
+        dtype = torch.bfloat16
+
+        Q, K, V = _make_inputs(B, N, H, H_kv, D, dtype)
+
+        out = nsa_forward(
+            Q, K, V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected,
+            window_size=window_size,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+
+class TestNSAForwardComponentIntegration:
+    """Test that individual components integrate correctly."""
+
+    def test_compress_then_fa4(self) -> None:
+        """FA4 can run on compressed KV sequence."""
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 4, 128
+        block_size = 64
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, V_cmp = compress_kv(K, V, block_size)
+        # K_cmp: (B, N//64, H, D) = (1, 16, 4, 128)
+
+        out, lse = flash_attn_func(Q, K_cmp, V_cmp, causal=True)
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_sliding_window_fa4(self) -> None:
+        """FA4 sliding window attention works correctly."""
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+        B, N, H, D = 1, 1024, 4, 128
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        out, lse = flash_attn_func(
+            Q, K, V, causal=True, window_size=(512, 0)
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_block_sparse_fa4(self) -> None:
+        """FA4 block-sparse attention works with our mask format."""
+        from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, N, H, D = 1, 1024, 4, 128
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        block_indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=256,
+        )
+        sparse_tensors = build_fa4_block_sparse_tensors(
+            block_indices, block_size, n_block_size=128, seqlen_k=N,
+        )
+
+        out, lse = _flash_attn_fwd(
+            Q, K, V,
+            causal=True,
+            block_sparse_tensors=sparse_tensors,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()

--- a/test/attention/test_sparse_attn_reference.py
+++ b/test/attention/test_sparse_attn_reference.py
@@ -1,0 +1,133 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for the pure PyTorch NSA reference implementation."""
+
+import math
+
+import pytest
+import torch
+
+
+class TestNSAReferenceBasic:
+    """Basic sanity checks for the reference implementation."""
+
+    def test_output_shape(self) -> None:
+        """Output shape matches input query shape."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        H_kv = 4
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert out.dtype == torch.bfloat16
+
+    def test_output_shape_gqa(self) -> None:
+        """Output shape correct with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 8, 64
+        H_kv = 2
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+
+    def test_output_finite(self) -> None:
+        """Output contains no NaN or Inf values."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 2, 512, 4, 64
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.float16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.float16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.float16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=True,
+        )
+        assert torch.isfinite(out).all(), "Output contains NaN or Inf"
+
+    def test_with_gate_weights(self) -> None:
+        """Test with explicit gate projection weights."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        gate_proj = torch.randn(H, 3, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            gate_proj_weight=gate_proj,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_with_compression_weights(self) -> None:
+        """Test with learned KV compression projections."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        H_kv = 4
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16) * 0.02
+        W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16) * 0.02
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            W_k_compress=W_k,
+            W_v_compress=W_v,
+            causal=True,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()
+
+    def test_noncausal(self) -> None:
+        """Test non-causal mode."""
+        from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+        B, N, H, D = 1, 512, 4, 64
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        out = nsa_forward_reference(
+            Q, K, V,
+            compress_block_size=64,
+            num_selected_blocks=4,
+            window_size=256,
+            causal=False,
+        )
+        assert out.shape == (B, N, H, D)
+        assert torch.isfinite(out).all()

--- a/test/attention/test_sparse_attn_select.py
+++ b/test/attention/test_sparse_attn_select.py
@@ -1,0 +1,157 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for block scoring and top-k selection."""
+
+import pytest
+import torch
+
+
+class TestScoreAndSelectBlocks:
+    """Test block scoring and selection."""
+
+    def test_output_shape(self) -> None:
+        """Selected indices have correct shape."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 2, 1024, 4, 64
+        H_kv = 4
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        N_cmp = N // block_size
+        k_actual = min(num_selected, N_cmp)
+        assert indices.shape == (B, H, N_q_tiles, k_actual)
+        assert indices.dtype == torch.int32
+
+    def test_indices_in_range(self) -> None:
+        """All selected indices are valid KV block indices."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=256,
+        )
+
+        N_cmp = N // block_size
+        assert (indices >= 0).all()
+        assert (indices < N_cmp).all()
+
+    def test_causal_no_future_blocks(self) -> None:
+        """Causal mode: no future blocks are selected."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 2, 64
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        for qt in range(N_q_tiles):
+            # Query tile qt covers positions [qt*q_tile_size, (qt+1)*q_tile_size)
+            # KV block idx covers positions [idx*block_size, (idx+1)*block_size)
+            # Causal: KV block start must be < query tile end
+            q_tile_end = (qt + 1) * q_tile_size
+            max_allowed_block = q_tile_end // block_size
+            assert (indices[:, :, qt, :] < max_allowed_block).all(), (
+                f"Query tile {qt}: found future block indices"
+            )
+
+    def test_indices_sorted(self) -> None:
+        """Selected indices are sorted per query tile."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size,
+            causal=True, q_tile_size=256,
+        )
+
+        # Check sorted along last dim
+        sorted_indices = indices.sort(dim=-1).values
+        assert (indices == sorted_indices).all()
+
+    def test_deterministic(self) -> None:
+        """Same input produces same selection."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices1 = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        indices2 = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        assert (indices1 == indices2).all()
+
+    def test_gqa(self) -> None:
+        """Works correctly with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
+        from mslk.attention.sparse_attn.compress import compress_kv
+
+        B, N, H, D = 1, 1024, 8, 64
+        H_kv = 2
+        block_size = 64
+        num_selected = 4
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        N_q_tiles = N // 256
+        assert indices.shape == (B, H, N_q_tiles, num_selected)

--- a/test/attention/test_sparse_attn_select.py
+++ b/test/attention/test_sparse_attn_select.py
@@ -11,8 +11,8 @@ class TestScoreAndSelectBlocks:
 
     def test_output_shape(self) -> None:
         """Selected indices have correct shape."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 2, 1024, 4, 64
         H_kv = 4
@@ -26,8 +26,12 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
-            Q, K_cmp, num_selected, block_size,
-            causal=True, q_tile_size=q_tile_size,
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=q_tile_size,
         )
 
         N_q_tiles = N // q_tile_size
@@ -38,8 +42,8 @@ class TestScoreAndSelectBlocks:
 
     def test_indices_in_range(self) -> None:
         """All selected indices are valid KV block indices."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 2, 1024, 4, 64
         block_size = 64
@@ -51,8 +55,12 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
-            Q, K_cmp, num_selected, block_size,
-            causal=True, q_tile_size=256,
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
         )
 
         N_cmp = N // block_size
@@ -61,8 +69,8 @@ class TestScoreAndSelectBlocks:
 
     def test_causal_no_future_blocks(self) -> None:
         """Causal mode: no future blocks are selected."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 1, 1024, 2, 64
         block_size = 64
@@ -75,8 +83,12 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
-            Q, K_cmp, num_selected, block_size,
-            causal=True, q_tile_size=q_tile_size,
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=q_tile_size,
         )
 
         N_q_tiles = N // q_tile_size
@@ -92,8 +104,8 @@ class TestScoreAndSelectBlocks:
 
     def test_indices_sorted(self) -> None:
         """Selected indices are sorted per query tile."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 2, 1024, 4, 64
         block_size = 64
@@ -105,8 +117,12 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
-            Q, K_cmp, num_selected, block_size,
-            causal=True, q_tile_size=256,
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
         )
 
         # Check sorted along last dim
@@ -115,8 +131,8 @@ class TestScoreAndSelectBlocks:
 
     def test_deterministic(self) -> None:
         """Same input produces same selection."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 1, 1024, 4, 64
         block_size = 64
@@ -137,8 +153,8 @@ class TestScoreAndSelectBlocks:
 
     def test_gqa(self) -> None:
         """Works correctly with GQA (H > H_kv)."""
-        from mslk.attention.sparse_attn.select import score_and_select_blocks
         from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import score_and_select_blocks
 
         B, N, H, D = 1, 1024, 8, 64
         H_kv = 2
@@ -151,6 +167,275 @@ class TestScoreAndSelectBlocks:
 
         K_cmp, _ = compress_kv(K, V, block_size)
         indices = score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        N_q_tiles = N // 256
+        assert indices.shape == (B, H, N_q_tiles, num_selected)
+
+
+def _q_mean_reference(
+    Q,
+    K_cmp,
+    num_selected_blocks,
+    compress_block_size,
+    causal=True,
+    q_tile_size=256,
+    softmax_scale=None,
+):
+    """Q_mean-based PyTorch reference for testing the fused kernel.
+
+    Computes Q_mean in PyTorch, then scores via einsum. This isolates
+    kernel correctness from the Q_mean algebraic equivalence.
+    """
+    import math
+
+    B, N, H, D = Q.shape
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+    N_q_tiles = N // q_tile_size
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    k_actual = min(num_selected_blocks, N_cmp)
+
+    # Q_mean: (B, N_q_tiles, H, D)
+    Q_mean = (
+        Q.reshape(B, N_q_tiles, q_tile_size, H, D).mean(dim=2).float() * softmax_scale
+    )
+
+    # Expand K_cmp for GQA
+    groups = H // H_kv
+    if groups > 1:
+        K_cmp_expanded = K_cmp.repeat_interleave(groups, dim=2)
+    else:
+        K_cmp_expanded = K_cmp
+
+    # Score: (B, N_q_tiles, H, N_cmp)
+    scores = torch.einsum(
+        "bthd,bjhd->bthj", Q_mean, K_cmp_expanded.float()
+    )  # (B, N_q_tiles, H, N_cmp)
+
+    # Causal mask
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
+        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+        scores.masked_fill_(future_mask.unsqueeze(0).unsqueeze(2), float("-inf"))
+
+    # Permute to (B, H, N_q_tiles, N_cmp) for topk
+    scores = scores.permute(0, 2, 1, 3)
+
+    topk_scores, topk_idx = scores.topk(k_actual, dim=-1)
+
+    # Replace -inf entries with 0
+    invalid = topk_scores == float("-inf")
+    if invalid.any():
+        topk_idx = topk_idx.masked_fill(invalid, 0)
+
+    # Sort ascending
+    block_indices = topk_idx.sort(dim=-1).values.to(torch.int32)
+    return block_indices
+
+
+class TestFusedScoreAndSelectBlocks:
+    """Test fused CuteDSL block scoring and selection."""
+
+    @pytest.mark.parametrize(
+        "B, N, H, H_kv, D, block_size, num_selected",
+        [
+            (1, 1024, 4, 4, 64, 64, 8),
+            (2, 1024, 4, 4, 64, 64, 8),
+            (1, 2048, 8, 2, 128, 64, 16),
+            (2, 4096, 4, 4, 64, 64, 8),
+            (1, 1024, 4, 4, 128, 64, 4),
+        ],
+    )
+    def test_index_agreement(self, B, N, H, H_kv, D, block_size, num_selected) -> None:
+        """Fused kernel matches Q_mean-based PyTorch reference (exact)."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        fused_idx = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
+        )
+        ref_idx = _q_mean_reference(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
+        )
+        assert (fused_idx == ref_idx).all(), (
+            f"Mismatch: fused vs Q_mean reference.\n"
+            f"Fused:\n{fused_idx}\nRef:\n{ref_idx}"
+        )
+
+    def test_output_shape(self) -> None:
+        """Selected indices have correct shape."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 2, 1024, 4, 64
+        H_kv = 4
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        N_cmp = N // block_size
+        k_actual = min(num_selected, N_cmp)
+        assert indices.shape == (B, H, N_q_tiles, k_actual)
+        assert indices.dtype == torch.int32
+
+    def test_indices_in_range(self) -> None:
+        """All selected indices are valid KV block indices."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
+        )
+
+        N_cmp = N // block_size
+        assert (indices >= 0).all()
+        assert (indices < N_cmp).all()
+
+    def test_causal_no_future_blocks(self) -> None:
+        """Causal mode: no future blocks are selected."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 1, 1024, 2, 64
+        block_size = 64
+        num_selected = 8
+        q_tile_size = 256
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=q_tile_size,
+        )
+
+        N_q_tiles = N // q_tile_size
+        for qt in range(N_q_tiles):
+            q_tile_end = (qt + 1) * q_tile_size
+            max_allowed_block = q_tile_end // block_size
+            assert (indices[:, :, qt, :] < max_allowed_block).all(), (
+                f"Query tile {qt}: found future block indices"
+            )
+
+    def test_indices_sorted(self) -> None:
+        """Selected indices are sorted per query tile."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 2, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
+            Q,
+            K_cmp,
+            num_selected,
+            block_size,
+            causal=True,
+            q_tile_size=256,
+        )
+
+        sorted_indices = indices.sort(dim=-1).values
+        assert (indices == sorted_indices).all()
+
+    def test_deterministic(self) -> None:
+        """Same input produces same selection."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 1, 1024, 4, 64
+        block_size = 64
+        num_selected = 8
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices1 = fused_score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        indices2 = fused_score_and_select_blocks(
+            Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
+        )
+        assert (indices1 == indices2).all()
+
+    def test_gqa(self) -> None:
+        """Works correctly with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.compress import compress_kv
+        from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
+
+        B, N, H, D = 1, 1024, 8, 64
+        H_kv = 2
+        block_size = 64
+        num_selected = 4
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        K_cmp, _ = compress_kv(K, V, block_size)
+        indices = fused_score_and_select_blocks(
             Q, K_cmp, num_selected, block_size, causal=True, q_tile_size=256
         )
         N_q_tiles = N // 256

--- a/test/attention/test_sparse_attn_sparsity_masks.py
+++ b/test/attention/test_sparse_attn_sparsity_masks.py
@@ -1,0 +1,99 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for sparsity mask construction."""
+
+import pytest
+import torch
+
+
+class TestBuildFA4BlockSparseTensors:
+    """Test conversion from NSA block indices to FA4 format."""
+
+    def test_output_types(self) -> None:
+        """Output is a valid BlockSparseTensorsTorch."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+        from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+
+        B, H, N_q_tiles, k = 2, 4, 4, 8
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+        assert isinstance(result, BlockSparseTensorsTorch)
+        assert result.full_block_cnt is not None
+        assert result.full_block_idx is not None
+        assert result.mask_block_cnt is not None
+        assert result.mask_block_idx is not None
+
+    def test_shapes(self) -> None:
+        """Output tensors have correct shapes."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 2, 4, 8, 4
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+
+        assert result.full_block_cnt.shape == (B, H, N_q_tiles)
+        assert result.full_block_idx.shape == (B, H, N_q_tiles, k)
+        assert result.mask_block_cnt.shape == (B, H, N_q_tiles)
+
+    def test_full_block_count(self) -> None:
+        """Full block count matches expected value."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 1, 2, 4, 8
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        # compress_block_size == n_block_size, so 1:1 mapping
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+        assert (result.full_block_cnt == k).all()
+
+    def test_block_expansion(self) -> None:
+        """When compress_block_size > n_block_size, blocks expand correctly."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 1, 1, 2, 2
+        # Select block 0 and block 3
+        indices = torch.tensor([[[[0, 3]]]], device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=256, n_block_size=128, seqlen_k=1024,
+        )
+
+        # Each NSA block of 256 -> 2 FA4 blocks of 128
+        assert (result.full_block_cnt == 4).all()  # 2 blocks * 2 FA4 blocks each
+
+        # Block 0 -> FA4 blocks [0, 1], Block 3 -> FA4 blocks [6, 7]
+        expected_idx = result.full_block_idx[0, 0, 0, :4]
+        assert expected_idx.tolist() == [0, 1, 6, 7]
+
+    def test_mask_blocks_are_zero(self) -> None:
+        """All mask block counts should be zero (selected blocks are fully attended)."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        B, H, N_q_tiles, k = 2, 4, 4, 8
+        indices = torch.randint(0, 16, (B, H, N_q_tiles, k), device="cuda", dtype=torch.int32)
+
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=2048,
+        )
+        assert (result.mask_block_cnt == 0).all()
+
+    def test_int32_dtype(self) -> None:
+        """All output tensors are int32."""
+        from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+        indices = torch.randint(0, 8, (1, 2, 4, 4), device="cuda", dtype=torch.int32)
+        result = build_fa4_block_sparse_tensors(
+            indices, compress_block_size=128, n_block_size=128, seqlen_k=1024,
+        )
+        assert result.full_block_cnt.dtype == torch.int32
+        assert result.full_block_idx.dtype == torch.int32
+        assert result.mask_block_cnt.dtype == torch.int32
+        assert result.mask_block_idx.dtype == torch.int32


### PR DESCRIPTION
Summary:
Adds SVG performance chart showing NSA vs dense FA4 latency, forward
speedup curve (10.2x at 1M), and fwd+bwd breakdown with OOM boundary.
Data from GB200 benchmarks (B=1, H=32, H_kv=8, D=128).

 {F1987203495}

Differential Revision: D98080758
