### PR TITLE
Add native MX8×MX4 mixed-precision GEMM kernel (f8f4bf16)

### DIFF
--- a/csrc/gemm/cutlass/mx8mx4bf16.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16.cu
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cutlass/util/device_memory.h>
+#include <mslk/utils/utils.h>
+#include <mslk/utils/tuning_cache.cuh>
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+#include "mx8mx4bf16/mx8mx4bf16_manifest.cuh"
+#endif
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+namespace {
+
+Kernel_mx8mx4bf16 get_kernel_via_heuristics(int M, int N, int K) {
+  if (M <= 64) {
+    return mx8mx4bf16_256_128_4_1_1;
+  }
+  if (M <= 128 && N > 4096) {
+    return mx8mx4bf16_256_128_2_1_1;
+  }
+  return mx8mx4bf16_256_128_2_2_1;
+}
+
+const std::unordered_map<std::string, Kernel_mx8mx4bf16>&
+get_mx8mx4bf16_kernels() {
+  static const std::unordered_map<std::string, Kernel_mx8mx4bf16> kernels = {
+      {"mx8mx4bf16_128_128_1_1_1", mx8mx4bf16_128_128_1_1_1},
+      {"mx8mx4bf16_128_128_2_2_1", mx8mx4bf16_128_128_2_2_1},
+      {"mx8mx4bf16_128_128_4_1_1", mx8mx4bf16_128_128_4_1_1},
+      {"mx8mx4bf16_256_128_2_1_1", mx8mx4bf16_256_128_2_1_1},
+      {"mx8mx4bf16_256_128_2_2_1", mx8mx4bf16_256_128_2_2_1},
+      {"mx8mx4bf16_256_128_4_1_1", mx8mx4bf16_256_128_4_1_1},
+      {"mx8mx4bf16_256_256_2_1_1", mx8mx4bf16_256_256_2_1_1},
+      {"mx8mx4bf16_256_256_2_4_1", mx8mx4bf16_256_256_2_4_1},
+  };
+  return kernels;
+}
+
+Kernel_mx8mx4bf16 get_kernel_via_tuning(
+    int M,
+    int N,
+    int K,
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  static TuningCache cache("mx8mx4bf16");
+
+  M = nextPowerOf2OrRoundUp(M, 1024, 1024);
+  N = nextPowerOf2OrRoundUp(N, 1024, 1024);
+  K = nextPowerOf2OrRoundUp(K, 1024, 1024);
+
+  const std::string shape_key =
+      std::to_string(M) + "_" + std::to_string(N) + "_" + std::to_string(K);
+
+  const auto& kernels = get_mx8mx4bf16_kernels();
+
+  auto kernel = cache.findBestKernelMaybeAutotune(
+      shape_key, kernels, XQ, WQ, x_scale, w_scale, output);
+  return kernel;
+}
+
+} // namespace
+
+at::Tensor mx8mx4bf16(
+    at::Tensor XQ, // MX FP8 (e4m3)
+    at::Tensor WQ, // MX FP4 (e2m1)
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    std::optional<at::Tensor> output) {
+  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
+  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
+  TORCH_CHECK(x_scale.is_cuda() && x_scale.is_contiguous());
+  TORCH_CHECK(w_scale.is_cuda() && w_scale.is_contiguous());
+
+  const auto M = XQ.size(0);
+  const auto N = WQ.size(0);
+  const auto K = XQ.size(1);
+  TORCH_CHECK(
+      K % 32 == 0,
+      "K must be a multiple of block size 32 for MX block-scaled GEMM");
+
+  if (M == 0 || N == 0 || K == 0) {
+    return at::zeros({M, N}, XQ.options().dtype(at::kBFloat16));
+  }
+
+  at::Tensor out = output.has_value()
+      ? output.value()
+      : at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
+
+  auto kernel = [&]() {
+    if (std::getenv("MSLK_AUTOTUNE_ENABLE")) {
+      return get_kernel_via_tuning(M, N, K, XQ, WQ, x_scale, w_scale, out);
+    }
+    return get_kernel_via_heuristics(M, N, K);
+  }();
+  return kernel(XQ, WQ, x_scale, w_scale, out);
+}
+
+#else
+
+at::Tensor mx8mx4bf16(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    std::optional<at::Tensor> output) {
+  throw std::runtime_error("CUDA version is older than 12.8");
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_128_128_1_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_128_128_1_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_128_128_1_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx8mx4bf16<128, 128, 1, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_128_128_2_2_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_128_128_2_2_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_128_128_2_2_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx8mx4bf16<128, 128, 2, 2, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_128_128_4_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_128_128_4_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_128_128_4_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx8mx4bf16<128, 128, 4, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_128_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_128_2_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_256_128_2_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx8mx4bf16<256, 128, 2, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_128_2_2_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_128_2_2_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_256_128_2_2_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx8mx4bf16<256, 128, 2, 2, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_128_4_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_128_4_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_256_128_4_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx8mx4bf16<256, 128, 4, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_256_2_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_256_256_2_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx8mx4bf16<256, 256, 2, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_256_2_4_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_256_256_2_4_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_256_256_2_4_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx8mx4bf16<256, 256, 2, 4, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_common.cuh
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_common.cuh
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define CUTLASS_NAMESPACE mslk
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cutlass/util/device_memory.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
+#include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
+#include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
+// clang-format on
+
+namespace mslk::gemm {
+
+namespace cutlass = cutlass_mslk;
+
+using MXFP8 = cutlass::mx_float8_t<cutlass::float_e4m3_t>;
+using MXFP4 = cutlass::mx_float4_t<cutlass::float_e2m1_t>;
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+template <
+    int TB_M,
+    int TB_N,
+    int TBS_M,
+    int TBS_N,
+    int TBS_K>
+at::Tensor _mx8mx4bf16(
+    at::Tensor XQ, // MX FP8 (e4m3)
+    at::Tensor WQ, // MX FP4 (e2m1)
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  c10::cuda::CUDAGuard deviceGuard(XQ.device());
+
+  const int M = XQ.size(0);
+  const int N = WQ.size(0);
+  const int K = XQ.size(1);
+
+  using ElementA = MXFP8;
+  using LayoutATag = cutlass::layout::RowMajor;
+  using LayoutATag_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutATag>::type;
+  constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+
+  using ElementB = MXFP4;
+  using LayoutBTag = cutlass::layout::ColumnMajor;
+  using LayoutBTag_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutBTag>::type;
+  constexpr int AlignmentB = 128;
+
+  using ElementScale = float;
+  using ElementCompute = float;
+  using ElementAccumulator = float;
+
+  using ElementOutput = cutlass::bfloat16_t;
+  using LayoutOutputTag = cutlass::layout::RowMajor;
+  using LayoutOutputTag_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutOutputTag>::type;
+  constexpr int AlignmentOutput =
+      128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+  using ArchTag = cutlass::arch::Sm100;
+  using OperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+
+  constexpr int TileShapeK = 256;
+
+  using MmaTileShape =
+      cute::Shape<cute::Int<TB_M>, cute::Int<TB_N>, cute::Int<TileShapeK>>;
+  using ClusterShape =
+      cute::Shape<cute::Int<TBS_M>, cute::Int<TBS_N>, cute::Int<TBS_K>>;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          MmaTileShape,
+          ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementAccumulator,
+          void,
+          void,
+          0,
+          ElementOutput,
+          LayoutOutputTag_Transpose,
+          AlignmentOutput,
+          cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          ElementB,
+          LayoutBTag_Transpose,
+          AlignmentB,
+          ElementA,
+          LayoutATag_Transpose,
+          AlignmentA,
+          ElementAccumulator,
+          MmaTileShape,
+          ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      cute::Shape<int, int, int, int>,
+      CollectiveMainloop,
+      CollectiveEpilogue,
+      void>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using LayoutA =
+      decltype(cute::make_layout(cute::make_shape(0, 0, 0), StrideA{}));
+  using LayoutSFA = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using LayoutB =
+      decltype(cute::make_layout(cute::make_shape(0, 0, 0), StrideB{}));
+  using LayoutSFB = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFB;
+  using StrideOutput = typename Gemm::GemmKernel::StrideC;
+  using LayoutOutput =
+      decltype(cute::make_layout(cute::make_shape(0, 0, 0), StrideOutput{}));
+
+  using Sm1xxBlkScaledConfig =
+      typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+
+  StrideA stride_A =
+      cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, 1));
+  StrideB stride_B =
+      cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N, K, 1));
+  StrideOutput stride_output = cutlass::make_cute_packed_stride(
+      StrideOutput{}, cute::make_shape(N, M, 1));
+
+  LayoutA layout_A = make_layout(cute::make_shape(M, K, 1), stride_A);
+  LayoutB layout_B = make_layout(cute::make_shape(N, K, 1), stride_B);
+  LayoutOutput layout_output =
+      make_layout(cute::make_shape(N, M, 1), stride_output);
+  LayoutSFA layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+      cute::make_shape(M, N, K, 1));
+  LayoutSFB layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+      cute::make_shape(M, N, K, 1));
+
+  using DataTypeA = typename ElementA::DataType;
+  using DataTypeB = typename ElementB::DataType;
+  using SFTypeA = typename ElementA::ScaleFactorType;
+  using SFTypeB = typename ElementB::ScaleFactorType;
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {N, M, K, 1},
+      {// Mainloop arguments
+       reinterpret_cast<DataTypeB*>(WQ.data_ptr()),
+       stride_B,
+       reinterpret_cast<DataTypeA*>(XQ.data_ptr()),
+       stride_A,
+       reinterpret_cast<SFTypeB*>(w_scale.data_ptr()),
+       layout_SFB,
+       reinterpret_cast<SFTypeA*>(x_scale.data_ptr()),
+       layout_SFA},
+      {// Epilogue arguments
+       {1, 0},
+       reinterpret_cast<ElementOutput*>(output.data_ptr()),
+       stride_output,
+       reinterpret_cast<ElementOutput*>(output.data_ptr()),
+       stride_output}};
+
+  Gemm gemm;
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  at::Tensor workspace =
+      at::empty(workspace_size, XQ.options().dtype(at::kByte));
+
+  cutlass::Status status = gemm.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  status = gemm.initialize(arguments, workspace.data_ptr());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm(at::cuda::getCurrentCUDAStream());
+
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot run") +
+        cutlass::cutlassGetStatusString(status));
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return output;
+}
+
+#endif
+
+} // namespace mslk::gemm
+
+#undef CUTLASS_NAMESPACE

