### PR TITLE
Add attn_vis to Triton Bench (#316)

### DIFF
--- a/mslk/attention/flash_attn/interface.py
+++ b/mslk/attention/flash_attn/interface.py
@@ -13,6 +13,7 @@ try:
     from mslk.fb.mslk.attention.flash_attn import flash_attn_func as _flash_attn_func
     from mslk.fb.mslk.attention.flash_attn.interface import (
         flash_attn_combine,
+        FlashAttnFunc,
         mslk_flash_attn_bwd as _flash_attn_bwd,
         mslk_flash_attn_decode as _flash_attn_decode,
         mslk_flash_attn_fwd as _flash_attn_fwd,
@@ -23,6 +24,7 @@ except ImportError:
         _flash_attn_fwd,
         flash_attn_combine,
         flash_attn_func as _flash_attn_func,
+        FlashAttnFunc,
     )
 
     _flash_attn_decode = not_implemented

--- a/mslk/attention/flash_attn/utils.py
+++ b/mslk/attention/flash_attn/utils.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from mslk.fb.mslk.attention.flash_attn.utils import *  # noqa: F401,F403


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/MSLK-NV/pull/227


X-link: https://github.com/mslsrc/mslk/pull/3

Added attn_vis to Triton Bench

Compare performance among mslk attn_vis vs fa4_flex(with mask_mode) vs triton flex_attn(with block_mask)

Reviewed By: sryap

Differential Revision: D98045422
