### PR TITLE
Pad m_block to power of two to avoid compilation issues (#336)

### DIFF
--- a/mslk/__init__.py
+++ b/mslk/__init__.py
@@ -56,8 +56,13 @@ else:
         #
         # To work around this problem, we introduce a fake build variant called
         # `docs` and we only throw a library load error when the variant is not
-        # `docs`.  For more information, see:
+        # `docs`.  We also suppress load failures when CUDA is not available
+        # (e.g. CPU-only CI) so that ``import mslk`` succeeds for availability
+        # checks by downstream packages like torchao.
+        #
+        # For more information, see:
         #
         #   https://github.com/pytorch/FBGEMM/pull/3477
         #   https://github.com/pytorch/FBGEMM/pull/3717
-        _load_library(f"{library}.so", __version__, __variant__ == "docs")
+        _no_throw = __variant__ == "docs" or not torch.cuda.is_available()
+        _load_library(f"{library}.so", __version__, _no_throw)

--- a/setup.py
+++ b/setup.py
@@ -246,12 +246,19 @@ class MSLKBuild:
         )
 
         if self.package_channel() == "nightly":
-            # Use date stamp for nightly versions
-            logging.debug(
-                "[SETUP.PY] Package is for NIGHTLY; using timestamp for the versioning"
-            )
-            today = date.today()
-            pkg_version = f"{today.year}.{today.month}.{today.day}"
+            # Use date stamp for nightly versions unless overridden
+            version_override = os.environ.get("MSLK_VERSION_OVERRIDE", "")
+            if version_override:
+                logging.debug(
+                    f"[SETUP.PY] Using MSLK_VERSION_OVERRIDE={version_override}"
+                )
+                pkg_version = version_override
+            else:
+                logging.debug(
+                    "[SETUP.PY] Package is for NIGHTLY; using timestamp for the versioning"
+                )
+                today = date.today()
+                pkg_version = f"{today.year}.{today.month}.{today.day}"
 
         elif self.nova_flag() is not None:
             # For Nova workflow contexts, we want to strip out the `rcN` suffix
@@ -642,8 +649,8 @@ def main(argv: List[str]) -> None:
 
     # Flash Attention 3 package is optional.
     # Install with:
-    # pip install mslk[flash3] --extra-index-url https://download.pytorch.org/whl/cu130
-    # where cu130 changes to match the cuda version..
+    # pip install mslk[flash3] --extra-index-url https://download.pytorch.org/whl/cu126
+    # where cu126 changes to match the cuda version..
     extras_require = {
         "flash3": ["flash-attn-3"],
     }


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexternal/MSLK-NV/pull/255

This small change adds some padding to m_block for cases where its not divisible by a power of two. Prior this change, it would crash during compilation. This is needed for sglang compatibility for many models due to the unusual batch sizes they use.

Also includes a minor setup.py change for better versioning control.

Sneaking in one more improvement to module loading where we dont throw errors when gpus arent available. This fixes a silly issue when trying to import mslk on cpu nodes.

Reviewed By: henrylhtsang

Differential Revision: D102898171


