### PR TITLE
Optimize NVFP4 stacked quantize kernel for Blackwell (#312)

### DIFF
--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -2198,7 +2198,8 @@ def _nvfp4_quantize_stacked_kernel(
     N,
     NUM_GROUPS: tl.constexpr,
     PREFIX_NUM: tl.constexpr,
-    M_PER_BLOCK: tl.constexpr = 64,  # type: ignore[Incompatible variable type]
+    BSEARCH_ITERS: tl.constexpr,
+    M_PER_BLOCK: tl.constexpr = 128,  # type: ignore[Incompatible variable type]
 ):
     """Quantize concatenated MoE activations to NVFP4 with per-expert global scales.
 
@@ -2246,7 +2247,9 @@ def _nvfp4_quantize_stacked_kernel(
     # Binary search: find largest seg_idx such that cumsum_exc[seg_idx] <= row
     lo = tl.zeros([M_PER_BLOCK], dtype=tl.int32)
     hi = tl.full([M_PER_BLOCK], NUM_GROUPS - 1, dtype=tl.int32)
-    for _ in range(10):  # log2(1024) = 10 iterations
+
+    # Optimized by KernelAgent: Use ceil(log2(NUM_GROUPS)) iterations
+    for _ in range(BSEARCH_ITERS):
         mid = (lo + hi + 1) // 2
         mid_val = tl.gather(cumsum_exc, mid, 0)
         lo = tl.where(mid_val <= rows, mid, lo)
@@ -2366,6 +2369,16 @@ def nvfp4_quantize_stacked(
         triton.cdiv(M, META["M_PER_BLOCK"]),
     )
 
+    # Optimized by KernelAgent: use larger tiles and software pipelining
+    # for M >= 256 where there are enough blocks to saturate SMs.
+    # For small M, keep defaults to avoid SM underutilization.
+    if M >= 256:
+        m_per_block = 128
+        n_stages = 3
+    else:
+        m_per_block = 64
+        n_stages = 1
+
     _nvfp4_quantize_stacked_kernel[grid](
         input,
         global_scale,
@@ -2379,6 +2392,9 @@ def nvfp4_quantize_stacked(
         # pyre-ignore[6]
         NUM_GROUPS=num_segments,
         PREFIX_NUM=triton.next_power_of_2(num_segments),
+        BSEARCH_ITERS=max(1, (num_segments - 1).bit_length()),
+        M_PER_BLOCK=m_per_block,  # pyre-ignore[6]
+        num_stages=n_stages,  # pyre-ignore[28]
     )
 
     return xq.view(torch.float4_e2m1fn_x2), scale.view(torch.float8_e4m3fn)


### PR DESCRIPTION
Summary:

Optimized by the blackwell-variant version of KernelAgent
(https://github.com/meta-pytorch/KernelAgent)

## Changes
- M_PER_BLOCK 64->128: larger tiles reduce grid size and amortize
  per-block overhead (cumsum, binary search, scale swizzle) across more rows
- Binary search 10->3 iterations: ceil(log2( 8 ))=3 is sufficient for
  NUM_GROUPS<=8 (typical MoE expert count)
- num_stages=3: enable Triton software pipelining for better memory
  latency hiding on Blackwell HBM3e

## Performance (GB200, num_groups=8, CUDA graph + buffer rotation)
Hardware roofline: 7928.064 GB/s
                                                 
                                                                          
  | Shape | Baseline GB/s (BW%) | Optimized GB/s (BW%) | Speedup |        
  |---|---|---|---|                                         
  | (128, 4096) | 585.73 (7.4%) | 637.19 (8.0%) | +8.8% |
  | (128, 8192) | 1066.98 (13.5%) | 1148.25 (14.5%) | +7.6% |             
  | (512, 4096) | 1645.02 (20.8%) | 1680.21 (21.2%) | +2.1% |             
  | (512, 8192) | 2448.34 (30.9%) | 2647.15 (33.4%) | +8.1% |             
  | (1024, 4096) | 2423.48 (30.6%) | 2651.32 (33.4%) | +9.4% |            
  | (1024, 8192) | 2582.36 (32.6%) | 2968.42 (37.4%) | +14.9% |           
  | (2048, 4096) | 2597.66 (32.8%) | 2985.64 (37.7%) | +14.9% |           
  | (2048, 8192) | 2979.82 (37.6%) | 3567.18 (45.0%) | +19.7% |           
  | (4096, 4096) | 2954.31 (37.3%) | 3540.46 (44.7%) | +19.8% |           
  | (4096, 8192) | 3019.33 (38.1%) | 3398.15 (42.9%) | +12.6% |           
  | (8192, 4096) | 3009.05 (38.0%) | 3412.37 (43.0%) | +13.4% |           
  | (8192, 8192) | 3221.37 (40.6%) | 3726.38 (47.0%) | +15.7% |           
                                                                          



**Peak BW utilization: 40.6% → 47.0% (+6.4pp)**                         
- **No regressions on any shape** — conditional M_PER_BLOCK/num_stages  
  for small vs large M                                      
 - **Small shapes (M=128):** +7.6–8.8% from binary search reduction alone
 - **Large shapes (M≥512):** +2–20% from combined optimizations

All 107 existing tests pass.

Reviewed By: cthi

Differential Revision: D99689989


