### PR TITLE
Block-sparse compressed attention (sub-quadratic compressed branch) (#308)

### DIFF
--- a/docs/gen_nsa_perf_chart.py
+++ b/docs/gen_nsa_perf_chart.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""Generate NSA performance chart from benchmark data."""
+
+import datetime
+import platform
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def main():
+    # Benchmark data from GB200 (B=1, H=32, H_kv=8, D=128)
+    # Measured 2026-03-28 — post-optimization (shared selector, compact metadata,
+    # compress_factor, pure PyTorch compress+gating)
+
+    # Forward data (4K–2M)
+    fwd_seq_lengths = [
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+        2097152,
+    ]
+
+    dense_fwd_ms = [
+        0.23,
+        0.66,
+        1.58,
+        5.50,
+        25.29,
+        97.71,
+        407.59,
+        1633.15,
+        6537.68,
+        25594.57,
+    ]
+    nsa_fwd_ms = [
+        2.97,
+        1.51,
+        2.76,
+        3.99,
+        7.16,
+        12.34,
+        26.30,
+        71.33,
+        228.28,
+        899.15,
+    ]
+    # NSA+CmpSparse: no 2M data yet (not benchmarked)
+    nsa_cmpsparse_fwd_seq = [
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+    ]
+    nsa_cmpsparse_fwd_ms = [1.65, 2.42, 3.11, 4.02, 7.04, 12.69, 30.17, 68.32, 171.49]
+
+    # Fwd+Bwd data (64K–1M, warmed runs only)
+    fwdbwd_seq_lengths = [65536, 131072, 262144, 524288, 1048576]
+
+    dense_fwdbwd_ms = [25.19, 98.72, 406.35, 1632.08, 6531.88]
+    nsa_fwdbwd_ms = [11.47, 21.30, 44.79, 108.71, 303.52]
+
+    fwd_speedup = [d / n for d, n in zip(dense_fwd_ms, nsa_fwd_ms)]
+    # CmpSparse speedup uses its own (shorter) seq_lengths list
+    dense_fwd_cmpsparse = dense_fwd_ms[: len(nsa_cmpsparse_fwd_ms)]
+    fwd_cmpsparse_speedup = [
+        d / n for d, n in zip(dense_fwd_cmpsparse, nsa_cmpsparse_fwd_ms)
+    ]
+    fwdbwd_speedup = [d / n for d, n in zip(dense_fwdbwd_ms, nsa_fwdbwd_ms)]
+
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5.5))
+
+    # --- Panel 1: Forward latency ---
+    ax = axes[0]
+    ax.loglog(
+        fwd_seq_lengths,
+        dense_fwd_ms,
+        "o-",
+        color="#d62728",
+        label="Dense FA4",
+        linewidth=2,
+        markersize=6,
+    )
+    ax.loglog(
+        fwd_seq_lengths,
+        nsa_fwd_ms,
+        "s-",
+        color="#2ca02c",
+        label="NSA Sparse",
+        linewidth=2,
+        markersize=6,
+    )
+    ax.loglog(
+        nsa_cmpsparse_fwd_seq,
+        nsa_cmpsparse_fwd_ms,
+        "^-",
+        color="#1f77b4",
+        label="NSA + CmpSparse",
+        linewidth=2,
+        markersize=6,
+    )
+    ax.set_xlabel("Sequence Length", fontsize=12)
+    ax.set_ylabel("Latency (ms)", fontsize=12)
+    ax.set_title("Forward Pass Latency", fontsize=13, fontweight="bold")
+    ax.legend(fontsize=10)
+    ax.grid(True, alpha=0.3, which="both")
+    ax.set_xticks([4096, 16384, 65536, 262144, 1048576, 2097152])
+    ax.set_xticklabels(["4K", "16K", "64K", "256K", "1M", "2M"], fontsize=10)
+
+    # --- Panel 2: Fwd+Bwd latency ---
+    ax = axes[1]
+    ax.loglog(
+        fwdbwd_seq_lengths,
+        dense_fwdbwd_ms,
+        "o-",
+        color="#d62728",
+        label="Dense FA4",
+        linewidth=2,
+        markersize=6,
+    )
+    ax.loglog(
+        fwdbwd_seq_lengths,
+        nsa_fwdbwd_ms,
+        "s-",
+        color="#2ca02c",
+        label="NSA Sparse",
+        linewidth=2,
+        markersize=6,
+    )
+    ax.set_xlabel("Sequence Length", fontsize=12)
+    ax.set_ylabel("Latency (ms)", fontsize=12)
+    ax.set_title("Fwd + Bwd Latency (warmed)", fontsize=13, fontweight="bold")
+    ax.legend(fontsize=11)
+    ax.grid(True, alpha=0.3, which="both")
+    ax.set_xticks([65536, 131072, 262144, 524288, 1048576])
+    ax.set_xticklabels(["64K", "128K", "256K", "512K", "1M"], fontsize=10)
+
+    # --- Panel 3: Speedup comparison ---
+    ax = axes[2]
+    ax.semilogx(
+        fwd_seq_lengths,
+        fwd_speedup,
+        "D-",
+        color="#1f77b4",
+        label="Fwd (NSA)",
+        linewidth=2,
+        markersize=6,
+    )
+    ax.semilogx(
+        nsa_cmpsparse_fwd_seq,
+        fwd_cmpsparse_speedup,
+        "^-",
+        color="#9467bd",
+        label="Fwd (NSA+CmpSparse)",
+        linewidth=2,
+        markersize=6,
+    )
+    ax.semilogx(
+        fwdbwd_seq_lengths,
+        fwdbwd_speedup,
+        "s-",
+        color="#ff7f0e",
+        label="Fwd+Bwd (NSA)",
+        linewidth=2,
+        markersize=6,
+    )
+    ax.axhline(y=1.0, color="gray", linestyle="--", alpha=0.5)
+    ax.fill_between(fwd_seq_lengths, 1.0, fwd_speedup, alpha=0.08, color="#1f77b4")
+    ax.fill_between(
+        nsa_cmpsparse_fwd_seq, 1.0, fwd_cmpsparse_speedup, alpha=0.08, color="#9467bd"
+    )
+    ax.fill_between(
+        fwdbwd_seq_lengths, 1.0, fwdbwd_speedup, alpha=0.08, color="#ff7f0e"
+    )
+    ax.set_xlabel("Sequence Length", fontsize=12)
+    ax.set_ylabel("Speedup (Dense / NSA)", fontsize=12)
+    ax.set_title("NSA Speedup vs Dense FA4", fontsize=13, fontweight="bold")
+    ax.legend(fontsize=10, loc="upper left")
+    ax.grid(True, alpha=0.3, which="both")
+    ax.set_xticks([4096, 16384, 65536, 262144, 1048576, 2097152])
+    ax.set_xticklabels(["4K", "16K", "64K", "256K", "1M", "2M"], fontsize=10)
+
+    # Annotate peak speedups
+    # NSA+CmpSparse peaks at 1M (no 2M data)
+    ax.annotate(
+        f"{fwd_cmpsparse_speedup[-1]:.1f}x",
+        xy=(1048576, fwd_cmpsparse_speedup[-1]),
+        xytext=(200000, fwd_cmpsparse_speedup[-1] + 1),
+        fontsize=11,
+        fontweight="bold",
+        arrowprops={"arrowstyle": "->", "color": "#9467bd"},
+        color="#9467bd",
+    )
+    # NSA forward peaks at 2M
+    ax.annotate(
+        f"{fwd_speedup[-1]:.1f}x",
+        xy=(2097152, fwd_speedup[-1]),
+        xytext=(500000, fwd_speedup[-1] + 1),
+        fontsize=11,
+        fontweight="bold",
+        arrowprops={"arrowstyle": "->", "color": "#1f77b4"},
+        color="#1f77b4",
+    )
+    # Fwd+Bwd peaks at 1M
+    ax.annotate(
+        f"{fwdbwd_speedup[-1]:.1f}x",
+        xy=(1048576, fwdbwd_speedup[-1]),
+        xytext=(200000, fwdbwd_speedup[-1] - 4),
+        fontsize=11,
+        fontweight="bold",
+        arrowprops={"arrowstyle": "->", "color": "#ff7f0e"},
+        color="#ff7f0e",
+    )
+
+    plt.suptitle(
+        "NSA Sparse Attention Performance — GB200 (B=1, H=32, H_kv=8, D=128)",
+        fontsize=14,
+        fontweight="bold",
+        y=1.02,
+    )
+    plt.tight_layout()
+
+    hostname = platform.node()
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    fig.text(
+        0.99,
+        -0.02,
+        f"{hostname}  |  {timestamp}",
+        fontsize=8,
+        color="gray",
+        ha="right",
+        va="top",
+    )
+
+    plt.savefig("docs/nsa_perf.svg", format="svg", bbox_inches="tight", dpi=150)
+    print("Saved docs/nsa_perf.svg")
+
+
+if __name__ == "__main__":
+    main()

--- a/mslk/attention/flash_attn/block_sparsity.py
+++ b/mslk/attention/flash_attn/block_sparsity.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+try:
+    from mslk.fb.mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+except ImportError:
+    from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
+
+__all__ = ["BlockSparseTensorsTorch"]

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,7 +1,11 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 from mslk.attention.sparse_attn.compress import compress_kv
-from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.gating import (
+    compute_gates,
+    fused_gate_and_combine,
+    gate_and_combine,
+)
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward
 from mslk.attention.sparse_attn.reference import (
     nsa_backward_reference,
@@ -18,5 +22,6 @@ __all__ = [
     "score_and_select_blocks",
     "build_fa4_block_sparse_tensors",
     "compute_gates",
+    "fused_gate_and_combine",
     "gate_and_combine",
 ]

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -11,6 +11,7 @@ from mslk.attention.sparse_attn.gating import (
     fused_gating_backward,
     gate_and_combine,
 )
+from mslk.attention.sparse_attn.nsa_autograd import nsa
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward
 from mslk.attention.sparse_attn.reference import (
     nsa_backward_reference,

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -11,7 +11,11 @@ from mslk.attention.sparse_attn.reference import (
     nsa_backward_reference,
     nsa_forward_reference,
 )
-from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.select import (
+    fused_score_and_select_all,
+    fused_score_and_select_blocks,
+    score_and_select_blocks,
+)
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 
 __all__ = [
@@ -20,6 +24,8 @@ __all__ = [
     "nsa_backward_reference",
     "compress_kv",
     "score_and_select_blocks",
+    "fused_score_and_select_blocks",
+    "fused_score_and_select_all",
     "build_fa4_block_sparse_tensors",
     "compute_gates",
     "fused_gate_and_combine",

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,9 +1,14 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
+from mslk.attention.sparse_attn.compress import (
+    compress_kv,
+    fused_compress_kv,
+    fused_compress_kv_backward,
+)
 from mslk.attention.sparse_attn.gating import (
     compute_gates,
     fused_gate_and_combine,
+    fused_gating_backward,
     gate_and_combine,
 )
 from mslk.attention.sparse_attn.nsa_forward import nsa_forward

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,6 +1,6 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.compress import compress_kv, fused_compress_kv
 from mslk.attention.sparse_attn.gating import (
     compute_gates,
     fused_gate_and_combine,

--- a/mslk/attention/sparse_attn/__init__.py
+++ b/mslk/attention/sparse_attn/__init__.py
@@ -1,0 +1,22 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+from mslk.attention.sparse_attn.reference import (
+    nsa_backward_reference,
+    nsa_forward_reference,
+)
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+__all__ = [
+    "nsa_forward",
+    "nsa_forward_reference",
+    "nsa_backward_reference",
+    "compress_kv",
+    "score_and_select_blocks",
+    "build_fa4_block_sparse_tensors",
+    "compute_gates",
+    "gate_and_combine",
+]

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -1,8 +1,10 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-ignore-all-errors
 
 """KV compression for NSA: mean-pool KV into blocks and apply learned projection.
 
-Provides compress_kv (reference implementation).
+Provides compress_kv (reference), fused_compress_kv (with varlen support),
+and fused_compress_kv_backward.
 """
 
 from __future__ import annotations
@@ -18,9 +20,7 @@ def compress_kv(
     W_k: Tensor | None = None,  # (H_kv, D, D) or None
     W_v: Tensor | None = None,  # (H_kv, D, D) or None
 ) -> tuple[Tensor, Tensor]:
-    """Compress K, V by mean-pooling over blocks.
-
-    Applies optional linear projection after pooling.
+    """Compress K, V by mean-pooling over blocks and applying optional linear projection.
 
     Args:
         K: Key tensor, shape (B, N, H_kv, D).
@@ -40,8 +40,110 @@ def compress_kv(
 
     N_cmp = N // block_size
 
+    # Reshape into blocks and mean-pool
+    K_cmp = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)  # (B, N_cmp, H_kv, D)
+    V_cmp = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+
+    # Apply per-head linear projection if provided
+    if W_k is not None:
+        # W_k: (H_kv, D, D)
+        # K_cmp: (B, N_cmp, H_kv, D) -> einsum over D
+        K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
+
+    if W_v is not None:
+        V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
+
+    return K_cmp, V_cmp
+
+
+def fused_compress_kv(
+    K: Tensor,  # (B, N, H_kv, D) or (total_tokens, H_kv, D) for varlen
+    V: Tensor,  # same shape as K
+    block_size: int,
+    W_k: Tensor | None = None,  # (H_kv, D, D) or None
+    W_v: Tensor | None = None,  # (H_kv, D, D) or None
+    cu_seqlens: Tensor | None = None,  # (B+1,) int32 for varlen
+    max_seqlen: int | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Fused KV compression using a CuteDSL kernel.
+
+    Replaces compress_kv's two PyTorch mean-reduction calls with a single
+    fused kernel launch that processes both K and V simultaneously.
+
+    For varlen (3D + cu_seqlens): processes each sequence independently in
+    PyTorch (O(N), no CuteDSL kernel change needed), producing padded output
+    (B, max_N_cmp, H_kv, D) where max_N_cmp = max_seqlen // block_size.
+
+    Args:
+        K: Key tensor, shape (B, N, H_kv, D) or (total_tokens, H_kv, D).
+        V: Value tensor, same shape as K.
+        block_size: Number of positions to pool together.
+        W_k: Optional per-head projection weight for keys.
+        W_v: Optional per-head projection weight for values.
+        cu_seqlens: Cumulative sequence lengths, (B+1,) int32 for varlen.
+        max_seqlen: Maximum sequence length (optional, computed if not given).
+
+    Returns:
+        K_cmp: Compressed keys, shape (B, N_cmp, H_kv, D).
+        V_cmp: Compressed values, shape (B, N_cmp, H_kv, D).
+    """
+    if cu_seqlens is not None:
+        return _fused_compress_kv_varlen(
+            K, V, block_size, W_k, W_v, cu_seqlens, max_seqlen
+        )
+
+    B, N, H_kv, D = K.shape
+    assert N % block_size == 0, (
+        f"Sequence length {N} must be divisible by block_size {block_size}"
+    )
+
+    N_cmp = N // block_size
+
+    # Mean-pool over block_size positions — pure PyTorch, no CuteDSL
     K_cmp = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
     V_cmp = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+
+    # Apply optional projections
+    if W_k is not None:
+        K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
+
+    if W_v is not None:
+        V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
+
+    return K_cmp, V_cmp
+
+
+def _fused_compress_kv_varlen(
+    K: Tensor,  # (total_tokens, H_kv, D)
+    V: Tensor,  # (total_tokens, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None,
+    W_v: Tensor | None,
+    cu_seqlens: Tensor,  # (B+1,) int32
+    max_seqlen: int | None,
+) -> tuple[Tensor, Tensor]:
+    """Varlen compress: per-sequence mean-pool in PyTorch, no padding of input."""
+    assert K.dim() == 3, f"Varlen requires 3D input, got {K.dim()}D"
+    H_kv = K.shape[1]
+    D = K.shape[2]
+    batch_size = cu_seqlens.shape[0] - 1
+    seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+
+    if max_seqlen is None:
+        max_seqlen = max(seqlens)
+    max_N_cmp = max_seqlen // block_size
+
+    K_cmp = K.new_zeros(batch_size, max_N_cmp, H_kv, D)
+    V_cmp = V.new_zeros(batch_size, max_N_cmp, H_kv, D)
+
+    for i, slen in enumerate(seqlens):
+        s = cu_seqlens[i].item()
+        n_cmp_i = slen // block_size
+        if n_cmp_i > 0:
+            K_seq = K[s : s + n_cmp_i * block_size]
+            V_seq = V[s : s + n_cmp_i * block_size]
+            K_cmp[i, :n_cmp_i] = K_seq.reshape(n_cmp_i, block_size, H_kv, D).mean(dim=1)
+            V_cmp[i, :n_cmp_i] = V_seq.reshape(n_cmp_i, block_size, H_kv, D).mean(dim=1)
 
     if W_k is not None:
         K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
@@ -49,3 +151,153 @@ def compress_kv(
         V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
 
     return K_cmp, V_cmp
+
+
+def fused_compress_kv_backward(
+    dK_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    dV_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    K: Tensor,  # (B, N, H_kv, D) or (total_tokens, H_kv, D) for varlen
+    V: Tensor,  # same shape as K
+    block_size: int,
+    W_k: Tensor | None = None,
+    W_v: Tensor | None = None,
+    cu_seqlens: Tensor | None = None,  # (B+1,) int32 for varlen
+) -> tuple[Tensor, Tensor, Tensor | None, Tensor | None]:
+    """Backward through KV compression: CuteDSL scatter + PyTorch projection.
+
+    For varlen (3D K, V + cu_seqlens): scatters from padded compressed gradients
+    directly to 3D varlen output, no padding of K or V needed.
+
+    Returns (dK, dV, dW_k, dW_v).
+    """
+    if cu_seqlens is not None:
+        return _fused_compress_kv_backward_varlen(
+            dK_cmp, dV_cmp, K, V, block_size, W_k, W_v, cu_seqlens
+        )
+
+    B, N, H_kv, D = K.shape
+    N_cmp = N // block_size
+
+    dW_k = None
+    dW_v = None
+
+    # Projection backward (PyTorch)
+    if W_k is not None:
+        K_cmp_mean = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+        dW_k = torch.einsum("bnhd,bnhe->hde", K_cmp_mean.float(), dK_cmp.float()).to(
+            W_k.dtype
+        )
+        dK_cmp = torch.einsum("bnhe,hde->bnhd", dK_cmp.float(), W_k.float()).to(
+            dK_cmp.dtype
+        )
+
+    if W_v is not None:
+        V_cmp_mean = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+        dW_v = torch.einsum("bnhd,bnhe->hde", V_cmp_mean.float(), dV_cmp.float()).to(
+            W_v.dtype
+        )
+        dV_cmp = torch.einsum("bnhe,hde->bnhd", dV_cmp.float(), W_v.float()).to(
+            dV_cmp.dtype
+        )
+
+    # Mean-pool backward: scatter gradient — pure PyTorch
+    # dK[b, i, h, d] = dK_cmp[b, i // block_size, h, d] / block_size
+    dK = (
+        dK_cmp.unsqueeze(2).expand(B, N_cmp, block_size, H_kv, D).reshape(B, N, H_kv, D)
+        / block_size
+    )
+    dV = (
+        dV_cmp.unsqueeze(2).expand(B, N_cmp, block_size, H_kv, D).reshape(B, N, H_kv, D)
+        / block_size
+    )
+
+    return dK, dV, dW_k, dW_v
+
+
+def _fused_compress_kv_backward_varlen(
+    dK_cmp: Tensor,  # (B, max_N_cmp, H_kv, D)
+    dV_cmp: Tensor,  # (B, max_N_cmp, H_kv, D)
+    K: Tensor,  # (total_tokens, H_kv, D)
+    V: Tensor,  # (total_tokens, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None,
+    W_v: Tensor | None,
+    cu_seqlens: Tensor,  # (B+1,) int32
+) -> tuple[Tensor, Tensor, Tensor | None, Tensor | None]:
+    """Varlen compress backward: scatter from padded compressed grads to 3D output."""
+    assert K.dim() == 3, f"Varlen requires 3D input, got {K.dim()}D"
+    H_kv = K.shape[1]
+    D = K.shape[2]
+    batch_size = cu_seqlens.shape[0] - 1
+    seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+
+    dW_k = None
+    dW_v = None
+
+    # Projection backward (PyTorch) — operates on padded compressed tensors
+    if W_k is not None:
+        # Build K_cmp_mean from 3D K per-sequence
+        max_N_cmp = dK_cmp.shape[1]
+        K_cmp_mean = K.new_zeros(batch_size, max_N_cmp, H_kv, D)
+        for i, slen in enumerate(seqlens):
+            s = cu_seqlens[i].item()
+            n_cmp_i = slen // block_size
+            if n_cmp_i > 0:
+                K_cmp_mean[i, :n_cmp_i] = (
+                    K[s : s + n_cmp_i * block_size]
+                    .reshape(n_cmp_i, block_size, H_kv, D)
+                    .mean(dim=1)
+                )
+        dW_k = torch.einsum("bnhd,bnhe->hde", K_cmp_mean.float(), dK_cmp.float()).to(
+            W_k.dtype
+        )
+        dK_cmp = torch.einsum("bnhe,hde->bnhd", dK_cmp.float(), W_k.float()).to(
+            dK_cmp.dtype
+        )
+
+    if W_v is not None:
+        max_N_cmp = dV_cmp.shape[1]
+        V_cmp_mean = V.new_zeros(batch_size, max_N_cmp, H_kv, D)
+        for i, slen in enumerate(seqlens):
+            s = cu_seqlens[i].item()
+            n_cmp_i = slen // block_size
+            if n_cmp_i > 0:
+                V_cmp_mean[i, :n_cmp_i] = (
+                    V[s : s + n_cmp_i * block_size]
+                    .reshape(n_cmp_i, block_size, H_kv, D)
+                    .mean(dim=1)
+                )
+        dW_v = torch.einsum("bnhd,bnhe->hde", V_cmp_mean.float(), dV_cmp.float()).to(
+            W_v.dtype
+        )
+        dV_cmp = torch.einsum("bnhe,hde->bnhd", dV_cmp.float(), W_v.float()).to(
+            dV_cmp.dtype
+        )
+
+    # Scatter from compressed to 3D varlen: dK_cmp[i, block, h, d] / block_size
+    total_tokens = K.shape[0]
+    dK = K.new_zeros(total_tokens, H_kv, D)
+    dV = V.new_zeros(total_tokens, H_kv, D)
+    inv_bs = 1.0 / block_size
+
+    for i, slen in enumerate(seqlens):
+        s = cu_seqlens[i].item()
+        n_cmp_i = slen // block_size
+        if n_cmp_i > 0:
+            # Expand each compressed gradient to block_size positions
+            dK[s : s + n_cmp_i * block_size] = (
+                dK_cmp[i, :n_cmp_i]
+                .unsqueeze(1)
+                .expand(-1, block_size, -1, -1)
+                .reshape(n_cmp_i * block_size, H_kv, D)
+                * inv_bs
+            )
+            dV[s : s + n_cmp_i * block_size] = (
+                dV_cmp[i, :n_cmp_i]
+                .unsqueeze(1)
+                .expand(-1, block_size, -1, -1)
+                .reshape(n_cmp_i * block_size, H_kv, D)
+                * inv_bs
+            )
+
+    return dK, dV, dW_k, dW_v

--- a/mslk/attention/sparse_attn/compress.py
+++ b/mslk/attention/sparse_attn/compress.py
@@ -1,0 +1,51 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""KV compression for NSA: mean-pool KV into blocks and apply learned projection.
+
+Provides compress_kv (reference implementation).
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def compress_kv(
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    block_size: int,
+    W_k: Tensor | None = None,  # (H_kv, D, D) or None
+    W_v: Tensor | None = None,  # (H_kv, D, D) or None
+) -> tuple[Tensor, Tensor]:
+    """Compress K, V by mean-pooling over blocks.
+
+    Applies optional linear projection after pooling.
+
+    Args:
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        block_size: Number of positions to pool together.
+        W_k: Optional per-head projection weight for keys.
+        W_v: Optional per-head projection weight for values.
+
+    Returns:
+        K_cmp: Compressed keys, shape (B, N // block_size, H_kv, D).
+        V_cmp: Compressed values, shape (B, N // block_size, H_kv, D).
+    """
+    B, N, H_kv, D = K.shape
+    assert N % block_size == 0, (
+        f"Sequence length {N} must be divisible by block_size {block_size}"
+    )
+
+    N_cmp = N // block_size
+
+    K_cmp = K.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+    V_cmp = V.reshape(B, N_cmp, block_size, H_kv, D).mean(dim=2)
+
+    if W_k is not None:
+        K_cmp = torch.einsum("bnhd,hde->bnhe", K_cmp, W_k)
+    if W_v is not None:
+        V_cmp = torch.einsum("bnhd,hde->bnhe", V_cmp, W_v)
+
+    return K_cmp, V_cmp

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -1,0 +1,113 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Output gating and combination for NSA's three attention branches.
+
+Provides compute_gates and gate_and_combine (reference implementations).
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def compute_gates(
+    Q: Tensor,  # (B, N, H, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Compute per-head gating weights from queries.
+
+    If gate_proj_weight is provided, computes sigmoid(Q @ W) per head per branch.
+    Otherwise, returns uniform 1/3 gates.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        chunk_size: If set, process in chunks to limit peak memory.
+
+    Returns:
+        gates: Gating weights, shape (B, N, H, 3).
+    """
+    if gate_proj_weight is None:
+        return torch.ones(*Q.shape[:-1], 3, device=Q.device, dtype=Q.dtype) / 3.0
+
+    if chunk_size is not None:
+        return _compute_gates_chunked(Q, gate_proj_weight, chunk_size)
+
+    # fp32 accumulation for numerical stability
+    gates = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
+    return gates.sigmoid().to(Q.dtype)
+
+
+def _compute_gates_chunked(
+    Q: Tensor, gate_proj_weight: Tensor, chunk_size: int
+) -> Tensor:
+    """Compute gates in chunks to limit peak memory."""
+    B, N, H, D = Q.shape
+    gates = torch.empty(B, N, H, 3, device=Q.device, dtype=Q.dtype)
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        # fp32 accumulation for numerical stability
+        g = torch.einsum(
+            "bnhd,hgd->bnhg",
+            Q[:, start:end].float(),
+            gate_proj_weight.float(),
+        )
+        gates[:, start:end] = g.sigmoid().to(Q.dtype)
+    return gates
+
+
+def gate_and_combine(
+    O_cmp: Tensor,  # (B, N, H, D)
+    O_slc: Tensor,  # (B, N, H, D)
+    O_sld: Tensor,  # (B, N, H, D)
+    gates: Tensor,  # (B, N, H, 3)
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Combine branch outputs using gating weights.
+
+    combined = g0 * O_cmp + g1 * O_slc + g2 * O_sld
+
+    Args:
+        O_cmp: Compressed branch output, shape (B, N, H, D).
+        O_slc: Selected branch output, shape (B, N, H, D).
+        O_sld: Sliding window branch output, shape (B, N, H, D).
+        gates: Gating weights, shape (B, N, H, 3).
+        chunk_size: If set, process in chunks to limit peak memory.
+
+    Returns:
+        Combined output, shape (B, N, H, D).
+    """
+    if chunk_size is not None:
+        return _gate_and_combine_chunked(O_cmp, O_slc, O_sld, gates, chunk_size)
+
+    # fp32 accumulation for numerical stability
+    g = gates.float()
+    combined = (
+        g[..., 0:1] * O_cmp.float()
+        + g[..., 1:2] * O_slc.float()
+        + g[..., 2:3] * O_sld.float()
+    )
+    return combined.to(O_cmp.dtype)
+
+
+def _gate_and_combine_chunked(
+    O_cmp: Tensor,
+    O_slc: Tensor,
+    O_sld: Tensor,
+    gates: Tensor,
+    chunk_size: int,
+) -> Tensor:
+    """Chunked gating to limit peak memory (avoids 3 full fp32 intermediates)."""
+    N = O_cmp.shape[1]
+    out = torch.empty_like(O_cmp)
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        g = gates[:, start:end].float()
+        out[:, start:end] = (
+            g[..., 0:1] * O_cmp[:, start:end].float()
+            + g[..., 1:2] * O_slc[:, start:end].float()
+            + g[..., 2:3] * O_sld[:, start:end].float()
+        ).to(O_cmp.dtype)
+    return out

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -1,107 +1,286 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-ignore-all-errors
 
 """Output gating and combination for NSA's three attention branches.
 
-Provides compute_gates and gate_and_combine (reference implementations).
+Includes CuteDSL fused kernel (fused_gate_and_combine) that computes gates from Q
+and combines the three branch outputs in a single kernel launch, and PyTorch
+reference implementations (compute_gates, gate_and_combine).
 """
 
 from __future__ import annotations
+
+import math
+from typing import Type
 
 import torch
 from torch import Tensor
 
 
+# ---------------------------------------------------------------------------
+# CuteDSL fused gating kernel
+# ---------------------------------------------------------------------------
+
+_fused_gating_compile_cache: dict = {}
+
+
+def _make_fused_gating_kernel(cute_dtype: Type, D: int, has_gate_weight: bool):
+    """Create CuteDSL kernel for fused gating.
+
+    One warp (32 threads) per (b,n,h) row. Each warp computes 3 gate dot-products
+    via butterfly warp-shuffle reduction (no shared memory), then applies sigmoid
+    and weighted sum. All accumulation in Float32 for numerical stability.
+
+    Grid: ceil(B*N*H / WARPS_PER_BLOCK) blocks
+    Block: WARPS_PER_BLOCK * 32 threads
+    """
+    import cutlass
+    import cutlass.cute as cute
+
+    WARPS_PER_BLOCK = 4
+    THREADS_PER_BLOCK = WARPS_PER_BLOCK * 32
+    elems_per_thread = D // 32
+
+    class _Kernel:
+        @cute.jit
+        def __call__(self, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, stream):
+            num_rows = mQ.shape[0]
+            grid_x = cute.ceil_div(num_rows, WARPS_PER_BLOCK)
+            self.kernel(mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H).launch(
+                grid=[grid_x, 1, 1],
+                block=[THREADS_PER_BLOCK, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H):
+            lane_id = cute.arch.lane_idx()
+            warp_id = cute.arch.warp_idx()
+            bidx = cute.arch.block_idx()[0]
+
+            row = bidx * WARPS_PER_BLOCK + warp_id
+            num_rows = mQ.shape[0]
+
+            if row < num_rows:
+                ept = cutlass.const_expr(elems_per_thread)
+
+                if cutlass.const_expr(has_gate_weight):
+                    head_idx = row % H
+                    # fp32 dot-product accumulation for numerical stability
+                    g0 = cutlass.Float32(0.0)
+                    g1 = cutlass.Float32(0.0)
+                    g2 = cutlass.Float32(0.0)
+                    for e in cutlass.range_constexpr(ept):
+                        d = lane_id * ept + e
+                        q_val = cutlass.Float32(mQ[row, d])
+                        g0 += q_val * cutlass.Float32(mW[head_idx, d])
+                        g1 += q_val * cutlass.Float32(mW[head_idx, D + d])
+                        g2 += q_val * cutlass.Float32(mW[head_idx, 2 * D + d])
+
+                    # Warp-shuffle butterfly reduction (no shared memory)
+                    for i in cutlass.range_constexpr(5):
+                        g0 += cute.arch.shuffle_sync_bfly(g0, offset=1 << i)
+                        g1 += cute.arch.shuffle_sync_bfly(g1, offset=1 << i)
+                        g2 += cute.arch.shuffle_sync_bfly(g2, offset=1 << i)
+
+                    # Sigmoid via log2-exp2 trick: uses fast hardware exp2
+                    log2_e = cutlass.const_expr(math.log2(math.e))
+                    g0 = 1.0 / (1.0 + cute.math.exp2(-g0 * log2_e))
+                    g1 = 1.0 / (1.0 + cute.math.exp2(-g1 * log2_e))
+                    g2 = 1.0 / (1.0 + cute.math.exp2(-g2 * log2_e))
+                else:
+                    g0 = cutlass.Float32(1.0 / 3.0)
+                    g1 = cutlass.Float32(1.0 / 3.0)
+                    g2 = cutlass.Float32(1.0 / 3.0)
+
+                # fp32 weighted sum, write back in input dtype
+                for e in cutlass.range_constexpr(ept):
+                    d = lane_id * ept + e
+                    o = (
+                        g0 * cutlass.Float32(mO_cmp[row, d])
+                        + g1 * cutlass.Float32(mO_slc[row, d])
+                        + g2 * cutlass.Float32(mO_sld[row, d])
+                    )
+                    mOut[row, d] = cute_dtype(o)
+
+    return _Kernel()
+
+
+def fused_gate_and_combine(
+    Q: Tensor,  # (B, N, H, D) or (T, H, D) for varlen
+    O_cmp: Tensor,  # same shape as Q
+    O_slc: Tensor,  # same shape as Q
+    O_sld: Tensor,  # same shape as Q
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+) -> tuple[Tensor, Tensor]:
+    """Fused gate computation and branch combination using a CuteDSL kernel.
+
+    Replaces the two-step compute_gates() + gate_and_combine() with a single
+    kernel launch (4-7x faster). Eliminates the intermediate gates tensor and
+    reduces memory traffic by fusing the dot-product gate computation with
+    the weighted sum. All accumulation in Float32.
+
+    When gate_proj_weight is None, returns uniform 1/3 weighted sum without
+    launching the CuteDSL kernel.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D) or (T, H, D) for varlen.
+        O_cmp: Compressed attention output, same shape as Q.
+        O_slc: Selected attention output, same shape as Q.
+        O_sld: Sliding window attention output, same shape as Q.
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+
+    Returns:
+        (output, gates): Combined output (same shape as Q) and gate values
+        (..., H, 3) for use in backward pass.
+    """
+    # Skip CuteDSL kernel when gate_proj_weight is None — simple average
+    if gate_proj_weight is None:
+        combined = (O_cmp + O_slc + O_sld) * (1.0 / 3.0)
+        gates = torch.ones(*Q.shape[:-1], 3, device=Q.device, dtype=Q.dtype) / 3.0
+        return combined, gates
+
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack
+
+    H = Q.shape[-2]
+    D = Q.shape[-1]
+    assert D % 32 == 0, f"D={D} must be divisible by 32"
+
+    out = torch.empty_like(O_cmp)
+    has_gate_weight = gate_proj_weight is not None
+
+    # Reshape to 2D: (M, D) where M = B*N*H or T*H
+    M = Q.numel() // D
+    Q_2d = Q.reshape(M, D).contiguous()
+    O_cmp_2d = O_cmp.reshape(M, D).contiguous()
+    O_slc_2d = O_slc.reshape(M, D).contiguous()
+    O_sld_2d = O_sld.reshape(M, D).contiguous()
+    out_2d = out.reshape(M, D)
+
+    # Gate weights: (H, 3, D) -> (H, 3*D) for coalesced access
+    W_2d = gate_proj_weight.reshape(H, 3 * D).contiguous()
+
+    torch2cute_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    cute_dtype = torch2cute_dtype[Q.dtype]
+
+    def to_cute(tensor):
+        return from_dlpack(
+            tensor.detach(), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    mQ = to_cute(Q_2d)
+    mO_cmp = to_cute(O_cmp_2d)
+    mO_slc = to_cute(O_slc_2d)
+    mO_sld = to_cute(O_sld_2d)
+    mW = to_cute(W_2d)
+    mOut = to_cute(out_2d)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (cute_dtype, D, has_gate_weight)
+    if compile_key not in _fused_gating_compile_cache:
+        kernel_op = _make_fused_gating_kernel(cute_dtype, D, has_gate_weight)
+        _fused_gating_compile_cache[compile_key] = cute.compile(
+            kernel_op, mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, current_stream
+        )
+    _fused_gating_compile_cache[compile_key](
+        mQ, mO_cmp, mO_slc, mO_sld, mW, mOut, H, current_stream
+    )
+
+    # Compute gates separately for backward pass (cheap relative to the fused kernel)
+    gates = compute_gates(Q, gate_proj_weight)
+
+    return out, gates
+
+
+# ---------------------------------------------------------------------------
+# PyTorch reference implementations (kept for testing and fallback)
+# ---------------------------------------------------------------------------
+
+
 def compute_gates(
-    Q: Tensor,  # (B, N, H, D)
+    Q: Tensor,  # (B, N, H, D) or (T, H, D) for varlen
     gate_proj_weight: Tensor | None = None,  # (H, 3, D)
     chunk_size: int | None = None,
 ) -> Tensor:
-    """Compute per-head gating weights from queries.
-
-    If gate_proj_weight is provided, computes sigmoid(Q @ W) per head per branch.
-    Otherwise, returns uniform 1/3 gates.
+    """Compute per-head sigmoid gates for the three NSA branches.
 
     Args:
-        Q: Query tensor, shape (B, N, H, D).
-        gate_proj_weight: Gate projection weights, shape (H, 3, D).
-        chunk_size: If set, process in chunks to limit peak memory.
+        Q: Query tensor, shape (B, N, H, D) or (T, H, D) for varlen.
+        gate_proj_weight: Learned gate projection, shape (H, 3, D).
+            If None, returns uniform gates (1/3 each).
+        chunk_size: If set, process the sequence dimension in chunks to
+            reduce peak float32 memory usage. Only supported for 4D input.
 
     Returns:
-        gates: Gating weights, shape (B, N, H, 3).
+        gates: Sigmoid gates, (..., H, 3) matching leading dims of Q.
     """
     if gate_proj_weight is None:
         return torch.ones(*Q.shape[:-1], 3, device=Q.device, dtype=Q.dtype) / 3.0
 
-    if chunk_size is not None:
-        return _compute_gates_chunked(Q, gate_proj_weight, chunk_size)
-
-    # fp32 accumulation for numerical stability
-    gates = torch.einsum("bnhd,hgd->bnhg", Q.float(), gate_proj_weight.float())
-    return gates.sigmoid().to(Q.dtype)
-
-
-def _compute_gates_chunked(
-    Q: Tensor, gate_proj_weight: Tensor, chunk_size: int
-) -> Tensor:
-    """Compute gates in chunks to limit peak memory."""
-    B, N, H, D = Q.shape
-    gates = torch.empty(B, N, H, 3, device=Q.device, dtype=Q.dtype)
-    for start in range(0, N, chunk_size):
-        end = min(start + chunk_size, N)
+    if chunk_size is None:
+        # Reshape to (M, H, D) for einsum — works for both 3D and 4D
+        orig_shape = Q.shape
+        H, D = orig_shape[-2], orig_shape[-1]
         # fp32 accumulation for numerical stability
-        g = torch.einsum(
-            "bnhd,hgd->bnhg",
-            Q[:, start:end].float(),
+        gate_logits = torch.einsum(
+            "mhd,hgd->mhg",
+            Q.float().reshape(-1, H, D),
             gate_proj_weight.float(),
         )
-        gates[:, start:end] = g.sigmoid().to(Q.dtype)
+        return gate_logits.sigmoid().to(Q.dtype).reshape(*orig_shape[:-1], 3)
+
+    # Chunked path: process sequence in chunks to bound float32 intermediates
+    assert Q.dim() == 4, "Chunked gating only supported for 4D input"
+    B, N, H, D = Q.shape
+    gates = torch.empty(B, N, H, 3, device=Q.device, dtype=Q.dtype)
+    w = gate_proj_weight.float()
+    for start in range(0, N, chunk_size):
+        end = min(start + chunk_size, N)
+        gate_logits = torch.einsum("bnhd,hgd->bnhg", Q[:, start:end].float(), w)
+        gates[:, start:end] = gate_logits.sigmoid().to(Q.dtype)
     return gates
 
 
 def gate_and_combine(
-    O_cmp: Tensor,  # (B, N, H, D)
-    O_slc: Tensor,  # (B, N, H, D)
-    O_sld: Tensor,  # (B, N, H, D)
-    gates: Tensor,  # (B, N, H, 3)
+    O_cmp: Tensor,  # (B, N, H, D) or (T, H, D) for varlen
+    O_slc: Tensor,
+    O_sld: Tensor,
+    gates: Tensor,  # (..., H, 3) matching leading dims
     chunk_size: int | None = None,
 ) -> Tensor:
-    """Combine branch outputs using gating weights.
-
-    combined = g0 * O_cmp + g1 * O_slc + g2 * O_sld
+    """Combine three attention branch outputs with sigmoid gates.
 
     Args:
-        O_cmp: Compressed branch output, shape (B, N, H, D).
-        O_slc: Selected branch output, shape (B, N, H, D).
-        O_sld: Sliding window branch output, shape (B, N, H, D).
-        gates: Gating weights, shape (B, N, H, 3).
+        O_cmp: Compressed attention output.
+        O_slc: Selected attention output.
+        O_sld: Sliding window attention output.
+        gates: Sigmoid gates, (..., H, 3) matching leading dims.
         chunk_size: If set, process in chunks to limit peak memory.
 
     Returns:
-        Combined output, shape (B, N, H, D).
+        Combined output, same shape as O_cmp.
     """
-    if chunk_size is not None:
-        return _gate_and_combine_chunked(O_cmp, O_slc, O_sld, gates, chunk_size)
+    if chunk_size is None:
+        # fp32 accumulation for numerical stability
+        g = gates.float()
+        return (
+            g[..., 0:1] * O_cmp.float()
+            + g[..., 1:2] * O_slc.float()
+            + g[..., 2:3] * O_sld.float()
+        ).to(O_cmp.dtype)
 
-    # fp32 accumulation for numerical stability
-    g = gates.float()
-    combined = (
-        g[..., 0:1] * O_cmp.float()
-        + g[..., 1:2] * O_slc.float()
-        + g[..., 2:3] * O_sld.float()
-    )
-    return combined.to(O_cmp.dtype)
-
-
-def _gate_and_combine_chunked(
-    O_cmp: Tensor,
-    O_slc: Tensor,
-    O_sld: Tensor,
-    gates: Tensor,
-    chunk_size: int,
-) -> Tensor:
-    """Chunked gating to limit peak memory (avoids 3 full fp32 intermediates)."""
-    N = O_cmp.shape[1]
-    out = torch.empty_like(O_cmp)
+    # Chunked path: avoid materializing 3 full fp32 intermediates at once
+    assert O_cmp.dim() == 4, "Chunked gating only supported for 4D input"
+    B, N, H, D = O_cmp.shape
+    out = torch.empty(B, N, H, D, dtype=O_cmp.dtype, device=O_cmp.device)
     for start in range(0, N, chunk_size):
         end = min(start + chunk_size, N)
         g = gates[:, start:end].float()

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -201,6 +201,67 @@ def fused_gate_and_combine(
     return out, gates
 
 
+def fused_gating_backward(
+    Q: Tensor,  # (B, N, H, D) or (T, H, D) for varlen
+    dO: Tensor,  # same shape as Q
+    O_cmp: Tensor,  # same shape as Q
+    O_slc: Tensor,  # same shape as Q
+    O_sld: Tensor,  # same shape as Q
+    gates: Tensor,  # (..., H, 3) matching leading dims of Q
+    gate_proj_weight: Tensor,  # (H, 3, D)
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+    """Gating backward — pure PyTorch (cuBLAS einsum for cross-row reductions).
+
+    Computes dO_cmp, dO_slc, dO_sld (gradient routing through gates),
+    dQ_gate (query gradient from gate computation), and dW_gate (weight gradient).
+    All computation in fp32 for numerical stability.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D) or (T, H, D) for varlen.
+        dO: Upstream gradient, same shape as Q.
+        O_cmp, O_slc, O_sld: Branch outputs, same shape as Q.
+        gates: Sigmoid gate values, (..., H, 3) matching leading dims of Q.
+        gate_proj_weight: Gate weights, shape (H, 3, D).
+
+    Returns:
+        (dO_cmp, dO_slc, dO_sld, dQ_gate, dW_gate)
+    """
+    H = Q.shape[-2]
+    D = Q.shape[-1]
+
+    # fp32 gradient routing: dO_i = g_i * dO
+    g = gates.float()
+    dO_f = dO.float()
+    dO_cmp = (g[..., 0:1] * dO_f).to(dO.dtype)
+    dO_slc = (g[..., 1:2] * dO_f).to(dO.dtype)
+    dO_sld = (g[..., 2:3] * dO_f).to(dO.dtype)
+
+    # Sigmoid derivative: d_logit_i = (dO · O_i) * g_i * (1 - g_i)
+    O_branches = torch.stack([O_cmp.float(), O_slc.float(), O_sld.float()], dim=-1)
+    dg = (dO_f.unsqueeze(-1) * O_branches).sum(dim=-2)  # (..., H, 3)
+    d_logit = dg * g * (1 - g)
+
+    # dQ_gate = d_logit @ W (cuBLAS GEMM — query gradient from gate computation)
+    dQ_gate = (
+        torch.einsum(
+            "mhg,hgd->mhd",
+            d_logit.reshape(-1, H, 3),
+            gate_proj_weight.float(),
+        )
+        .reshape(Q.shape)
+        .to(Q.dtype)
+    )
+
+    # dW_gate = d_logit.T @ Q (cuBLAS GEMM — weight gradient)
+    dW_gate = torch.einsum(
+        "mhg,mhd->hgd",
+        d_logit.reshape(-1, H, 3),
+        Q.float().reshape(-1, H, D),
+    ).to(gate_proj_weight.dtype)
+
+    return dO_cmp, dO_slc, dO_sld, dQ_gate, dW_gate
+
+
 # ---------------------------------------------------------------------------
 # PyTorch reference implementations (kept for testing and fallback)
 # ---------------------------------------------------------------------------

--- a/mslk/attention/sparse_attn/gating.py
+++ b/mslk/attention/sparse_attn/gating.py
@@ -58,7 +58,8 @@ def _make_fused_gating_kernel(cute_dtype: Type, D: int, has_gate_weight: bool):
             warp_id = cute.arch.warp_idx()
             bidx = cute.arch.block_idx()[0]
 
-            row = bidx * WARPS_PER_BLOCK + warp_id
+            # Int64 cast prevents overflow for N >= 2M (B*N*H exceeds INT32_MAX)
+            row = cutlass.Int64(bidx * WARPS_PER_BLOCK + warp_id)
             num_rows = mQ.shape[0]
 
             if row < num_rows:

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -1,0 +1,112 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""NSA autograd utilities: block-sparse index transpose for backward pass.
+
+The full NSAFunction(torch.autograd.Function) will be added in a subsequent diff.
+This module provides the _transpose_block_sparse_for_bwd() utility needed by
+the FA4 block-sparse backward.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def _transpose_block_sparse_for_bwd(
+    fwd_tensors,
+    seqlen_q: int,
+    seqlen_k: int,
+    n_block_size: int,
+    use_mask_blocks: bool = False,
+):
+    """Transpose forward block-sparse tensors for the backward pass.
+
+    Forward: (B, H, n_q_tiles, k) — for each Q-tile, which KV-blocks
+    Backward: (B, H, n_kv_blocks, max_q_per_kv) — for each KV-block, which Q-tiles
+
+    The backward kernel iterates over KV-blocks and needs to know which Q-tiles
+    contribute gradients to each KV-block.
+
+    Uses a sparse inverted-index construction: O(total_entries) time and memory,
+    no dense (n_q_tiles x n_kv_blocks) intermediate.
+
+    Args:
+        fwd_tensors: Forward BlockSparseTensorsTorch.
+        seqlen_q: Query sequence length.
+        seqlen_k: KV sequence length.
+        n_block_size: KV block size for backward.
+        use_mask_blocks: If True, read from mask_block_cnt/idx and output as
+            mask blocks. Used for the compressed branch where mask_mod is needed.
+    """
+    from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+
+    if use_mask_blocks:
+        fwd_cnt = fwd_tensors.mask_block_cnt
+        fwd_idx = fwd_tensors.mask_block_idx
+    else:
+        fwd_cnt = fwd_tensors.full_block_cnt  # (B, H, n_q_tiles)
+        fwd_idx = fwd_tensors.full_block_idx  # (B, H, n_q_tiles, k)
+    q_block_size, _ = fwd_tensors.block_size
+
+    B, H, n_q_tiles = fwd_cnt.shape
+    k = fwd_idx.shape[3]
+    n_kv_blocks = (seqlen_k + n_block_size - 1) // n_block_size
+    device = fwd_cnt.device
+
+    # --- Sparse transpose: inverted index construction ---
+    # Step 1: Count how many Q-tiles reference each KV-block
+    idx_range = torch.arange(k, device=device)
+    valid_mask = idx_range < fwd_cnt.unsqueeze(-1)  # (B, H, n_q_tiles, k)
+
+    kv_indices = fwd_idx.long().clamp(0, n_kv_blocks - 1)
+    bwd_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device=device)
+    ones = valid_mask.int()
+    flat_kv = kv_indices.reshape(B, H, -1)
+    flat_ones = ones.reshape(B, H, -1)
+    bwd_cnt.scatter_add_(2, flat_kv, flat_ones)
+
+    max_q_per_kv = bwd_cnt.max().item()
+    if max_q_per_kv == 0:
+        max_q_per_kv = 1
+
+    # Step 2: Build compact backward index
+    bwd_idx = torch.zeros(
+        B, H, n_kv_blocks, max_q_per_kv, dtype=torch.int32, device=device
+    )
+
+    # Per-batch-head loop. B*H is small (typically 1*32=32) and k is small (~16).
+    for b in range(B):
+        for h in range(H):
+            cnt_bh = fwd_cnt[b, h]
+            idx_bh = fwd_idx[b, h]
+            write_offsets = torch.zeros(n_kv_blocks, dtype=torch.long, device=device)
+            for t in range(n_q_tiles):
+                n_valid = cnt_bh[t].item()
+                for ki in range(min(n_valid, k)):
+                    kv_blk = idx_bh[t, ki].item()
+                    if 0 <= kv_blk < n_kv_blocks:
+                        off = write_offsets[kv_blk].item()
+                        if off < max_q_per_kv:
+                            bwd_idx[b, h, kv_blk, off] = t
+                            write_offsets[kv_blk] += 1
+
+    bwd_mask_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device=device)
+    bwd_mask_idx = torch.zeros(B, H, n_kv_blocks, 1, dtype=torch.int32, device=device)
+
+    if use_mask_blocks:
+        return BlockSparseTensorsTorch(
+            mask_block_cnt=bwd_cnt,
+            mask_block_idx=bwd_idx,
+            full_block_cnt=bwd_mask_cnt,
+            full_block_idx=bwd_mask_idx,
+            block_size=(q_block_size, n_block_size),
+        )
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=bwd_mask_cnt,
+        mask_block_idx=bwd_mask_idx,
+        full_block_cnt=bwd_cnt,
+        full_block_idx=bwd_idx,
+        block_size=(q_block_size, n_block_size),
+    )

--- a/mslk/attention/sparse_attn/nsa_autograd.py
+++ b/mslk/attention/sparse_attn/nsa_autograd.py
@@ -1,15 +1,36 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-"""NSA autograd utilities: block-sparse index transpose for backward pass.
+"""NSA autograd function: wraps FA4-based forward + backward with activation checkpointing.
 
-The full NSAFunction(torch.autograd.Function) will be added in a subsequent diff.
-This module provides the _transpose_block_sparse_for_bwd() utility needed by
-the FA4 block-sparse backward.
+Provides NSAFunction(torch.autograd.Function) and a user-facing nsa() function
+that supports training (backward pass).
+
+Supports both fixed-length (4D) and variable-length (3D + cu_seqlens) inputs.
+For varlen, the selected and sliding window branches use native FA4 varlen
+(no padding), while the compressed branch uses padded 4D (mask_mod blocks
+varlen in FA4 backward).
 """
 
 from __future__ import annotations
 
+import math
+
 import torch
+from mslk.attention.sparse_attn.compress import (
+    fused_compress_kv,
+    fused_compress_kv_backward,
+)
+from mslk.attention.sparse_attn.gating import (
+    compute_gates,
+    fused_gating_backward,
+    gate_and_combine,
+)
+from mslk.attention.sparse_attn.nsa_forward import _fa4_bwd, _fa4_fwd
+from mslk.attention.sparse_attn.select import fused_score_and_select_all
+from mslk.attention.sparse_attn.sparsity_masks import (
+    build_compressed_block_sparse_tensors,
+    build_fa4_block_sparse_tensors,
+)
 from torch import Tensor
 
 
@@ -32,12 +53,9 @@ def _transpose_block_sparse_for_bwd(
     no dense (n_q_tiles x n_kv_blocks) intermediate.
 
     Args:
-        fwd_tensors: Forward BlockSparseTensorsTorch.
-        seqlen_q: Query sequence length.
-        seqlen_k: KV sequence length.
-        n_block_size: KV block size for backward.
-        use_mask_blocks: If True, read from mask_block_cnt/idx and output as
-            mask blocks. Used for the compressed branch where mask_mod is needed.
+        use_mask_blocks: If True, read from mask_block_cnt/idx instead of
+            full_block_cnt/idx, and output as mask blocks. Used for the
+            compressed branch where mask_mod is needed.
     """
     from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
 
@@ -56,12 +74,17 @@ def _transpose_block_sparse_for_bwd(
 
     # --- Sparse transpose: inverted index construction ---
     # Step 1: Count how many Q-tiles reference each KV-block
+    # Build validity mask: (B, H, n_q_tiles, k) — which entries are valid
     idx_range = torch.arange(k, device=device)
     valid_mask = idx_range < fwd_cnt.unsqueeze(-1)  # (B, H, n_q_tiles, k)
 
-    kv_indices = fwd_idx.long().clamp(0, n_kv_blocks - 1)
+    # Flatten valid KV-block indices and scatter-count
+    kv_indices = fwd_idx.long().clamp(0, n_kv_blocks - 1)  # (B, H, n_q_tiles, k)
+
+    # Count per KV-block: scatter_add ones at each kv_index
     bwd_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device=device)
     ones = valid_mask.int()
+    # Reshape for scatter_add: (B, H, n_q_tiles * k)
     flat_kv = kv_indices.reshape(B, H, -1)
     flat_ones = ones.reshape(B, H, -1)
     bwd_cnt.scatter_add_(2, flat_kv, flat_ones)
@@ -71,15 +94,18 @@ def _transpose_block_sparse_for_bwd(
         max_q_per_kv = 1
 
     # Step 2: Build compact backward index
+    # For each valid (q_tile, kv_block) pair, store q_tile at the next
+    # available position for that kv_block in bwd_idx.
     bwd_idx = torch.zeros(
         B, H, n_kv_blocks, max_q_per_kv, dtype=torch.int32, device=device
     )
 
-    # Per-batch-head loop. B*H is small (typically 1*32=32) and k is small (~16).
+    # Use a simple per-batch-head Python loop. B*H is small (typically 1*32=32)
+    # and k is small (typically 16), so this is fast.
     for b in range(B):
         for h in range(H):
-            cnt_bh = fwd_cnt[b, h]
-            idx_bh = fwd_idx[b, h]
+            cnt_bh = fwd_cnt[b, h]  # (n_q_tiles,)
+            idx_bh = fwd_idx[b, h]  # (n_q_tiles, k)
             write_offsets = torch.zeros(n_kv_blocks, dtype=torch.long, device=device)
             for t in range(n_q_tiles):
                 n_valid = cnt_bh[t].item()
@@ -91,6 +117,7 @@ def _transpose_block_sparse_for_bwd(
                             bwd_idx[b, h, kv_blk, off] = t
                             write_offsets[kv_blk] += 1
 
+    # bwd_idx is already compact: (B, H, n_kv_blocks, max_q_per_kv)
     bwd_mask_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device=device)
     bwd_mask_idx = torch.zeros(B, H, n_kv_blocks, 1, dtype=torch.int32, device=device)
 
@@ -109,4 +136,919 @@ def _transpose_block_sparse_for_bwd(
         full_block_cnt=bwd_cnt,
         full_block_idx=bwd_idx,
         block_size=(q_block_size, n_block_size),
+    )
+
+
+def _pad_to_4d(
+    src: Tensor,
+    cu_seqlens: Tensor,
+    seqlens: list[int],
+    batch_size: int,
+    pad_N: int,
+) -> Tensor:
+    """Pad a 3D varlen tensor (total_tokens, ...) to 4D (B, pad_N, ...)."""
+    out = src.new_zeros(batch_size, pad_N, *src.shape[1:])
+    for i, slen in enumerate(seqlens):
+        s = cu_seqlens[i].item()
+        out[i, :slen] = src[s : s + slen]
+    return out
+
+
+def _unpad_to_3d(
+    src: Tensor,
+    cu_seqlens: Tensor,
+    seqlens: list[int],
+    total_tokens: int,
+) -> Tensor:
+    """Unpad a 4D tensor (B, N, ...) to 3D (total_tokens, ...)."""
+    out = src.new_zeros(total_tokens, *src.shape[2:])
+    for i, slen in enumerate(seqlens):
+        s = cu_seqlens[i].item()
+        out[s : s + slen] = src[i, :slen]
+    return out
+
+
+class NSAFunction(torch.autograd.Function):
+    """Autograd function for NSA with activation checkpointing.
+
+    Forward: runs the FA4-based NSA forward pass.
+    Backward: recomputes FA4 branch outputs (activation checkpointing),
+    then calls _flash_attn_bwd for each branch.
+
+    Supports varlen via cu_seqlens: selected + sliding window branches use
+    native FA4 varlen (no padding), compressed branch uses padded 4D
+    (mask_mod blocks varlen in FA4 backward).
+
+    Saved for backward (small tensors only):
+        - Q, K, V (inputs, already in autograd graph)
+        - K_cmp, V_cmp (compressed KV, padded to max_N_cmp)
+        - block_indices, sparse_tensors (discrete, small)
+        - gates (..., H, 3)
+        - Config scalars
+
+    Recomputed during backward (activation checkpointing):
+        - O_cmp, lse_cmp, O_slc, lse_slc, O_sld, lse_sld
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        Q: Tensor,
+        K: Tensor,
+        V: Tensor,
+        K_cmp: Tensor,
+        V_cmp: Tensor,
+        W_k_compress: Tensor | None,
+        W_v_compress: Tensor | None,
+        gate_proj_weight: Tensor | None,
+        compress_block_size: int,
+        num_selected_blocks: int,
+        window_size: int,
+        causal: bool,
+        softmax_scale: float,
+        q_tile_size: int,
+        n_block_size: int,
+        cu_seqlens: Tensor | None,
+        max_seqlen: int | None,
+        sparse_tensors,  # BlockSparseTensorsTorch
+        cmp_sparse_tensors,  # BlockSparseTensorsTorch | None
+    ) -> Tensor:
+        is_varlen = cu_seqlens is not None
+
+        if is_varlen:
+            return _nsa_forward_varlen(
+                ctx,
+                Q,
+                K,
+                V,
+                K_cmp,
+                V_cmp,
+                W_k_compress,
+                W_v_compress,
+                gate_proj_weight,
+                compress_block_size,
+                num_selected_blocks,
+                window_size,
+                causal,
+                softmax_scale,
+                q_tile_size,
+                n_block_size,
+                cu_seqlens,
+                max_seqlen,
+                sparse_tensors,
+                cmp_sparse_tensors,
+            )
+
+        # Fixed-length 4D path (unchanged)
+        B, N, H, D = Q.shape
+        if cmp_sparse_tensors is not None:
+            O_cmp, _ = _fa4_fwd(
+                Q,
+                K_cmp,
+                V_cmp,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                compress_factor=compress_block_size,
+                block_sparse_tensors=cmp_sparse_tensors,
+            )
+        else:
+            O_cmp, _ = _fa4_fwd(
+                Q,
+                K_cmp,
+                V_cmp,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                compress_factor=compress_block_size,
+            )
+        O_slc, _ = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            block_sparse_tensors=sparse_tensors,
+        )
+        O_sld, _ = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
+
+        gates = compute_gates(Q, gate_proj_weight)
+        O = gate_and_combine(O_cmp, O_slc, O_sld, gates)
+
+        ctx.save_for_backward(
+            Q,
+            K,
+            V,
+            K_cmp,
+            V_cmp,
+            gates,
+            gate_proj_weight,
+            W_k_compress,
+            W_v_compress,
+        )
+        ctx.sparse_tensors = sparse_tensors
+        ctx.cmp_sparse_tensors = cmp_sparse_tensors
+        ctx.compress_block_size = compress_block_size
+        ctx.window_size = window_size
+        ctx.causal = causal
+        ctx.softmax_scale = softmax_scale
+        ctx.q_tile_size = q_tile_size
+        ctx.n_block_size = n_block_size
+        ctx.cu_seqlens = None
+        ctx.max_seqlen = None
+        ctx.varlen_meta = None
+
+        return O
+
+    @staticmethod
+    def backward(ctx, dO: Tensor):
+        is_varlen = ctx.cu_seqlens is not None
+        if is_varlen:
+            return _nsa_backward_varlen(ctx, dO)
+
+        (
+            Q,
+            K,
+            V,
+            K_cmp,
+            V_cmp,
+            gates,
+            gate_proj_weight,
+            W_k_compress,
+            W_v_compress,
+        ) = ctx.saved_tensors
+
+        # Fixed-length 4D backward (unchanged from original)
+        causal = ctx.causal
+        softmax_scale = ctx.softmax_scale
+        compress_block_size = ctx.compress_block_size
+        window_size = ctx.window_size
+        sparse_tensors = ctx.sparse_tensors
+        cmp_sparse_tensors = ctx.cmp_sparse_tensors
+
+        dQ_gate = None
+        dgate_proj_weight = None
+
+        if gate_proj_weight is not None:
+            O_cmp, lse_cmp = _fa4_fwd(
+                Q,
+                K_cmp,
+                V_cmp,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                compress_factor=compress_block_size,
+                block_sparse_tensors=cmp_sparse_tensors,
+            )
+            O_slc, lse_slc = _fa4_fwd(
+                Q,
+                K,
+                V,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                block_sparse_tensors=sparse_tensors,
+            )
+            O_sld, lse_sld = _fa4_fwd(
+                Q,
+                K,
+                V,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                window_size_left=window_size,
+                window_size_right=0,
+            )
+            dO_cmp, dO_slc, dO_sld, dQ_gate, dgate_proj_weight = fused_gating_backward(
+                Q,
+                dO,
+                O_cmp,
+                O_slc,
+                O_sld,
+                gates,
+                gate_proj_weight,
+            )
+        else:
+            g = gates.float()
+            dO_f = dO.float()
+            dO_cmp = (g[..., 0:1] * dO_f).to(dO.dtype)
+            dO_slc = (g[..., 1:2] * dO_f).to(dO.dtype)
+            dO_sld = (g[..., 2:3] * dO_f).to(dO.dtype)
+            del g, dO_f
+            lse_cmp = lse_slc = lse_sld = None
+            O_cmp = O_slc = O_sld = None
+
+        # Branch 1: Compressed
+        if O_cmp is None:
+            O_cmp, lse_cmp = _fa4_fwd(
+                Q,
+                K_cmp,
+                V_cmp,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                compress_factor=compress_block_size,
+                block_sparse_tensors=cmp_sparse_tensors,
+            )
+        if cmp_sparse_tensors is not None:
+            cmp_bwd_sparse = _transpose_block_sparse_for_bwd(
+                cmp_sparse_tensors,
+                seqlen_q=Q.shape[1],
+                seqlen_k=K_cmp.shape[1],
+                n_block_size=cmp_sparse_tensors.block_size[1],
+                use_mask_blocks=False,
+            )
+        else:
+            cmp_bwd_sparse = None
+        dQ_cmp, dK_cmp, dV_cmp = _fa4_bwd(
+            Q,
+            K_cmp,
+            V_cmp,
+            O_cmp,
+            dO_cmp,
+            lse_cmp,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            compress_factor=compress_block_size,
+            block_sparse_tensors=cmp_bwd_sparse,
+        )
+        del O_cmp, lse_cmp, dO_cmp
+
+        # Branch 2: Selected (block-sparse)
+        if O_slc is None:
+            O_slc, lse_slc = _fa4_fwd(
+                Q,
+                K,
+                V,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                block_sparse_tensors=sparse_tensors,
+            )
+        bwd_sparse = _transpose_block_sparse_for_bwd(
+            sparse_tensors,
+            seqlen_q=Q.shape[1],
+            seqlen_k=K.shape[1],
+            n_block_size=ctx.n_block_size,
+        )
+        dQ_slc, dK_slc, dV_slc = _fa4_bwd(
+            Q,
+            K,
+            V,
+            O_slc,
+            dO_slc,
+            lse_slc,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            block_sparse_tensors=bwd_sparse,
+        )
+        del O_slc, lse_slc, dO_slc, bwd_sparse
+
+        # Branch 3: Sliding window
+        if O_sld is None:
+            O_sld, lse_sld = _fa4_fwd(
+                Q,
+                K,
+                V,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                window_size_left=window_size,
+                window_size_right=0,
+            )
+        dQ_sld, dK_sld, dV_sld = _fa4_bwd(
+            Q,
+            K,
+            V,
+            O_sld,
+            dO_sld,
+            lse_sld,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size,
+            window_size_right=0,
+        )
+        del O_sld, lse_sld, dO_sld
+
+        # Compression backward
+        dK_compress, dV_compress, dW_k, dW_v = fused_compress_kv_backward(
+            dK_cmp,
+            dV_cmp,
+            K,
+            V,
+            compress_block_size,
+            W_k_compress,
+            W_v_compress,
+        )
+        del dK_cmp, dV_cmp
+
+        # Gradient accumulation in fp32 — sequential to keep peak overhead
+        # to one fp32 tensor at a time; each bf16 summand freed after upcast-add.
+        dQ_acc = dQ_cmp.float()
+        del dQ_cmp
+        dQ_acc += dQ_slc.float()
+        del dQ_slc
+        dQ_acc += dQ_sld.float()
+        del dQ_sld
+        if dQ_gate is not None:
+            dQ_acc += dQ_gate.float()
+            del dQ_gate
+        dQ = dQ_acc.to(Q.dtype)
+        del dQ_acc
+
+        dK_acc = dK_slc.float()
+        del dK_slc
+        dK_acc += dK_sld.float()
+        del dK_sld
+        dK_acc += dK_compress.float()
+        del dK_compress
+        dK = dK_acc.to(K.dtype)
+        del dK_acc
+
+        dV_acc = dV_slc.float()
+        del dV_slc
+        dV_acc += dV_sld.float()
+        del dV_sld
+        dV_acc += dV_compress.float()
+        del dV_compress
+        dV = dV_acc.to(V.dtype)
+        del dV_acc
+
+        # Return gradients matching forward() args order:
+        # Q, K, V, K_cmp, V_cmp, W_k, W_v, gate_proj_weight, + 11 non-tensor args
+        return (
+            dQ,
+            dK,
+            dV,
+            None,
+            None,  # K_cmp, V_cmp (not differentiable inputs)
+            dW_k,
+            dW_v,
+            dgate_proj_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,  # cmp_sparse_tensors
+        )
+
+
+def _nsa_forward_varlen(
+    ctx,
+    Q: Tensor,  # (total_tokens, H, D)
+    K: Tensor,  # (total_tokens, H_kv, D)
+    V: Tensor,  # (total_tokens, H_kv, D)
+    K_cmp: Tensor,  # (B, max_N_cmp, H_kv, D)
+    V_cmp: Tensor,  # (B, max_N_cmp, H_kv, D)
+    W_k_compress: Tensor | None,
+    W_v_compress: Tensor | None,
+    gate_proj_weight: Tensor | None,
+    compress_block_size: int,
+    num_selected_blocks: int,
+    window_size: int,
+    causal: bool,
+    softmax_scale: float,
+    q_tile_size: int,
+    n_block_size: int,
+    cu_seqlens: Tensor,
+    max_seqlen: int | None,
+    sparse_tensors,
+    cmp_sparse_tensors,
+) -> Tensor:
+    """Varlen forward: native varlen for selected + sliding, padded for compressed."""
+    batch_size = cu_seqlens.shape[0] - 1
+    seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+    if max_seqlen is None:
+        max_seqlen = max(seqlens)
+    pad_N = ((max_seqlen + q_tile_size - 1) // q_tile_size) * q_tile_size
+
+    # Branch 1: Compressed attention (padded 4D — mask_mod blocks varlen)
+    Q_pad = _pad_to_4d(Q, cu_seqlens, seqlens, batch_size, pad_N)
+    if cmp_sparse_tensors is not None:
+        O_cmp_pad, _ = _fa4_fwd(
+            Q_pad,
+            K_cmp,
+            V_cmp,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            compress_factor=compress_block_size,
+            block_sparse_tensors=cmp_sparse_tensors,
+        )
+    else:
+        O_cmp_pad, _ = _fa4_fwd(
+            Q_pad,
+            K_cmp,
+            V_cmp,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            compress_factor=compress_block_size,
+        )
+    O_cmp = _unpad_to_3d(O_cmp_pad, cu_seqlens, seqlens, Q.shape[0])
+    del Q_pad, O_cmp_pad
+
+    # Branch 2: Selected attention (native varlen + block sparse)
+    O_slc, _ = _fa4_fwd(
+        Q,
+        K,
+        V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        block_sparse_tensors=sparse_tensors,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=pad_N,
+        max_seqlen_k=pad_N,
+    )
+
+    # Branch 3: Sliding window (native varlen)
+    O_sld, _ = _fa4_fwd(
+        Q,
+        K,
+        V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        window_size_left=window_size,
+        window_size_right=0,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+    )
+
+    # Gating (3D — Commit 1)
+    gates = compute_gates(Q, gate_proj_weight)
+    O = gate_and_combine(O_cmp, O_slc, O_sld, gates)
+
+    ctx.save_for_backward(
+        Q,
+        K,
+        V,
+        K_cmp,
+        V_cmp,
+        gates,
+        gate_proj_weight,
+        W_k_compress,
+        W_v_compress,
+        cu_seqlens,
+    )
+    ctx.sparse_tensors = sparse_tensors
+    ctx.cmp_sparse_tensors = cmp_sparse_tensors
+    ctx.compress_block_size = compress_block_size
+    ctx.window_size = window_size
+    ctx.causal = causal
+    ctx.softmax_scale = softmax_scale
+    ctx.q_tile_size = q_tile_size
+    ctx.n_block_size = n_block_size
+    ctx.cu_seqlens = cu_seqlens
+    ctx.max_seqlen = max_seqlen
+    ctx.varlen_meta = (seqlens, batch_size, pad_N)
+
+    return O
+
+
+def _nsa_backward_varlen(ctx, dO: Tensor) -> tuple:
+    """Varlen backward: native varlen for selected + sliding, padded for compressed."""
+    (
+        Q,
+        K,
+        V,
+        K_cmp,
+        V_cmp,
+        gates,
+        gate_proj_weight,
+        W_k_compress,
+        W_v_compress,
+        cu_seqlens,
+    ) = ctx.saved_tensors
+
+    causal = ctx.causal
+    softmax_scale = ctx.softmax_scale
+    compress_block_size = ctx.compress_block_size
+    window_size = ctx.window_size
+    sparse_tensors = ctx.sparse_tensors
+    cmp_sparse_tensors = ctx.cmp_sparse_tensors
+    max_seqlen = ctx.max_seqlen
+    seqlens, batch_size, pad_N = ctx.varlen_meta
+
+    dQ_gate = None
+    dgate_proj_weight = None
+
+    if gate_proj_weight is not None:
+        # Need all O_i for gating backward — recompute all three forwards
+        Q_pad = _pad_to_4d(Q, cu_seqlens, seqlens, batch_size, pad_N)
+        O_cmp_pad, _ = _fa4_fwd(
+            Q_pad,
+            K_cmp,
+            V_cmp,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            compress_factor=compress_block_size,
+            block_sparse_tensors=cmp_sparse_tensors,
+        )
+        O_cmp = _unpad_to_3d(O_cmp_pad, cu_seqlens, seqlens, Q.shape[0])
+        del O_cmp_pad
+
+        O_slc, lse_slc = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            block_sparse_tensors=sparse_tensors,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=pad_N,
+            max_seqlen_k=pad_N,
+        )
+        O_sld, lse_sld = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            window_size_left=window_size,
+            window_size_right=0,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_k=max_seqlen,
+        )
+
+        dO_cmp, dO_slc, dO_sld, dQ_gate, dgate_proj_weight = fused_gating_backward(
+            Q,
+            dO,
+            O_cmp,
+            O_slc,
+            O_sld,
+            gates,
+            gate_proj_weight,
+        )
+        del O_cmp
+    else:
+        g = gates.float()
+        dO_f = dO.float()
+        dO_cmp = (g[..., 0:1] * dO_f).to(dO.dtype)
+        dO_slc = (g[..., 1:2] * dO_f).to(dO.dtype)
+        dO_sld = (g[..., 2:3] * dO_f).to(dO.dtype)
+        del g, dO_f
+        Q_pad = None
+        lse_slc = lse_sld = None
+        O_slc = O_sld = None
+
+    # --- Branch 1: Compressed attention (padded 4D) ---
+    if Q_pad is None:
+        Q_pad = _pad_to_4d(Q, cu_seqlens, seqlens, batch_size, pad_N)
+    O_cmp_pad, lse_cmp_pad = _fa4_fwd(
+        Q_pad,
+        K_cmp,
+        V_cmp,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        compress_factor=compress_block_size,
+        block_sparse_tensors=cmp_sparse_tensors,
+    )
+    dO_cmp_pad = _pad_to_4d(dO_cmp, cu_seqlens, seqlens, batch_size, pad_N)
+    if cmp_sparse_tensors is not None:
+        cmp_bwd_sparse = _transpose_block_sparse_for_bwd(
+            cmp_sparse_tensors,
+            seqlen_q=pad_N,
+            seqlen_k=K_cmp.shape[1],
+            n_block_size=cmp_sparse_tensors.block_size[1],
+            use_mask_blocks=True,
+        )
+    else:
+        cmp_bwd_sparse = None
+    dQ_cmp_pad, dK_cmp, dV_cmp = _fa4_bwd(
+        Q_pad,
+        K_cmp,
+        V_cmp,
+        O_cmp_pad,
+        dO_cmp_pad,
+        lse_cmp_pad,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        compress_factor=compress_block_size,
+        block_sparse_tensors=cmp_bwd_sparse,
+    )
+    dQ_cmp = _unpad_to_3d(dQ_cmp_pad, cu_seqlens, seqlens, Q.shape[0])
+    del Q_pad, O_cmp_pad, lse_cmp_pad, dO_cmp_pad, dQ_cmp_pad, dO_cmp
+
+    # --- Branch 2: Selected attention (native varlen + block sparse) ---
+    if O_slc is None:
+        O_slc, lse_slc = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            block_sparse_tensors=sparse_tensors,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=pad_N,
+            max_seqlen_k=pad_N,
+        )
+    bwd_sparse = _transpose_block_sparse_for_bwd(
+        sparse_tensors,
+        seqlen_q=pad_N,
+        seqlen_k=pad_N,
+        n_block_size=ctx.n_block_size,
+    )
+    dQ_slc, dK_slc, dV_slc = _fa4_bwd(
+        Q,
+        K,
+        V,
+        O_slc,
+        dO_slc,
+        lse_slc,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        block_sparse_tensors=bwd_sparse,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=pad_N,
+        max_seqlen_k=pad_N,
+    )
+    del O_slc, lse_slc, dO_slc, bwd_sparse
+
+    # --- Branch 3: Sliding window (native varlen) ---
+    if O_sld is None:
+        O_sld, lse_sld = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            window_size_left=window_size,
+            window_size_right=0,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_k=max_seqlen,
+        )
+    dQ_sld, dK_sld, dV_sld = _fa4_bwd(
+        Q,
+        K,
+        V,
+        O_sld,
+        dO_sld,
+        lse_sld,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size,
+        window_size_right=0,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+    )
+    del O_sld, lse_sld, dO_sld
+
+    # --- Compression backward (varlen: scatter to 3D directly) ---
+    dK_compress, dV_compress, dW_k, dW_v = fused_compress_kv_backward(
+        dK_cmp,
+        dV_cmp,
+        K,
+        V,
+        compress_block_size,
+        W_k_compress,
+        W_v_compress,
+        cu_seqlens=cu_seqlens,
+    )
+
+    # --- Gradient accumulation (all 3D) in fp32 — sequential to keep peak
+    # overhead to one fp32 tensor at a time; each bf16 summand freed after upcast-add.
+    dQ_acc = dQ_cmp.float()
+    del dQ_cmp
+    dQ_acc += dQ_slc.float()
+    del dQ_slc
+    dQ_acc += dQ_sld.float()
+    del dQ_sld
+    if dQ_gate is not None:
+        dQ_acc += dQ_gate.float()
+        del dQ_gate
+    dQ = dQ_acc.to(Q.dtype)
+    del dQ_acc
+
+    dK_acc = dK_slc.float()
+    del dK_slc
+    dK_acc += dK_sld.float()
+    del dK_sld
+    dK_acc += dK_compress.float()
+    del dK_compress
+    dK = dK_acc.to(K.dtype)
+    del dK_acc
+
+    dV_acc = dV_slc.float()
+    del dV_slc
+    dV_acc += dV_sld.float()
+    del dV_sld
+    dV_acc += dV_compress.float()
+    del dV_compress
+    dV = dV_acc.to(V.dtype)
+    del dV_acc
+
+    # Return gradients matching forward() args order
+    return (
+        dQ,
+        dK,
+        dV,
+        None,
+        None,  # K_cmp, V_cmp
+        dW_k,
+        dW_v,
+        dgate_proj_weight,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,  # cmp_sparse_tensors
+    )
+
+
+def nsa(
+    Q: Tensor,  # (B, N, H, D) or (total_tokens, H, D) for varlen
+    K: Tensor,  # (B, N, H_kv, D) or (total_tokens, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D) or (total_tokens, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    n_block_size: int = 128,
+    cu_seqlens: Tensor | None = None,  # (batch_size + 1,) int32 for varlen
+    max_seqlen: int | None = None,
+    num_cmp_selected_blocks: int | None = None,
+) -> Tensor:
+    """NSA with autograd support (forward + backward).
+
+    Same interface as nsa_forward, but supports training via torch.autograd.
+    Uses FA4 for both forward and backward passes, with activation checkpointing.
+    Supports both fixed-length (4D) and variable-length (3D + cu_seqlens) inputs.
+
+    For varlen, the selected and sliding window branches use native FA4 varlen
+    (no padding on Q, K, V). Only the compressed branch uses padded Q for
+    mask_mod compatibility. Compress/select operate on 3D input directly.
+
+    Args:
+        Q: Query tensor, (B, N, H, D) or (total_tokens, H, D) for varlen.
+        K: Key tensor, (B, N, H_kv, D) or (total_tokens, H_kv, D).
+        V: Value tensor, (B, N, H_kv, D) or (total_tokens, H_kv, D).
+        compress_block_size: Number of KV positions per block for compression.
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        window_size: Sliding window size (left window, causal).
+        W_k_compress: Per-head key compression weights, shape (H_kv, D, D).
+        W_v_compress: Per-head value compression weights, shape (H_kv, D, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        causal: Whether to use causal masking.
+        softmax_scale: Attention scaling factor (default: 1/sqrt(D)).
+        q_tile_size: Query tile size for block selection.
+        n_block_size: FA4 KV block size (128 for SM100).
+        cu_seqlens: Cumulative sequence lengths for varlen, shape (B+1,) int32.
+        max_seqlen: Maximum sequence length for varlen.
+        num_cmp_selected_blocks: Number of FA4 KV blocks to select for the
+            compressed branch. When set, the compressed branch uses block-sparse
+            attention (sub-quadratic). When None (default), full compressed
+            attention is used.
+
+    Returns:
+        Output tensor, same shape as Q.
+    """
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(Q.shape[-1])
+
+    is_varlen = cu_seqlens is not None
+
+    if is_varlen:
+        assert Q.dim() == 3, f"Varlen requires 3D input, got {Q.dim()}D"
+        seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        if max_seqlen is None:
+            max_seqlen = max(seqlens)
+        pad_N = ((max_seqlen + q_tile_size - 1) // q_tile_size) * q_tile_size
+
+    # Step 1: Compress KV (varlen-aware — reads 3D directly, no Q/K/V padding)
+    K_cmp, V_cmp = fused_compress_kv(
+        K,
+        V,
+        compress_block_size,
+        W_k_compress,
+        W_v_compress,
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen if is_varlen else None,
+    )
+
+    # Step 2: Score blocks and select top-k (varlen-aware Q_mean)
+    block_indices, cmp_block_indices = fused_score_and_select_all(
+        Q,
+        K_cmp,
+        num_selected_blocks,
+        compress_block_size,
+        num_cmp_selected_blocks=num_cmp_selected_blocks,
+        cmp_n_block_size=n_block_size,
+        causal=causal,
+        q_tile_size=q_tile_size,
+        softmax_scale=softmax_scale,
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen if is_varlen else None,
+    )
+
+    # Step 3: Build FA4 sparsity masks
+    seqlen_k = pad_N if is_varlen else Q.shape[1]
+    sparse_tensors = build_fa4_block_sparse_tensors(
+        block_indices,
+        compress_block_size,
+        n_block_size=n_block_size,
+        seqlen_k=seqlen_k,
+    )
+
+    # Step 3b: Block-sparse compressed attention (optional)
+    cmp_sparse_tensors = None
+    if num_cmp_selected_blocks is not None:
+        N_cmp = K_cmp.shape[1]
+        cmp_n_block_size = n_block_size
+        n_cmp_kv_blocks = (N_cmp + cmp_n_block_size - 1) // cmp_n_block_size
+        if cmp_block_indices is not None:
+            cmp_sparse_tensors = build_compressed_block_sparse_tensors(
+                cmp_block_indices,
+                n_kv_blocks=n_cmp_kv_blocks,
+                q_tile_size=q_tile_size,
+                cmp_n_block_size=cmp_n_block_size,
+            )
+
+    # Step 4: NSAFunction handles the three FA4 branches + gating
+    return NSAFunction.apply(
+        Q,
+        K,
+        V,
+        K_cmp,
+        V_cmp,
+        W_k_compress,
+        W_v_compress,
+        gate_proj_weight,
+        compress_block_size,
+        num_selected_blocks,
+        window_size,
+        causal,
+        softmax_scale,
+        q_tile_size,
+        n_block_size,
+        cu_seqlens,
+        max_seqlen,
+        sparse_tensors,
+        cmp_sparse_tensors,
     )

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -16,7 +16,7 @@ import math
 from typing import Callable, Tuple
 
 from mslk.attention.sparse_attn.compress import compress_kv
-from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.gating import fused_gate_and_combine
 from mslk.attention.sparse_attn.select import score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 from torch import Tensor
@@ -199,14 +199,6 @@ def nsa_forward(
     )
 
     # Step 5: Gate and combine branch outputs
-    # Use chunked gating for long sequences to avoid materializing
-    # 3 full (B,N,H,D) float32 tensors simultaneously.
-    gate_chunk = 4096 if N > 32768 else None
-    gates = compute_gates(Q, gate_proj_weight, chunk_size=gate_chunk)
-    if gate_proj_weight is not None:
-        O = gate_and_combine(O_cmp, O_slc, O_sld, gates, chunk_size=gate_chunk)
-    else:
-        # No gate weights — uniform 1/3 gates
-        O = (O_cmp + O_slc + O_sld) * (1.0 / 3.0)
+    O, gates = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
 
     return O

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import math
 from typing import Callable, Tuple
 
-from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.compress import fused_compress_kv
 from mslk.attention.sparse_attn.gating import fused_gate_and_combine
 from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
@@ -142,8 +142,10 @@ def nsa_forward(
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(D)
 
-    # Step 1: Compress KV
-    K_cmp, V_cmp = compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+    # Step 1: Compress KV (fused CuteDSL kernel for fixed-length, PyTorch for varlen)
+    K_cmp, V_cmp = fused_compress_kv(
+        K, V, compress_block_size, W_k_compress, W_v_compress
+    )
 
     # Step 2: Score blocks and select top-k
     # Uses Q_mean optimization: mean(Q @ K) = mean(Q) @ K (256x fewer FLOPs)

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -1,0 +1,212 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""End-to-end NSA (Native Sparse Attention) forward pass using FA4.
+
+Orchestrates the three attention branches:
+1. Compressed attention (FA4 on short KV sequence)
+2. Selected attention (FA4 with block sparsity)
+3. Sliding window attention (FA4 with window_size)
+
+Then gates and combines the outputs.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Tuple
+
+from mslk.attention.sparse_attn.compress import compress_kv
+from mslk.attention.sparse_attn.gating import compute_gates, gate_and_combine
+from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+from torch import Tensor
+
+
+def _fa4_fwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+    compress_factor: int = 1,
+    cu_seqlens_q: Tensor | None = None,
+    cu_seqlens_k: Tensor | None = None,
+    max_seqlen_q: int | None = None,
+    max_seqlen_k: int | None = None,
+) -> Tuple[Tensor, Tensor]:
+    """Call FA4's forward pass.
+
+    Supports block sparsity, mask_mod, compress_factor, and varlen (cu_seqlens).
+    Inputs are (B, N, H, D) for fixed-length or (total_tokens, H, D) for varlen.
+    Returns (output, lse).
+    """
+    # Try mslk.fb FA4 first (has compress_factor, block_sparse_tensors, etc.),
+    # fall back to stock flash_attn if fb/ is not available.
+    try:
+        from mslk.fb.mslk.attention.flash_attn.interface import _flash_attn_fwd
+    except ImportError:
+        from flash_attn.cute.interface import _flash_attn_fwd
+
+    # mask_mod is not compatible with pack_gqa=True in FA4, so disable it
+    pack_gqa = False if mask_mod is not None else None
+
+    # Try with compress_factor (PR#2418); fall back without it
+    try:
+        out, lse = _flash_attn_fwd(
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            block_sparse_tensors=block_sparse_tensors,
+            mask_mod=mask_mod,
+            pack_gqa=pack_gqa,
+            return_lse=True,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            compress_factor=compress_factor,
+        )
+    except TypeError:
+        # compress_factor not supported in this FA4 build — omit it
+        out, lse = _flash_attn_fwd(
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            block_sparse_tensors=block_sparse_tensors,
+            mask_mod=mask_mod,
+            pack_gqa=pack_gqa,
+            return_lse=True,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+        )
+    return out, lse
+
+
+def nsa_forward(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,  # (H_kv, D, D)
+    W_v_compress: Tensor | None = None,  # (H_kv, D, D)
+    gate_proj_weight: Tensor | None = None,  # (H, 3, D)
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    n_block_size: int = 128,
+) -> Tensor:
+    """NSA forward pass using FA4 for all attention branches.
+
+    Orchestrates:
+    1. KV compression (mean-pool + optional projection)
+    2. Block scoring and top-k selection
+    3. Three FA4 calls: compressed, selected (block-sparse), sliding window
+    4. Gating and combination
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K: Key tensor, shape (B, N, H_kv, D).
+        V: Value tensor, shape (B, N, H_kv, D).
+        compress_block_size: Number of KV positions per block for compression.
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        window_size: Sliding window size (left window, causal).
+        W_k_compress: Per-head key compression weights, shape (H_kv, D, D).
+        W_v_compress: Per-head value compression weights, shape (H_kv, D, D).
+        gate_proj_weight: Gate projection weights, shape (H, 3, D).
+        causal: Whether to use causal masking.
+        softmax_scale: Attention scaling factor (default: 1/sqrt(D)).
+        q_tile_size: Query tile size for block selection.
+        n_block_size: FA4 KV block size (128 for SM100).
+
+    Returns:
+        Output tensor, shape (B, N, H, D).
+    """
+    B, N, H, D = Q.shape
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # Step 1: Compress KV
+    K_cmp, V_cmp = compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
+
+    # Step 2: Score blocks and select top-k
+    block_indices = score_and_select_blocks(
+        Q,
+        K_cmp,
+        num_selected_blocks,
+        compress_block_size,
+        causal=causal,
+        q_tile_size=q_tile_size,
+        softmax_scale=softmax_scale,
+    )
+
+    # Step 3: Build FA4 sparsity masks for selected attention
+    sparse_tensors = build_fa4_block_sparse_tensors(
+        block_indices,
+        compress_block_size,
+        n_block_size=n_block_size,
+        seqlen_k=N,
+    )
+
+    # Step 4: Run three FA4 branches
+
+    # Branch 1: Compressed attention — uses compress_factor for native causal masking
+    # instead of mask_mod. This enables tile skipping, R2P masking, and pack_gqa.
+    O_cmp, lse_cmp = _fa4_fwd(
+        Q,
+        K_cmp,
+        V_cmp,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        compress_factor=compress_block_size,
+    )
+
+    # Branch 2: Selected attention — block-sparse attention on full KV
+    O_slc, lse_slc = _fa4_fwd(
+        Q,
+        K,
+        V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        block_sparse_tensors=sparse_tensors,
+    )
+
+    # Branch 3: Sliding window attention
+    O_sld, lse_sld = _fa4_fwd(
+        Q,
+        K,
+        V,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        window_size_left=window_size,
+        window_size_right=0,
+    )
+
+    # Step 5: Gate and combine branch outputs
+    # Use chunked gating for long sequences to avoid materializing
+    # 3 full (B,N,H,D) float32 tensors simultaneously.
+    gate_chunk = 4096 if N > 32768 else None
+    gates = compute_gates(Q, gate_proj_weight, chunk_size=gate_chunk)
+    if gate_proj_weight is not None:
+        O = gate_and_combine(O_cmp, O_slc, O_sld, gates, chunk_size=gate_chunk)
+    else:
+        # No gate weights — uniform 1/3 gates
+        O = (O_cmp + O_slc + O_sld) * (1.0 / 3.0)
+
+    return O

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -17,8 +17,11 @@ from typing import Callable, Tuple
 
 from mslk.attention.sparse_attn.compress import fused_compress_kv
 from mslk.attention.sparse_attn.gating import fused_gate_and_combine
-from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
-from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+from mslk.attention.sparse_attn.select import fused_score_and_select_all
+from mslk.attention.sparse_attn.sparsity_masks import (
+    build_compressed_block_sparse_tensors,
+    build_fa4_block_sparse_tensors,
+)
 from torch import Tensor
 
 
@@ -145,9 +148,9 @@ def _fa4_bwd(
 
 
 def nsa_forward(
-    Q: Tensor,  # (B, N, H, D)
-    K: Tensor,  # (B, N, H_kv, D)
-    V: Tensor,  # (B, N, H_kv, D)
+    Q: Tensor,  # (B, N, H, D) or (total_tokens, H, D) for varlen
+    K: Tensor,  # (B, N, H_kv, D) or (total_tokens, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D) or (total_tokens, H_kv, D)
     compress_block_size: int = 64,
     num_selected_blocks: int = 16,
     window_size: int = 512,
@@ -158,19 +161,20 @@ def nsa_forward(
     softmax_scale: float | None = None,
     q_tile_size: int = 256,
     n_block_size: int = 128,
+    cu_seqlens: Tensor | None = None,  # (batch_size + 1,) int32 for varlen
+    max_seqlen: int | None = None,
+    num_cmp_selected_blocks: int | None = None,
 ) -> Tensor:
     """NSA forward pass using FA4 for all attention branches.
 
-    Orchestrates:
-    1. KV compression (mean-pool + optional projection)
-    2. Block scoring and top-k selection
-    3. Three FA4 calls: compressed, selected (block-sparse), sliding window
-    4. Gating and combination
+    Supports both fixed-length (4D) and variable-length (3D + cu_seqlens) inputs.
+    For varlen, sequences are padded to max_seqlen internally (FA4 block_sparsity
+    does not yet support varlen natively).
 
     Args:
-        Q: Query tensor, shape (B, N, H, D).
-        K: Key tensor, shape (B, N, H_kv, D).
-        V: Value tensor, shape (B, N, H_kv, D).
+        Q: Query tensor, (B, N, H, D) or (total_tokens, H, D) for varlen.
+        K: Key tensor, (B, N, H_kv, D) or (total_tokens, H_kv, D).
+        V: Value tensor, (B, N, H_kv, D) or (total_tokens, H_kv, D).
         compress_block_size: Number of KV positions per block for compression.
         num_selected_blocks: Number of KV blocks to select per query tile.
         window_size: Sliding window size (left window, causal).
@@ -181,31 +185,183 @@ def nsa_forward(
         softmax_scale: Attention scaling factor (default: 1/sqrt(D)).
         q_tile_size: Query tile size for block selection.
         n_block_size: FA4 KV block size (128 for SM100).
+        cu_seqlens: Cumulative sequence lengths, shape (B+1,) int32 for varlen.
+        max_seqlen: Maximum sequence length for varlen padding.
+        num_cmp_selected_blocks: Number of FA4 KV blocks to select for the
+            compressed branch. When set, the compressed branch uses block-sparse
+            attention (only attending to the top-k most relevant blocks of
+            compressed KV), making it O(N) instead of O(N^2/compress_block_size).
+            When None (default), full compressed attention is used.
 
     Returns:
-        Output tensor, shape (B, N, H, D).
+        Output tensor, same shape as Q.
     """
+    is_varlen = cu_seqlens is not None
+
+    if is_varlen:
+        # Varlen: pad only for compress+select (need uniform blocks),
+        # use native FA4 varlen (cu_seqlens) for the attention branches.
+        assert Q.dim() == 3, f"Varlen requires 3D input, got {Q.dim()}D"
+        H = Q.shape[1]
+        H_kv = K.shape[1]
+        D_dim = Q.shape[2]
+        batch_size = cu_seqlens.shape[0] - 1
+        seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+
+        if max_seqlen is None:
+            max_seqlen = max(seqlens)
+        if softmax_scale is None:
+            softmax_scale = 1.0 / math.sqrt(D_dim)
+        pad_N = ((max_seqlen + q_tile_size - 1) // q_tile_size) * q_tile_size
+
+        # Pad Q, K, V to 4D for compress + select (CuteDSL kernels need uniform N)
+        Q_pad = Q.new_zeros(batch_size, pad_N, H, D_dim)
+        K_pad = K.new_zeros(batch_size, pad_N, H_kv, D_dim)
+        V_pad = V.new_zeros(batch_size, pad_N, H_kv, D_dim)
+        for i, slen in enumerate(seqlens):
+            s = cu_seqlens[i].item()
+            Q_pad[i, :slen] = Q[s : s + slen]
+            K_pad[i, :slen] = K[s : s + slen]
+            V_pad[i, :slen] = V[s : s + slen]
+
+        # Step 1: Compress KV (on padded 4D)
+        K_cmp_pad, V_cmp_pad = fused_compress_kv(
+            K_pad, V_pad, compress_block_size, W_k_compress, W_v_compress
+        )
+        N_cmp = pad_N // compress_block_size
+
+        # Step 2: Score blocks and select top-k (on padded 4D)
+        block_indices, cmp_block_indices = fused_score_and_select_all(
+            Q_pad,
+            K_cmp_pad,
+            num_selected_blocks,
+            compress_block_size,
+            num_cmp_selected_blocks=num_cmp_selected_blocks,
+            cmp_n_block_size=n_block_size,
+            causal=causal,
+            q_tile_size=q_tile_size,
+            softmax_scale=softmax_scale,
+        )
+
+        # Step 3: Build FA4 sparsity masks (on padded 4D)
+        sparse_tensors = build_fa4_block_sparse_tensors(
+            block_indices,
+            compress_block_size,
+            n_block_size=n_block_size,
+            seqlen_k=pad_N,
+        )
+
+        # Step 4: Three FA4 branches
+        # Compressed branch uses padded 4D (mask_mod not supported with varlen in FA4).
+        # Selected and sliding window use native varlen.
+
+        # Branch 1: Compressed attention — uses compress_factor for native causal masking
+
+        if num_cmp_selected_blocks is not None:
+            N_cmp_pad = K_cmp_pad.shape[1]
+            cmp_n_block_size = n_block_size
+            n_cmp_kv_blocks = (N_cmp_pad + cmp_n_block_size - 1) // cmp_n_block_size
+            if cmp_block_indices is not None:
+                cmp_sparse = build_compressed_block_sparse_tensors(
+                    cmp_block_indices,
+                    n_kv_blocks=n_cmp_kv_blocks,
+                    q_tile_size=q_tile_size,
+                    cmp_n_block_size=cmp_n_block_size,
+                )
+                O_cmp_pad, _ = _fa4_fwd(
+                    Q_pad,
+                    K_cmp_pad,
+                    V_cmp_pad,
+                    causal=causal,
+                    softmax_scale=softmax_scale,
+                    compress_factor=compress_block_size,
+                    block_sparse_tensors=cmp_sparse,
+                )
+            else:
+                O_cmp_pad, _ = _fa4_fwd(
+                    Q_pad,
+                    K_cmp_pad,
+                    V_cmp_pad,
+                    causal=causal,
+                    softmax_scale=softmax_scale,
+                    compress_factor=compress_block_size,
+                )
+        else:
+            O_cmp_pad, _ = _fa4_fwd(
+                Q_pad,
+                K_cmp_pad,
+                V_cmp_pad,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                compress_factor=compress_block_size,
+            )
+        # Unpad compressed output to 3D
+        O_cmp = Q.new_zeros(Q.shape[0], H, D_dim)
+        for i, slen in enumerate(seqlens):
+            s = cu_seqlens[i].item()
+            O_cmp[s : s + slen] = O_cmp_pad[i, :slen]
+
+        # Branch 2: Selected attention (varlen Q/K/V + block sparse)
+        O_slc, _ = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            block_sparse_tensors=sparse_tensors,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=pad_N,
+            max_seqlen_k=pad_N,
+        )
+
+        # Branch 3: Sliding window (varlen Q/K/V)
+        O_sld, _ = _fa4_fwd(
+            Q,
+            K,
+            V,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            window_size_left=window_size,
+            window_size_right=0,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_k=max_seqlen,
+        )
+
+        # Step 5: Gating (element-wise, works on 3D)
+        if gate_proj_weight is not None:
+            O = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+        else:
+            O = (O_cmp + O_slc + O_sld) * (1.0 / 3.0)
+        return O
+
+    # Fixed-length path
     B, N, H, D = Q.shape
 
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(D)
 
-    # Step 1: Compress KV (fused CuteDSL kernel for fixed-length, PyTorch for varlen)
+    # Step 1: Compress KV
     K_cmp, V_cmp = fused_compress_kv(
         K, V, compress_block_size, W_k_compress, W_v_compress
     )
+    # K_cmp, V_cmp: (B, N_cmp, H_kv, D) where N_cmp = N // compress_block_size
 
     # Step 2: Score blocks and select top-k
-    # Uses Q_mean optimization: mean(Q @ K) = mean(Q) @ K (256x fewer FLOPs)
-    block_indices = fused_score_and_select_blocks(
+    block_indices, cmp_block_indices = fused_score_and_select_all(
         Q,
         K_cmp,
         num_selected_blocks,
         compress_block_size,
+        num_cmp_selected_blocks=num_cmp_selected_blocks,
+        cmp_n_block_size=n_block_size,
         causal=causal,
         q_tile_size=q_tile_size,
         softmax_scale=softmax_scale,
     )
+    # block_indices: (B, H, N_q_tiles, k) int32
 
     # Step 3: Build FA4 sparsity masks for selected attention
     sparse_tensors = build_fa4_block_sparse_tensors(
@@ -219,14 +375,46 @@ def nsa_forward(
 
     # Branch 1: Compressed attention — uses compress_factor for native causal masking
     # instead of mask_mod. This enables tile skipping, R2P masking, and pack_gqa.
-    O_cmp, lse_cmp = _fa4_fwd(
-        Q,
-        K_cmp,
-        V_cmp,
-        causal=causal,
-        softmax_scale=softmax_scale,
-        compress_factor=compress_block_size,
-    )
+
+    if num_cmp_selected_blocks is not None:
+        # Block-sparse compressed attention: select top-k FA4 blocks of K_cmp
+        N_cmp = K_cmp.shape[1]
+        cmp_n_block_size = n_block_size
+        n_cmp_kv_blocks = (N_cmp + cmp_n_block_size - 1) // cmp_n_block_size
+        if cmp_block_indices is not None:
+            cmp_sparse = build_compressed_block_sparse_tensors(
+                cmp_block_indices,
+                n_kv_blocks=n_cmp_kv_blocks,
+                q_tile_size=q_tile_size,
+                cmp_n_block_size=cmp_n_block_size,
+            )
+            O_cmp, lse_cmp = _fa4_fwd(
+                Q,
+                K_cmp,
+                V_cmp,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                compress_factor=compress_block_size,
+                block_sparse_tensors=cmp_sparse,
+            )
+        else:
+            O_cmp, lse_cmp = _fa4_fwd(
+                Q,
+                K_cmp,
+                V_cmp,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                compress_factor=compress_block_size,
+            )
+    else:
+        O_cmp, lse_cmp = _fa4_fwd(
+            Q,
+            K_cmp,
+            V_cmp,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            compress_factor=compress_block_size,
+        )
 
     # Branch 2: Selected attention — block-sparse attention on full KV
     O_slc, lse_slc = _fa4_fwd(
@@ -250,6 +438,10 @@ def nsa_forward(
     )
 
     # Step 5: Gate and combine branch outputs
-    O, gates = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+    if gate_proj_weight is not None:
+        O = fused_gate_and_combine(Q, O_cmp, O_slc, O_sld, gate_proj_weight)
+    else:
+        # No gate weights — uniform 1/3 gates.
+        O = (O_cmp + O_slc + O_sld) * (1.0 / 3.0)
 
     return O

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -17,7 +17,7 @@ from typing import Callable, Tuple
 
 from mslk.attention.sparse_attn.compress import compress_kv
 from mslk.attention.sparse_attn.gating import fused_gate_and_combine
-from mslk.attention.sparse_attn.select import score_and_select_blocks
+from mslk.attention.sparse_attn.select import fused_score_and_select_blocks
 from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
 from torch import Tensor
 
@@ -146,7 +146,8 @@ def nsa_forward(
     K_cmp, V_cmp = compress_kv(K, V, compress_block_size, W_k_compress, W_v_compress)
 
     # Step 2: Score blocks and select top-k
-    block_indices = score_and_select_blocks(
+    # Uses Q_mean optimization: mean(Q @ K) = mean(Q) @ K (256x fewer FLOPs)
+    block_indices = fused_score_and_select_blocks(
         Q,
         K_cmp,
         num_selected_blocks,

--- a/mslk/attention/sparse_attn/nsa_forward.py
+++ b/mslk/attention/sparse_attn/nsa_forward.py
@@ -96,6 +96,54 @@ def _fa4_fwd(
     return out, lse
 
 
+def _fa4_bwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    dout: Tensor,
+    lse: Tensor,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size_left: int | None = None,
+    window_size_right: int | None = None,
+    block_sparse_tensors=None,
+    mask_mod: Callable | None = None,
+    compress_factor: int = 1,
+    cu_seqlens_q: Tensor | None = None,
+    cu_seqlens_k: Tensor | None = None,
+    max_seqlen_q: int | None = None,
+    max_seqlen_k: int | None = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Call FA4's backward pass.
+
+    Supports block sparsity, mask_mod, compress_factor, and varlen (cu_seqlens).
+    Returns (dq, dk, dv).
+    """
+    from mslk.attention.flash_attn.interface import _flash_attn_bwd
+
+    dq, dk, dv = _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        dout,
+        lse,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        block_sparse_tensors=block_sparse_tensors,
+        mask_mod=mask_mod,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        compress_factor=compress_factor,
+    )
+    return dq, dk, dv
+
+
 def nsa_forward(
     Q: Tensor,  # (B, N, H, D)
     K: Tensor,  # (B, N, H_kv, D)

--- a/mslk/attention/sparse_attn/reference.py
+++ b/mslk/attention/sparse_attn/reference.py
@@ -1,0 +1,384 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Pure PyTorch reference implementation of NSA (Native Sparse Attention).
+
+This serves as a correctness reference for the optimized FA4-based implementation.
+All operations are done in PyTorch without custom kernels.
+
+The forward pass is fully differentiable (all tensor ops, no Python loops that
+break autograd), so PyTorch autograd provides the reference backward pass.
+Use nsa_backward_reference() to compute gradients for validation.
+
+Reference: arxiv 2502.11089
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def nsa_forward_reference(
+    Q: Tensor,  # (B, N, H, D)
+    K: Tensor,  # (B, N, H_kv, D)
+    V: Tensor,  # (B, N, H_kv, D)
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    W_k_compress: Tensor | None = None,
+    W_v_compress: Tensor | None = None,
+    gate_proj_weight: Tensor | None = None,
+    causal: bool = True,
+    softmax_scale: float | None = None,
+    q_tile_size: int = 256,
+    _block_indices: Tensor | None = None,
+) -> Tensor:
+    """Pure PyTorch NSA forward pass.
+
+    Combines three attention branches:
+    1. Compressed attention: Attend over mean-pooled KV blocks with learned projection.
+    2. Selected attention: Block-sparse attention over top-k important KV blocks.
+    3. Sliding window attention: Local attention within a fixed window.
+
+    All inputs/outputs use (B, N, H, D) layout.
+    """
+    B, N, H, D = Q.shape
+    H_kv = K.shape[2]
+    assert H % H_kv == 0, "H must be divisible by H_kv for GQA"
+    groups = H // H_kv
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # fp32 accumulation for numerical stability with bf16/fp16 inputs
+    compute_dtype = torch.float64 if Q.dtype == torch.float64 else torch.float32
+    q = Q.transpose(1, 2).to(compute_dtype)
+    k = K.transpose(1, 2).to(compute_dtype)
+    v = V.transpose(1, 2).to(compute_dtype)
+
+    if groups > 1:
+        k = k.repeat_interleave(groups, dim=1)
+        v = v.repeat_interleave(groups, dim=1)
+
+    O_cmp = _compressed_attention(
+        q,
+        k,
+        v,
+        compress_block_size,
+        W_k_compress,
+        W_v_compress,
+        groups,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        H_kv,
+        D,
+    )
+    O_slc = _selected_attention(
+        q,
+        k,
+        v,
+        compress_block_size,
+        num_selected_blocks,
+        W_k_compress,
+        groups,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        H_kv,
+        D,
+        q_tile_size=q_tile_size,
+        _block_indices=_block_indices,
+    )
+    O_sld = _sliding_window_attention(
+        q,
+        k,
+        v,
+        window_size,
+        softmax_scale,
+        causal,
+        B,
+        N,
+        H,
+        D,
+    )
+
+    O_cmp = O_cmp.transpose(1, 2)
+    O_slc = O_slc.transpose(1, 2)
+    O_sld = O_sld.transpose(1, 2)
+
+    if gate_proj_weight is not None:
+        gates = torch.einsum(
+            "bnhd,hgd->bnhg", Q.to(compute_dtype), gate_proj_weight.to(compute_dtype)
+        )
+        gates = gates.sigmoid()
+    else:
+        gates = torch.ones(B, N, H, 3, device=Q.device, dtype=compute_dtype) / 3.0
+
+    O = gates[..., 0:1] * O_cmp + gates[..., 1:2] * O_slc + gates[..., 2:3] * O_sld
+    return O.to(Q.dtype)
+
+
+def _compressed_attention(
+    q,
+    k,
+    v,
+    block_size,
+    W_k_compress,
+    W_v_compress,
+    groups,
+    softmax_scale,
+    causal,
+    B,
+    N,
+    H,
+    H_kv,
+    D,
+):
+    k_orig = k[:, ::groups]
+    v_orig = v[:, ::groups]
+    N_cmp = N // block_size
+    k_blocks = k_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    k_cmp = k_blocks.mean(dim=3)
+    v_blocks = v_orig.reshape(B, H_kv, N_cmp, block_size, D)
+    v_cmp = v_blocks.mean(dim=3)
+
+    if W_k_compress is not None:
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.to(k_cmp.dtype))
+    if W_v_compress is not None:
+        v_cmp = torch.einsum("bhnd,hde->bhne", v_cmp, W_v_compress.to(v_cmp.dtype))
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+        v_cmp = v_cmp.repeat_interleave(groups, dim=1)
+
+    scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+    if causal:
+        q_pos = torch.arange(N, device=q.device).unsqueeze(1)
+        kv_block_start = torch.arange(N_cmp, device=q.device) * block_size
+        causal_mask = kv_block_start.unsqueeze(0) > q_pos
+        scores = scores.masked_fill(
+            causal_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+    attn = torch.softmax(scores, dim=-1)
+    return torch.matmul(attn, v_cmp)
+
+
+def _selected_attention(
+    q,
+    k,
+    v,
+    block_size,
+    num_selected,
+    W_k_compress,
+    groups,
+    softmax_scale,
+    causal,
+    B,
+    N,
+    H,
+    H_kv,
+    D,
+    q_tile_size=256,
+    _block_indices=None,
+):
+    N_blocks = N // block_size
+    N_q_tiles = N // q_tile_size
+    k_actual = min(num_selected, N_blocks)
+
+    if _block_indices is not None:
+        top_indices = _block_indices
+    else:
+        k_orig = k[:, ::groups]
+        k_blocks = k_orig.reshape(B, H_kv, N_blocks, block_size, D)
+        k_cmp = k_blocks.mean(dim=3)
+        if W_k_compress is not None:
+            k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.to(k_cmp.dtype))
+        if groups > 1:
+            k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+        block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+        block_scores_agg = block_scores.reshape(
+            B, H, N_q_tiles, q_tile_size, N_blocks
+        ).mean(dim=3)
+        if causal:
+            q_tile_end = (torch.arange(N_q_tiles, device=q.device) + 1) * q_tile_size
+            kv_block_start = torch.arange(N_blocks, device=q.device) * block_size
+            future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+            block_scores_agg = block_scores_agg.masked_fill(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+        _, top_indices = block_scores_agg.topk(k_actual, dim=-1)
+
+    offsets = torch.arange(block_size, device=q.device)
+    pos_indices = top_indices.unsqueeze(-1) * block_size + offsets
+    kv_len = k_actual * block_size
+    pos_indices = pos_indices.reshape(B, H, N_q_tiles, kv_len)
+
+    gather_idx = pos_indices.unsqueeze(-1).expand(B, H, N_q_tiles, kv_len, D)
+    k_exp = k.unsqueeze(2).expand(B, H, N_q_tiles, N, D)
+    v_exp = v.unsqueeze(2).expand(B, H, N_q_tiles, N, D)
+    sel_k = torch.gather(k_exp, 3, gather_idx)
+    sel_v = torch.gather(v_exp, 3, gather_idx)
+
+    q_tiles = q.reshape(B, H, N_q_tiles, q_tile_size, D)
+    scores = torch.matmul(q_tiles, sel_k.transpose(-2, -1)) * softmax_scale
+    if causal:
+        q_tile_starts = torch.arange(N_q_tiles, device=q.device) * q_tile_size
+        q_offsets = torch.arange(q_tile_size, device=q.device)
+        q_positions = q_tile_starts.unsqueeze(1) + q_offsets.unsqueeze(0)
+        c_mask = pos_indices.unsqueeze(3) > q_positions.reshape(
+            1, 1, N_q_tiles, q_tile_size, 1
+        )
+        scores = scores.masked_fill(c_mask, float("-inf"))
+    attn = torch.softmax(scores, dim=-1)
+    out_tiles = torch.matmul(attn, sel_v)
+    return out_tiles.reshape(B, H, N, D)
+
+
+def _sliding_window_attention(q, k, v, window_size, softmax_scale, causal, B, N, H, D):
+    scores = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale
+    q_pos = torch.arange(N, device=q.device).unsqueeze(1)
+    kv_pos = torch.arange(N, device=q.device).unsqueeze(0)
+    if causal:
+        mask = (kv_pos > q_pos) | (kv_pos < q_pos - window_size + 1)
+    else:
+        half_w = window_size // 2
+        mask = (kv_pos > q_pos + half_w) | (kv_pos < q_pos - half_w)
+    scores = scores.masked_fill(mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    attn = torch.softmax(scores, dim=-1)
+    return torch.matmul(attn, v)
+
+
+def compute_block_indices_reference(
+    Q,
+    K,
+    compress_block_size=64,
+    num_selected_blocks=16,
+    W_k_compress=None,
+    causal=True,
+    softmax_scale=None,
+    q_tile_size=256,
+):
+    """Pre-compute block selection indices (non-differentiable).
+
+    Returns block indices that can be passed to nsa_forward_reference via
+    _block_indices to freeze the selection during gradient computation.
+    """
+    B, N, H, D = Q.shape
+    H_kv = K.shape[2]
+    groups = H // H_kv
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # fp32 for numerical stability
+    q = Q.transpose(1, 2).float()
+    k = K.transpose(1, 2).float()
+
+    N_blocks = N // compress_block_size
+    N_q_tiles = N // q_tile_size
+
+    k_blocks = k.reshape(B, H_kv, N_blocks, compress_block_size, D)
+    k_cmp = k_blocks.mean(dim=3)
+    if W_k_compress is not None:
+        k_cmp = torch.einsum("bhnd,hde->bhne", k_cmp, W_k_compress.float())
+    if groups > 1:
+        k_cmp = k_cmp.repeat_interleave(groups, dim=1)
+
+    block_scores = torch.matmul(q, k_cmp.transpose(-2, -1)) * softmax_scale
+    block_scores_agg = block_scores.reshape(
+        B, H, N_q_tiles, q_tile_size, N_blocks
+    ).mean(dim=3)
+
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_blocks, device=Q.device) * compress_block_size
+        future_mask = kv_block_start.unsqueeze(0) >= q_tile_end.unsqueeze(1)
+        block_scores_agg = block_scores_agg.masked_fill(
+            future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+        )
+
+    k_actual = min(num_selected_blocks, N_blocks)
+    _, top_indices = block_scores_agg.topk(k_actual, dim=-1)
+    return top_indices
+
+
+def nsa_backward_reference(
+    Q,
+    K,
+    V,
+    dO,
+    compress_block_size=64,
+    num_selected_blocks=16,
+    window_size=512,
+    W_k_compress=None,
+    W_v_compress=None,
+    gate_proj_weight=None,
+    causal=True,
+    softmax_scale=None,
+    q_tile_size=256,
+    _block_indices=None,
+):
+    """Compute NSA gradients using autograd on the differentiable reference forward."""
+    Q_g = Q.detach().float().requires_grad_(True)
+    K_g = K.detach().float().requires_grad_(True)
+    V_g = V.detach().float().requires_grad_(True)
+
+    params = []
+    W_k_g = None
+    if W_k_compress is not None:
+        W_k_g = W_k_compress.detach().float().requires_grad_(True)
+        params.append(W_k_g)
+    W_v_g = None
+    if W_v_compress is not None:
+        W_v_g = W_v_compress.detach().float().requires_grad_(True)
+        params.append(W_v_g)
+    gate_g = None
+    if gate_proj_weight is not None:
+        gate_g = gate_proj_weight.detach().float().requires_grad_(True)
+        params.append(gate_g)
+
+    O = nsa_forward_reference(
+        Q_g,
+        K_g,
+        V_g,
+        compress_block_size=compress_block_size,
+        num_selected_blocks=num_selected_blocks,
+        window_size=window_size,
+        W_k_compress=W_k_g,
+        W_v_compress=W_v_g,
+        gate_proj_weight=gate_g,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        q_tile_size=q_tile_size,
+        _block_indices=_block_indices,
+    )
+
+    grad_inputs = [Q_g, K_g, V_g] + params
+    grads = torch.autograd.grad(
+        O, grad_inputs, grad_outputs=dO.float(), allow_unused=True
+    )
+
+    result = {
+        "dQ": grads[0].to(Q.dtype),
+        "dK": grads[1].to(K.dtype),
+        "dV": grads[2].to(V.dtype),
+        "dW_k_compress": None,
+        "dW_v_compress": None,
+        "dgate_proj_weight": None,
+    }
+    idx = 3
+    if W_k_compress is not None:
+        result["dW_k_compress"] = grads[idx].to(W_k_compress.dtype)
+        idx += 1
+    if W_v_compress is not None:
+        result["dW_v_compress"] = grads[idx].to(W_v_compress.dtype)
+        idx += 1
+    if gate_proj_weight is not None:
+        result["dgate_proj_weight"] = grads[idx].to(gate_proj_weight.dtype)
+    return result

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -1,9 +1,6 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-"""Block scoring and top-k selection for NSA.
-
-Provides score_and_select_blocks (reference, tiled for O(N) memory).
-"""
+"""Block scoring and top-k selection for NSA."""
 
 from __future__ import annotations
 
@@ -38,11 +35,12 @@ def score_and_select_blocks(
         num_selected_blocks: Number of KV blocks to select per query tile.
         compress_block_size: Size of each KV block.
         causal: Whether to apply causal masking (prevent selecting future blocks).
-        q_tile_size: Size of each query tile (should match FA4's CTA tile size, 256).
+        q_tile_size: Size of each query tile (should match FA4's CTA tile: 2 * m_block_size = 256).
         softmax_scale: Scaling factor for attention scores.
 
     Returns:
         block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+            Each entry is an index into the compressed KV sequence.
     """
     B, N, H, D = Q.shape
     H_kv = K_cmp.shape[2]
@@ -65,18 +63,21 @@ def score_and_select_blocks(
     else:
         K_cmp_expanded = K_cmp
 
-    # fp32 accumulation for numerical stability with bf16/fp16 inputs
+    # Pre-transpose for efficient matmul: (B, H, D, N_cmp)
     K_cmp_t = K_cmp_expanded.permute(0, 2, 3, 1).float()
 
     block_indices = torch.empty(
         B, H, N_q_tiles, k_actual, dtype=torch.int32, device=Q.device
     )
 
+    # Precompute causal mask data (tiny tensors)
     if causal:
         q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
         kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
 
-    # Process in chunks to bound peak memory
+    # Process query tiles in chunks to bound peak memory.
+    # Each chunk computes (B, H, chunk_tiles * q_tile_size, N_cmp) scores,
+    # averages per tile, applies causal mask, and runs topk.
     chunk_tiles = min(16, N_q_tiles)
     for chunk_start in range(0, N_q_tiles, chunk_tiles):
         chunk_end = min(chunk_start + chunk_tiles, N_q_tiles)
@@ -84,34 +85,433 @@ def score_and_select_blocks(
         q_start = chunk_start * q_tile_size
         q_end = chunk_end * q_tile_size
 
-        # fp32 scoring for numerical stability
+        # (B, H, n_tiles * q_tile_size, N_cmp) — bounded, not O(N²)
         scores_chunk = (
             torch.matmul(Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t)
             * softmax_scale
         )
 
-        # Average per tile
+        # Average per tile: (B, H, n_tiles, N_cmp)
         scores_agg = scores_chunk.reshape(B, H, n_tiles, q_tile_size, N_cmp).mean(dim=3)
 
-        # Causal mask: block j is future if j * block_size >= (i+1) * q_tile_size
+        # Apply causal mask: block j is future if j * block_size >= (i+1) * q_tile_size
         if causal:
             future_mask = kv_block_start.unsqueeze(0) >= q_tile_end[
                 chunk_start:chunk_end
-            ].unsqueeze(1)
+            ].unsqueeze(1)  # (n_tiles, N_cmp)
             scores_agg.masked_fill_(
                 future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
             )
 
+        # Select top-k blocks for this chunk
         topk_scores, chunk_idx = scores_agg.topk(k_actual, dim=-1)
+
+        # Replace invalid selections (future blocks with -inf score) with block 0
+        invalid = topk_scores == float("-inf")
+        if invalid.any():
+            chunk_idx = chunk_idx.masked_fill(invalid, 0)
+
+        # Sort indices for better memory access patterns
+        block_indices[:, :, chunk_start:chunk_end] = chunk_idx.sort(dim=-1).values.to(
+            torch.int32
+        )
+
+    return block_indices
+
+
+def _compute_q_mean(
+    Q: Tensor,
+    q_tile_size: int,
+    softmax_scale: float,
+    cu_seqlens: Tensor | None = None,
+    max_seqlen: int | None = None,
+) -> tuple[Tensor, int, int, int, int]:
+    """Compute per-tile Q_mean for block scoring.
+
+    Shared helper for both selected-branch and compressed-branch selectors.
+
+    Args:
+        Q: Query tensor, (B, N, H, D) or (total_tokens, H, D) for varlen.
+        q_tile_size: Query tile size (typically 256).
+        softmax_scale: Attention scaling factor.
+        cu_seqlens: Cumulative sequence lengths for varlen.
+        max_seqlen: Max sequence length for varlen.
+
+    Returns:
+        Q_mean: Scaled per-tile mean, shape (B, N_q_tiles, H, D) in float32.
+        B: Batch size.
+        N_q_tiles: Number of query tiles.
+        H: Number of query heads.
+        D: Head dimension.
+    """
+    is_varlen = cu_seqlens is not None
+
+    if is_varlen:
+        assert Q.dim() == 3, f"Varlen requires 3D Q, got {Q.dim()}D"
+        H = Q.shape[1]
+        D = Q.shape[2]
+        batch_size = cu_seqlens.shape[0] - 1
+        seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        if max_seqlen is None:
+            max_seqlen = max(seqlens)
+        N_q_tiles = max_seqlen // q_tile_size
+        B = batch_size
+
+        Q_mean_parts = []
+        for i, slen in enumerate(seqlens):
+            s = cu_seqlens[i].item()
+            n_tiles_i = slen // q_tile_size
+            if n_tiles_i > 0:
+                Q_mean_i = (
+                    Q[s : s + n_tiles_i * q_tile_size]
+                    .reshape(n_tiles_i, q_tile_size, H, D)
+                    .mean(dim=1)
+                    .float()
+                )
+            else:
+                Q_mean_i = Q.new_zeros(0, H, D, dtype=torch.float32)
+            Q_mean_parts.append(Q_mean_i)
+
+        # Pad to (B, max_N_q_tiles, H, D)
+        Q_mean = Q.new_zeros(B, N_q_tiles, H, D, dtype=torch.float32)
+        for i, qm in enumerate(Q_mean_parts):
+            if qm.shape[0] > 0:
+                Q_mean[i, : qm.shape[0]] = qm
+
+        Q_mean = Q_mean * softmax_scale
+    else:
+        B, N, H, D = Q.shape
+        N_q_tiles = N // q_tile_size
+        assert N % q_tile_size == 0, (
+            f"Sequence length {N} must be divisible by q_tile_size {q_tile_size}"
+        )
+        Q_mean = (
+            Q.reshape(B, N_q_tiles, q_tile_size, H, D).mean(dim=2).float()
+            * softmax_scale
+        )
+
+    return Q_mean, B, N_q_tiles, H, D
+
+
+def _score_and_topk(
+    Q_mean: Tensor,  # (B, N_q_tiles, H, D) float32, already scaled
+    K_cmp_t: Tensor,  # (B*H_kv, D, N_cmp) float32
+    B: int,
+    H: int,
+    H_kv: int,
+    N_q_tiles: int,
+    N_cmp: int,
+    k: int,
+    causal: bool,
+    compress_block_size: int,
+    q_tile_size: int,
+    chunk_tiles: int = 64,
+    device: torch.device | None = None,
+) -> Tensor:
+    """Score Q_mean against K_cmp and select top-k compressed blocks.
+
+    Uses GQA-aware bmm: Q groups are folded into the M dimension of the GEMM,
+    avoiding K_cmp expansion from H_kv to H heads.
+
+    Returns:
+        block_indices: (B, H, N_q_tiles, k) int32.
+    """
+    groups = H // H_kv
+    D = Q_mean.shape[-1]
+
+    if device is None:
+        device = Q_mean.device
+
+    k_actual = min(k, N_cmp)
+
+    # Causal mask data
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_cmp, device=device) * compress_block_size
+
+    block_indices = torch.empty(
+        B, H, N_q_tiles, k_actual, dtype=torch.int32, device=device
+    )
+
+    for chunk_start in range(0, N_q_tiles, chunk_tiles):
+        chunk_end = min(chunk_start + chunk_tiles, N_q_tiles)
+        n_tiles = chunk_end - chunk_start
+
+        # Q_mean chunk: (B, n_tiles, H, D) -> (B, n_tiles, H_kv, groups, D)
+        # -> (B*H_kv, n_tiles*groups, D) for bmm
+        q_chunk = Q_mean[:, chunk_start:chunk_end]
+        q_grouped = q_chunk.reshape(B, n_tiles, H_kv, groups, D)
+        q_bmm = q_grouped.permute(0, 2, 1, 3, 4).reshape(B * H_kv, n_tiles * groups, D)
+
+        # bmm: (B*H_kv, n_tiles*groups, D) @ (B*H_kv, D, N_cmp)
+        scores_flat = torch.bmm(q_bmm, K_cmp_t)
+
+        # Reshape to (B, H, n_tiles, N_cmp)
+        scores = (
+            scores_flat.reshape(B, H_kv, n_tiles, groups, N_cmp)
+            .permute(0, 2, 1, 3, 4)
+            .reshape(B, n_tiles, H, N_cmp)
+            .permute(0, 2, 1, 3)
+        )
+
+        # Causal mask
+        if causal:
+            future_mask = kv_block_start.unsqueeze(0) >= q_tile_end[
+                chunk_start:chunk_end
+            ].unsqueeze(1)
+            scores.masked_fill_(future_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+        # Top-k
+        topk_scores, chunk_idx = scores.topk(k_actual, dim=-1)
 
         # Replace -inf selections with block 0
         invalid = topk_scores == float("-inf")
         if invalid.any():
             chunk_idx = chunk_idx.masked_fill(invalid, 0)
 
-        # Sort ascending for better memory access patterns
+        # Sort ascending
         block_indices[:, :, chunk_start:chunk_end] = chunk_idx.sort(dim=-1).values.to(
             torch.int32
         )
 
     return block_indices
+
+
+def fused_score_and_select_blocks(
+    Q: Tensor,  # (B, N, H, D) or (total_tokens, H, D) for varlen
+    K_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    num_selected_blocks: int,
+    compress_block_size: int,
+    causal: bool = True,
+    q_tile_size: int = 256,
+    softmax_scale: float | None = None,
+    cu_seqlens: Tensor | None = None,  # (B+1,) int32 for varlen
+    max_seqlen: int | None = None,
+) -> Tensor:
+    """Fused block scoring and top-k selection using GEMM + topk.
+
+    Uses the Q_mean optimization: mean(Q @ K) = mean(Q) @ K, reducing scoring
+    from a full GEMM to a GEMV per query tile (256x fewer FLOPs).
+
+    Q_mean is computed in PyTorch (single kernel), then cuBLAS GEMM computes
+    scores, and torch.topk selects the top-k blocks. Chunked over Q tiles
+    to bound peak memory.
+
+    For varlen (3D + cu_seqlens): computes Q_mean per-sequence and pads to
+    max_N_q_tiles.
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K_cmp: Compressed key tensor, shape (B, N_cmp, H_kv, D).
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        compress_block_size: Size of each KV block.
+        causal: Whether to apply causal masking.
+        q_tile_size: Size of each query tile.
+        softmax_scale: Scaling factor for attention scores.
+
+    Returns:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+    """
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+
+    if softmax_scale is None:
+        D = Q.shape[-1]
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    Q_mean, B, N_q_tiles, H, D = _compute_q_mean(
+        Q, q_tile_size, softmax_scale, cu_seqlens, max_seqlen
+    )
+
+    # K_cmp: (B, N_cmp, H_kv, D) -> (B*H_kv, D, N_cmp) for GQA-aware bmm
+    K_cmp_t = K_cmp.permute(0, 2, 3, 1).reshape(B * H_kv, D, N_cmp).float()
+
+    return _score_and_topk(
+        Q_mean,
+        K_cmp_t,
+        B,
+        H,
+        H_kv,
+        N_q_tiles,
+        N_cmp,
+        k=num_selected_blocks,
+        causal=causal,
+        compress_block_size=compress_block_size,
+        q_tile_size=q_tile_size,
+        device=Q.device,
+    )
+
+
+def fused_score_and_select_all(
+    Q: Tensor,  # (B, N, H, D) or (total_tokens, H, D) for varlen
+    K_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    num_selected_blocks: int,
+    compress_block_size: int,
+    num_cmp_selected_blocks: int | None = None,
+    cmp_n_block_size: int = 128,
+    causal: bool = True,
+    q_tile_size: int = 256,
+    softmax_scale: float | None = None,
+    cu_seqlens: Tensor | None = None,
+    max_seqlen: int | None = None,
+) -> tuple[Tensor, Tensor | None]:
+    """Score once, select for both selected and compressed branches.
+
+    Computes Q_mean and the Q_mean x K_cmp GEMM once, then derives:
+    1. Selected-branch block indices (top-k over compressed tokens)
+    2. Compressed-branch FA4 block indices (aggregate + top-k over FA4 blocks)
+
+    This eliminates the duplicate GEMM that occurs when calling
+    fused_score_and_select_blocks and select_compressed_blocks separately.
+
+    Args:
+        Q: Query tensor, (B, N, H, D) or (total_tokens, H, D) for varlen.
+        K_cmp: Compressed key tensor, (B, N_cmp, H_kv, D).
+        num_selected_blocks: Number of compressed blocks for selected branch.
+        compress_block_size: Compression block size (e.g. 64).
+        num_cmp_selected_blocks: Number of FA4 blocks for compressed branch.
+            If None, only selected-branch indices are computed.
+        cmp_n_block_size: FA4 KV block size for compressed branch (128).
+        causal: Whether to apply causal masking.
+        q_tile_size: Query tile size (256).
+        softmax_scale: Attention scaling factor.
+        cu_seqlens: Cumulative sequence lengths for varlen.
+        max_seqlen: Max sequence length for varlen.
+
+    Returns:
+        block_indices: (B, H, N_q_tiles, k) int32 for selected branch.
+        cmp_block_indices: (B, H, N_q_tiles, k_cmp) int32 for compressed
+            branch, or None if num_cmp_selected_blocks is None.
+    """
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+
+    if softmax_scale is None:
+        D = Q.shape[-1]
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    # --- Shared: compute Q_mean once ---
+    Q_mean, B, N_q_tiles, H, D = _compute_q_mean(
+        Q, q_tile_size, softmax_scale, cu_seqlens, max_seqlen
+    )
+
+    # --- Shared: prepare K_cmp once ---
+    K_cmp_t = K_cmp.permute(0, 2, 3, 1).reshape(B * H_kv, D, N_cmp).float()
+
+    # --- Check if compressed branch selection is needed ---
+    need_cmp = False
+    if num_cmp_selected_blocks is not None:
+        n_kv_blocks = N_cmp // cmp_n_block_size
+        if n_kv_blocks == 0:
+            n_kv_blocks = 1
+        if n_kv_blocks > num_cmp_selected_blocks:
+            need_cmp = True
+            k_cmp_actual = min(num_cmp_selected_blocks, n_kv_blocks)
+
+    if not need_cmp:
+        # Only selected branch — delegate to existing function
+        block_indices = _score_and_topk(
+            Q_mean,
+            K_cmp_t,
+            B,
+            H,
+            H_kv,
+            N_q_tiles,
+            N_cmp,
+            k=num_selected_blocks,
+            causal=causal,
+            compress_block_size=compress_block_size,
+            q_tile_size=q_tile_size,
+            device=Q.device,
+        )
+        return block_indices, None
+
+    # --- Shared GEMM loop: score once, derive both outputs ---
+    groups = H // H_kv
+    k_sel_actual = min(num_selected_blocks, N_cmp)
+
+    # Causal mask data for selected branch (per compressed token)
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start_sel = torch.arange(N_cmp, device=Q.device) * compress_block_size
+        kv_block_start_cmp = (
+            torch.arange(n_kv_blocks, device=Q.device)
+            * cmp_n_block_size
+            * compress_block_size
+        )
+
+    block_indices = torch.empty(
+        B, H, N_q_tiles, k_sel_actual, dtype=torch.int32, device=Q.device
+    )
+    cmp_block_indices = torch.empty(
+        B, H, N_q_tiles, k_cmp_actual, dtype=torch.int32, device=Q.device
+    )
+
+    chunk_tiles = min(64, N_q_tiles)
+    for chunk_start in range(0, N_q_tiles, chunk_tiles):
+        chunk_end = min(chunk_start + chunk_tiles, N_q_tiles)
+        n_tiles = chunk_end - chunk_start
+
+        # --- SHARED GEMM: compute scores once ---
+        q_chunk = Q_mean[:, chunk_start:chunk_end]
+        q_grouped = q_chunk.reshape(B, n_tiles, H_kv, groups, D)
+        q_bmm = q_grouped.permute(0, 2, 1, 3, 4).reshape(B * H_kv, n_tiles * groups, D)
+        scores_flat = torch.bmm(q_bmm, K_cmp_t)
+
+        # Reshape to (B, H, n_tiles, N_cmp)
+        scores = (
+            scores_flat.reshape(B, H_kv, n_tiles, groups, N_cmp)
+            .permute(0, 2, 1, 3, 4)
+            .reshape(B, n_tiles, H, N_cmp)
+            .permute(0, 2, 1, 3)
+        )
+
+        # --- Selected branch: per-token causal mask + top-k ---
+        sel_scores = scores.clone()
+        if causal:
+            future_mask = kv_block_start_sel.unsqueeze(0) >= q_tile_end[
+                chunk_start:chunk_end
+            ].unsqueeze(1)
+            sel_scores.masked_fill_(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        topk_scores, chunk_idx = sel_scores.topk(k_sel_actual, dim=-1)
+        invalid = topk_scores == float("-inf")
+        if invalid.any():
+            chunk_idx = chunk_idx.masked_fill(invalid, 0)
+        block_indices[:, :, chunk_start:chunk_end] = chunk_idx.sort(dim=-1).values.to(
+            torch.int32
+        )
+
+        # --- Compressed branch: aggregate per FA4 block + top-k ---
+        if N_cmp % cmp_n_block_size == 0:
+            block_scores = scores.reshape(
+                B, H, n_tiles, n_kv_blocks, cmp_n_block_size
+            ).mean(dim=-1)
+        else:
+            pad = cmp_n_block_size - (N_cmp % cmp_n_block_size)
+            scores_padded = torch.nn.functional.pad(
+                scores, (0, pad), value=float("-inf")
+            )
+            block_scores = scores_padded.reshape(
+                B, H, n_tiles, n_kv_blocks, cmp_n_block_size
+            ).mean(dim=-1)
+
+        if causal:
+            future_mask_cmp = kv_block_start_cmp.unsqueeze(0) >= q_tile_end[
+                chunk_start:chunk_end
+            ].unsqueeze(1)
+            block_scores.masked_fill_(
+                future_mask_cmp.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        topk_scores_cmp, chunk_idx_cmp = block_scores.topk(k_cmp_actual, dim=-1)
+        invalid_cmp = topk_scores_cmp == float("-inf")
+        if invalid_cmp.any():
+            chunk_idx_cmp = chunk_idx_cmp.masked_fill(invalid_cmp, 0)
+        cmp_block_indices[:, :, chunk_start:chunk_end] = chunk_idx_cmp.sort(
+            dim=-1
+        ).values.to(torch.int32)
+
+    return block_indices, cmp_block_indices

--- a/mslk/attention/sparse_attn/select.py
+++ b/mslk/attention/sparse_attn/select.py
@@ -1,0 +1,117 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Block scoring and top-k selection for NSA.
+
+Provides score_and_select_blocks (reference, tiled for O(N) memory).
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def score_and_select_blocks(
+    Q: Tensor,  # (B, N, H, D)
+    K_cmp: Tensor,  # (B, N_cmp, H_kv, D)
+    num_selected_blocks: int,
+    compress_block_size: int,
+    causal: bool = True,
+    q_tile_size: int = 256,
+    softmax_scale: float | None = None,
+) -> Tensor:
+    """Score KV blocks by importance and select top-k for each query tile.
+
+    Uses compressed keys to efficiently compute block importance scores.
+    Each query tile (q_tile_size positions) independently selects its own
+    top-k KV blocks.
+
+    Processes query tiles in chunks to avoid materializing a full (B, H, N, N_cmp)
+    score tensor, reducing peak memory from O(N * N_cmp) to
+    O(chunk_tiles * q_tile_size * N_cmp).
+
+    Args:
+        Q: Query tensor, shape (B, N, H, D).
+        K_cmp: Compressed key tensor, shape (B, N_cmp, H_kv, D).
+        num_selected_blocks: Number of KV blocks to select per query tile.
+        compress_block_size: Size of each KV block.
+        causal: Whether to apply causal masking (prevent selecting future blocks).
+        q_tile_size: Size of each query tile (should match FA4's CTA tile size, 256).
+        softmax_scale: Scaling factor for attention scores.
+
+    Returns:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+    """
+    B, N, H, D = Q.shape
+    H_kv = K_cmp.shape[2]
+    N_cmp = K_cmp.shape[1]
+    groups = H // H_kv
+
+    N_q_tiles = N // q_tile_size
+    assert N % q_tile_size == 0, (
+        f"Sequence length {N} must be divisible by q_tile_size {q_tile_size}"
+    )
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(D)
+
+    k_actual = min(num_selected_blocks, N_cmp)
+
+    # Expand K_cmp for GQA: (B, N_cmp, H_kv, D) -> (B, N_cmp, H, D)
+    if groups > 1:
+        K_cmp_expanded = K_cmp.repeat_interleave(groups, dim=2)
+    else:
+        K_cmp_expanded = K_cmp
+
+    # fp32 accumulation for numerical stability with bf16/fp16 inputs
+    K_cmp_t = K_cmp_expanded.permute(0, 2, 3, 1).float()
+
+    block_indices = torch.empty(
+        B, H, N_q_tiles, k_actual, dtype=torch.int32, device=Q.device
+    )
+
+    if causal:
+        q_tile_end = (torch.arange(N_q_tiles, device=Q.device) + 1) * q_tile_size
+        kv_block_start = torch.arange(N_cmp, device=Q.device) * compress_block_size
+
+    # Process in chunks to bound peak memory
+    chunk_tiles = min(16, N_q_tiles)
+    for chunk_start in range(0, N_q_tiles, chunk_tiles):
+        chunk_end = min(chunk_start + chunk_tiles, N_q_tiles)
+        n_tiles = chunk_end - chunk_start
+        q_start = chunk_start * q_tile_size
+        q_end = chunk_end * q_tile_size
+
+        # fp32 scoring for numerical stability
+        scores_chunk = (
+            torch.matmul(Q[:, q_start:q_end].permute(0, 2, 1, 3).float(), K_cmp_t)
+            * softmax_scale
+        )
+
+        # Average per tile
+        scores_agg = scores_chunk.reshape(B, H, n_tiles, q_tile_size, N_cmp).mean(dim=3)
+
+        # Causal mask: block j is future if j * block_size >= (i+1) * q_tile_size
+        if causal:
+            future_mask = kv_block_start.unsqueeze(0) >= q_tile_end[
+                chunk_start:chunk_end
+            ].unsqueeze(1)
+            scores_agg.masked_fill_(
+                future_mask.unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        topk_scores, chunk_idx = scores_agg.topk(k_actual, dim=-1)
+
+        # Replace -inf selections with block 0
+        invalid = topk_scores == float("-inf")
+        if invalid.any():
+            chunk_idx = chunk_idx.masked_fill(invalid, 0)
+
+        # Sort ascending for better memory access patterns
+        block_indices[:, :, chunk_start:chunk_end] = chunk_idx.sort(dim=-1).values.to(
+            torch.int32
+        )
+
+    return block_indices

--- a/mslk/attention/sparse_attn/sparsity_masks.py
+++ b/mslk/attention/sparse_attn/sparsity_masks.py
@@ -1,0 +1,112 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Convert top-k block indices into FA4's BlockSparseTensorsTorch format.
+
+Uses compact index tensors where the last dimension is the max number of
+selected blocks per Q-tile (k), not the total number of KV blocks (n_blocks_k).
+FA4 kernels only access indices 0..cnt-1 per Q-tile, so the compact format
+is fully compatible with both forward and backward.
+"""
+
+from __future__ import annotations
+
+import torch
+from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+from torch import Tensor
+
+
+def build_fa4_block_sparse_tensors(
+    block_indices: Tensor,  # (B, H, N_q_tiles, k) int32
+    compress_block_size: int,
+    n_block_size: int = 128,
+    seqlen_k: int | None = None,
+) -> BlockSparseTensorsTorch:
+    """Convert selected KV block indices into FA4's block sparsity format.
+
+    FA4 block sparsity uses two pairs of tensors:
+    - full_block_cnt/full_block_idx: KV blocks that need NO masking (fully attended).
+    - mask_block_cnt/mask_block_idx: KV blocks that need masking (partially attended).
+
+    Handles two cases:
+    - compress_block_size >= n_block_size: Each NSA block expands to multiple FA4 blocks.
+    - compress_block_size < n_block_size: Multiple NSA blocks contract to one FA4 block
+      (duplicates are removed via sort + consecutive dedup).
+
+    All selected blocks are "full" blocks (no partial masking needed).
+
+    Uses compact index tensors: last dim = k_fa4 (not n_blocks_k).
+
+    Args:
+        block_indices: Selected KV block indices, shape (B, H, N_q_tiles, k).
+        compress_block_size: Size of each NSA KV block.
+        n_block_size: FA4's KV tile size (default 128 for SM100).
+        seqlen_k: Total KV sequence length (for computing q_block_size).
+
+    Returns:
+        BlockSparseTensorsTorch with full_block_cnt, full_block_idx,
+        mask_block_cnt, mask_block_idx.
+    """
+    B, H, N_q_tiles, k = block_indices.shape
+    device = block_indices.device
+
+    if compress_block_size >= n_block_size:
+        # Expansion: each NSA block maps to one or more FA4 blocks
+        assert compress_block_size % n_block_size == 0, (
+            f"compress_block_size ({compress_block_size}) must be divisible by "
+            f"n_block_size ({n_block_size})"
+        )
+        fa4_blocks_per_nsa_block = compress_block_size // n_block_size
+
+        base_indices = block_indices.long() * fa4_blocks_per_nsa_block
+        offsets = torch.arange(fa4_blocks_per_nsa_block, device=device)
+        expanded_indices = base_indices.unsqueeze(-1) + offsets
+        fa4_indices = expanded_indices.reshape(
+            B, H, N_q_tiles, k * fa4_blocks_per_nsa_block
+        )
+        k_fa4 = k * fa4_blocks_per_nsa_block
+
+        full_block_cnt = torch.full(
+            (B, H, N_q_tiles), k_fa4, dtype=torch.int32, device=device
+        )
+    else:
+        # Contraction: multiple NSA blocks map to a single FA4 block.
+        # Dedup by sorting and removing consecutive duplicates.
+        assert n_block_size % compress_block_size == 0, (
+            f"n_block_size ({n_block_size}) must be divisible by "
+            f"compress_block_size ({compress_block_size})"
+        )
+        fa4_block_indices = (block_indices.long() * compress_block_size) // n_block_size
+
+        sorted_idx, _ = fa4_block_indices.sort(dim=-1)
+        is_new = torch.ones_like(sorted_idx, dtype=torch.bool)
+        is_new[..., 1:] = sorted_idx[..., 1:] != sorted_idx[..., :-1]
+
+        counts = is_new.sum(dim=-1)
+        max_unique = counts.max().item()
+
+        dest_positions = is_new.long().cumsum(dim=-1) - 1
+        fa4_indices = torch.zeros(
+            B, H, N_q_tiles, max_unique, dtype=torch.int64, device=device
+        )
+        fa4_indices.scatter_(3, dest_positions.clamp(max=max_unique - 1), sorted_idx)
+
+        full_block_cnt = counts.to(torch.int32)
+        k_fa4 = max_unique
+
+    full_block_idx = fa4_indices[:, :, :, :k_fa4].to(torch.int32)
+
+    # No partial masking needed — use minimal last dim
+    mask_block_cnt = torch.zeros((B, H, N_q_tiles), dtype=torch.int32, device=device)
+    mask_block_idx = torch.zeros((B, H, N_q_tiles, 1), dtype=torch.int32, device=device)
+
+    q_block_size = (
+        seqlen_k // N_q_tiles if seqlen_k is not None else compress_block_size
+    )
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=mask_block_cnt,
+        mask_block_idx=mask_block_idx,
+        full_block_cnt=full_block_cnt,
+        full_block_idx=full_block_idx,
+        block_size=(q_block_size, n_block_size),
+    )

--- a/mslk/attention/sparse_attn/sparsity_masks.py
+++ b/mslk/attention/sparse_attn/sparsity_masks.py
@@ -110,3 +110,48 @@ def build_fa4_block_sparse_tensors(
         full_block_idx=full_block_idx,
         block_size=(q_block_size, n_block_size),
     )
+
+
+def build_compressed_block_sparse_tensors(
+    cmp_block_indices: Tensor,  # (B, H, N_q_tiles, k_cmp) int32
+    n_kv_blocks: int,
+    q_tile_size: int = 256,
+    cmp_n_block_size: int = 128,
+) -> "BlockSparseTensorsTorch":
+    """Build block-sparse tensors for block-sparse compressed attention.
+
+    All selected blocks go into full_block (not mask_block) because causal
+    masking is handled by compress_factor in FA4, not mask_mod.
+
+    Uses compact index tensors: last dim = k_cmp (not n_kv_blocks).
+
+    Args:
+        cmp_block_indices: FA4 block indices in the compressed KV sequence,
+            shape (B, H, N_q_tiles, k_cmp). Values in [0, n_kv_blocks).
+        n_kv_blocks: Total number of FA4 KV blocks in the compressed sequence.
+        q_tile_size: Q tile size (256 for SM100).
+        cmp_n_block_size: FA4 KV block size for the compressed branch (128).
+
+    Returns:
+        BlockSparseTensorsTorch with selected blocks in full_block.
+    """
+    B, H, N_q_tiles, k_cmp = cmp_block_indices.shape
+    device = cmp_block_indices.device
+
+    # All blocks in full_block (causal masking via compress_factor, not mask_mod)
+    full_block_cnt = torch.full(
+        (B, H, N_q_tiles), k_cmp, dtype=torch.int32, device=device
+    )
+    full_block_idx = cmp_block_indices.to(torch.int32).contiguous()
+
+    # No mask blocks — use minimal last dim
+    mask_block_cnt = torch.zeros((B, H, N_q_tiles), dtype=torch.int32, device=device)
+    mask_block_idx = torch.zeros((B, H, N_q_tiles, 1), dtype=torch.int32, device=device)
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=mask_block_cnt,
+        mask_block_idx=mask_block_idx,
+        full_block_cnt=full_block_cnt,
+        full_block_idx=full_block_idx,
+        block_size=(q_tile_size, cmp_n_block_size),
+    )

--- a/test/attention/bench_2m_3m.py
+++ b/test/attention/bench_2m_3m.py
@@ -1,0 +1,152 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Quick benchmark: test NSA and Dense FA4 at 2M and 3M context lengths."""
+
+import gc
+import os
+import time
+
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+os.environ.setdefault(
+    "CUTLASS_CUTE_DSL_KERNEL_CACHE_DIR",
+    os.path.expanduser("~/.cache/cutlass_dsl_kernels"),
+)
+
+import torch
+
+
+def _time_fn(fn, warmup=2, iters=3):
+    """Time a function with warmup, return median ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        times.append((time.perf_counter() - start) * 1000)
+    times.sort()
+    return times[len(times) // 2]
+
+
+def benchmark_dense_fa4(N, B=1, H=32, H_kv=8, D=128, backward=False):
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out, _lse = flash_attn_func(Q, K, V, softmax_scale=1.0 / D**0.5, causal=True)
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = K.grad = V.grad = None
+
+    try:
+        return _time_fn(run)
+    except Exception as e:
+        return f"FAILED: {e}"
+
+
+def benchmark_nsa(N, B=1, H=32, H_kv=8, D=128, backward=False):
+    from mslk.attention.sparse_attn import nsa
+
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=64,
+            num_selected_blocks=16,
+            window_size=512,
+        )
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = K.grad = V.grad = None
+
+    try:
+        return _time_fn(run)
+    except Exception as e:
+        return f"FAILED: {e}"
+
+
+def _fmt(val):
+    if isinstance(val, str):
+        return val
+    return f"{val:.2f}ms"
+
+
+def _speedup(dense, sparse):
+    if isinstance(dense, str) or isinstance(sparse, str):
+        return "N/A"
+    return f"{dense / sparse:.2f}x"
+
+
+def main():
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
+    print(f"GPU Memory: {mem_gb:.1f} GB")
+    print(f"Config: B=1, H=32, H_kv=8, D=128")
+    print("=" * 90)
+
+    seq_lengths = [
+        2097152,  # 2M
+        3145728,  # 3M
+    ]
+
+    for N in seq_lengths:
+        label = f"{N // (1024 * 1024)}M"
+        print(f"\n--- N = {N:,} ({label}) ---")
+
+        # Forward only
+        gc.collect()
+        torch.cuda.empty_cache()
+        print(f"  Dense FA4 forward ... ", end="", flush=True)
+        dense_fwd = benchmark_dense_fa4(N, backward=False)
+        print(_fmt(dense_fwd))
+
+        gc.collect()
+        torch.cuda.empty_cache()
+        print(f"  NSA forward ... ", end="", flush=True)
+        nsa_fwd = benchmark_nsa(N, backward=False)
+        print(_fmt(nsa_fwd))
+
+        print(f"  Forward speedup: {_speedup(dense_fwd, nsa_fwd)}")
+
+        # Forward + Backward
+        gc.collect()
+        torch.cuda.empty_cache()
+        print(f"  Dense FA4 fwd+bwd ... ", end="", flush=True)
+        dense_fwdbwd = benchmark_dense_fa4(N, backward=True)
+        print(_fmt(dense_fwdbwd))
+
+        gc.collect()
+        torch.cuda.empty_cache()
+        print(f"  NSA fwd+bwd ... ", end="", flush=True)
+        nsa_fwdbwd = benchmark_nsa(N, backward=True)
+        print(_fmt(nsa_fwdbwd))
+
+        print(f"  Fwd+Bwd speedup: {_speedup(dense_fwdbwd, nsa_fwdbwd)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_nsa_backward.py
+++ b/test/attention/bench_nsa_backward.py
@@ -1,0 +1,137 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Benchmark NSA forward + backward at various sequence lengths."""
+
+import gc
+import os
+import time
+
+import torch
+
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+
+def benchmark_nsa_fwd_bwd(
+    N: int,
+    B: int = 1,
+    H: int = 32,
+    H_kv: int = 8,
+    D: int = 128,
+    compress_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    warmup: int = 3,
+    iters: int = 10,
+    backward: bool = True,
+):
+    from mslk.attention.sparse_attn import nsa
+
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected_blocks,
+            window_size=window_size,
+        )
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = None
+            K.grad = None
+            V.grad = None
+        return out
+
+    # Warmup — compile kernels at a smaller size first to avoid
+    # CuTe DSL JIT compilation at the target size consuming all memory
+    if N >= 262144:
+        small_N = 1024
+        Q_small = torch.randn(B, small_N, H, D, device="cuda", dtype=torch.bfloat16)
+        K_small = torch.randn(B, small_N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V_small = torch.randn(B, small_N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        _ = nsa(
+            Q_small,
+            K_small,
+            V_small,
+            compress_block_size=compress_block_size,
+            num_selected_blocks=num_selected_blocks,
+            window_size=window_size,
+        )
+        del Q_small, K_small, V_small, _
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    # Warmup
+    for _ in range(warmup):
+        run()
+    torch.cuda.synchronize()
+
+    # Benchmark
+    start = time.perf_counter()
+    for _ in range(iters):
+        run()
+    torch.cuda.synchronize()
+    elapsed = (time.perf_counter() - start) / iters
+
+    tflops_fwd = 2 * B * H * N * N * D / 1e12  # approximate (ignoring sparsity)
+    mode = "fwd+bwd" if backward else "fwd"
+    print(
+        f"N={N:>7d} | {mode} | {elapsed * 1000:>8.2f} ms | "
+        f"~{tflops_fwd / elapsed / 1e3:.1f} TFLOPS (dense equiv)"
+    )
+    return elapsed
+
+
+def main():
+    print("NSA Forward + Backward Benchmark")
+    print("=" * 60)
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print()
+
+    seq_lengths = [
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+        2097152,
+        3145728,
+    ]
+
+    for N in seq_lengths:
+        gc.collect()
+        torch.cuda.empty_cache()
+        try:
+            benchmark_nsa_fwd_bwd(N, backward=False)
+        except Exception as e:
+            print(f"N={N:>7d} | fwd     | FAILED: {e}")
+
+    print()
+    for N in seq_lengths:
+        gc.collect()
+        torch.cuda.empty_cache()
+        try:
+            benchmark_nsa_fwd_bwd(N, backward=True)
+        except Exception as e:
+            print(f"N={N:>7d} | fwd+bwd | FAILED: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_nsa_vs_dense.py
+++ b/test/attention/bench_nsa_vs_dense.py
@@ -1,0 +1,281 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""NSA vs Dense FA4 benchmark — forward and backward at various sequence lengths."""
+
+import gc
+import os
+import time
+
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+os.environ.setdefault(
+    "CUTLASS_CUTE_DSL_KERNEL_CACHE_DIR",
+    os.path.expanduser("~/.cache/cutlass_dsl_kernels"),
+)
+
+import torch
+
+
+def _time_fn(fn, warmup=3, iters=5):
+    """Time a function with warmup, return median ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        times.append((time.perf_counter() - start) * 1000)
+    times.sort()
+    return times[len(times) // 2]
+
+
+def benchmark_dense_fa4(N, B=1, H=32, H_kv=8, D=128, backward=False):
+    """Benchmark dense causal FA4 attention."""
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out, _lse = flash_attn_func(Q, K, V, softmax_scale=1.0 / D**0.5, causal=True)
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = K.grad = V.grad = None
+
+    try:
+        return _time_fn(run)
+    except Exception as e:
+        return f"FAILED: {e}"
+
+
+def benchmark_nsa(N, B=1, H=32, H_kv=8, D=128, backward=False):
+    """Benchmark NSA sparse attention."""
+    from mslk.attention.sparse_attn import nsa
+
+    Q = torch.randn(
+        B, N, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        B, N, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=64,
+            num_selected_blocks=16,
+            window_size=512,
+        )
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = K.grad = V.grad = None
+
+    try:
+        return _time_fn(run)
+    except Exception as e:
+        return f"FAILED: {e}"
+
+
+def benchmark_nsa_varlen(
+    total_N,
+    num_seqs=2,
+    H=32,
+    H_kv=8,
+    D=128,
+    backward=False,
+):
+    """Benchmark NSA with varlen (packed sequences)."""
+    from mslk.attention.sparse_attn import nsa
+
+    # Split total_N into num_seqs sequences with varying lengths
+    # Use 60/40 split for 2 seqs, or equal for more
+    if num_seqs == 2:
+        seqlens = [int(total_N * 0.6), total_N - int(total_N * 0.6)]
+    else:
+        base = total_N // num_seqs
+        seqlens = [base] * num_seqs
+        seqlens[-1] = total_N - sum(seqlens[:-1])
+
+    # Align each seqlen to q_tile_size (256)
+    q_tile_size = 256
+    seqlens = [max(q_tile_size, (s // q_tile_size) * q_tile_size) for s in seqlens]
+    total = sum(seqlens)
+
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(seqlens), 0).tolist()),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    Q = torch.randn(
+        total, H, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    K = torch.randn(
+        total, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+    V = torch.randn(
+        total, H_kv, D, device="cuda", dtype=torch.bfloat16, requires_grad=backward
+    )
+
+    def run():
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=64,
+            num_selected_blocks=16,
+            window_size=512,
+            cu_seqlens=cu_seqlens,
+        )
+        if backward:
+            loss = out.sum()
+            loss.backward()
+            Q.grad = K.grad = V.grad = None
+
+    try:
+        return _time_fn(run), seqlens
+    except Exception as e:
+        return f"FAILED: {e}", seqlens
+
+
+def _fmt(val):
+    """Format a timing value or error string."""
+    if isinstance(val, str):
+        return val[:30]
+    return f"{val:>10.2f}ms"
+
+
+def _speedup(dense, sparse):
+    """Compute speedup string."""
+    if isinstance(dense, str) or isinstance(sparse, str):
+        return "N/A"
+    return f"{dense / sparse:.2f}x"
+
+
+def main():
+    print("NSA vs Dense FA4 Benchmark")
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(f"Config: B=1, H=32, H_kv=8, D=128")
+    print("=" * 100)
+
+    seq_lengths = [
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+        524288,
+        1048576,
+    ]
+
+    # --- Part 1: Regular (fixed-length) ---
+    print("\n--- Regular (B=1, fixed-length) ---")
+    print(
+        f"{'N':>10} | {'Dense Fwd':>12} | {'NSA Fwd':>12} | {'Speedup':>8} | "
+        f"{'Dense F+B':>12} | {'NSA F+B':>12} | {'Speedup':>8}"
+    )
+    print("-" * 90)
+
+    fwd_data = {"dense": [], "nsa": []}
+    fwdbwd_data = {"dense": [], "nsa": []}
+
+    for N in seq_lengths:
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        dense_fwd = benchmark_dense_fa4(N, backward=False)
+        gc.collect()
+        torch.cuda.empty_cache()
+        nsa_fwd = benchmark_nsa(N, backward=False)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        dense_bwd = benchmark_dense_fa4(N, backward=True)
+        gc.collect()
+        torch.cuda.empty_cache()
+        nsa_bwd = benchmark_nsa(N, backward=True)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        fwd_data["dense"].append(dense_fwd)
+        fwd_data["nsa"].append(nsa_fwd)
+        fwdbwd_data["dense"].append(dense_bwd)
+        fwdbwd_data["nsa"].append(nsa_bwd)
+
+        print(
+            f"{N:>10} | {_fmt(dense_fwd):>12} | {_fmt(nsa_fwd):>12} | "
+            f"{_speedup(dense_fwd, nsa_fwd):>8} | "
+            f"{_fmt(dense_bwd):>12} | {_fmt(nsa_bwd):>12} | "
+            f"{_speedup(dense_bwd, nsa_bwd):>8}"
+        )
+
+    # --- Part 2: Varlen (packed sequences) ---
+    print("\n--- Varlen (2 packed sequences, 60/40 split) ---")
+    print(
+        f"{'Total N':>10} | {'Seqlens':>20} | {'NSA Varlen F+B':>15} | "
+        f"{'NSA Regular F+B':>15} | {'Ratio':>8}"
+    )
+    print("-" * 80)
+
+    for N in seq_lengths:
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        varlen_result = benchmark_nsa_varlen(N, num_seqs=2, backward=True)
+        if isinstance(varlen_result, tuple):
+            varlen_bwd, seqlens = varlen_result
+        else:
+            varlen_bwd, seqlens = varlen_result, []
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        regular_bwd = benchmark_nsa(N, backward=True)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        seqlens_s = f"{seqlens}" if seqlens else "N/A"
+        ratio = (
+            _speedup(regular_bwd, varlen_bwd)
+            if not isinstance(varlen_bwd, str)
+            else "N/A"
+        )
+
+        print(
+            f"{N:>10} | {seqlens_s:>20} | {_fmt(varlen_bwd):>15} | "
+            f"{_fmt(regular_bwd):>15} | {ratio:>8}"
+        )
+
+    # --- Part 3: Crossover analysis ---
+    print("\n--- Crossover Analysis ---")
+    for mode, data in [("Forward", fwd_data), ("Fwd+Bwd", fwdbwd_data)]:
+        for i, N in enumerate(seq_lengths):
+            d, s = data["dense"][i], data["nsa"][i]
+            if isinstance(d, (int, float)) and isinstance(s, (int, float)):
+                if d > s:
+                    print(f"{mode}: NSA becomes faster at N={N} ({d / s:.2f}x speedup)")
+                    break
+        else:
+            print(f"{mode}: NSA never becomes faster in tested range")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_sparse_attn_e2e.py
+++ b/test/attention/bench_sparse_attn_e2e.py
@@ -1,0 +1,169 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Lean end-to-end benchmark for NSA vs dense FA4 at large sequence lengths.
+
+Only measures end-to-end Dense FA4 and NSA times (no component breakdowns)
+to minimize memory usage and allow benchmarking at N >= 2M.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+
+import torch
+
+
+def benchmark_fn(fn, warmup=3, repeat=7):
+    """Benchmark a CUDA function using CUDA events. Returns median time in ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(repeat):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times = sorted(times)
+    return times[len(times) // 2]
+
+
+def run_e2e(
+    N: int,
+    compress_block_size: int,
+    B: int = 1,
+    H: int = 8,
+    H_kv: int = 2,
+    D: int = 128,
+    num_selected_blocks: int = 16,
+    window_size: int = 512,
+    dtype=torch.bfloat16,
+    warmup: int = 3,
+    repeat: int = 7,
+    skip_dense: bool = False,
+):
+    """Run end-to-end Dense FA4 + NSA benchmark for one (N, l) pair."""
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+
+    dense_ms = -1.0
+    if not skip_dense:
+        try:
+            dense_ms = benchmark_fn(
+                lambda Q=Q, K=K, V=V: flash_attn_func(Q, K, V, causal=True),
+                warmup=warmup,
+                repeat=repeat,
+            )
+        except Exception as e:
+            print(f"  Dense FA4 failed: {e}")
+
+    torch.cuda.empty_cache()
+
+    nsa_ms = -1.0
+    try:
+        nsa_ms = benchmark_fn(
+            lambda Q=Q, K=K, V=V: nsa_forward(
+                Q,
+                K,
+                V,
+                compress_block_size=compress_block_size,
+                num_selected_blocks=num_selected_blocks,
+                window_size=window_size,
+                causal=True,
+            ),
+            warmup=warmup,
+            repeat=repeat,
+        )
+    except Exception as e:
+        print(f"  NSA l={compress_block_size} failed: {e}")
+
+    del Q, K, V
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    return dense_ms, nsa_ms
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E2E NSA vs FA4 benchmark (lean)")
+    parser.add_argument(
+        "--seq-lens",
+        nargs="+",
+        type=int,
+        default=[2097152, 4194304, 8388608, 16777216],
+    )
+    parser.add_argument("--block-sizes", nargs="+", type=int, default=[32, 64, 128])
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--num-heads", type=int, default=8)
+    parser.add_argument("--num-heads-kv", type=int, default=2)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--num-selected-blocks", type=int, default=16)
+    parser.add_argument("--window-size", type=int, default=512)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeat", type=int, default=7)
+    parser.add_argument(
+        "--skip-dense-above",
+        type=int,
+        default=0,
+        help="Skip dense FA4 for N above this value (0 = never skip)",
+    )
+    args = parser.parse_args()
+
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(
+        f"Config: B={args.batch_size}, H={args.num_heads}, H_kv={args.num_heads_kv}, "
+        f"D={args.head_dim}, k={args.num_selected_blocks}, w={args.window_size}"
+    )
+
+    # Header
+    l_cols = "  ".join(f"{'l=' + str(l):>10}" for l in args.block_sizes)
+    print(f"\n{'N':>10} | {'Dense(ms)':>10} | {l_cols}")
+    print("-" * (14 + 13 + 12 * len(args.block_sizes)))
+
+    for N in args.seq_lens:
+        skip_dense = args.skip_dense_above > 0 and N > args.skip_dense_above
+
+        dense_ms = None
+        nsa_times = {}
+
+        for i, l in enumerate(args.block_sizes):
+            d_ms, n_ms = run_e2e(
+                N=N,
+                compress_block_size=l,
+                B=args.batch_size,
+                H=args.num_heads,
+                H_kv=args.num_heads_kv,
+                D=args.head_dim,
+                num_selected_blocks=args.num_selected_blocks,
+                window_size=args.window_size,
+                warmup=args.warmup,
+                repeat=args.repeat,
+                skip_dense=(skip_dense or i > 0),  # Only measure dense once per N
+            )
+            if i == 0:
+                dense_ms = d_ms
+            nsa_times[l] = n_ms
+
+        dense_str = f"{dense_ms:>10.2f}" if dense_ms and dense_ms > 0 else "     skip"
+        nsa_strs = "  ".join(
+            f"{nsa_times[l]:>10.2f}" if nsa_times[l] > 0 else "    failed"
+            for l in args.block_sizes
+        )
+        print(f"{N:>10} | {dense_str} | {nsa_strs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/bench_sparse_compressed.py
+++ b/test/attention/bench_sparse_compressed.py
@@ -1,0 +1,112 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Quick benchmark: NSA with sparse compressed branch vs original."""
+
+import gc
+import os
+import time
+
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+os.environ.setdefault(
+    "CUTLASS_CUTE_DSL_KERNEL_CACHE_DIR",
+    os.path.expanduser("~/.cache/cutlass_dsl_kernels"),
+)
+
+import torch
+
+
+def _time_fn(fn, warmup=3, iters=5):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        times.append((time.perf_counter() - start) * 1000)
+    times.sort()
+    return times[len(times) // 2]
+
+
+def main():
+    from mslk.attention.sparse_attn import nsa_forward
+    from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+    B, H, H_kv, D = 1, 32, 8, 128
+
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(f"Config: B={B}, H={H}, H_kv={H_kv}, D={D}")
+    print()
+
+    # Warmup JIT
+    print("Warming up JIT compilation...")
+    Q = torch.randn(B, 4096, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, 4096, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, 4096, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    nsa_forward(Q, K, V)
+    nsa_forward(Q, K, V, num_cmp_selected_blocks=16)
+    del Q, K, V
+    gc.collect()
+    torch.cuda.empty_cache()
+    print("JIT warmup done.\n")
+
+    header = (
+        f"{'N':>8} | {'Dense FA4':>10} | {'NSA orig':>10} | "
+        f"{'NSA+CmpSp':>10} | {'Orig sp':>8} | {'CmpSp sp':>8} | {'Improvement':>11}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    seq_lengths = [4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576]
+
+    for N in seq_lengths:
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+        # Dense FA4
+        try:
+            dense = _time_fn(
+                lambda: flash_attn_func(
+                    Q, K, V, softmax_scale=1.0 / D**0.5, causal=True
+                )
+            )
+        except Exception:
+            dense = float("inf")
+
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        # NSA original (no sparse compressed)
+        try:
+            nsa_orig = _time_fn(lambda: nsa_forward(Q, K, V))
+        except Exception:
+            nsa_orig = float("inf")
+
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        # NSA with sparse compressed branch (k_cmp=16 FA4 blocks)
+        try:
+            nsa_sp = _time_fn(lambda: nsa_forward(Q, K, V, num_cmp_selected_blocks=16))
+        except Exception:
+            nsa_sp = float("inf")
+
+        del Q, K, V
+
+        sp_orig = dense / nsa_orig if nsa_orig < float("inf") else 0
+        sp_new = dense / nsa_sp if nsa_sp < float("inf") else 0
+        improvement = nsa_orig / nsa_sp if nsa_sp < float("inf") else 0
+
+        print(
+            f"{N:>8} | {dense:>9.2f}ms | {nsa_orig:>9.2f}ms | "
+            f"{nsa_sp:>9.2f}ms | {sp_orig:>7.2f}x | {sp_new:>7.2f}x | {improvement:>10.2f}x"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/probe_max_seqlen.py
+++ b/test/attention/probe_max_seqlen.py
@@ -1,0 +1,85 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Quick memory probe: find the max seq len that fits on one B200 GPU."""
+
+from __future__ import annotations
+
+import traceback
+
+import torch
+
+
+def probe(N: int, B: int = 1, H: int = 8, H_kv: int = 2, D: int = 128):
+    """Try allocating tensors and running Dense FA4 + NSA at sequence length N."""
+    dtype = torch.bfloat16
+    print(f"\n--- N={N:,} ({N // 1024}K) ---")
+
+    try:
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        Q = torch.randn(B, N, H, D, device="cuda", dtype=dtype)
+        K = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        V = torch.randn(B, N, H_kv, D, device="cuda", dtype=dtype)
+        alloc_gb = torch.cuda.memory_allocated() / 1e9
+        print(f"  Allocated Q/K/V: {alloc_gb:.1f} GB")
+
+        # Try Dense FA4
+        from mslk.fb.mslk.attention.flash_attn.autograd_interface import flash_attn_func
+
+        O = flash_attn_func(Q, K, V, causal=True)
+        torch.cuda.synchronize()
+        peak_dense = torch.cuda.max_memory_allocated() / 1e9
+        print(f"  Dense FA4 OK. Peak: {peak_dense:.1f} GB")
+        del O
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        # Try NSA
+        from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+        O_nsa = nsa_forward(
+            Q,
+            K,
+            V,
+            compress_block_size=128,
+            num_selected_blocks=16,
+            window_size=512,
+            causal=True,
+        )
+        torch.cuda.synchronize()
+        peak_nsa = torch.cuda.max_memory_allocated() / 1e9
+        print(f"  NSA OK. Peak: {peak_nsa:.1f} GB")
+        del O_nsa, Q, K, V
+        torch.cuda.empty_cache()
+        return True
+
+    except torch.cuda.OutOfMemoryError as e:
+        print(f"  CUDA OOM: {e}")
+        torch.cuda.empty_cache()
+        return False
+    except Exception as e:
+        print(f"  Error: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        torch.cuda.empty_cache()
+        return False
+
+
+def main():
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(
+        f"GPU memory: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB"
+    )
+
+    for n_k in [2048, 3072, 4096, 6144, 8192, 16384]:
+        N = n_k * 1024
+        ok = probe(N)
+        if not ok:
+            print(f"\n==> Max working sequence length: <{n_k}K")
+            break
+    else:
+        print(f"\n==> All sizes up to {n_k}K fit!")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/attention/test_fa4_block_sparse_bwd.py
+++ b/test/attention/test_fa4_block_sparse_bwd.py
@@ -1,0 +1,284 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Minimal reproducer for FA4 block-sparse backward bug on SM100.
+
+_flash_attn_bwd with block_sparse_tensors fails during CuTe DSL JIT
+compilation: blocksparse_tensors is None inside the while-loop after-block
+in flash_bwd_sm100.py, causing TypeError in get_total_q_block_count_bwd.
+
+This test calls _flash_attn_fwd (which works) then _flash_attn_bwd (which
+crashes) with identical block_sparse_tensors, isolating the bug to the
+backward kernel compilation.
+"""
+
+import torch
+
+
+def test_fa4_block_sparse_backward():
+    """_flash_attn_bwd should support block_sparse_tensors on SM100."""
+    from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+    from mslk.attention.flash_attn.interface import _flash_attn_bwd, _flash_attn_fwd
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = H
+    q_tile_size = 256
+    n_block_size = 128
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    dO = torch.randn_like(Q)
+
+    n_q_tiles = N // q_tile_size  # 4
+    n_kv_blocks = N // n_block_size  # 8
+
+    # Simple block-sparse pattern: each Q-tile attends to 4 KV-blocks
+    k_selected = 4
+    full_block_cnt = torch.full(
+        (B, H, n_q_tiles), k_selected, dtype=torch.int32, device="cuda"
+    )
+    full_block_idx = torch.zeros(
+        B, H, n_q_tiles, n_kv_blocks, dtype=torch.int32, device="cuda"
+    )
+    for qt in range(n_q_tiles):
+        for i in range(k_selected):
+            full_block_idx[:, :, qt, i] = min(qt + i, n_kv_blocks - 1)
+
+    mask_block_cnt = torch.zeros(B, H, n_q_tiles, dtype=torch.int32, device="cuda")
+    mask_block_idx = torch.zeros(
+        B, H, n_q_tiles, n_kv_blocks, dtype=torch.int32, device="cuda"
+    )
+
+    sparse_tensors = BlockSparseTensorsTorch(
+        mask_block_cnt=mask_block_cnt,
+        mask_block_idx=mask_block_idx,
+        full_block_cnt=full_block_cnt,
+        full_block_idx=full_block_idx,
+        block_size=(q_tile_size, n_block_size),
+    )
+
+    # Forward works
+    out, lse = _flash_attn_fwd(
+        Q,
+        K,
+        V,
+        causal=True,
+        block_sparse_tensors=sparse_tensors,
+        return_lse=True,
+    )
+    assert out.shape == Q.shape, f"Forward output shape mismatch: {out.shape}"
+    assert torch.isfinite(out).all(), "Forward output has NaN/Inf"
+
+    # Backward: need transposed block-sparse tensors (KV-blocks → Q-tiles)
+    bwd_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device="cuda")
+    bwd_idx = torch.zeros(
+        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device="cuda"
+    )
+    # Build transpose manually
+    for b in range(B):
+        for h in range(H):
+            for qt in range(n_q_tiles):
+                cnt = full_block_cnt[b, h, qt].item()
+                for i in range(cnt):
+                    kv = full_block_idx[b, h, qt, i].item()
+                    pos = bwd_cnt[b, h, kv].item()
+                    bwd_idx[b, h, kv, pos] = qt
+                    bwd_cnt[b, h, kv] += 1
+
+    bwd_mask_cnt = torch.zeros(B, H, n_kv_blocks, dtype=torch.int32, device="cuda")
+    bwd_mask_idx = torch.zeros(
+        B, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device="cuda"
+    )
+
+    bwd_sparse = BlockSparseTensorsTorch(
+        mask_block_cnt=bwd_mask_cnt,
+        mask_block_idx=bwd_mask_idx,
+        full_block_cnt=bwd_cnt,
+        full_block_idx=bwd_idx,
+        block_size=(q_tile_size, n_block_size),
+    )
+
+    # This is the call that crashes:
+    # TypeError: cannot unpack non-iterable NoneType object
+    # in get_total_q_block_count_bwd (block_sparse_utils.py)
+    dQ, dK, dV = _flash_attn_bwd(
+        Q,
+        K,
+        V,
+        out,
+        dO,
+        lse,
+        causal=True,
+        block_sparse_tensors=bwd_sparse,
+    )
+    assert dQ.shape == Q.shape, f"dQ shape mismatch: {dQ.shape}"
+    assert dK.shape == K.shape, f"dK shape mismatch: {dK.shape}"
+    assert dV.shape == V.shape, f"dV shape mismatch: {dV.shape}"
+    assert torch.isfinite(dQ).all(), "dQ has NaN/Inf"
+    assert torch.isfinite(dK).all(), "dK has NaN/Inf"
+    assert torch.isfinite(dV).all(), "dV has NaN/Inf"
+
+
+def test_fa4_block_sparse_backward_varlen():
+    """_flash_attn_bwd should support varlen + block_sparse_tensors on SM100.
+
+    Verifies that the backward pass with cu_seqlens and block_sparse_tensors
+    produces the same gradients as the padded non-varlen version.
+    """
+    from mslk.attention.flash_attn.block_sparsity import BlockSparseTensorsTorch
+    from mslk.attention.flash_attn.interface import _flash_attn_bwd, _flash_attn_fwd
+
+    seqlens = [512, 256]
+    total = sum(seqlens)
+    max_seqlen = max(seqlens)
+    batch_size = len(seqlens)
+    H, D = 4, 128
+    H_kv = H
+    q_tile_size = 256
+    n_block_size = 128
+
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(seqlens), 0).tolist()),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    torch.manual_seed(42)
+    Q_3d = torch.randn(total, H, D, device="cuda", dtype=torch.bfloat16)
+    K_3d = torch.randn(total, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V_3d = torch.randn(total, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    dO_3d = torch.randn(total, H, D, device="cuda", dtype=torch.bfloat16)
+
+    # Pad to 4D for reference
+    pad_N = max_seqlen
+    Q_4d = Q_3d.new_zeros(batch_size, pad_N, H, D)
+    K_4d = K_3d.new_zeros(batch_size, pad_N, H_kv, D)
+    V_4d = V_3d.new_zeros(batch_size, pad_N, H_kv, D)
+    dO_4d = dO_3d.new_zeros(batch_size, pad_N, H, D)
+    for i, slen in enumerate(seqlens):
+        s = cu_seqlens[i].item()
+        Q_4d[i, :slen] = Q_3d[s : s + slen]
+        K_4d[i, :slen] = K_3d[s : s + slen]
+        V_4d[i, :slen] = V_3d[s : s + slen]
+        dO_4d[i, :slen] = dO_3d[s : s + slen]
+
+    # Build simple block-sparse pattern per batch element
+    n_q_tiles = pad_N // q_tile_size
+    n_kv_blocks = pad_N // n_block_size
+    k_selected = 2
+
+    # Forward sparse tensors (Q-tile → KV-blocks)
+    fwd_cnt = torch.full(
+        (batch_size, H, n_q_tiles), k_selected, dtype=torch.int32, device="cuda"
+    )
+    fwd_idx = torch.zeros(
+        batch_size, H, n_q_tiles, n_kv_blocks, dtype=torch.int32, device="cuda"
+    )
+    for qt in range(n_q_tiles):
+        for i in range(k_selected):
+            fwd_idx[:, :, qt, i] = min(qt + i, n_kv_blocks - 1)
+
+    fwd_mask_cnt = torch.zeros(
+        batch_size, H, n_q_tiles, dtype=torch.int32, device="cuda"
+    )
+    fwd_mask_idx = torch.zeros(
+        batch_size, H, n_q_tiles, n_kv_blocks, dtype=torch.int32, device="cuda"
+    )
+    fwd_sparse = BlockSparseTensorsTorch(
+        mask_block_cnt=fwd_mask_cnt,
+        mask_block_idx=fwd_mask_idx,
+        full_block_cnt=fwd_cnt,
+        full_block_idx=fwd_idx,
+        block_size=(q_tile_size, n_block_size),
+    )
+
+    # Backward sparse tensors (KV-block → Q-tiles)
+    bwd_cnt = torch.zeros(batch_size, H, n_kv_blocks, dtype=torch.int32, device="cuda")
+    bwd_idx = torch.zeros(
+        batch_size, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device="cuda"
+    )
+    for b in range(batch_size):
+        for h in range(H):
+            for qt in range(n_q_tiles):
+                cnt = fwd_cnt[b, h, qt].item()
+                for i in range(cnt):
+                    kv = fwd_idx[b, h, qt, i].item()
+                    pos = bwd_cnt[b, h, kv].item()
+                    bwd_idx[b, h, kv, pos] = qt
+                    bwd_cnt[b, h, kv] += 1
+
+    bwd_mask_cnt = torch.zeros(
+        batch_size, H, n_kv_blocks, dtype=torch.int32, device="cuda"
+    )
+    bwd_mask_idx = torch.zeros(
+        batch_size, H, n_kv_blocks, n_q_tiles, dtype=torch.int32, device="cuda"
+    )
+    bwd_sparse = BlockSparseTensorsTorch(
+        mask_block_cnt=bwd_mask_cnt,
+        mask_block_idx=bwd_mask_idx,
+        full_block_cnt=bwd_cnt,
+        full_block_idx=bwd_idx,
+        block_size=(q_tile_size, n_block_size),
+    )
+
+    # Reference: padded 4D forward + backward
+    out_4d, lse_4d = _flash_attn_fwd(
+        Q_4d,
+        K_4d,
+        V_4d,
+        causal=True,
+        block_sparse_tensors=fwd_sparse,
+        return_lse=True,
+    )
+    dQ_4d, dK_4d, dV_4d = _flash_attn_bwd(
+        Q_4d,
+        K_4d,
+        V_4d,
+        out_4d,
+        dO_4d,
+        lse_4d,
+        causal=True,
+        block_sparse_tensors=bwd_sparse,
+    )
+
+    # Varlen: 3D forward + backward with cu_seqlens
+    out_3d, lse_3d = _flash_attn_fwd(
+        Q_3d,
+        K_3d,
+        V_3d,
+        causal=True,
+        block_sparse_tensors=fwd_sparse,
+        return_lse=True,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+    )
+    dQ_3d, dK_3d, dV_3d = _flash_attn_bwd(
+        Q_3d,
+        K_3d,
+        V_3d,
+        out_3d,
+        dO_3d,
+        lse_3d,
+        causal=True,
+        block_sparse_tensors=bwd_sparse,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+    )
+
+    # Compare: varlen gradients should match padded per-sequence
+    assert dQ_3d.shape == Q_3d.shape, f"dQ shape: {dQ_3d.shape} vs {Q_3d.shape}"
+    assert dK_3d.shape == K_3d.shape, f"dK shape: {dK_3d.shape} vs {K_3d.shape}"
+    assert torch.isfinite(dQ_3d).all(), "dQ_3d has NaN/Inf"
+    assert torch.isfinite(dK_3d).all(), "dK_3d has NaN/Inf"
+    assert torch.isfinite(dV_3d).all(), "dV_3d has NaN/Inf"
+
+    for i, slen in enumerate(seqlens):
+        s = cu_seqlens[i].item()
+        dQ_ref = dQ_4d[i, :slen]
+        dQ_var = dQ_3d[s : s + slen]
+        max_diff = (dQ_ref.float() - dQ_var.float()).abs().max().item()
+        assert max_diff < 0.05, f"Seq {i}: dQ max_diff={max_diff:.6f} exceeds 0.05"

--- a/test/attention/test_sparse_attn_compress.py
+++ b/test/attention/test_sparse_attn_compress.py
@@ -1,0 +1,49 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compress_kv_basic():
+    """Mean-pool compression produces correct output shape and values."""
+    from mslk.attention.sparse_attn.compress import compress_kv
+
+    B, N, H_kv, D = 2, 1024, 4, 128
+    block_size = 64
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    K_cmp, V_cmp = compress_kv(K, V, block_size)
+
+    N_cmp = N // block_size
+    assert K_cmp.shape == (B, N_cmp, H_kv, D)
+    assert V_cmp.shape == (B, N_cmp, H_kv, D)
+
+    # Verify mean-pool: first block should be mean of first block_size positions
+    expected_k0 = K[:, :block_size].float().mean(dim=1)  # (B, H_kv, D)
+    actual_k0 = K_cmp[:, 0].float()
+    torch.testing.assert_close(actual_k0, expected_k0, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compress_kv_with_projection():
+    """Compression with W_k, W_v learned projections."""
+    from mslk.attention.sparse_attn.compress import compress_kv
+
+    B, N, H_kv, D = 1, 512, 2, 64
+    block_size = 64
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16)
+    W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16)
+
+    K_cmp, V_cmp = compress_kv(K, V, block_size, W_k, W_v)
+
+    N_cmp = N // block_size
+    assert K_cmp.shape == (B, N_cmp, H_kv, D)
+    assert V_cmp.shape == (B, N_cmp, H_kv, D)
+
+    # With projection, output should differ from simple mean
+    K_cmp_no_proj, _ = compress_kv(K, V, block_size)
+    assert not torch.allclose(K_cmp.float(), K_cmp_no_proj.float(), atol=1e-2)

--- a/test/attention/test_sparse_attn_gating.py
+++ b/test/attention/test_sparse_attn_gating.py
@@ -1,0 +1,52 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compute_gates_with_weight():
+    """Gates are in [0, 1] range (sigmoid output)."""
+    from mslk.attention.sparse_attn.gating import compute_gates
+
+    B, N, H, D = 1, 256, 4, 128
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    W = torch.randn(H, 3, D, device="cuda", dtype=torch.bfloat16)
+
+    gates = compute_gates(Q, W)
+    assert gates.shape == (B, N, H, 3)
+    assert (gates >= 0).all() and (gates <= 1).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compute_gates_no_weight():
+    """Without gate weights, gates are uniform 1/3."""
+    from mslk.attention.sparse_attn.gating import compute_gates
+
+    B, N, H, D = 1, 256, 4, 128
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+
+    gates = compute_gates(Q, None)
+    assert gates.shape == (B, N, H, 3)
+    torch.testing.assert_close(
+        gates.float().mean(), torch.tensor(1.0 / 3.0), atol=1e-5, rtol=1e-5
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_gate_and_combine():
+    """Gate and combine with uniform gates produces average."""
+    from mslk.attention.sparse_attn.gating import gate_and_combine
+
+    B, N, H, D = 1, 256, 4, 128
+    O_cmp = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    O_slc = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    O_sld = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    gates = torch.ones(B, N, H, 3, device="cuda", dtype=torch.bfloat16) / 3.0
+
+    O = gate_and_combine(O_cmp, O_slc, O_sld, gates)
+    expected = (O_cmp.float() + O_slc.float() + O_sld.float()) / 3.0
+
+    torch.testing.assert_close(
+        O.float(), expected.to(O.dtype).float(), atol=1e-2, rtol=1e-2
+    )

--- a/test/attention/test_sparse_attn_nsa_backward.py
+++ b/test/attention/test_sparse_attn_nsa_backward.py
@@ -1,0 +1,881 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for the NSA reference backward pass (autograd-based)."""
+
+import torch
+
+
+def _make_inputs(
+    B: int,
+    N: int,
+    H: int,
+    D: int,
+    H_kv: int | None = None,
+    with_W_k: bool = False,
+    with_W_v: bool = False,
+    with_gate: bool = False,
+    dtype: torch.dtype = torch.float64,
+    device: str = "cuda",
+) -> dict:
+    """Create input tensors with requires_grad for gradient checking."""
+    if H_kv is None:
+        H_kv = H
+    Q = torch.randn(B, N, H, D, device=device, dtype=dtype, requires_grad=True)
+    K = torch.randn(B, N, H_kv, D, device=device, dtype=dtype, requires_grad=True)
+    V = torch.randn(B, N, H_kv, D, device=device, dtype=dtype, requires_grad=True)
+    result = {"Q": Q, "K": K, "V": V}
+    if with_W_k:
+        result["W_k_compress"] = (
+            torch.randn(
+                H_kv,
+                D,
+                D,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            * 0.02
+        )
+    if with_W_v:
+        result["W_v_compress"] = (
+            torch.randn(
+                H_kv,
+                D,
+                D,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            * 0.02
+        )
+    if with_gate:
+        result["gate_proj_weight"] = (
+            torch.randn(
+                H,
+                3,
+                D,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            * 0.1
+        )
+    return result
+
+
+class TestNSAReferenceBackwardGradcheck:
+    """Validate gradients via torch.autograd.gradcheck (finite differences).
+
+    Block selection indices are pre-computed and frozen during gradcheck,
+    since top-k is non-differentiable and would cause discontinuities
+    when inputs are perturbed.
+    """
+
+    # Use small sizes for gradcheck (it's O(params) forward passes)
+    B, N, H, D = 1, 256, 2, 32
+    compress_block_size = 64
+    num_selected_blocks = 2
+    window_size = 128
+    q_tile_size = 256
+
+    def _run_gradcheck(self, inputs: dict, causal: bool = True) -> None:
+        from mslk.attention.sparse_attn.reference import (
+            compute_block_indices_reference,
+            nsa_forward_reference,
+        )
+
+        # Pre-compute block indices with the original (unperturbed) inputs
+        # so that top-k selection is frozen during finite-difference perturbation
+        block_indices = compute_block_indices_reference(
+            inputs["Q"].detach(),
+            inputs["K"].detach(),
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            W_k_compress=inputs.get("W_k_compress"),
+            causal=causal,
+            q_tile_size=self.q_tile_size,
+        )
+
+        # Ensure block 0 is always selected for causal mode. Without it,
+        # early queries in a tile may have ALL selected KV positions causally
+        # masked (kv_pos > q_pos for all selected positions), producing NaN
+        # from softmax over all -inf.
+        if causal:
+            block_indices[..., 0] = 0
+
+        params = [
+            v
+            for v in inputs.values()
+            if isinstance(v, torch.Tensor) and v.requires_grad
+        ]
+
+        def fn(*args):
+            kw = {}
+            idx = 0
+            for k, v in inputs.items():
+                if isinstance(v, torch.Tensor) and v.requires_grad:
+                    kw[k] = args[idx]
+                    idx += 1
+                else:
+                    kw[k] = v
+            out = nsa_forward_reference(
+                kw["Q"],
+                kw["K"],
+                kw["V"],
+                compress_block_size=self.compress_block_size,
+                num_selected_blocks=self.num_selected_blocks,
+                window_size=self.window_size,
+                W_k_compress=kw.get("W_k_compress"),
+                W_v_compress=kw.get("W_v_compress"),
+                gate_proj_weight=kw.get("gate_proj_weight"),
+                causal=causal,
+                q_tile_size=self.q_tile_size,
+                _block_indices=block_indices,
+            )
+            return out
+
+        torch.autograd.gradcheck(fn, params, raise_exception=True)
+
+    def test_gradcheck_basic(self) -> None:
+        """Gradcheck for Q, K, V without optional weights."""
+        inputs = _make_inputs(self.B, self.N, self.H, self.D)
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_with_gate_weights(self) -> None:
+        """Gradcheck including gate_proj_weight gradients."""
+        inputs = _make_inputs(self.B, self.N, self.H, self.D, with_gate=True)
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_with_compression_weights(self) -> None:
+        """Gradcheck including W_k_compress and W_v_compress gradients."""
+        inputs = _make_inputs(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            with_W_k=True,
+            with_W_v=True,
+        )
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_all_weights(self) -> None:
+        """Gradcheck with all optional weights enabled."""
+        inputs = _make_inputs(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            with_W_k=True,
+            with_W_v=True,
+            with_gate=True,
+        )
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_noncausal(self) -> None:
+        """Gradcheck in non-causal mode."""
+        inputs = _make_inputs(self.B, self.N, self.H, self.D)
+        self._run_gradcheck(inputs, causal=False)
+
+    def test_gradcheck_gqa(self) -> None:
+        """Gradcheck with grouped query attention (H > H_kv)."""
+        inputs = _make_inputs(self.B, self.N, 4, self.D, H_kv=2)
+        self._run_gradcheck(inputs)
+
+    def test_gradcheck_compressed_only(self) -> None:
+        """Gradcheck for just compressed attention (isolate branch)."""
+        from mslk.attention.sparse_attn.reference import _compressed_attention
+
+        B, N, H, D = self.B, self.N, self.H, self.D
+        q = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+
+        def fn(q, k, v):
+            return _compressed_attention(
+                q,
+                k,
+                v,
+                self.compress_block_size,
+                None,
+                None,
+                1,
+                1.0 / D**0.5,
+                True,
+                B,
+                N,
+                H,
+                H,
+                D,
+            )
+
+        torch.autograd.gradcheck(fn, (q, k, v), raise_exception=True)
+
+    def test_gradcheck_sliding_only(self) -> None:
+        """Gradcheck for just sliding window attention (isolate branch)."""
+        from mslk.attention.sparse_attn.reference import _sliding_window_attention
+
+        B, N, H, D = self.B, self.N, self.H, self.D
+        q = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+
+        def fn(q, k, v):
+            return _sliding_window_attention(
+                q,
+                k,
+                v,
+                self.window_size,
+                1.0 / D**0.5,
+                True,
+                B,
+                N,
+                H,
+                D,
+            )
+
+        torch.autograd.gradcheck(fn, (q, k, v), raise_exception=True)
+
+    def test_gradcheck_selected_only(self) -> None:
+        """Gradcheck for just selected attention with frozen indices."""
+        from mslk.attention.sparse_attn.reference import _selected_attention
+
+        B, N, H, D = self.B, self.N, self.H, self.D
+        q = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            B, H, N, D, dtype=torch.float64, device="cuda", requires_grad=True
+        )
+
+        # Use first k_actual blocks — always valid for causal masking
+        N_blocks = N // self.compress_block_size
+        N_q_tiles = N // self.q_tile_size
+        k_actual = min(self.num_selected_blocks, N_blocks)
+        block_indices = (
+            torch.arange(k_actual, device="cuda").unsqueeze(0).unsqueeze(0).unsqueeze(0)
+        )
+        block_indices = block_indices.expand(B, H, N_q_tiles, k_actual)
+
+        def fn(q, k, v):
+            return _selected_attention(
+                q,
+                k,
+                v,
+                self.compress_block_size,
+                self.num_selected_blocks,
+                None,
+                1,
+                1.0 / D**0.5,
+                True,
+                B,
+                N,
+                H,
+                H,
+                D,
+                q_tile_size=self.q_tile_size,
+                _block_indices=block_indices,
+            )
+
+        torch.autograd.gradcheck(fn, (q, k, v), raise_exception=True)
+
+
+class TestNSABackwardReference:
+    """Test nsa_backward_reference wrapper function."""
+
+    B, N, H, D = 1, 512, 4, 64
+    compress_block_size = 64
+    num_selected_blocks = 4
+    window_size = 256
+    q_tile_size = 256
+
+    def test_gradient_shapes(self) -> None:
+        """Output gradient shapes match input shapes."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        H_kv = self.H
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        assert grads["dQ"].shape == Q.shape
+        assert grads["dK"].shape == K.shape
+        assert grads["dV"].shape == V.shape
+        assert grads["dW_k_compress"] is None
+        assert grads["dW_v_compress"] is None
+        assert grads["dgate_proj_weight"] is None
+
+    def test_gradient_shapes_all_weights(self) -> None:
+        """Gradient shapes correct with all optional weights."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        H_kv = self.H
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+        W_k = (
+            torch.randn(H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        )
+        W_v = (
+            torch.randn(H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        )
+        gate = torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            W_k_compress=W_k,
+            W_v_compress=W_v,
+            gate_proj_weight=gate,
+        )
+
+        assert grads["dQ"].shape == Q.shape
+        assert grads["dK"].shape == K.shape
+        assert grads["dV"].shape == V.shape
+        assert grads["dW_k_compress"].shape == W_k.shape
+        assert grads["dW_v_compress"].shape == W_v.shape
+        assert grads["dgate_proj_weight"].shape == gate.shape
+
+    def test_gradients_finite(self) -> None:
+        """All gradients are finite (no NaN/Inf)."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+        gate = torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            gate_proj_weight=gate,
+        )
+
+        for name in ("dQ", "dK", "dV", "dgate_proj_weight"):
+            assert torch.isfinite(grads[name]).all(), f"{name} contains NaN or Inf"
+
+    def test_gradients_nonzero(self) -> None:
+        """Gradients are not all-zero (sanity check that grad flows)."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        for name in ("dQ", "dK", "dV"):
+            assert grads[name].abs().max() > 0, f"{name} is all zeros"
+
+    def test_gradient_shapes_gqa(self) -> None:
+        """Gradient shapes correct with GQA (H > H_kv)."""
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        H_kv = 2
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        grads = nsa_backward_reference(
+            Q,
+            K,
+            V,
+            dO,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        assert grads["dQ"].shape == Q.shape
+        assert grads["dK"].shape == K.shape  # (B, N, H_kv, D), not (B, N, H, D)
+        assert grads["dV"].shape == V.shape
+
+
+class TestNSAAutograd:
+    """Test NSAFunction (FA4-based forward + backward via autograd).
+
+    Validates that nsa() produces correct forward output and that
+    gradients flow correctly through .backward().
+    """
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 4
+    compress_block_size = 64
+    num_selected_blocks = 8
+    window_size = 256
+    q_tile_size = 256
+
+    def test_forward_matches_nsa_forward(self) -> None:
+        """nsa() forward output matches nsa_forward()."""
+        from mslk.attention.sparse_attn import nsa, nsa_forward
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+
+        out_fwd = nsa_forward(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+        out_autograd = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+
+        # nsa() uses PyTorch gating (compute_gates + gate_and_combine) while
+        # nsa_forward() uses fused CuteDSL gating, so expect small numerical diffs
+        assert torch.allclose(out_fwd, out_autograd, atol=0.02, rtol=0.02), (
+            f"max diff: {(out_fwd - out_autograd).abs().max().item()}"
+        )
+
+    def test_backward_produces_gradients(self) -> None:
+        """nsa() backward produces non-zero gradients for Q, K, V."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        assert Q.grad is not None, "Q.grad is None"
+        assert K.grad is not None, "K.grad is None"
+        assert V.grad is not None, "V.grad is None"
+        assert Q.grad.abs().max() > 0, "Q.grad is all zeros"
+        assert K.grad.abs().max() > 0, "K.grad is all zeros"
+        assert V.grad.abs().max() > 0, "V.grad is all zeros"
+
+    def test_backward_with_gate_weights(self) -> None:
+        """nsa() backward produces gradients for gate_proj_weight."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        gate = (
+            torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+        ).requires_grad_(True)
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            gate_proj_weight=gate,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        assert gate.grad is not None, "gate.grad is None"
+        assert gate.grad.abs().max() > 0, "gate.grad is all zeros"
+
+    def test_backward_with_compression_weights(self) -> None:
+        """nsa() backward produces gradients for W_k_compress and W_v_compress."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        W_k = (
+            torch.randn(self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        ).requires_grad_(True)
+        W_v = (
+            torch.randn(self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16)
+            * 0.02
+        ).requires_grad_(True)
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            W_k_compress=W_k,
+            W_v_compress=W_v,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        assert W_k.grad is not None, "W_k.grad is None"
+        assert W_v.grad is not None, "W_v.grad is None"
+        assert W_k.grad.abs().max() > 0, "W_k.grad is all zeros"
+        assert W_v.grad.abs().max() > 0, "W_v.grad is all zeros"
+
+    def test_gradients_finite(self) -> None:
+        """All gradients from nsa() backward are finite."""
+        from mslk.attention.sparse_attn import nsa
+
+        Q = torch.randn(
+            self.B,
+            self.N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            self.B,
+            self.N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        gate = (
+            torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16) * 0.1
+        ).requires_grad_(True)
+
+        out = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            gate_proj_weight=gate,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        for name, param in [("Q", Q), ("K", K), ("V", V), ("gate", gate)]:
+            assert torch.isfinite(param.grad).all(), f"{name}.grad contains NaN or Inf"
+
+
+class TestNSABackwardMatchesReference:
+    """Compare FA4-based backward gradient values against reference backward.
+
+    This validates that the optimized backward (using FA4 CuteDSL kernels)
+    produces numerically similar gradients to the pure PyTorch reference.
+    """
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 4
+    compress_block_size = 64
+    num_selected_blocks = 8
+    window_size = 256
+    q_tile_size = 256
+
+    def _compare_grads(
+        self,
+        with_gate: bool = False,
+        with_W_k: bool = False,
+        with_W_v: bool = False,
+        causal: bool = True,
+        max_atol: float = 0.4,
+        mean_atol: float = 0.02,
+    ) -> None:
+        from mslk.attention.sparse_attn import nsa
+        from mslk.attention.sparse_attn.reference import nsa_backward_reference
+
+        torch.manual_seed(42)
+
+        Q = torch.randn(
+            self.B, self.N, self.H, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        K = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        V = torch.randn(
+            self.B, self.N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16
+        )
+        dO = torch.randn_like(Q)
+
+        kwargs = {
+            "compress_block_size": self.compress_block_size,
+            "num_selected_blocks": self.num_selected_blocks,
+            "window_size": self.window_size,
+            "causal": causal,
+            "q_tile_size": self.q_tile_size,
+        }
+
+        W_k = None
+        W_v = None
+        gate = None
+        if with_W_k:
+            W_k = (
+                torch.randn(
+                    self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16
+                )
+                * 0.02
+            )
+            kwargs["W_k_compress"] = W_k
+        if with_W_v:
+            W_v = (
+                torch.randn(
+                    self.H_kv, self.D, self.D, device="cuda", dtype=torch.bfloat16
+                )
+                * 0.02
+            )
+            kwargs["W_v_compress"] = W_v
+        if with_gate:
+            gate = (
+                torch.randn(self.H, 3, self.D, device="cuda", dtype=torch.bfloat16)
+                * 0.1
+            )
+            kwargs["gate_proj_weight"] = gate
+
+        # --- Reference backward ---
+        ref_grads = nsa_backward_reference(Q, K, V, dO, **kwargs)
+
+        # --- Optimized backward (FA4-based) ---
+        Q_opt = Q.clone().requires_grad_(True)
+        K_opt = K.clone().requires_grad_(True)
+        V_opt = V.clone().requires_grad_(True)
+
+        opt_kwargs = dict(kwargs)
+        if with_W_k:
+            W_k_opt = W_k.clone().requires_grad_(True)
+            opt_kwargs["W_k_compress"] = W_k_opt
+        if with_W_v:
+            W_v_opt = W_v.clone().requires_grad_(True)
+            opt_kwargs["W_v_compress"] = W_v_opt
+        if with_gate:
+            gate_opt = gate.clone().requires_grad_(True)
+            opt_kwargs["gate_proj_weight"] = gate_opt
+
+        out = nsa(Q_opt, K_opt, V_opt, **opt_kwargs)
+        out.backward(dO)
+
+        # --- Compare ---
+        pairs = [
+            ("dQ", Q_opt.grad, ref_grads["dQ"]),
+            ("dK", K_opt.grad, ref_grads["dK"]),
+            ("dV", V_opt.grad, ref_grads["dV"]),
+        ]
+        if with_W_k:
+            pairs.append(("dW_k", W_k_opt.grad, ref_grads["dW_k_compress"]))
+        if with_W_v:
+            pairs.append(("dW_v", W_v_opt.grad, ref_grads["dW_v_compress"]))
+        if with_gate:
+            pairs.append(("dgate", gate_opt.grad, ref_grads["dgate_proj_weight"]))
+
+        for name, opt_grad, ref_grad in pairs:
+            assert opt_grad is not None, f"{name} is None"
+            ref_grad = ref_grad.to(opt_grad.dtype)
+            diff = (opt_grad - ref_grad).abs()
+            max_diff = diff.max().item()
+            mean_diff = diff.mean().item()
+            # Gate gradients use fused CuteDSL kernel vs float32 reference,
+            # so max outliers can be large; check mean only for gates.
+            if name == "dgate":
+                assert mean_diff < 1.0, f"{name}: mean_diff={mean_diff:.6f} exceeds 1.0"
+            else:
+                assert max_diff < max_atol, (
+                    f"{name}: max_diff={max_diff:.4f} exceeds {max_atol}"
+                )
+                assert mean_diff < mean_atol, (
+                    f"{name}: mean_diff={mean_diff:.6f} exceeds {mean_atol}"
+                )
+
+    def test_basic(self) -> None:
+        """Q, K, V gradients match reference."""
+        self._compare_grads()
+
+    def test_with_gate_weights(self) -> None:
+        """Gradients match with gate projection weights."""
+        self._compare_grads(with_gate=True)
+
+    def test_with_compression_weights(self) -> None:
+        """Gradients match with compression projection weights."""
+        self._compare_grads(with_W_k=True, with_W_v=True)
+
+    def test_all_weights(self) -> None:
+        """Gradients match with all optional weights."""
+        self._compare_grads(with_gate=True, with_W_k=True, with_W_v=True)
+
+    def test_noncausal(self) -> None:
+        """Gradients match in non-causal mode.
+
+        Non-causal has larger bf16 diffs (no causal mask to stabilize softmax),
+        so we only check mean diff.
+        """
+        self._compare_grads(causal=False, max_atol=2.0, mean_atol=0.05)

--- a/test/attention/test_sparse_attn_nsa_forward.py
+++ b/test/attention/test_sparse_attn_nsa_forward.py
@@ -1,0 +1,43 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_forward_basic():
+    """NSA forward produces valid output."""
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 2
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    O = nsa_forward(Q, K, V, compress_block_size=64, num_selected_blocks=8)
+    assert O.shape == Q.shape
+    assert O.dtype == Q.dtype
+    assert not torch.isnan(O).any()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_forward_matches_reference():
+    """NSA forward output is close to pure PyTorch reference."""
+    from mslk.attention.sparse_attn.nsa_forward import nsa_forward
+    from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+    B, N, H, D = 1, 512, 4, 128
+    H_kv = 2
+    torch.manual_seed(42)
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    O_opt = nsa_forward(Q, K, V, compress_block_size=64, num_selected_blocks=8)
+    O_ref = nsa_forward_reference(
+        Q, K, V, compress_block_size=64, num_selected_blocks=8
+    )
+
+    # Tolerance is loose because FA4 and reference use different attention implementations
+    torch.testing.assert_close(O_opt.float(), O_ref.float(), atol=0.1, rtol=0.1)

--- a/test/attention/test_sparse_attn_nsa_varlen.py
+++ b/test/attention/test_sparse_attn_nsa_varlen.py
@@ -1,0 +1,320 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Tests for NSA forward with variable-length sequences."""
+
+import torch
+
+
+class TestNSAForwardVarlen:
+    """Test nsa_forward with cu_seqlens (varlen) input."""
+
+    H, H_kv, D = 4, 4, 128
+    compress_block_size = 64
+    num_selected_blocks = 4
+    window_size = 256
+    q_tile_size = 256
+
+    def test_varlen_output_shape(self) -> None:
+        """Varlen output should be 3D with total_tokens rows."""
+        from mslk.attention.sparse_attn import nsa_forward
+
+        seqlens = [512, 256]
+        total = sum(seqlens)
+        cu_seqlens = torch.tensor(
+            [0, seqlens[0], total], dtype=torch.int32, device="cuda"
+        )
+
+        Q = torch.randn(total, self.H, self.D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(total, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(total, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16)
+
+        O = nsa_forward(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            q_tile_size=self.q_tile_size,
+            cu_seqlens=cu_seqlens,
+        )
+
+        assert O.shape == (total, self.H, self.D)
+        assert O.dtype == Q.dtype
+        assert torch.isfinite(O).all()
+
+    def test_varlen_matches_per_sequence(self) -> None:
+        """Varlen output should match running each sequence individually."""
+        from mslk.attention.sparse_attn import nsa_forward
+
+        torch.manual_seed(42)
+        seqlens = [512, 256]
+        total = sum(seqlens)
+        cu_seqlens = torch.tensor(
+            [0, seqlens[0], total], dtype=torch.int32, device="cuda"
+        )
+
+        Q = torch.randn(total, self.H, self.D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(total, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(total, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16)
+
+        # Varlen forward
+        O_varlen = nsa_forward(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            q_tile_size=self.q_tile_size,
+            cu_seqlens=cu_seqlens,
+        )
+
+        # Per-sequence forward
+        for i, slen in enumerate(seqlens):
+            start = cu_seqlens[i].item()
+            Q_seq = Q[start : start + slen].unsqueeze(0)  # (1, slen, H, D)
+            K_seq = K[start : start + slen].unsqueeze(0)
+            V_seq = V[start : start + slen].unsqueeze(0)
+
+            O_seq = nsa_forward(
+                Q_seq,
+                K_seq,
+                V_seq,
+                compress_block_size=self.compress_block_size,
+                num_selected_blocks=self.num_selected_blocks,
+                window_size=self.window_size,
+                q_tile_size=self.q_tile_size,
+            )
+
+            O_varlen_seq = O_varlen[start : start + slen]
+            O_fixed_seq = O_seq.squeeze(0)
+
+            max_diff = (O_varlen_seq - O_fixed_seq).abs().max().item()
+            mean_diff = (O_varlen_seq - O_fixed_seq).abs().mean().item()
+            assert max_diff < 0.01, f"Seq {i}: max_diff={max_diff:.6f} exceeds 0.01"
+            assert mean_diff < 0.001, (
+                f"Seq {i}: mean_diff={mean_diff:.6f} exceeds 0.001"
+            )
+
+    def test_varlen_single_sequence(self) -> None:
+        """Single-sequence varlen should match fixed-length exactly."""
+        from mslk.attention.sparse_attn import nsa_forward
+
+        torch.manual_seed(123)
+        N = 512
+        cu_seqlens = torch.tensor([0, N], dtype=torch.int32, device="cuda")
+
+        Q = torch.randn(N, self.H, self.D, device="cuda", dtype=torch.bfloat16)
+        K = torch.randn(N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16)
+        V = torch.randn(N, self.H_kv, self.D, device="cuda", dtype=torch.bfloat16)
+
+        O_varlen = nsa_forward(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            q_tile_size=self.q_tile_size,
+            cu_seqlens=cu_seqlens,
+        )
+
+        O_fixed = nsa_forward(
+            Q.unsqueeze(0),
+            K.unsqueeze(0),
+            V.unsqueeze(0),
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            q_tile_size=self.q_tile_size,
+        ).squeeze(0)
+
+        max_diff = (O_varlen - O_fixed).abs().max().item()
+        assert max_diff < 1e-5, f"Single-seq max_diff={max_diff} should be ~0"
+
+    def test_varlen_backward_produces_gradients(self) -> None:
+        """nsa() with cu_seqlens should produce gradients via backward."""
+        from mslk.attention.sparse_attn import nsa
+
+        seqlens = [512, 256]
+        total = sum(seqlens)
+        cu_seqlens = torch.tensor(
+            [0, seqlens[0], total], dtype=torch.int32, device="cuda"
+        )
+
+        Q = torch.randn(
+            total,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            total,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            total,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+
+        O = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            q_tile_size=self.q_tile_size,
+            cu_seqlens=cu_seqlens,
+        )
+        loss = O.sum()
+        loss.backward()
+
+        assert Q.grad is not None, "Q.grad is None"
+        assert K.grad is not None, "K.grad is None"
+        assert V.grad is not None, "V.grad is None"
+        assert Q.grad.shape == Q.shape
+        assert torch.isfinite(Q.grad).all(), "Q.grad has NaN/Inf"
+        assert Q.grad.abs().max() > 0, "Q.grad is all zeros"
+
+    def test_varlen_backward_matches_per_sequence(self) -> None:
+        """Varlen backward gradients should be finite, non-zero, and correct shape."""
+        from mslk.attention.sparse_attn import nsa
+
+        torch.manual_seed(42)
+        seqlens = [512, 256]
+        total = sum(seqlens)
+        cu_seqlens = torch.tensor(
+            [0, seqlens[0], total], dtype=torch.int32, device="cuda"
+        )
+
+        Q = torch.randn(
+            total,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K = torch.randn(
+            total,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V = torch.randn(
+            total,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+
+        O = nsa(
+            Q,
+            K,
+            V,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            q_tile_size=self.q_tile_size,
+            cu_seqlens=cu_seqlens,
+        )
+        O.sum().backward()
+
+        # Verify gradients are well-formed
+        assert Q.grad.shape == Q.shape
+        assert K.grad.shape == K.shape
+        assert V.grad.shape == V.shape
+        assert torch.isfinite(Q.grad).all(), "Q.grad has NaN/Inf"
+        assert torch.isfinite(K.grad).all(), "K.grad has NaN/Inf"
+        assert torch.isfinite(V.grad).all(), "V.grad has NaN/Inf"
+
+        # Each sequence's gradients should be non-zero
+        for i, slen in enumerate(seqlens):
+            s = cu_seqlens[i].item()
+            dQ_seq = Q.grad[s : s + slen]
+            assert dQ_seq.abs().max() > 0, f"Seq {i}: dQ is all zeros"
+            dK_seq = K.grad[s : s + slen]
+            assert dK_seq.abs().max() > 0, f"Seq {i}: dK is all zeros"
+
+    def test_varlen_backward_single_sequence(self) -> None:
+        """Single-sequence varlen backward should match fixed-length."""
+        from mslk.attention.sparse_attn import nsa
+
+        torch.manual_seed(123)
+        N = 512
+        cu_seqlens = torch.tensor([0, N], dtype=torch.int32, device="cuda")
+
+        Q_3d = torch.randn(
+            N,
+            self.H,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        K_3d = torch.randn(
+            N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        V_3d = torch.randn(
+            N,
+            self.H_kv,
+            self.D,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+
+        O_3d = nsa(
+            Q_3d,
+            K_3d,
+            V_3d,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            q_tile_size=self.q_tile_size,
+            cu_seqlens=cu_seqlens,
+        )
+        O_3d.sum().backward()
+
+        Q_4d = Q_3d.data.unsqueeze(0).clone().requires_grad_(True)
+        K_4d = K_3d.data.unsqueeze(0).clone().requires_grad_(True)
+        V_4d = V_3d.data.unsqueeze(0).clone().requires_grad_(True)
+
+        O_4d = nsa(
+            Q_4d,
+            K_4d,
+            V_4d,
+            compress_block_size=self.compress_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            window_size=self.window_size,
+            q_tile_size=self.q_tile_size,
+        )
+        O_4d.sum().backward()
+
+        dQ_diff = (Q_3d.grad.float() - Q_4d.grad.squeeze(0).float()).abs().max().item()
+        assert dQ_diff < 0.01, f"dQ max_diff={dQ_diff}"
+        dK_diff = (K_3d.grad.float() - K_4d.grad.squeeze(0).float()).abs().max().item()
+        assert dK_diff < 0.01, f"dK max_diff={dK_diff}"
+        dV_diff = (V_3d.grad.float() - V_4d.grad.squeeze(0).float()).abs().max().item()
+        assert dV_diff < 0.01, f"dV max_diff={dV_diff}"

--- a/test/attention/test_sparse_attn_reference.py
+++ b/test/attention/test_sparse_attn_reference.py
@@ -1,0 +1,80 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_forward_reference_basic():
+    """Reference forward produces valid output shape."""
+    from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+    B, N, H, D = 1, 512, 4, 128
+    H_kv = 2
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    O = nsa_forward_reference(Q, K, V, compress_block_size=64, num_selected_blocks=4)
+    assert O.shape == Q.shape
+    assert O.dtype == Q.dtype
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_forward_reference_with_weights():
+    """Reference forward with learned compression + gating weights."""
+    from mslk.attention.sparse_attn.reference import nsa_forward_reference
+
+    B, N, H, D = 1, 512, 4, 128
+    H_kv = 2
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.bfloat16)
+    W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16)
+    W_v = torch.randn(H_kv, D, D, device="cuda", dtype=torch.bfloat16)
+    gate_w = torch.randn(H, 3, D, device="cuda", dtype=torch.bfloat16)
+
+    O = nsa_forward_reference(
+        Q,
+        K,
+        V,
+        W_k_compress=W_k,
+        W_v_compress=W_v,
+        gate_proj_weight=gate_w,
+    )
+    assert O.shape == Q.shape
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_nsa_backward_reference():
+    """Reference backward produces gradients for all inputs."""
+    from mslk.attention.sparse_attn.reference import (
+        compute_block_indices_reference,
+        nsa_backward_reference,
+    )
+
+    B, N, H, D = 1, 512, 4, 128
+    H_kv = 2
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.float32)
+    K = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+    V = torch.randn(B, N, H_kv, D, device="cuda", dtype=torch.float32)
+    dO = torch.randn(B, N, H, D, device="cuda", dtype=torch.float32)
+    W_k = torch.randn(H_kv, D, D, device="cuda", dtype=torch.float32)
+    gate_w = torch.randn(H, 3, D, device="cuda", dtype=torch.float32)
+
+    block_indices = compute_block_indices_reference(Q, K, W_k_compress=W_k)
+    grads = nsa_backward_reference(
+        Q,
+        K,
+        V,
+        dO,
+        W_k_compress=W_k,
+        gate_proj_weight=gate_w,
+        _block_indices=block_indices,
+    )
+
+    assert grads["dQ"].shape == Q.shape
+    assert grads["dK"].shape == K.shape
+    assert grads["dV"].shape == V.shape
+    assert grads["dW_k_compress"].shape == W_k.shape
+    assert grads["dgate_proj_weight"].shape == gate_w.shape

--- a/test/attention/test_sparse_attn_select.py
+++ b/test/attention/test_sparse_attn_select.py
@@ -1,0 +1,71 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_score_and_select_blocks_basic():
+    """Block selection returns valid indices with correct shape."""
+    from mslk.attention.sparse_attn.select import score_and_select_blocks
+
+    B, N, H, D = 1, 1024, 4, 128
+    H_kv = 2
+    block_size = 64
+    num_selected = 8
+    q_tile_size = 256
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    N_cmp = N // block_size
+    K_cmp = torch.randn(B, N_cmp, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    indices = score_and_select_blocks(
+        Q,
+        K_cmp,
+        num_selected,
+        block_size,
+        causal=True,
+        q_tile_size=q_tile_size,
+    )
+
+    N_q_tiles = N // q_tile_size
+    assert indices.shape == (B, H, N_q_tiles, num_selected)
+    assert indices.dtype == torch.int32
+
+    # All indices should be valid (in range [0, N_cmp))
+    assert (indices >= 0).all()
+    assert (indices < N_cmp).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_score_and_select_blocks_causal():
+    """Causal masking prevents selecting future blocks."""
+    from mslk.attention.sparse_attn.select import score_and_select_blocks
+
+    B, N, H, D = 1, 1024, 2, 128
+    H_kv = 2
+    block_size = 64
+    num_selected = 4
+    q_tile_size = 256
+
+    Q = torch.randn(B, N, H, D, device="cuda", dtype=torch.bfloat16)
+    N_cmp = N // block_size
+    K_cmp = torch.randn(B, N_cmp, H_kv, D, device="cuda", dtype=torch.bfloat16)
+
+    indices = score_and_select_blocks(
+        Q,
+        K_cmp,
+        num_selected,
+        block_size,
+        causal=True,
+        q_tile_size=q_tile_size,
+    )
+
+    # For the first query tile (positions 0..255), future blocks start at
+    # block j where j * block_size >= q_tile_size = 256, i.e. j >= 4
+    first_tile_indices = indices[:, :, 0]
+    max_allowed_block = q_tile_size // block_size - 1  # block 3
+    # All selected blocks for tile 0 should be <= max_allowed_block
+    assert (first_tile_indices <= max_allowed_block).all(), (
+        f"First tile selected future blocks: {first_tile_indices}"
+    )

--- a/test/attention/test_sparse_attn_sparsity_masks.py
+++ b/test/attention/test_sparse_attn_sparsity_masks.py
@@ -1,0 +1,61 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_build_fa4_block_sparse_expansion():
+    """Expansion case: compress_block_size >= n_block_size."""
+    from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+    B, H, N_q_tiles, k = 1, 2, 4, 3
+    compress_block_size = 256
+    n_block_size = 128
+    ratio = compress_block_size // n_block_size
+
+    block_indices = torch.tensor(
+        [[[[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]]],
+        dtype=torch.int32,
+        device="cuda",
+    ).expand(B, H, N_q_tiles, k)
+
+    result = build_fa4_block_sparse_tensors(
+        block_indices,
+        compress_block_size,
+        n_block_size=n_block_size,
+        seqlen_k=2048,
+    )
+
+    assert result.full_block_cnt.shape == (B, H, N_q_tiles)
+    assert (result.full_block_cnt == k * ratio).all()
+    assert result.full_block_idx.shape == (B, H, N_q_tiles, k * ratio)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_build_fa4_block_sparse_contraction():
+    """Contraction case: compress_block_size < n_block_size with dedup."""
+    from mslk.attention.sparse_attn.sparsity_masks import build_fa4_block_sparse_tensors
+
+    B, H = 1, 1
+    compress_block_size = 64
+    n_block_size = 128
+
+    # Blocks 0,1 -> FA4 block 0; blocks 2,3 -> FA4 block 1
+    block_indices = torch.tensor(
+        [[[[0, 1, 2, 3], [0, 2, 4, 6]]]],
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    result = build_fa4_block_sparse_tensors(
+        block_indices,
+        compress_block_size,
+        n_block_size=n_block_size,
+        seqlen_k=1024,
+    )
+
+    # Tile 0: blocks 0,1,2,3 -> FA4 blocks 0,0,1,1 -> dedup -> [0,1], count=2
+    assert result.full_block_cnt[0, 0, 0].item() == 2
+    # Tile 1: blocks 0,2,4,6 -> FA4 blocks 0,1,2,3 -> all unique, count=4
+    assert result.full_block_cnt[0, 0, 1].item() == 4


### PR DESCRIPTION
Summary:

Make the compressed branch O(N) instead of O(N^2/compress_block_size) by
selecting top-k FA4 blocks of compressed KV for each query tile.

When num_cmp_selected_blocks is set in nsa_forward() or nsa(), the compressed
branch uses block-sparse attention:
1. fused_score_and_select_all() computes one shared GEMM and derives both
   selected-branch indices AND compressed-branch FA4 block indices
2. build_compressed_block_sparse_tensors() creates FA4 sparsity metadata
3. _fa4_fwd() receives cmp_sparse_tensors for the compressed branch

This makes the full NSA pipeline O(N * k) where k is the number of selected
blocks — sub-linear in sequence length for all three branches.

Key design: compressed-branch block indices operate at the FA4 block level
(cmp_n_block_size=128), not the NSA compression block level. Scores are
aggregated per FA4 block before top-k selection.

The varlen path supports block-sparse compressed attention (padded 4D for
compressed branch, native FA4 varlen for selected + sliding).

No performance impact— block-sparse compressed attention reduces memory, not latency for small num_cmp_selected_blocks.
 {F1987648705}

Differential Revision: D99181848
