### PR TITLE
[CUDA] [PERFORMANCE] Increase speed of bf16bf16bf16_grouped_wgrad via indicating that ElementC is void / nullptr

### DIFF
--- a/csrc/gemm/cutlass/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_common.cuh
+++ b/csrc/gemm/cutlass/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_common.cuh
@@ -184,7 +184,7 @@ at::Tensor bf16bf16bf16_grouped_wgrad_impl(
           cutlass::epilogue::collective::EpilogueTileAuto,
           ElementAccumulator,
           ElementAccumulator,
-          ElementC, // Use source tensor for epilogue operations.
+          void,
           LayoutC*,
           128 / cutlass::sizeof_bits<ElementC>::value,
           ElementC,
@@ -327,7 +327,7 @@ at::Tensor bf16bf16bf16_grouped_wgrad_impl(
       {kernel_groups, problem_shape_ptr, nullptr},
       {x_ptr, stride_a_ptr, w_ptr, stride_b_ptr},
       {{},
-       (const ElementC**)output_ptr,
+       OUTPUT_ACCUM ? (const ElementC**)output_ptr : nullptr,
        stride_c_ptr,
        output_ptr,
        stride_c_ptr}};
@@ -499,7 +499,7 @@ at::Tensor bf16bf16bf16_grouped_wgrad_sm100_impl(
           cutlass::epilogue::collective::EpilogueTileAuto,
           ElementAccumulator,
           ElementAccumulator,
-          ElementC, // Use source tensor for epilogue operations.
+          void,
           LayoutC*,
           128 / cutlass::sizeof_bits<ElementC>::value,
           ElementC,
@@ -642,7 +642,7 @@ at::Tensor bf16bf16bf16_grouped_wgrad_sm100_impl(
       {kernel_groups, problem_shape_ptr, nullptr},
       {x_ptr, stride_a_ptr, w_ptr, stride_b_ptr},
       {{},
-       (const ElementC**)output_ptr,
+       OUTPUT_ACCUM ? (const ElementC**)output_ptr : nullptr,
        stride_c_ptr,
        output_ptr,
        stride_c_ptr}};


### PR DESCRIPTION
I'm not quite sure whether it's true that we really don't have beta scaling here / ElementC needed here and I've not tested the changes because I don't have a cuda device, but I'm pretty confident that this is correct, but I'm not 100% sure whether this works correctly and I'm also not 100% sure whether it increases performance and doesn't decrease performance or let it be the same (I'm not 100% sure in general (because it's not tested) and also I'm not 100% sure because we use another check ("OUTPUT_ACCUM ? ... : ...,") two times (but I think it should automatically be constexpr) and also I'm not quite sure because of other things (and I'm not quite sure in general, in terms of performance and in terms of correctness (and in all terms I'm not 100% sure (also I'm not quite sure whether it's true that we really don't have beta scaling here / ElementC needed here)) (as already said), so please correct me if I'm mistaken))

Contributed by Benedikt Johannes