### PR TITLE
Update OSS build and README (#332)

### DIFF
--- a/.github/scripts/generate_ci_matrix.py
+++ b/.github/scripts/generate_ci_matrix.py
@@ -283,8 +283,8 @@ class BuildConfigScheme:
 
     def cuda_versions(self) -> List[str]:
         if GitRepo.ref() == REFS_MAIN and GitRepo.event_name() == EVENT_NAME_PUSH:
-            return ["12.8.1"]
-        return ["12.6.3", "12.8.1", "12.9.1", "13.0.2"]
+            return ["13.0.2"]
+        return ["13.0.2"]
 
     def rocm_versions(self) -> List[str]:
         if GitRepo.ref() == REFS_MAIN and GitRepo.event_name() == EVENT_NAME_PUSH:

--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -59,7 +59,7 @@ jobs:
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter desired_cuda:cu126 )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -55,15 +55,14 @@ jobs:
       env:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
       # Nova Coordinate Filters:
-      # cuda/11.8: No longer supported in MSLK
-      # cuda/12.9: No longer supported in PyTorch
+      # cuda/12.6: No longer supported in MSLK
       # rocm/3.13t: causes segfaults at runtime
       # python/3.14: torch.compile support is missing, see https://github.com/pytorch/pytorch/issues/156856
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'desired_cuda:cu126' --filter 'gpu_arch_type:rocm;python_version:3.13t' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/mslk_release_cuda.yml
+++ b/.github/workflows/mslk_release_cuda.yml
@@ -34,8 +34,8 @@ on:
         description: CUDA Version to Use for Building Artifact
         type: choice
         required: false
-        options: [ "12.6.3", "12.8.1", "12.9.1", "13.0.2" ]
-        default: "12.8.1"
+        options: [ "13.0.2" ]
+        default: "13.0.2"
       publish-to-pypi:
         description: Publish Artifact to PyPI
         type: boolean

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ primitives for GenAI training and inference.
 
 ```bash
 # Install MSLK for CUDA
-pip install mslk-cuda==1.0.0
+pip install mslk --index-url https://download.pytorch.org/whl/cu130
 # Install MSLK for ROCm
-pip install mslk-rocm==1.0.0
+pip install mslk --index-url https://download.pytorch.org/whl/rocm7.1/
 # Install a nightly CUDA version
-pip install --pre mslk --index-url https://download.pytorch.org/whl/nightly/cu128
+pip install --pre mslk --index-url https://download.pytorch.org/whl/nightly/cu130
 # Install a nightly ROCm version
 pip install --pre mslk --index-url https://download.pytorch.org/whl/nightly/rocm7.1/
 ```

--- a/ci/scripts/mslk_build.bash
+++ b/ci/scripts/mslk_build.bash
@@ -121,15 +121,10 @@ __configure_mslk_build_nvcc () {
     -diag-suppress 20012
   )
 
-  # NOTE: This check covers both Nova and non-Nova builds, as we set
-  # BUILD_CUDA_VERSION to be CU_VERSION in the Nova build case
-  if ! [[ "$BUILD_CUDA_VERSION" =~ ^12.6.*$ ]] && [[ "$BUILD_CUDA_VERSION" != "cu126" ]]; then
-    # NOTE: This flag is only supported in NVCC 12.8+
-    nvcc_prepend_flags+=(
-      -diag-suppress 20280
-      -diag-suppress 20281
-    )
-  fi
+  nvcc_prepend_flags+=(
+    -diag-suppress 20280
+    -diag-suppress 20281
+  )
 
   if print_exec "conda run ${env_prefix} c++ --version | grep -i clang"; then
     echo "[BUILD] Host compiler is clang; setting stdlib to libstdc++..."
