### PR TITLE
Fix TRITON_ALLOW_NON_CONSTEXPR_GLOBALS in fp4 grouped quant

### DIFF
--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -2224,6 +2224,8 @@ def _nvfp4_quantize_stacked_kernel(
     """
     tl.static_assert(M_PER_BLOCK <= 128)
     E4M3_EPS: tl.constexpr = 1.5258789e-05  # type: ignore[Incompatible variable type]
+    FP8_E4M3_MAX = 448.0  # type: ignore[Incompatible variable type]
+    FP4_E2M1_MAX: tl.constexpr = 6  # type: ignore[Incompatible variable type]
 
     NUM_ELEM_PER_LAYOUT: tl.constexpr = 128 * 4  # type: ignore[Incompatible variable type]
     NUM_N_BLOCKS = tl.cdiv(N, 64)


### PR DESCRIPTION
Summary: as titled

Differential Revision: D102351505


