### PR TITLE
Switch FP8 Rowwise Autotuning with Heuristic (#311)

### DIFF
--- a/mslk/quantize/triton/fp8_quantize.py
+++ b/mslk/quantize/triton/fp8_quantize.py
@@ -33,16 +33,6 @@ except ModuleNotFoundError:
         yield None
 
 
-@triton.autotune(
-    configs=[
-        Config({"BLOCK_SIZE": 512}),
-        Config({"BLOCK_SIZE": 1024}),
-        Config({"BLOCK_SIZE": 2048}),
-        Config({"BLOCK_SIZE": 4096}),
-        Config({"BLOCK_SIZE": 8192}),
-    ],
-    key=["K"],
-)
 @triton.jit
 def _kernel_quantize_fp8_row(
     A,
@@ -273,6 +263,7 @@ def triton_quantize_fp8_row(
     # If input tensor is sufficiently large, we need to use int64 indexing.
     use_int64 = a.numel() > (2**31 - 1)
     grid = (num_rows,)
+    BLOCK_SIZE = min(triton.next_power_of_2(a_fp8.shape[3]), 8192)
     # Pick a conservative value for inference shapes for disabling BufferOps.
     should_disable_bufferops = torch.version.hip is not None and a_shape[0] < 32
     with disable_bufferops(should_disable_bufferops):
@@ -306,11 +297,19 @@ def triton_quantize_fp8_row(
                     if zero_start_index_M is not None
                     else None
                 ),
+                # pyre-ignore[6]: Incompatible parameter type [6]
                 TL_FP8_DTYPE=tl_dtype,
+                # pyre-ignore[6]: Incompatible parameter type [6]
                 MAX_FP8=max_fp8,
+                # pyre-ignore[6]: Incompatible parameter type [6]
                 EPS=eps,
+                # pyre-ignore[6]: Incompatible parameter type [6]
                 CLAMP_MAX=scale_ub is not None,
+                # pyre-ignore[6]: Incompatible parameter type [6]
                 JAGGED=zero_start_index_M is not None,
+                # pyre-ignore[6]: Incompatible parameter type [6]
+                BLOCK_SIZE=BLOCK_SIZE,
+                # pyre-ignore[6]: Incompatible parameter type [6]
                 USE_INT64=use_int64,
             )
 


### PR DESCRIPTION
Summary:

The MSLK fp8 rowwise quantize kernel used unneeded autotuning when we could instead use a more deterministic heuristic. This gives consistent numerical behavior which is needed to fully replace the much slower (and already deprecated) cuda kernel.

Before:
```
-----------------------------------------------------------------------------------
OpName               Problem Shape   Sim        Us         GB/s       Mem BW Util %
-----------------------------------------------------------------------------------
TritonFP8Rowwise     (128, 128)      0.001      2.721      18.25      0.75
TritonFP8Rowwise     (128, 512)      0.001      2.374      83.03      3.39
TritonFP8Rowwise     (128, 2048)     0.001      2.995      262.78     10.74
TritonFP8Rowwise     (128, 8192)     0.001      5.550      566.85     23.17
TritonFP8Rowwise     (128, 16384)    0.001      9.791      642.65     26.26
TritonFP8Rowwise     (2048, 128)     0.001      4.181      190.07     7.77
TritonFP8Rowwise     (2048, 512)     0.001      3.655      862.96     35.27
TritonFP8Rowwise     (2048, 2048)    0.001      8.249      1526.39    62.38
TritonFP8Rowwise     (2048, 8192)    0.001      27.804     1810.55    74.00
TritonFP8Rowwise     (2048, 16384)   0.001      53.698     1874.75    76.62
TritonFP8Rowwise     (8192, 128)     0.001      11.482     276.82     11.31
TritonFP8Rowwise     (8192, 512)     0.001      8.662      1456.41    59.52
TritonFP8Rowwise     (8192, 2048)    0.001      26.458     1903.60    77.80
TritonFP8Rowwise     (8192, 8192)    0.001      93.533     2152.81    87.98
TritonFP8Rowwise     (8192, 16384)   0.001      187.802    2144.20    87.63
```

After:
```
-----------------------------------------------------------------------------------
OpName               Problem Shape   Sim        Us         GB/s       Mem BW Util %
-----------------------------------------------------------------------------------
TritonFP8Rowwise     (128, 128)      0.001      2.199      22.59      0.92
TritonFP8Rowwise     (128, 512)      0.001      2.366      83.31      3.40
TritonFP8Rowwise     (128, 2048)     0.001      2.998      262.46     10.73
TritonFP8Rowwise     (128, 8192)     0.001      5.556      566.32     23.14
TritonFP8Rowwise     (128, 16384)    0.001      9.799      642.08     26.24
TritonFP8Rowwise     (2048, 128)     0.001      2.974      267.20     10.92
TritonFP8Rowwise     (2048, 512)     0.001      3.662      861.20     35.20
TritonFP8Rowwise     (2048, 2048)    0.001      8.272      1522.13    62.21
TritonFP8Rowwise     (2048, 8192)    0.001      27.816     1809.73    73.96
TritonFP8Rowwise     (2048, 16384)   0.001      53.552     1879.87    76.83
TritonFP8Rowwise     (8192, 128)     0.001      6.907      460.16     18.81
TritonFP8Rowwise     (8192, 512)     0.001      8.628      1462.09    59.75
TritonFP8Rowwise     (8192, 2048)    0.001      26.551     1896.92    77.53
TritonFP8Rowwise     (8192, 8192)    0.001      93.608     2151.08    87.91
TritonFP8Rowwise     (8192, 16384)   0.001      187.764    2144.64    87.65
```

Reviewed By: cthi

Differential Revision: D99629066


