### PR TITLE
Gate mslk cutlass/cublas GEMM deps behind select_accelerator(mtia=[]) for MTIA builds (#318)

### DIFF
--- a/csrc/conv/conv_ops.cpp
+++ b/csrc/conv/conv_ops.cpp
@@ -18,11 +18,13 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
 #endif
 }
 
+#if !defined(USE_MTIA)
 TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
 #ifndef USE_ROCM
   m.impl("f8f8bf16_conv", f8f8bf16_conv);
 #endif
 }
+#endif // !defined(USE_MTIA)
 
 at::Tensor f8f8bf16_conv_meta(
     at::Tensor activation,

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -91,6 +91,7 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
 #endif
 }
 
+#if !defined(USE_MTIA)
 TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("f8f8bf16_blockwise", f8f8bf16_blockwise);
   m.impl("f8f8bf16_tensorwise", f8f8bf16_tensorwise);
@@ -135,7 +136,9 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("preshuffle_i4", preshuffle_i4);
 #endif
 }
+#endif // !defined(USE_MTIA)
 
+#if !defined(USE_MTIA)
 // Unfortunately there's broken code in production sometimes calling these ops
 // on CPU for silly reasons. To prevent breaking the models, we need to keep the
 // ops registered on CPU.
@@ -183,6 +186,7 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("preshuffle_i4", preshuffle_i4);
 #endif
 }
+#endif // !defined(USE_MTIA)
 
 at::Tensor i8i8bf16_meta(
     at::Tensor XQ, // INT8


### PR DESCRIPTION
Summary:

Move cutlass and cublas GEMM deps from cuda_deps to select_accelerator in
mslk/csrc/gemm:gemm_ops. The gpu_cpp_library macro's cuda_deps parameter
does not exclude deps for MTIA builds because MTIA is treated as a GPU
platform. Using select_accelerator(cuda=[...], mtia=[]) explicitly excludes
these CUDA-only kernel libraries from MTIA builds.

This gates 20 cutlass targets and 1 cublas target from the MTIA Athena
dep graph. These are CUDA kernel implementations (cutlass GEMM, cublas GEMM)
that MTIA cannot execute.

#build_oncall[mtia_sw_inference]

Reviewed By: cthi

Differential Revision: D99231444