--- a/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_manifest.cuh
+++ b/csrc/gemm/cutlass/mx8mx4bf16/mx8mx4bf16_manifest.cuh
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_128_128_1_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+
+at::Tensor mx8mx4bf16_128_128_2_2_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+
+at::Tensor mx8mx4bf16_256_128_2_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+
+at::Tensor mx8mx4bf16_256_128_2_2_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+
+at::Tensor mx8mx4bf16_256_256_2_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+
+at::Tensor mx8mx4bf16_256_256_2_4_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+
+at::Tensor mx8mx4bf16_256_128_4_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+
+at::Tensor mx8mx4bf16_128_128_4_1_1(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+
+using Kernel_mx8mx4bf16 =
+    at::Tensor (*)(at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor);
+
+#endif
+} // namespace mslk::gemm

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -53,6 +53,8 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   m.def(
       "f4f4bf16(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? output=None, Tensor? global_scale=None, int mxfp4_block_size=32) -> Tensor");
   m.def(
+      "mx8mx4bf16(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? output=None) -> Tensor");
+  m.def(
       "f4f4bf16_grouped_stacked(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes, Tensor? global_scale=None, Tensor? starting_row_after_padding=None, bool use_mx=True) -> Tensor");
   m.def(
       "mx8mx8bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None, int? actual_num_tokens=None) -> Tensor");
