### PR TITLE
Remove FBGEMM as a conda dependency

### DIFF
--- a/MslkDefault.cmake
+++ b/MslkDefault.cmake
@@ -30,6 +30,12 @@ if(BUILD_FB_CODE
   glob_files_nohip(fb_only_sources_gpu
       fb/csrc/*/*.cu)
 
+  # natten is a BUCK-only kernel. Its vendor headers, defines, and .cu sources
+  # are not wired into this cmake build, so exclude the wrapper .cpp that would
+  # otherwise be picked up by the fb/csrc/*/*.cpp glob above.
+  list(FILTER fb_only_sources_cpu EXCLUDE REGEX "fb/csrc/natten/")
+  list(FILTER fb_only_sources_gpu EXCLUDE REGEX "fb/csrc/natten/")
+
   if(MSLK_FBPKG_BUILD)
     BLOCK_PRINT("[FBPKG] MSLK_FBPKG_BUILD is set.")
 


### PR DESCRIPTION
Summary:
This build follows D97621806, which removes fbgemm usage and cuts FBGEMM from all conda packages.


```
======== BUILD COMPLETE ========
18:15:06 INFO     H100: xlformers_msl_rl_conda:ba4f08260f8812075af7ff8d620039be                                                                                     rich_print.py:10
18:15:06 INFO       Pip conflicts paste: P2264509528                                                                                                                rich_print.py:10
18:15:06 INFO       Lockfile updated from: P2264509639                                                                                                              rich_print.py:10
18:15:06 INFO     GB200: xlformers_msl_rl_gb200_conda:194d7be09c830545fcdc270dfec83aa5                                                                              rich_print.py:10
18:15:06 INFO       Pip conflicts paste: P2264490441                                                                                                                rich_print.py:10
18:15:06 INFO       Lockfile updated from: P2264490487                                                                                                              rich_print.py:10
18:15:06 INFO     GB300: xlformers_msl_rl_gb300_conda:e14e1adb30842ce321c575ccdee367ac                                                                              rich_print.py:10
18:15:06 INFO       Pip conflicts paste: P2264445298                                                                                                                rich_print.py:10
18:15:06 INFO       Lockfile updated from: P2264445347                                                                                                              rich_print.py:10
```

Reviewed By: yuchenhao

Differential Revision: D99392533


