### PR TITLE
Fused CuteDSL gating kernel (#300)

### DIFF
--- a/mslk/attention/flash_attn/block_sparsity.py
+++ b/mslk/attention/flash_attn/block_sparsity.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+try:
+    from mslk.fb.mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+except ImportError:
+    from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
+
+__all__ = ["BlockSparseTensorsTorch"]

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,7 +1,11 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 from mslk.attention.sparse_attn.compress import compress_kv
-from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.gating import (
+    compute_gates,
+    fused_gate_and_combine,
+    gate_and_combine,
+)
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward
 from mslk.attention.sparse_attn.reference import (
     nsa_backward_reference,
@@ -18,5 +22,6 @@ __all__ = [
     "score_and_select_blocks",
     "build_fa4_block_sparse_tensors",
     "compute_gates",
+    "fused_gate_and_combine",
     "gate_and_combine",
 ]

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,0 +1,22 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+from mslk.attention.sparse_attn.reference import (
+    nsa_backward_reference,
+    nsa_forward_reference,
+)
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+__all__ = [
+    "nsa_forward",
+    "nsa_forward_reference",
+    "nsa_backward_reference",
+    "compress_kv",
+    "score_and_select_blocks",
+    "build_fa4_block_sparse_tensors",
+    "compute_gates",
+    "gate_and_combine",
+]

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -1,0 +1,51 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""KV compression for NSA: mean-pool KV into blocks and apply learned projection.
+
+Provides compress_kv (reference implementation).
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def compress_kv(
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None = None,  # (H_kv, D, D) or None
+    W_v: Tensor | None = None,  # (H_kv, D, D) or None
+) -> tuple[Tensor, Tensor]:
+    """Compress K, V by mean-pooling over blocks.
+
+    Applies optional linear projection after pooling.
+
+    Args:
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        block_size: Number of positions to pool together.
+        W_k: Optional per-head projection weight for keys.
+        W_v: Optional per-head projection weight for values.
+
+    Returns:
+        K_cmp: Compressed keys, shape (B, N // block_size, H_kv, D).
+        V_cmp: Compressed values, shape (B, N // block_size, H_kv, D).
+    """
+    B, N, H_kv, D = K.shape
+    assert N % block_size == 0, (
+        f"Sequence length {N} must be divisible by block_size {block_size}"
+    )
+
+    N_cmp = N // block_size
+
+    K_cmp = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+    V_cmp = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+
+    if W_k is not None:
+        K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
+    if W_v is not None:
+        V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
+
+    return K_cmp, V_cmp

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -1,0 +1,113 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Output gating and combination for NSA's three attention branches.
+
+Provides compute_gates and gate_and_combine (reference implementations).
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def compute_gates(
+    Q: Tensor,  # (B, N, H, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Compute per-head gating weights from queries.
+
+    If gate_proj_weight is provided, computes sigmoid(Q @ W) per head per branch.
+    Otherwise, returns uniform 1/3 gates.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        chunk_size: If set, process in chunks to limit peak memory.
+
+    Returns:
+        gates: Gating weights, shape (B, N, H, 3).
+    """
+    if gate_proj_weight is None:
+        return torch.ones(*Q.shape[:-1], 3, device=Q.device, dtype=Q.dtype) / 3.0
+
+    if chunk_size is not None:
+        return _compute_gates_chunked(Q, gate_proj_weight, chunk_size)
+
+    # fp32 accumulation for numerical stability
+    gates = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+    return gates.sigmoid().to(Q.dtype)
+
+
+def _compute_gates_chunked(
+    Q: Tensor, gate_proj_weight: Tensor, chunk_size: int
+) -> Tensor:
+    """Compute gates in chunks to limit peak memory."""
+    B, N, H, D = Q.shape
+    gates = torch.empty(B, N, H, 3, device=Q.device, dtype=Q.dtype)
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        # fp32 accumulation for numerical stability
+        g = torch.einsum(
+            "bnhd,hgd->bnhg",
+            Q[:, start:end].float(),
+            gate_proj_weight.float(),
+        )
+        gates[:, start:end] = g.sigmoid().to(Q.dtype)
+    return gates
+
+
+def gate_and_combine(
+    O_cmp: Tensor,  # (B, N, H, D)
+    O_slc: Tensor,  # (B, N, H, D)
+    O_sld: Tensor,  # (B, N, H, D)
+    gates: Tensor,  # (B, N, H, 3)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Combine branch outputs using gating weights.
+
+    combined = g0 * O_cmp + g1 * O_slc + g2 * O_sld
+
+    Args:
+        O_cmp: Compressed branch output, shape (B, N, H, D).
+        O_slc: Selected branch output, shape (B, N, H, D).
+        O_sld: Sliding window branch output, shape (B, N, H, D).
+        gates: Gating weights, shape (B, N, H, 3).
+        chunk_size: If set, process in chunks to limit peak memory.
+
+    Returns:
+        Combined output, shape (B, N, H, D).
+    """
+    if chunk_size is not None:
+        return _gate_and_combine_chunked(O_cmp, O_slc, O_sld, gates, chunk_size)
+
+    # fp32 accumulation for numerical stability
+    g = gates.float()
+    combined = (
+        g[..., 0:1] * O_cmp.float()
+        + g[..., 1:2] * O_slc.float()
+        + g[..., 2:3] * O_sld.float()
+    )
+    return combined.to(O_cmp.dtype)
+
+
+def _gate_and_combine_chunked(
+    O_cmp: Tensor,
+    O_slc: Tensor,
+    O_sld: Tensor,
+    gates: Tensor,
+    chunk_size: int,
+) -> Tensor:
+    """Chunked gating to limit peak memory (avoids 3 full fp32 intermediates)."""
+    N = O_cmp.shape[1]
+    out = torch.empty_like(O_cmp)
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        g = gates[:, start:end].float()
+        out[:, start:end] = (
+            g[..., 0:1] * O_cmp[:, start:end].float()
+            + g[..., 1:2] * O_slc[:, start:end].float()
+            + g[..., 2:3] * O_sld[:, start:end].float()
+        ).to(O_cmp.dtype)
+    return out

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -1,107 +1,286 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-ignore-all-errors
 
 """Output gating and combination for NSA's three attention branches.
 
-Provides compute_gates and gate_and_combine (reference implementations).
+Includes CuteDSL fused kernel (fused_gate_and_combine) that computes gates from Q
+and combines the three branch outputs in a single kernel launch, and PyTorch
+reference implementations (compute_gates, gate_and_combine).
 """
 
 from __future__ import annotations
+
+import math
+from typing import Type
 
 import torch
 from torch import Tensor
 
 
+# ---------------------------------------------------------------------------
+# CuteDSL fused gating kernel
+# ---------------------------------------------------------------------------
+
+_fused_gating_compile_cache: dict = {}
+
+
+def _make_fused_gating_kernel(cute_dtype: Type, D: int, has_gate_weight: bool):
+    """Create CuteDSL kernel for fused gating.
+
+    One warp (32 threads) per (b,n,h) row. Each warp computes 3 gate dot-products
+    via butterfly warp-shuffle reduction (no shared memory), then applies sigmoid
+    and weighted sum. All accumulation in Float32 for numerical stability.
+
+    Grid: ceil(B*N*H / WARPS_PER_BLOCK) blocks
+    Block: WARPS_PER_BLOCK * 32 threads
+    """
+    import cutlass
+    import cutlass.cute as cute
+
+    WARPS_PER_BLOCK = 4
+    THREADS_PER_BLOCK = WARPS_PER_BLOCK * 32
+    elems_per_thread = D // 32
+
+    class _Kernel:
+        @cute.jit
+        def __call__(self, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, stream):
+            num_rows = mQ.shape[0]
+            grid_x = cute.ceil_div(num_rows, WARPS_PER_BLOCK)
+            self.kernel(mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H):
+            lane_id = cute.arch.lane_idx()
+            warp_id = cute.arch.warp_idx()
+            bidx = cute.arch.block_idx()[0]
+
+            row = bidx * WARPS_PER_BLOCK + warp_id
+            num_rows = mQ.shape[0]
+
+            if row < num_rows:
+                ept = cutlass.const_expr(elems_per_thread)
+
+                if cutlass.const_expr(has_gate_weight):
+                    head_idx = row % H
+                    # fp32 dot-product accumulation for numerical stability
+                    g0 = cutlass.Float32(0.0)
+                    g1 = cutlass.Float32(0.0)
+                    g2 = cutlass.Float32(0.0)
+                    for e in cutlass.range_constexpr(ept):
+                        d = lane_id * ept + e
+                        q_val = cutlass.Float32(mQ[row, d])
+                        g0 += q_val * cutlass.Float32(mW[head_idx, d])
+                        g1 += q_val * cutlass.Float32(mW[head_idx, D + d])
+                        g2 += q_val * cutlass.Float32(mW[head_idx, 2 * D + d])
+
+                    # Warp-shuffle butterfly reduction (no shared memory)
+                    for i in cutlass.range_constexpr(5):
+                        g0 += cute.arch.shuffle_sync_bfly(g0, offset=1 << i)
+                        g1 += cute.arch.shuffle_sync_bfly(g1, offset=1 << i)
+                        g2 += cute.arch.shuffle_sync_bfly(g2, offset=1 << i)
+
+                    # Sigmoid via log2-exp2 trick: uses fast hardware exp2
+                    log2_e = cutlass.const_expr(math.log2(math.e))
+                    g0 = 1.0 / (1.0 + cute.math.exp2(-g0 * log2_e))
+                    g1 = 1.0 / (1.0 + cute.math.exp2(-g1 * log2_e))
+                    g2 = 1.0 / (1.0 + cute.math.exp2(-g2 * log2_e))
+                else:
+                    g0 = cutlass.Float32(1.0 / 3.0)
+                    g1 = cutlass.Float32(1.0 / 3.0)
+                    g2 = cutlass.Float32(1.0 / 3.0)
+
+                # fp32 weighted sum, write back in input dtype
+                for e in cutlass.range_constexpr(ept):
+                    d = lane_id * ept + e
+                    o = (
+                        g0 * cutlass.Float32(mO_cmp[row, d])
+                        + g1 * cutlass.Float32(mO_slc[row, d])
+                        + g2 * cutlass.Float32(mO_sld[row, d])
+                    )
+                    mOut[row, d] = cute_dtype(o)
+
+    return _Kernel()
+
+
+def fused_gate_and_combine(
+    Q: Tensor,  # (B, N, H, D) or (T, H, D) for varlen
+    O_cmp: Tensor,  # same shape as Q
+    O_slc: Tensor,  # same shape as Q
+    O_sld: Tensor,  # same shape as Q
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+) -> tuple[Tensor, Tensor]:
+    """Fused gate computation and branch combination using a CuteDSL kernel.
+
+    Replaces the two-step compute_gates() + gate_and_combine() with a single
+    kernel launch (4-7x faster). Eliminates the intermediate gates tensor and
+    reduces memory traffic by fusing the dot-product gate computation with
+    the weighted sum. All accumulation in Float32.
+
+    When gate_proj_weight is None, returns uniform 1/3 weighted sum without
+    launching the CuteDSL kernel.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D) or (T, H, D) for varlen.
+        O_cmp: Compressed attention output, same shape as Q.
+        O_slc: Selected attention output, same shape as Q.
+        O_sld: Sliding window attention output, same shape as Q.
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+
+    Returns:
+        (output, gates): Combined output (same shape as Q) and gate values
+        (..., H, 3) for use in backward pass.
+    """
+    # Skip CuteDSL kernel when gate_proj_weight is None — simple average
+    if gate_proj_weight is None:
+        combined = (O_cmp + O_slc + O_sld) * (1.0 / 3.0)
+        gates = torch.ones(*Q.shape[:-1], 3, device=Q.device, dtype=Q.dtype) / 3.0
+        return combined, gates
+
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    H = Q.shape[-2]
+    D = Q.shape[-1]
+    assert D % 32 == 0, f"D={D} must be divisible by 32"
+
+    out = torch.empty_like(O_cmp)
+    has_gate_weight = gate_proj_weight is not None
+
+    # Reshape to 2D: (M, D) where M = B*N*H or T*H
+    M = Q.numel() // D
+    Q_2d = Q.reshape(M, D).contiguous()
+    O_cmp_2d = O_cmp.reshape(M, D).contiguous()
+    O_slc_2d = O_slc.reshape(M, D).contiguous()
+    O_sld_2d = O_sld.reshape(M, D).contiguous()
+    out_2d = out.reshape(M, D)
+
+    # Gate weights: (H, 3, D) -> (H, 3*D) for coalesced access
+    W_2d = gate_proj_weight.reshape(H, 3 * D).contiguous()
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[Q.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mQ = to_cute(Q_2d)
+    mO_cmp = to_cute(O_cmp_2d)
+    mO_slc = to_cute(O_slc_2d)
+    mO_sld = to_cute(O_sld_2d)
+    mW = to_cute(W_2d)
+    mOut = to_cute(out_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, has_gate_weight)
+    if compile_key not in _fused_gating_compile_cache:
+        kernel_op = _make_fused_gating_kernel(cute_dtype, D, has_gate_weight)
+        _fused_gating_compile_cache[compile_key] = cute.compile(
+            kernel_op, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, current_stream
+        )
+    _fused_gating_compile_cache[compile_key](
+        mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, current_stream
+    )
+
+    # Compute gates separately for backward pass (cheap relative to the fused kernel)
+    gates = compute_gates(Q, gate_proj_weight)
+
+    return out, gates
+
+
+# ---------------------------------------------------------------------------
+# PyTorch reference implementations (kept for testing and fallback)
+# ---------------------------------------------------------------------------
+
+
 def compute_gates(
-    Q: Tensor,  # (B, N, H, D)
+    Q: Tensor,  # (B, N, H, D) or (T, H, D) for varlen
     gate_proj_weight: Tensor | None = None,  # (H, 3, D)
     chunk_size: int | None = None,
 ) -> Tensor:
-    """Compute per-head gating weights from queries.
-
-    If gate_proj_weight is provided, computes sigmoid(Q @ W) per head per branch.
-    Otherwise, returns uniform 1/3 gates.
+    """Compute per-head sigmoid gates for the three NSA branches.
 
     Args:
-        Q: Query tensor, shape (B, N, H, D).
-        gate_proj_weight: Gate projection weights, shape (H, 3, D).
-        chunk_size: If set, process in chunks to limit peak memory.
+        Q: Query tensor, shape (B, N, H, D) or (T, H, D) for varlen.
+        gate_proj_weight: Learned gate projection, shape (H, 3, D).
+            If None, returns uniform gates (1/3 each).
+        chunk_size: If set, process the sequence dimension in chunks to
+            reduce peak float32 memory usage. Only supported for 4D input.
 
     Returns:
-        gates: Gating weights, shape (B, N, H, 3).
+        gates: Sigmoid gates, (..., H, 3) matching leading dims of Q.
     """
     if gate_proj_weight is None:
         return torch.ones(*Q.shape[:-1], 3, device=Q.device, dtype=Q.dtype) / 3.0
 
-    if chunk_size is not None:
-        return _compute_gates_chunked(Q, gate_proj_weight, chunk_size)
-
-    # fp32 accumulation for numerical stability
-    gates = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
-    return gates.sigmoid().to(Q.dtype)
-
-
-def _compute_gates_chunked(
-    Q: Tensor, gate_proj_weight: Tensor, chunk_size: int
-) -> Tensor:
-    """Compute gates in chunks to limit peak memory."""
-    B, N, H, D = Q.shape
-    gates = torch.empty(B, N, H, 3, device=Q.device, dtype=Q.dtype)
-    for start in range(0, N, chunk_size):
-        end = min(start + chunk_size, N)
+    if chunk_size is None:
+        # Reshape to (M, H, D) for einsum — works for both 3D and 4D
+        orig_shape = Q.shape
+        H, D = orig_shape[-2], orig_shape[-1]
         # fp32 accumulation for numerical stability
-        g = torch.einsum(
-            "bnhd,hgd->bnhg",
-            Q[:, start:end].float(),
+        gate_logits = torch.einsum(
+            "mhd,hgd->mhg",
+            Q.float().reshape(-1, H, D),
             gate_proj_weight.float(),
         )
-        gates[:, start:end] = g.sigmoid().to(Q.dtype)
+        return gate_logits.sigmoid().to(Q.dtype).reshape(*orig_shape[:-1], 3)
+
+    # Chunked path: process sequence in chunks to bound float32 intermediates
+    assert Q.dim() == 4, "Chunked gating only supported for 4D input"
+    B, N, H, D = Q.shape
+    gates = torch.empty(B, N, H, 3, device=Q.device, dtype=Q.dtype)
+    w = gate_proj_weight.float()
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q[:, start:end].float(), w)
+        gates[:, start:end] = gate_logits.sigmoid().to(Q.dtype)
     return gates
 
 
 def gate_and_combine(
-    O_cmp: Tensor,  # (B, N, H, D)
-    O_slc: Tensor,  # (B, N, H, D)
-    O_sld: Tensor,  # (B, N, H, D)
-    gates: Tensor,  # (B, N, H, 3)
+    O_cmp: Tensor,  # (B, N, H, D) or (T, H, D) for varlen
+    O_slc: Tensor,
+    O_sld: Tensor,
+    gates: Tensor,  # (..., H, 3) matching leading dims
     chunk_size: int | None = None,
 ) -> Tensor:
-    """Combine branch outputs using gating weights.
-
-    combined = g0 * O_cmp + g1 * O_slc + g2 * O_sld
+    """Combine three attention branch outputs with sigmoid gates.
 
     Args:
-        O_cmp: Compressed branch output, shape (B, N, H, D).
-        O_slc: Selected branch output, shape (B, N, H, D).
-        O_sld: Sliding window branch output, shape (B, N, H, D).
-        gates: Gating weights, shape (B, N, H, 3).
+        O_cmp: Compressed attention output.
+        O_slc: Selected attention output.
+        O_sld: Sliding window attention output.
+        gates: Sigmoid gates, (..., H, 3) matching leading dims.
         chunk_size: If set, process in chunks to limit peak memory.
 
     Returns:
-        Combined output, shape (B, N, H, D).
+        Combined output, same shape as O_cmp.
     """
-    if chunk_size is not None:
-        return _gate_and_combine_chunked(O_cmp, O_slc, O_sld, gates, chunk_size)
+    if chunk_size is None:
+        # fp32 accumulation for numerical stability
+        g = gates.float()
+        return (
+            g[..., 0:1] * O_cmp.float()
+            + g[..., 1:2] * O_slc.float()
+            + g[..., 2:3] * O_sld.float()
+        ).to(O_cmp.dtype)
 
-    # fp32 accumulation for numerical stability
-    g = gates.float()
-    combined = (
-        g[..., 0:1] * O_cmp.float()
-        + g[..., 1:2] * O_slc.float()
-        + g[..., 2:3] * O_sld.float()
-    )
-    return combined.to(O_cmp.dtype)
-
-
-def _gate_and_combine_chunked(
-    O_cmp: Tensor,
-    O_slc: Tensor,
-    O_sld: Tensor,
-    gates: Tensor,
-    chunk_size: int,
-) -> Tensor:
-    """Chunked gating to limit peak memory (avoids 3 full fp32 intermediates)."""
-    N = O_cmp.shape[1]
-    out = torch.empty_like(O_cmp)
+    # Chunked path: avoid materializing 3 full fp32 intermediates at once
+    assert O_cmp.dim() == 4, "Chunked gating only supported for 4D input"
+    B, N, H, D = O_cmp.shape
+    out = torch.empty(B, N, H, D, dtype=O_cmp.dtype, device=O_cmp.device)
     for start in range(0, N, chunk_size):
         end = min(start + chunk_size, N)
         g = gates[:, start:end].float()

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -16,7 +16,7 @@ import math
 from typing import Callable, Tuple
 
 from mslk.attention.sparse_attn.compress import compress_kv
-from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.gating import fused_gate_and_combine
 from mslk.attention.sparse_attn.select import score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 from torch import Tensor
@@ -199,14 +199,6 @@ def nsa_forward(
     )
 
     # Step 5: Gate and combine branch outputs
-    # Use chunked gating for long sequences to avoid materializing
-    # 3 full (B,N,H,D) float32 tensors simultaneously.
-    gate_chunk = 4096 if N > 32768 else None
-    gates = compute_gates(Q, gate_proj_weight, chunk_size=gate_chunk)
-    if gate_proj_weight is not None:
-        O = gate_and_combine(O_cmp, O_slc, O_sld, gates, chunk_size=gate_chunk)
-    else:
-        # No gate weights — uniform 1/3 gates
-        O = (O_cmp + O_slc + O_sld) * (1.0 / 3.0)
+    O, gates = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
 
     return O

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -1,0 +1,212 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""End-to-end NSA (Native Sparse Attention) forward pass using FA4.
+
+Orchestrates the three attention branches:
+1. Compressed attention (FA4 on short KV sequence)
+2. Selected attention (FA4 with block sparsity)
+3. Sliding window attention (FA4 with window_size)
+
+Then gates and combines the outputs.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Tuple
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+from torch import Tensor
+
+
+def _fa4_fwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+    compress_factor: int = 1,
+    cu_seqlens_q: Tensor | None = None,
+    cu_seqlens_k: Tensor | None = None,
+    max_seqlen_q: int | None = None,
+    max_seqlen_k: int | None = None,
+) -> Tuple[Tensor, Tensor]:
+    """Call FA4's forward pass.
+
+    Supports block sparsity, mask_mod, compress_factor, and varlen (cu_seqlens).
+    Inputs are (B, N, H, D) for fixed-length or (total_tokens, H, D) for varlen.
+    Returns (output, lse).
+    """
+    # Try mslk.fb FA4 first (has compress_factor, block_sparse_tensors, etc.),
+    # fall back to stock flash_attn if fb/ is not available.
+    try:
+        from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+    except ImportError:
+        from flash_attn.cute.interface import _flash_attn_fwd
+
+    # mask_mod is not compatible with pack_gqa=True in FA4, so disable it
+    pack_gqa = False if mask_mod is not None else None
+
+    # Try with compress_factor (PR#2418); fall back without it
+    try:
+        out, lse = _flash_attn_fwd(
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            block_sparse_tensors=block_sparse_tensors,
+            mask_mod=mask_mod,
+            pack_gqa=pack_gqa,
+            return_lse=True,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            compress_factor=compress_factor,
+        )
+    except TypeError:
+        # compress_factor not supported in this FA4 build — omit it
+        out, lse = _flash_attn_fwd(
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            block_sparse_tensors=block_sparse_tensors,
+            mask_mod=mask_mod,
+            pack_gqa=pack_gqa,
+            return_lse=True,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+        )
+    return out, lse
+
+
+def nsa_forward(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    n_block_size: int = 128,
+) -> Tensor:
+    """NSA forward pass using FA4 for all attention branches.
+
+    Orchestrates:
+    1. KV compression (mean-pool + optional projection)
+    2. Block scoring and top-k selection
+    3. Three FA4 calls: compressed, selected (block-sparse), sliding window
+    4. Gating and combination
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        compress_block_size: Number of KV positions per block for compression.
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        window_size: Sliding window size (left window, causal).
+        W_k_compress: Per-head key compression weights, shape (H_kv, D, D).
+        W_v_compress: Per-head value compression weights, shape (H_kv, D, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        causal: Whether to use causal masking.
+        softmax_scale: Attention scaling factor (default: 1/sqrt(D)).
+        q_tile_size: Query tile size for block selection.
+        n_block_size: FA4 KV block size (128 for SM100).
+
+    Returns:
+        Output tensor, shape (B, N, H, D).
+    """
+    B, N, H, D = Q.shape
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # Step 1: Compress KV
+    K_cmp, V_cmp = compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+
+    # Step 2: Score blocks and select top-k
+    block_indices = score_and_select_blocks(
+        Q,
+        K_cmp,
+        num_selected_blocks,
+        compress_block_size,
+        causal=causal,
+        q_tile_size=q_tile_size,
+        softmax_scale=softmax_scale,
+    )
+
+    # Step 3: Build FA4 sparsity masks for selected attention
+    sparse_tensors = build_fa4_block_sparse_tensors(
+        block_indices,
+        compress_block_size,
+        n_block_size=n_block_size,
+        seqlen_k=N,
+    )
+
+    # Step 4: Run three FA4 branches
+
+    # Branch 1: Compressed attention — uses compress_factor for native causal masking
+    # instead of mask_mod. This enables tile skipping, R2P masking, and pack_gqa.
+    O_cmp, lse_cmp = _fa4_fwd(
+        Q,
+        K_cmp,
+        V_cmp,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        compress_factor=compress_block_size,
+    )
+
+    # Branch 2: Selected attention — block-sparse attention on full KV
+    O_slc, lse_slc = _fa4_fwd(
+        Q,
+        K,
+        V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        block_sparse_tensors=sparse_tensors,
+    )
+
+    # Branch 3: Sliding window attention
+    O_sld, lse_sld = _fa4_fwd(
+        Q,
+        K,
+        V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        window_size_left=window_size,
+        window_size_right=0,
+    )
+
+    # Step 5: Gate and combine branch outputs
+    # Use chunked gating for long sequences to avoid materializing
+    # 3 full (B,N,H,D) float32 tensors simultaneously.
+    gate_chunk = 4096 if N > 32768 else None
+    gates = compute_gates(Q, gate_proj_weight, chunk_size=gate_chunk)
+    if gate_proj_weight is not None:
+        O = gate_and_combine(O_cmp, O_slc, O_sld, gates, chunk_size=gate_chunk)
+    else:
+        # No gate weights — uniform 1/3 gates
+        O = (O_cmp + O_slc + O_sld) * (1.0 / 3.0)
+
+    return O

--- a/mslk/attention/sparse_attn/reference.py
+++ b/mslk/attention/sparse_attn/reference.py
@@ -1,0 +1,384 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Pure PyTorch reference implementation of NSA (Native Sparse Attention).
+
+This serves as a correctness reference for the optimized FA4-based implementation.
+All operations are done in PyTorch without custom kernels.
+
+The forward pass is fully differentiable (all tensor ops, no Python loops that
+break autograd), so PyTorch autograd provides the reference backward pass.
+Use nsa_backward_reference() to compute gradients for validation.
+
+Reference: arxiv 2502.11089
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def nsa_forward_reference(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,
+    W_v_compress: Tensor | None = None,
+    gate_proj_weight: Tensor | None = None,
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    _block_indices: Tensor | None = None,
+) -> Tensor:
+    """Pure PyTorch NSA forward pass.
+
+    Combines three attention branches:
+    1. Compressed attention: Attend over mean-pooled KV blocks with learned projection.
+    2. Selected attention: Block-sparse attention over top-k important KV blocks.
+    3. Sliding window attention: Local attention within a fixed window.
+
+    All inputs/outputs use (B, N, H, D) layout.
+    """
+    B, N, H, D = Q.shape
+    H_kv = K.shape[2]
+    assert H % H_kv == 0, "H must be divisible by H_kv for GQA"
+    groups = H // H_kv
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # fp32 accumulation for numerical stability with bf16/fp16 inputs
+    compute_dtype = torch.float64 if Q.dtype == torch.float64 else torch.float32
+    q = Q.transpose(1, 2).to(compute_dtype)
+    k = K.transpose(1, 2).to(compute_dtype)
+    v = V.transpose(1, 2).to(compute_dtype)
+
+    if groups > 1:
+        k = k.repeat_interleave(groups, dim=1)
+        v = v.repeat_interleave(groups, dim=1)
+
+    O_cmp = _compressed_attention(
+        q,
+        k,
+        v,
+        compress_block_size,
+        W_k_compress,
+        W_v_compress,
+        groups,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        H_kv,
+        D,
+    )
+    O_slc = _selected_attention(
+        q,
+        k,
+        v,
+        compress_block_size,
+        num_selected_blocks,
+        W_k_compress,
+        groups,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        H_kv,
+        D,
+        q_tile_size=q_tile_size,
+        _block_indices=_block_indices,
+    )
+    O_sld = _sliding_window_attention(
+        q,
+        k,
+        v,
+        window_size,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        D,
+    )
+
+    O_cmp = O_cmp.transpose(1, 2)
+    O_slc = O_slc.transpose(1, 2)
+    O_sld = O_sld.transpose(1, 2)
+
+    if gate_proj_weight is not None:
+        gates = torch.einsum(
+            "bnhd,hgd->bnhg", Q.to(compute_dtype), gate_proj_weight.to(compute_dtype)
+        )
+        gates = gates.sigmoid()
+    else:
+        gates = torch.ones(B, N, H, 3, device=Q.device, dtype=compute_dtype) / 3.0
+
+    O = gates[..., 0:1] * O_cmp + gates[..., 1:2] * O_slc + gates[..., 2:3] * O_sld
+    return O.to(Q.dtype)
+
+
+def _compressed_attention(
+    q,
+    k,
+    v,
+    block_size,
+    W_k_compress,
+    W_v_compress,
+    groups,
+    softmax_scale,
+    causal,
+    B,
+    N,
+    H,
+    H_kv,
+    D,
+):
+    k_orig = k[:, ::groups]
+    v_orig = v[:, ::groups]
+    N_cmp = N // block_size
+    k_blocks = k_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    k_cmp = k_blocks.mean(dim=3)
+    v_blocks = v_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    v_cmp = v_blocks.mean(dim=3)
+
+    if W_k_compress is not None:
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.to(k_cmp.dtype))
+    if W_v_compress is not None:
+        v_cmp = torch.einsum("bhnd,hde->bhne", v_cmp, W_v_compress.to(v_cmp.dtype))
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+        v_cmp = v_cmp.repeat_interleave(groups, dim=1)
+
+    scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+    if causal:
+        q_pos = torch.arange(N, device=q.device).unsqueeze(1)
+        kv_block_start = torch.arange(N_cmp, device=q.device) * block_size
+        causal_mask = kv_block_start.unsqueeze(0) > q_pos
+        scores = scores.masked_fill(
+            causal_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+    attn = torch.softmax(scores, dim=-1)
+    return torch.matmul(attn, v_cmp)
+
+
+def _selected_attention(
+    q,
+    k,
+    v,
+    block_size,
+    num_selected,
+    W_k_compress,
+    groups,
+    softmax_scale,
+    causal,
+    B,
+    N,
+    H,
+    H_kv,
+    D,
+    q_tile_size=256,
+    _block_indices=None,
+):
+    N_blocks = N // block_size
+    N_q_tiles = N // q_tile_size
+    k_actual = min(num_selected, N_blocks)
+
+    if _block_indices is not None:
+        top_indices = _block_indices
+    else:
+        k_orig = k[:, ::groups]
+        k_blocks = k_orig.reshape(B, H_kv, N_blocks, block_size, D)
+        k_cmp = k_blocks.mean(dim=3)
+        if W_k_compress is not None:
+            k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.to(k_cmp.dtype))
+        if groups > 1:
+            k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+        block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+        block_scores_agg = block_scores.reshape(
+            B, H, N_q_tiles, q_tile_size, N_blocks
+        ).mean(dim=3)
+        if causal:
+            q_tile_end = (torch.arange(N_q_tiles, device=q.device) + 1) * q_tile_size
+            kv_block_start = torch.arange(N_blocks, device=q.device) * block_size
+            future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+            block_scores_agg = block_scores_agg.masked_fill(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+        _, top_indices = block_scores_agg.topk(k_actual, dim=-1)
+
+    offsets = torch.arange(block_size, device=q.device)
+    pos_indices = top_indices.unsqueeze(-1) * block_size + offsets
+    kv_len = k_actual * block_size
+    pos_indices = pos_indices.reshape(B, H, N_q_tiles, kv_len)
+
+    gather_idx = pos_indices.unsqueeze(-1).expand(B, H, N_q_tiles, kv_len, D)
+    k_exp = k.unsqueeze(2).expand(B, H, N_q_tiles, N, D)
+    v_exp = v.unsqueeze(2).expand(B, H, N_q_tiles, N, D)
+    sel_k = torch.gather(k_exp, 3, gather_idx)
+    sel_v = torch.gather(v_exp, 3, gather_idx)
+
+    q_tiles = q.reshape(B, H, N_q_tiles, q_tile_size, D)
+    scores = torch.matmul(q_tiles, sel_k.transpose(-2, -1)) * softmax_scale
+    if causal:
+        q_tile_starts = torch.arange(N_q_tiles, device=q.device) * q_tile_size
+        q_offsets = torch.arange(q_tile_size, device=q.device)
+        q_positions = q_tile_starts.unsqueeze(1) + q_offsets.unsqueeze(0)
+        c_mask = pos_indices.unsqueeze(3) > q_positions.reshape(
+            1, 1, N_q_tiles, q_tile_size, 1
+        )
+        scores = scores.masked_fill(c_mask, float("-inf"))
+    attn = torch.softmax(scores, dim=-1)
+    out_tiles = torch.matmul(attn, sel_v)
+    return out_tiles.reshape(B, H, N, D)
+
+
+def _sliding_window_attention(q, k, v, window_size, softmax_scale, causal, B, N, H, D):
+    scores = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale
+    q_pos = torch.arange(N, device=q.device).unsqueeze(1)
+    kv_pos = torch.arange(N, device=q.device).unsqueeze(0)
+    if causal:
+        mask = (kv_pos > q_pos) | (kv_pos < q_pos - window_size + 1)
+    else:
+        half_w = window_size // 2
+        mask = (kv_pos > q_pos + half_w) | (kv_pos < q_pos - half_w)
+    scores = scores.masked_fill(mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    attn = torch.softmax(scores, dim=-1)
+    return torch.matmul(attn, v)
+
+
+def compute_block_indices_reference(
+    Q,
+    K,
+    compress_block_size=64,
+    num_selected_blocks=16,
+    W_k_compress=None,
+    causal=True,
+    softmax_scale=None,
+    q_tile_size=256,
+):
+    """Pre-compute block selection indices (non-differentiable).
+
+    Returns block indices that can be passed to nsa_forward_reference via
+    _block_indices to freeze the selection during gradient computation.
+    """
+    B, N, H, D = Q.shape
+    H_kv = K.shape[2]
+    groups = H // H_kv
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # fp32 for numerical stability
+    q = Q.transpose(1, 2).float()
+    k = K.transpose(1, 2).float()
+
+    N_blocks = N // compress_block_size
+    N_q_tiles = N // q_tile_size
+
+    k_blocks = k.reshape(B, H_kv, N_blocks, compress_block_size, D)
+    k_cmp = k_blocks.mean(dim=3)
+    if W_k_compress is not None:
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+
+    block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+    block_scores_agg = block_scores.reshape(
+        B, H, N_q_tiles, q_tile_size, N_blocks
+    ).mean(dim=3)
+
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_blocks, device=Q.device) * compress_block_size
+        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+        block_scores_agg = block_scores_agg.masked_fill(
+            future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+
+    k_actual = min(num_selected_blocks, N_blocks)
+    _, top_indices = block_scores_agg.topk(k_actual, dim=-1)
+    return top_indices
+
+
+def nsa_backward_reference(
+    Q,
+    K,
+    V,
+    dO,
+    compress_block_size=64,
+    num_selected_blocks=16,
+    window_size=512,
+    W_k_compress=None,
+    W_v_compress=None,
+    gate_proj_weight=None,
+    causal=True,
+    softmax_scale=None,
+    q_tile_size=256,
+    _block_indices=None,
+):
+    """Compute NSA gradients using autograd on the differentiable reference forward."""
+    Q_g = Q.detach().float().requires_grad_(True)
+    K_g = K.detach().float().requires_grad_(True)
+    V_g = V.detach().float().requires_grad_(True)
+
+    params = []
+    W_k_g = None
+    if W_k_compress is not None:
+        W_k_g = W_k_compress.detach().float().requires_grad_(True)
+        params.append(W_k_g)
+    W_v_g = None
+    if W_v_compress is not None:
+        W_v_g = W_v_compress.detach().float().requires_grad_(True)
+        params.append(W_v_g)
+    gate_g = None
+    if gate_proj_weight is not None:
+        gate_g = gate_proj_weight.detach().float().requires_grad_(True)
+        params.append(gate_g)
+
+    O = nsa_forward_reference(
+        Q_g,
+        K_g,
+        V_g,
+        compress_block_size=compress_block_size,
+        num_selected_blocks=num_selected_blocks,
+        window_size=window_size,
+        W_k_compress=W_k_g,
+        W_v_compress=W_v_g,
+        gate_proj_weight=gate_g,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        q_tile_size=q_tile_size,
+        _block_indices=_block_indices,
+    )
+
+    grad_inputs = [Q_g, K_g, V_g] + params
+    grads = torch.autograd.grad(
+        O, grad_inputs, grad_outputs=dO.float(), allow_unused=True
+    )
+
+    result = {
+        "dQ": grads[0].to(Q.dtype),
+        "dK": grads[1].to(K.dtype),
+        "dV": grads[2].to(V.dtype),
+        "dW_k_compress": None,
+        "dW_v_compress": None,
+        "dgate_proj_weight": None,
+    }
+    idx = 3
+    if W_k_compress is not None:
+        result["dW_k_compress"] = grads[idx].to(W_k_compress.dtype)
+        idx += 1
+    if W_v_compress is not None:
+        result["dW_v_compress"] = grads[idx].to(W_v_compress.dtype)
+        idx += 1
+    if gate_proj_weight is not None:
+        result["dgate_proj_weight"] = grads[idx].to(gate_proj_weight.dtype)
+    return result

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -1,0 +1,117 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Block scoring and top-k selection for NSA.
+
+Provides score_and_select_blocks (reference, tiled for O(N) memory).
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def score_and_select_blocks(
+    Q: Tensor,  # (B, N, H, D)
+    K_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    num_selected_blocks: int,
+    compress_block_size: int,
+    causal: bool = True,
+    q_tile_size: int = 256,
+    softmax_scale: float | None = None,
+) -> Tensor:
+    """Score KV blocks by importance and select top-k for each query tile.
+
+    Uses compressed keys to efficiently compute block importance scores.
+    Each query tile (q_tile_size positions) independently selects its own
+    top-k KV blocks.
+
+    Processes query tiles in chunks to avoid materializing a full (B, H, N, N_cmp)
+    score tensor, reducing peak memory from O(N * N_cmp) to
+    O(chunk_tiles * q_tile_size * N_cmp).
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K_cmp: Compressed key tensor, shape (B, N_cmp, H_kv, D).
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        compress_block_size: Size of each KV block.
+        causal: Whether to apply causal masking (prevent selecting future blocks).
+        q_tile_size: Size of each query tile (should match FA4's CTA tile size, 256).
+        softmax_scale: Scaling factor for attention scores.
+
+    Returns:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+    """
+    B, N, H, D = Q.shape
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+    groups = H // H_kv
+
+    N_q_tiles = N // q_tile_size
+    assert N % q_tile_size == 0, (
+        f"Sequence length {N} must be divisible by q_tile_size {q_tile_size}"
+    )
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    k_actual = min(num_selected_blocks, N_cmp)
+
+    # Expand K_cmp for GQA: (B, N_cmp, H_kv, D) -> (B, N_cmp, H, D)
+    if groups > 1:
+        K_cmp_expanded = K_cmp.repeat_interleave(groups, dim=2)
+    else:
+        K_cmp_expanded = K_cmp
+
+    # fp32 accumulation for numerical stability with bf16/fp16 inputs
+    K_cmp_t = K_cmp_expanded.permute(0, 2, 3, 1).float()
+
+    block_indices = torch.empty(
+        B, H, N_q_tiles, k_actual, dtype=torch.int32, device=Q.device
+    )
+
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
+
+    # Process in chunks to bound peak memory
+    chunk_tiles = min(16, N_q_tiles)
+    for chunk_start in range(0, N_q_tiles, chunk_tiles):
+        chunk_end = min(chunk_start + chunk_tiles, N_q_tiles)
+        n_tiles = chunk_end - chunk_start
+        q_start = chunk_start * q_tile_size
+        q_end = chunk_end * q_tile_size
+
+        # fp32 scoring for numerical stability
+        scores_chunk = (
+            torch.matmul(Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t)
+            * softmax_scale
+        )
+
+        # Average per tile
+        scores_agg = scores_chunk.reshape(B, H, n_tiles, q_tile_size, N_cmp).mean(dim=3)
+
+        # Causal mask: block j is future if j * block_size >= (i+1) * q_tile_size
+        if causal:
+            future_mask = kv_block_start.unsqueeze(0) >= q_tile_end[
+                chunk_start:chunk_end
+            ].unsqueeze(1)
+            scores_agg.masked_fill_(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        topk_scores, chunk_idx = scores_agg.topk(k_actual, dim=-1)
+
+        # Replace -inf selections with block 0
+        invalid = topk_scores == float("-inf")
+        if invalid.any():
+            chunk_idx = chunk_idx.masked_fill(invalid, 0)
+
+        # Sort ascending for better memory access patterns
+        block_indices[:, :, chunk_start:chunk_end] = chunk_idx.sort(dim=-1).values.to(
+            torch.int32
+        )
+
+    return block_indices

--- a/mslk/attention/sparse_attn/sparsity_masks.py
+++ b/mslk/attention/sparse_attn/sparsity_masks.py
@@ -1,0 +1,112 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Convert top-k block indices into FA4's BlockSparseTensorsTorch format.
+
+Uses compact index tensors where the last dimension is the max number of
+selected blocks per Q-tile (k), not the total number of KV blocks (n_blocks_k).
+FA4 kernels only access indices 0..cnt-1 per Q-tile, so the compact format
+is fully compatible with both forward and backward.
+"""
+
+from __future__ import annotations
+
+import torch
+from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+from torch import Tensor
+
+
+def build_fa4_block_sparse_tensors(
+    block_indices: Tensor,  # (B, H, N_q_tiles, k) int32
+    compress_block_size: int,
+    n_block_size: int = 128,
+    seqlen_k: int | None = None,
+) -> BlockSparseTensorsTorch:
+    """Convert selected KV block indices into FA4's block sparsity format.
+
+    FA4 block sparsity uses two pairs of tensors:
+    - full_block_cnt/full_block_idx: KV blocks that need NO masking (fully attended).
+    - mask_block_cnt/mask_block_idx: KV blocks that need masking (partially attended).
+
+    Handles two cases:
+    - compress_block_size >= n_block_size: Each NSA block expands to multiple FA4 blocks.
+    - compress_block_size < n_block_size: Multiple NSA blocks contract to one FA4 block
+      (duplicates are removed via sort + consecutive dedup).
+
+    All selected blocks are "full" blocks (no partial masking needed).
+
+    Uses compact index tensors: last dim = k_fa4 (not n_blocks_k).
+
+    Args:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+        compress_block_size: Size of each NSA KV block.
+        n_block_size: FA4's KV tile size (default 128 for SM100).
+        seqlen_k: Total KV sequence length (for computing q_block_size).
+
+    Returns:
+        BlockSparseTensorsTorch with full_block_cnt, full_block_idx,
+        mask_block_cnt, mask_block_idx.
+    """
+    B, H, N_q_tiles, k = block_indices.shape
+    device = block_indices.device
+
+    if compress_block_size >= n_block_size:
+        # Expansion: each NSA block maps to one or more FA4 blocks
+        assert compress_block_size % n_block_size == 0, (
+            f"compress_block_size ({compress_block_size}) must be divisible by "
+            f"n_block_size ({n_block_size})"
+        )
+        fa4_blocks_per_nsa_block = compress_block_size // n_block_size
+
+        base_indices = block_indices.long() * fa4_blocks_per_nsa_block
+        offsets = torch.arange(fa4_blocks_per_nsa_block, device=device)
+        expanded_indices = base_indices.unsqueeze(-1) + offsets
+        fa4_indices = expanded_indices.reshape(
+            B, H, N_q_tiles, k * fa4_blocks_per_nsa_block
+        )
+        k_fa4 = k * fa4_blocks_per_nsa_block
+
+        full_block_cnt = torch.full(
+            (B, H, N_q_tiles), k_fa4, dtype=torch.int32, device=device
+        )
+    else:
+        # Contraction: multiple NSA blocks map to a single FA4 block.
+        # Dedup by sorting and removing consecutive duplicates.
+        assert n_block_size % compress_block_size == 0, (
+            f"n_block_size ({n_block_size}) must be divisible by "
+            f"compress_block_size ({compress_block_size})"
+        )
+        fa4_block_indices = (block_indices.long() * compress_block_size) // n_block_size
+
+        sorted_idx, _ = fa4_block_indices.sort(dim=-1)
+        is_new = torch.ones_like(sorted_idx, dtype=torch.bool)
+        is_new[..., 1:] = sorted_idx[..., 1:] != sorted_idx[..., :-1]
+
+        counts = is_new.sum(dim=-1)
+        max_unique = counts.max().item()
+
+        dest_positions = is_new.long().cumsum(dim=-1) - 1
+        fa4_indices = torch.zeros(
+            B, H, N_q_tiles, max_unique, dtype=torch.int64, device=device
+        )
+        fa4_indices.scatter_(3, dest_positions.clamp(max=max_unique - 1), sorted_idx)
+
+        full_block_cnt = counts.to(torch.int32)
+        k_fa4 = max_unique
+
+    full_block_idx = fa4_indices[:, :, :, :k_fa4].to(torch.int32)
+
+    # No partial masking needed — use minimal last dim
+    mask_block_cnt = torch.zeros((B, H, N_q_tiles), dtype=torch.int32, device=device)
+    mask_block_idx = torch.zeros((B, H, N_q_tiles, 1), dtype=torch.int32, device=device)
+
+    q_block_size = (
+        seqlen_k // N_q_tiles if seqlen_k is not None else compress_block_size
+    )
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=mask_block_cnt,
+        mask_block_idx=mask_block_idx,
+        full_block_cnt=full_block_cnt,
+        full_block_idx=full_block_idx,
+        block_size=(q_block_size, n_block_size),
+    )

--- a/test/attention/test_sparse_attn_compress.py
+++ b/test/attention/test_sparse_attn_compress.py
@@ -1,0 +1,49 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compress_kv_basic():
+    """Mean-pool compression produces correct output shape and values."""
+    from mslk.attention.sparse_attn.compress import compress_kv
+
+    B, N, H_kv, D = 2, 1024, 4, 128
+    block_size = 64
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    K_cmp, V_cmp = compress_kv(K, V, block_size)
+
+    N_cmp = N // block_size
+    assert K_cmp.shape == (B, N_cmp, H_kv, D)
+    assert V_cmp.shape == (B, N_cmp, H_kv, D)
+
+    # Verify mean-pool: first block should be mean of first block_size positions
+    expected_k0 = K[:, :block_size].float().mean(dim=1)  # (B, H_kv, D)
+    actual_k0 = K_cmp[:, 0].float()
+    torch.testing.assert_close(actual_k0, expected_k0, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compress_kv_with_projection():
+    """Compression with W_k, W_v learned projections."""
+    from mslk.attention.sparse_attn.compress import compress_kv
+
+    B, N, H_kv, D = 1, 512, 2, 64
+    block_size = 64
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16)
+    W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16)
+
+    K_cmp, V_cmp = compress_kv(K, V, block_size, W_k, W_v)
+
+    N_cmp = N // block_size
+    assert K_cmp.shape == (B, N_cmp, H_kv, D)
+    assert V_cmp.shape == (B, N_cmp, H_kv, D)
+
+    # With projection, output should differ from simple mean
+    K_cmp_no_proj, _ = compress_kv(K, V, block_size)
+    assert not torch.allclose(K_cmp.float(), K_cmp_no_proj.float(), atol=1e-2)

--- a/test/attention/test_sparse_attn_gating.py
+++ b/test/attention/test_sparse_attn_gating.py
@@ -1,0 +1,52 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compute_gates_with_weight():
+    """Gates are in [0, 1] range (sigmoid output)."""
+    from mslk.attention.sparse_attn.gating import compute_gates
+
+    B, N, H, D = 1, 256, 4, 128
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    W = torch.randn(H, 3, D, device="cuda", dtype=torch.bfloat16)
+
+    gates = compute_gates(Q, W)
+    assert gates.shape == (B, N, H, 3)
+    assert (gates >= 0).all() and (gates <= 1).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compute_gates_no_weight():
+    """Without gate weights, gates are uniform 1/3."""
+    from mslk.attention.sparse_attn.gating import compute_gates
+
+    B, N, H, D = 1, 256, 4, 128
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+    gates = compute_gates(Q, None)
+    assert gates.shape == (B, N, H, 3)
+    torch.testing.assert_close(
+        gates.float().mean(), torch.tensor(1.0 / 3.0), atol=1e-5, rtol=1e-5
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_gate_and_combine():
+    """Gate and combine with uniform gates produces average."""
+    from mslk.attention.sparse_attn.gating import gate_and_combine
+
+    B, N, H, D = 1, 256, 4, 128
+    O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    O_slc = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    O_sld = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    gates = torch.ones(B, N, H, 3, device="cuda", dtype=torch.bfloat16) / 3.0
+
+    O = gate_and_combine(O_cmp, O_slc, O_sld, gates)
+    expected = (O_cmp.float() + O_slc.float() + O_sld.float()) / 3.0
+
+    torch.testing.assert_close(
+        O.float(), expected.to(O.dtype).float(), atol=1e-2, rtol=1e-2
+    )

--- a/test/attention/test_sparse_attn_nsa_forward.py
+++ b/test/attention/test_sparse_attn_nsa_forward.py
@@ -1,0 +1,43 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_forward_basic():
+    """NSA forward produces valid output."""
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 2
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    O = nsa_forward(Q, K, V, compress_block_size=64, num_selected_blocks=8)
+    assert O.shape == Q.shape
+    assert O.dtype == Q.dtype
+    assert not torch.isnan(O).any()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_forward_matches_reference():
+    """NSA forward output is close to pure PyTorch reference."""
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+    from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+    B, N, H, D = 1, 512, 4, 128
+    H_kv = 2
+    torch.manual_seed(42)
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    O_opt = nsa_forward(Q, K, V, compress_block_size=64, num_selected_blocks=8)
+    O_ref = nsa_forward_reference(
+        Q, K, V, compress_block_size=64, num_selected_blocks=8
+    )
+
+    # Tolerance is loose because FA4 and reference use different attention implementations
+    torch.testing.assert_close(O_opt.float(), O_ref.float(), atol=0.1, rtol=0.1)

--- a/test/attention/test_sparse_attn_reference.py
+++ b/test/attention/test_sparse_attn_reference.py
@@ -1,0 +1,80 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_forward_reference_basic():
+    """Reference forward produces valid output shape."""
+    from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+    B, N, H, D = 1, 512, 4, 128
+    H_kv = 2
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    O = nsa_forward_reference(Q, K, V, compress_block_size=64, num_selected_blocks=4)
+    assert O.shape == Q.shape
+    assert O.dtype == Q.dtype
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_forward_reference_with_weights():
+    """Reference forward with learned compression + gating weights."""
+    from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+    B, N, H, D = 1, 512, 4, 128
+    H_kv = 2
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16)
+    W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16)
+    gate_w = torch.randn(H, 3, D, device="cuda", dtype=torch.bfloat16)
+
+    O = nsa_forward_reference(
+        Q,
+        K,
+        V,
+        W_k_compress=W_k,
+        W_v_compress=W_v,
+        gate_proj_weight=gate_w,
+    )
+    assert O.shape == Q.shape
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_backward_reference():
+    """Reference backward produces gradients for all inputs."""
+    from mslk.attention.sparse_attn.reference import (
+        compute_block_indices_reference,
+        nsa_backward_reference,
+    )
+
+    B, N, H, D = 1, 512, 4, 128
+    H_kv = 2
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.float32)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+    dO = torch.randn(B, N, H, D, device="cuda", dtype=torch.float32)
+    W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+    gate_w = torch.randn(H, 3, D, device="cuda", dtype=torch.float32)
+
+    block_indices = compute_block_indices_reference(Q, K, W_k_compress=W_k)
+    grads = nsa_backward_reference(
+        Q,
+        K,
+        V,
+        dO,
+        W_k_compress=W_k,
+        gate_proj_weight=gate_w,
+        _block_indices=block_indices,
+    )
+
+    assert grads["dQ"].shape == Q.shape
+    assert grads["dK"].shape == K.shape
+    assert grads["dV"].shape == V.shape
+    assert grads["dW_k_compress"].shape == W_k.shape
+    assert grads["dgate_proj_weight"].shape == gate_w.shape

--- a/test/attention/test_sparse_attn_select.py
+++ b/test/attention/test_sparse_attn_select.py
@@ -1,0 +1,71 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_score_and_select_blocks_basic():
+    """Block selection returns valid indices with correct shape."""
+    from mslk.attention.sparse_attn.select import score_and_select_blocks
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 2
+    block_size = 64
+    num_selected = 8
+    q_tile_size = 256
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    N_cmp = N // block_size
+    K_cmp = torch.randn(B, N_cmp, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    indices = score_and_select_blocks(
+        Q,
+        K_cmp,
+        num_selected,
+        block_size,
+        causal=True,
+        q_tile_size=q_tile_size,
+    )
+
+    N_q_tiles = N // q_tile_size
+    assert indices.shape == (B, H, N_q_tiles, num_selected)
+    assert indices.dtype == torch.int32
+
+    # All indices should be valid (in range [0, N_cmp))
+    assert (indices >= 0).all()
+    assert (indices < N_cmp).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_score_and_select_blocks_causal():
+    """Causal masking prevents selecting future blocks."""
+    from mslk.attention.sparse_attn.select import score_and_select_blocks
+
+    B, N, H, D = 1, 1024, 2, 128
+    H_kv = 2
+    block_size = 64
+    num_selected = 4
+    q_tile_size = 256
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    N_cmp = N // block_size
+    K_cmp = torch.randn(B, N_cmp, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    indices = score_and_select_blocks(
+        Q,
+        K_cmp,
+        num_selected,
+        block_size,
+        causal=True,
+        q_tile_size=q_tile_size,
+    )
+
+    # For the first query tile (positions 0..255), future blocks start at
+    # block j where j * block_size >= q_tile_size = 256, i.e. j >= 4
+    first_tile_indices = indices[:, :, 0]
+    max_allowed_block = q_tile_size // block_size - 1  # block 3
+    # All selected blocks for tile 0 should be <= max_allowed_block
+    assert (first_tile_indices <= max_allowed_block).all(), (
+        f"First tile selected future blocks: {first_tile_indices}"
+    )

--- a/test/attention/test_sparse_attn_sparsity_masks.py
+++ b/test/attention/test_sparse_attn_sparsity_masks.py
@@ -1,0 +1,61 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_build_fa4_block_sparse_expansion():
+    """Expansion case: compress_block_size >= n_block_size."""
+    from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+    B, H, N_q_tiles, k = 1, 2, 4, 3
+    compress_block_size = 256
+    n_block_size = 128
+    ratio = compress_block_size // n_block_size
+
+    block_indices = torch.tensor(
+        [[[[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]]],
+        dtype=torch.int32,
+        device="cuda",
+    ).expand(B, H, N_q_tiles, k)
+
+    result = build_fa4_block_sparse_tensors(
+        block_indices,
+        compress_block_size,
+        n_block_size=n_block_size,
+        seqlen_k=2048,
+    )
+
+    assert result.full_block_cnt.shape == (B, H, N_q_tiles)
+    assert (result.full_block_cnt == k * ratio).all()
+    assert result.full_block_idx.shape == (B, H, N_q_tiles, k * ratio)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_build_fa4_block_sparse_contraction():
+    """Contraction case: compress_block_size < n_block_size with dedup."""
+    from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+    B, H = 1, 1
+    compress_block_size = 64
+    n_block_size = 128
+
+    # Blocks 0,1 -> FA4 block 0; blocks 2,3 -> FA4 block 1
+    block_indices = torch.tensor(
+        [[[[0, 1, 2, 3], [0, 2, 4, 6]]]],
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    result = build_fa4_block_sparse_tensors(
+        block_indices,
+        compress_block_size,
+        n_block_size=n_block_size,
+        seqlen_k=1024,
+    )
+
+    # Tile 0: blocks 0,1,2,3 -> FA4 blocks 0,0,1,1 -> dedup -> [0,1], count=2
+    assert result.full_block_cnt[0, 0, 0].item() == 2
+    # Tile 1: blocks 0,2,4,6 -> FA4 blocks 0,1,2,3 -> all unique, count=4
+    assert result.full_block_cnt[0, 0, 1].item() == 4


### PR DESCRIPTION
Summary:

Replace the multi-kernel PyTorch gating (compute_gates + gate_and_combine) with
a single fused CuteDSL kernel (fused_gate_and_combine) — 4-7x faster on B200.

Key design:
- One warp (32 threads) per (b,n,h) row — each warp handles one output position
- Warp-shuffle butterfly reduction for 3 gate dot-products (no shared memory)
- elems_per_thread = D // 32, staying in registers (4 for D=128)
- Sigmoid via log2-exp2 trick: uses fast hardware exp2
- All accumulation in Float32 for numerical stability with bf16/fp16 inputs
- In-memory compile cache keyed by (dtype, D, has_gate_weight)

When gate_proj_weight is None, skips the CuteDSL kernel entirely and returns
a simple (O_cmp + O_slc + O_sld) / 3 average — avoids kernel launch overhead
for the ungated case.

Returns (output, gates) tuple so gates are available for the backward pass.

PyTorch reference implementations (compute_gates, gate_and_combine) retained
for testing and fallback.

No performance impact — gating alone is not the bottleneck.
{F1987648122}

Differential Revision: D99181847