@@ -300,18 +295,11 @@ __configure_mslk_build_cuda () {
     # NOTE: It turns out that the order of the arch_list matters, and that
     # appending 7.0/7.5 to the back of the list mysteriously results in
     # undefined symbol errors on .SO loads
-    if  [[ $cuda_version_nvcc == *"V13.0"* ]] ||
-          [[ $cuda_version_nvcc == *"V12.9"* ]] ||
-          [[ $cuda_version_nvcc == *"V12.8"* ]]; then
+    if  [[ $cuda_version_nvcc == *"V13.0"* ]]; then
       local arch_list="8.0;9.0a;10.0a;12.0a"
 
-    elif  [[ $cuda_version_nvcc == *"V12.6"* ]] ||
-          [[ $cuda_version_nvcc == *"V12.4"* ]] ||
-          [[ $cuda_version_nvcc == *"V12.1"* ]]; then
-      local arch_list="8.0;9.0a"
-
     else
-      local arch_list="8.0;9.0a"
+      local arch_list="8.0;9.0a;10.0a;12.0a"
       echo "[BUILD] Unknown NVCC version $cuda_version_nvcc - setting TORCH_CUDA_ARCH_LIST to: ${arch_list}"
     fi
   fi
@@ -344,7 +332,7 @@ __configure_mslk_build_cuda () {
     -DTORCH_CUDA_ARCH_LIST="'${arch_list}'"
   )
 
-  # Explicitly set CUDA_HOME (for CUDA 12.6+)
+  # Explicitly set CUDA_HOME
   __configure_mslk_cuda_home
 
   # Set NVCC flags

--- a/ci/scripts/mslk_install.bash
+++ b/ci/scripts/mslk_install.bash
@@ -197,8 +197,8 @@ install_mslk_pip () {
     echo "Usage: ${FUNCNAME[0]} ENV_NAME MSLK_CHANNEL[/VERSION] MSLK_VARIANT_TYPE[/VARIANT_VERSION]"
     echo "Example(s):"
     echo "    ${FUNCNAME[0]} build_env 0.8.0 cpu                  # Install the CPU variant, specific version from release channel"
-    echo "    ${FUNCNAME[0]} build_env release cuda/12.6.3        # Install the CUDA 12.3 variant, latest version from release channel"
-    echo "    ${FUNCNAME[0]} build_env test/0.8.0 cuda/12.6.3     # Install the CUDA 12.3 variant, specific version from test channel"
+    echo "    ${FUNCNAME[0]} build_env release cuda/13.0.0        # Install the CUDA 13.0 variant, latest version from release channel"
+    echo "    ${FUNCNAME[0]} build_env test/0.8.0 cuda/13.0.0     # Install the CUDA 13.0 variant, specific version from test channel"
     echo "    ${FUNCNAME[0]} build_env nightly rocm/6.2           # Install the ROCM 6.2 variant, latest version from nightly channel"
     return 1
   else

--- a/ci/scripts/mslk_integration.bash
+++ b/ci/scripts/mslk_integration.bash
@@ -26,7 +26,7 @@ integration_setup_conda_environment () {
   if [ "$pytorch_variant_type_version" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME COMPILER PYTHON_VERSION PYTORCH_INSTALLER PYTORCH_CHANNEL[/VERSION] PYTORCH_VARIANT_TYPE/PYTORCH_VARIANT_VERSION"
     echo "Example(s):"
-    echo "    ${FUNCNAME[0]} build_env clang 3.13 pip test/1.0.0 cuda/12.6.3       # Setup environment with pytorch-test 1.0.0 for Clang + Python 3.13 + CUDA 12.6.3"
+    echo "    ${FUNCNAME[0]} build_env clang 3.13 pip test/1.0.0 cuda/13.0.0       # Setup environment with pytorch-test 1.0.0 for Clang + Python 3.13 + CUDA 13.0.0"
     return 1
   else
     echo "################################################################################"
@@ -201,9 +201,6 @@ integration_mslk_pip_install_matrix_run () {
 
   if [ "$variant_type" == "cuda" ]; then
     local variant_versions=(
-      12.6.3
-      12.8.1
-      12.9.1
       13.0.0
     )
   elif [ "$variant_type" == "rocm" ]; then

--- a/ci/scripts/utils_build.bash
+++ b/ci/scripts/utils_build.bash
@@ -148,15 +148,15 @@ __remove_gcc_activation_scripts () {
   #   https://github.com/conda-forge/ctng-compiler-activation-feedstock/blob/main/recipe/activate-g%2B%2B.sh
   #
   # When we build under CUDA + Clang, we have to set NVCC_PREPEND_FLAGS to point
-  # out Clang as the host compiler.  But CUDA, as of 12.6+, also comes with its
-  # own activation scripts, where NVCC_PREPEND_FLAGS is appended to point out
-  # CXX as the host compiler.  See
+  # out Clang as the host compiler.  But CUDA also comes with its own activation
+  # scripts, where NVCC_PREPEND_FLAGS is appended to point out CXX as the host
+  # compiler.  See
   #   https://github.com/conda-forge/cuda-nvcc-feedstock/issues/20
   #   https://github.com/conda-forge/cuda-nvcc-feedstock/blob/main/recipe/activate.sh
   #
   # When -ccbin is added twice to NVCC_PREPEND_FLAGS, the last entry wins, and
   # so combining these two phenomenon, it becomes impossible to actually set
-  # Clang as the host compiler in CUDA 12.6+.
+  # Clang as the host compiler.
   #
   # The workaround for this issue is to delete the activation scripts for gcc,
   # since we only need gcc for the presence of libstdc++ when we build using
@@ -164,13 +164,11 @@ __remove_gcc_activation_scripts () {
   #   https://stackoverflow.com/questions/64289376/how-to-circumvent-anaconda-gcc-compiler
   #
   # shellcheck disable=SC2155,SC2086
-  if [[ "$BUILD_CUDA_VERSION" =~ ^12.6.*$ ]]; then
-      echo "[INSTALL] Removing GCC package activation scripts ..."
-      local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
-      print_exec ls -la ${conda_prefix}/etc/conda/activate.d
-      print_exec rm -rf ${conda_prefix}/etc/conda/activate.d/activate-gcc_linux-${COMPILER_ARCHNAME}.sh
-      print_exec rm -rf ${conda_prefix}/etc/conda/activate.d/activate-gxx_linux-${COMPILER_ARCHNAME}.sh
-  fi
+  echo "[INSTALL] Removing GCC package activation scripts ..."
+  local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
+  print_exec ls -la ${conda_prefix}/etc/conda/activate.d
+  print_exec rm -rf ${conda_prefix}/etc/conda/activate.d/activate-gcc_linux-${COMPILER_ARCHNAME}.sh
+  print_exec rm -rf ${conda_prefix}/etc/conda/activate.d/activate-gxx_linux-${COMPILER_ARCHNAME}.sh
 }
 
 __conda_install_clang () {

--- a/ci/scripts/utils_cuda.bash
+++ b/ci/scripts/utils_cuda.bash
@@ -18,27 +18,19 @@ __set_cuda_symlinks_envvars () {
   local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
   local new_cuda_home="${conda_prefix}/targets/${MACHINE_NAME_LC}-linux"
 
-  if  [[ "$BUILD_CUDA_VERSION" =~ ^11.*$ ]] ||
-      [[ "$BUILD_CUDA_VERSION" =~ ^12.1.*$ ]] ||
-      [[ "$BUILD_CUDA_VERSION" =~ ^12.4.*$ ]]; then
-    echo "[INSTALL] Target CUDA version is ${BUILD_CUDA_VERSION}, no need to add extra symlinks and env vars ..."
+  # NVTX has been moved in CUDA 12.6+ package layout, which causes PyTorch
+  # CMake scripts to complain.
+  echo "[INSTALL] Fixing file placements for CUDA ${BUILD_CUDA_VERSION} ..."
 
-  else
-    # CUDA 12.6 installation has a very different package layout than previous
-    # CUDA versions - notably, NVTX has been moved elsewhere, which causes
-    # PyTorch CMake scripts to complain.
-    echo "[INSTALL] Fixing file placements for CUDA ${BUILD_CUDA_VERSION}+ ..."
+  echo "[INSTALL] Creating symlinks: libnvToolsExt.so"
+  print_exec ln -sf "${conda_prefix}/lib/libnvToolsExt.so.1" "${conda_prefix}/lib/libnvToolsExt.so"
+  print_exec ln -sf "${new_cuda_home}/lib/libnvToolsExt.so.1" "${new_cuda_home}/lib/libnvToolsExt.so"
 
-    echo "[INSTALL] Creating symlinks: libnvToolsExt.so"
-    print_exec ln -sf "${conda_prefix}/lib/libnvToolsExt.so.1" "${conda_prefix}/lib/libnvToolsExt.so"
-    print_exec ln -sf "${new_cuda_home}/lib/libnvToolsExt.so.1" "${new_cuda_home}/lib/libnvToolsExt.so"
-
-    echo "[INSTALL] Copying nvtx3 headers ..."
-    # shellcheck disable=SC2086
-    print_exec cp -r ${conda_prefix}/nsight-compute*/host/*/nvtx/include/nvtx3/* ${conda_prefix}/include/
-    # shellcheck disable=SC2086
-    print_exec cp -r ${conda_prefix}/nsight-compute*/host/*/nvtx/include/nvtx3/* ${new_cuda_home}/include/
-  fi
+  echo "[INSTALL] Copying nvtx3 headers ..."
+  # shellcheck disable=SC2086
+  print_exec cp -r ${conda_prefix}/nsight-compute*/host/*/nvtx/include/nvtx3/* ${conda_prefix}/include/
+  # shellcheck disable=SC2086
+  print_exec cp -r ${conda_prefix}/nsight-compute*/host/*/nvtx/include/nvtx3/* ${new_cuda_home}/include/
 
   echo "[INSTALL] Appending libcuda.so path to LD_LIBRARY_PATH ..."
   # shellcheck disable=SC2155
@@ -191,24 +183,8 @@ install_cuda () {
   local env_prefix=$(env_name_or_prefix "${env_name}")
   echo "[INSTALL] Installing CUDA ${cuda_version} ..."
 
-  # NOTE: Currently, CUDA 12.6 and later cannot be installed using the
-  # nvidia/label/cuda-* conda channels, because we run into the following error:
-  #
-  #   LibMambaUnsatisfiableError: Encountered problems while solving:
-  #     - nothing provides __win needed by cuda-12.6.3-0
-  #
-  # As such, we use conda-forge for installing all CUDA versions, except for
-  # versions 12.4 and below, which are only available through
-  # nvidia/label/cuda-*)
-  if  [[ "$BUILD_CUDA_VERSION" =~ ^11.*$ ]] ||
-      [[ "$BUILD_CUDA_VERSION" =~ ^12.1.*$ ]] ||
-      [[ "$BUILD_CUDA_VERSION" =~ ^12.4.*$ ]]; then
-    # shellcheck disable=SC2086
-    (exec_with_retries 3 conda install --force-reinstall ${env_prefix} -c "nvidia/label/cuda-${cuda_version}" -y \
-      cuda) || return 1
-  else
-    # shellcheck disable=SC2086
-    (exec_with_retries 3 conda install ${env_prefix} -c conda-forge --override-channels -y \
+  # shellcheck disable=SC2086
+  (exec_with_retries 3 conda install ${env_prefix} -c conda-forge --override-channels -y \
       "cuda-version=${cuda_version%.*}" \
       cuda-compiler \
       cuda-libraries-dev \
@@ -222,7 +198,6 @@ install_cuda () {
       cuda-profiler-api \
       cuda-opencl-dev \
       nsight-compute) || return 1
-  fi
 
   # Set the symlinks and environment variables not covered by conda install
   __set_cuda_symlinks_envvars

--- a/ci/scripts/utils_pip.bash
+++ b/ci/scripts/utils_pip.bash
@@ -41,7 +41,7 @@ __export_package_channel_info () {
 __export_package_variant_info () {
   local package_variant_type_version="$1"
 
-  local FALLBACK_VERSION_CUDA="12.6.3"
+  local FALLBACK_VERSION_CUDA="13.0.0"
   local FALLBACK_VERSION_ROCM="6.3"
 
   if [ "$package_variant_type_version" == "cuda" ]; then

--- a/ci/scripts/utils_pytorch.bash
+++ b/ci/scripts/utils_pytorch.bash
@@ -73,9 +73,9 @@ install_pytorch_pip () {
 
   # Install the main dependencies
   #
-  # NOTE: Since CUDA 12.6, the conda channels information after CUDA installation
-  # gets messed up, and adding the --override-channels flag is needed to get
-  # packages to be installed correctly.  See:
+  # NOTE: The conda channels information after CUDA installation gets messed up,
+  # and adding the --override-channels flag is needed to get packages to be
+  # installed correctly.  See:
   #   https://github.com/conda/conda/issues/14063#issuecomment-2244508044
   #
   # shellcheck disable=SC2086

--- a/setup.py
+++ b/setup.py
@@ -642,8 +642,8 @@ def main(argv: List[str]) -> None:
 
     # Flash Attention 3 package is optional.
     # Install with:
-    # pip install mslk[flash3] --extra-index-url https://download.pytorch.org/whl/cu126
-    # where cu126 changes to match the cuda version..
+    # pip install mslk[flash3] --extra-index-url https://download.pytorch.org/whl/cu130
+    # where cu130 changes to match the cuda version..
     extras_require = {
         "flash3": ["flash-attn-3"],
     }


### PR DESCRIPTION
Summary:

- Update README to use PyTorch wheels instead of PyPI in install
- Remove CUDA 12.8 from OSS build as it's deprecated in PyTorch 2.12.
- Remove CUDA 12.6 from OSS build as theres minimal value for MSLK since most kernels are CUTLASS and SM90/SM100+
- Remove other legacy CUDA version logic.
- Later we would add CUDA 13.2 as experimental in line with PyTorch

Differential Revision: D102388968