@@ -114,6 +116,7 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("f8f8bf16_groupwise_grouped", f8f8bf16_groupwise_grouped);
   m.impl("i8i8bf16", i8i8bf16);
   m.impl("f4f4bf16", f4f4bf16);
+  m.impl("mx8mx4bf16", mx8mx4bf16);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
   m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
   m.impl("f4f4bf16_grouped_mm", f4f4bf16_grouped_mm);
@@ -161,6 +164,7 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("f8f8bf16_groupwise_grouped", f8f8bf16_groupwise_grouped);
   m.impl("i8i8bf16", i8i8bf16);
   m.impl("f4f4bf16", f4f4bf16);
+  m.impl("mx8mx4bf16", mx8mx4bf16);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
   m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
   m.impl("f4f4bf16_grouped_mm", f4f4bf16_grouped_mm);
@@ -199,6 +203,30 @@ at::Tensor f4f4bf16_meta(
     std::optional<at::Tensor> /* output = std::nullopt */,
     std::optional<at::Tensor> /* global_scale = std::nullopt */,
     int64_t /* mxfp4_block_size = 32 */) {
+  const at::SymInt M = XQ.sym_size(0);
+  const at::SymInt N = WQ.sym_size(0);
+  auto Y = at::empty_symint({M, N}, XQ.options().dtype(at::kBFloat16));
+  return Y;
+}
+
+at::Tensor mx8mx4bf16_meta(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP4
+    at::Tensor /* x_scale */,
+    at::Tensor /* w_scale */,
+    std::optional<at::Tensor> /* output = std::nullopt */) {
+  const at::SymInt M = XQ.sym_size(0);
+  const at::SymInt N = WQ.sym_size(0);
+  auto Y = at::empty_symint({M, N}, XQ.options().dtype(at::kBFloat16));
+  return Y;
+}
+
+at::Tensor mx8mx8bf16_meta(
+    at::Tensor XQ, // MX FP8
+    at::Tensor WQ, // MX FP8
+    at::Tensor /* x_scale */,
+    at::Tensor /* w_scale */,
+    std::optional<at::Tensor> /* output = std::nullopt */) {
   const at::SymInt M = XQ.sym_size(0);
   const at::SymInt N = WQ.sym_size(0);
   auto Y = at::empty_symint({M, N}, XQ.options().dtype(at::kBFloat16));
@@ -528,6 +556,7 @@ TORCH_LIBRARY_IMPL(mslk, Meta, m) {
 #else
   m.impl("i8i8bf16", i8i8bf16_meta);
   m.impl("f4f4bf16", f4f4bf16_meta);
+  m.impl("mx8mx4bf16", mx8mx4bf16_meta);
   m.impl("f8f8bf16", f8f8bf16_meta);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas_meta);
   m.impl("bf16x9_gemm", bf16x9_gemm_meta);

--- a/include/mslk/gemm/gemm.h
+++ b/include/mslk/gemm/gemm.h
@@ -231,4 +231,13 @@ std::tuple<at::Tensor, at::Tensor> preshuffle_i4(
     at::Tensor WQ,
     at::Tensor w_scale);
 
+// Mixed MX8 x MX4 GEMM using mxf8f6f4 block-scaled tensor core instruction
+// ElementA = mx_float8_t<float_e4m3_t>, ElementB = mx_float4_t<float_e2m1_t>
+at::Tensor mx8mx4bf16(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    std::optional<at::Tensor> output = std::nullopt);
+
 } // namespace mslk::gemm

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -2781,3 +2781,43 @@ class MXFP4BlockSize16Tests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class MX8MX4Tests(unittest.TestCase):
+    """Tests for the mixed MX8 x MX4 CUTLASS GEMM kernel (mx8mx4bf16)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.device = torch.accelerator.current_accelerator()
+
+    @settings(deadline=None)
+    @given(
+        M=st.sampled_from([1, 64, 256]),
+        N=st.sampled_from([256, 1024]),
+        K=st.sampled_from([2048, 4096]),
+    )
+    def test_gemm(self, M: int, N: int, K: int) -> None:
+        from mslk.gemm.triton.fp8_gemm import to_mxfp8
+
+        A = torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        B = torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+
+        # Quantize A to MX8 with blocked scale layout
+        (a_scale_raw, aq) = to_mxfp8(A)
+        a_scale = _to_blocked(a_scale_raw.view(torch.int8).reshape(M, -1)).view(
+            torch.uint8
+        )
+
+        # Quantize B to MX4
+        bq, b_scale = triton_quantize_mx4_unpack(B)
+        bq = bq.view(torch.float4_e2m1fn_x2)
+
+        out_mx8mx4 = torch.ops.mslk.mx8mx4bf16(aq, bq, a_scale, b_scale)
+        out_bf16 = A @ B.t()
+
+        # No NaN or Inf
+        self.assertFalse(out_mx8mx4.isnan().any().item(), "Output contains NaN")
+        self.assertFalse(out_mx8mx4.isinf().any().item(), "Output contains Inf")
+
+        # Mixed MX8xMX4 has higher tolerance than MX4xMX4 due to mixed precision
+        torch.testing.assert_close(out_mx8mx4, out_bf16, atol=1.0e-1, rtol=1.0e-1)


### PR DESCRIPTION
Summary:
Add a native mixed-precision CUTLASS GEMM kernel for MX8 (MXFP8 e4m3) x MX4 (MXFP4 e2m1) using the Blackwell mxf8f6f4 block-scaled tensor core instruction.

This follows the exact same dispatch path as the CUTLASS 4.3.5 example 72c_blackwell_mixed_mxfp8_bf16_gemm.cu: separate ElementA = mx_float8_t<float_e4m3_t> and ElementB = mx_float4_t<float_e2m1_t> types with OpClassBlockScaledTensorOp and KernelScheduleAuto, which causes the CollectiveBuilder to auto-select the mxf8f6f4 variant of the block-scaled tensor core MMA instruction (tcgen05.mma.blockscaled). Both operands use E8M0 scale factors with block size 32. The kernel template uses AlignmentA=128/sizeof_bits<ElementA> (=16), AlignmentB=128 (FP4, from CUTLASS 72c example), TileShapeK=256, and TN layout.

Changes:
- New CUTLASS kernel directory mx8mx4bf16/ with 8 tile configurations
- Dispatch file with heuristic-based and autotune-based kernel selection
- TORCH_CHECK(K % 32 == 0) for block size validation
- Registered as torch.ops.mslk.mx8mx4bf16 PyTorch op (CUDA + Meta dispatch)
- Added NativeMX8MX4Quant class in quant_ops.py for benchmarking framework
- Scale format fix: to_mxfp8() returns plain row-major scales, applied _to_blocked() conversion to match CUTLASS block-scaled kernel interleaved layout

Note: native_mx8 (MX8xMX8 CUTLASS kernel) numbers shown below are from D99386004, a separate stacked diff. cuBLAS via torch._scaled_mm is 3-6x slower at small M (e.g., 1.4 vs 8.9 TFLOPS at M=1).

Benchmark on B200 (750W), N=K=8192, num_iters=20:

GEMM-Only TFLOPS (higher is better):
       | BF16 Fallback |          Native Block-Scaled Tensor Core                          |
       | (torch.matmul)|          (tcgen05.mma.blockscaled)                                |
     M | bf16_mm       | native_mx8*  | native_mx8_mx4 | native_nvfp4 | native_mxfp4     |
       |               | (mx8mx8bf16) | (mx8mx4bf16)   | (f4f4bf16)   | (f4f4bf16)       |
  -----+---------------+--------------+----------------+--------------+------------------+
     1 |           4.7 |          8.9 |            8.8 |         10.1 |             10.7 |
    16 |          88.3 |        141.4 |          143.5 |        164.5 |            175.6 |
    64 |         337.7 |        556.1 |          572.7 |        691.1 |            700.2 |
   128 |         636.3 |       1010.7 |         1120.3 |       1367.8 |           1432.4 |
   256 |         984.8 |       1806.7 |         2013.4 |       2796.2 |           2834.6 |
   512 |        1109.0 |       1987.9 |         2380.5 |       3618.0 |           4012.9 |
  1024 |        1211.0 |       2066.1 |         2457.5 |       4431.2 |           4635.4 |

  * native_mx8 CUTLASS kernel is in a separate diff (D99386004). Numbers shown for comparison only.

Output SQNR vs BF16 (dB, higher is better):
     M | native_mx8*  | native_mx8_mx4 | native_nvfp4 | native_mxfp4 |
       | (mx8mx8bf16) | (mx8mx4bf16)   | (f4f4bf16)   | (f4f4bf16)   |
  -----+--------------+----------------+--------------+--------------+
     1 |        28.56 |          18.80 |        17.56 |        16.13 |
    16 |        28.46 |          18.80 |        17.41 |        16.03 |
    64 |        28.45 |          18.79 |        17.43 |        16.06 |
   128 |        28.46 |          18.79 |        17.43 |        16.04 |
   256 |        28.46 |          18.79 |        17.43 |        16.04 |
   512 |        28.46 |          18.79 |        17.43 |        16.05 |
  1024 |        28.46 |          18.79 |        17.44 |        16.04 |

  * native_mx8 numbers from D99386004.

Activation Quantization Overhead (ms):
       |       Per-Format Quant Time          |                                        |
     M | to_mxfp8 | triton_mx4 | triton_nvfp4 | mx8_mx4 total                          |
       |          |            |              | (to_mxfp8 + _to_blocked + triton_mx4)  |
  -----+----------+------------+--------------+----------------------------------------+
     1 |    0.182 |      0.063 |        0.054 |                                  0.310 |
    16 |    0.191 |      0.055 |        0.053 |                                  0.306 |
    64 |    0.173 |      0.053 |        0.054 |                                  0.308 |
   128 |    0.179 |      0.053 |        0.053 |                                  0.272 |
   256 |    0.179 |      0.056 |        0.053 |                                  0.279 |
   512 |    0.183 |      0.071 |        0.063 |                                  0.287 |
  1024 |    0.189 |      0.053 |        0.056 |                                  0.278 |

Key takeaways:
- native_mx8_mx4 SQNR is 18.79 dB — 2.75 dB better than native_mxfp4 (16.04 dB), thanks to MX8 activation fidelity (31.49 dB input A SQNR vs 19.03 dB for MX4)
- mxf8f8 and mxf8f6f4 have the same peak throughput on B200 (~3,600 TFLOPS at 750W), so native_mx8 and native_mx8_mx4 show similar GEMM TFLOPS as expected
- The value of native_mx8_mx4 over native_mx8 is 2x weight compression (4-bit vs 8-bit) with no compute penalty and acceptable quality (18.79 dB SQNR)
- Correctness verified: 6/6 shapes pass, no NaN/Inf, consistent 18.79 dB SQNR

Reviewed By: cthi

Differential Revision: D97844552


