### PR TITLE
NVFP4 Ultra Grouped Gemm (#338)

### DIFF
--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -20,6 +20,7 @@ from mslk.quantize.triton.fp4_quantize import (
     mega_fp4_quantize_kernel,
     mega_fp4_unpack,
     nvfp4_quantize_stacked,
+    nvfp4_quantize_stacked_with_token_scale,
     triton_quantize_mx4_unpack,
     triton_quantize_nvfp4,
 )
@@ -2627,6 +2628,110 @@ class CutlassNVFP4TorchGrouped(GemmOpBase):
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM100, Accelerator.NVIDIA_SM103}
+
+    @property
+    def supported_gemm_types(self) -> set[GemmType]:
+        return {GemmType.GROUPED}
+
+    @property
+    def compute_dtype(self) -> ComputeDtype:
+        return ComputeDtype.FP4
+
+
+@register_gemm_op
+class NVFP4UltraGroupwise(GemmOpBase):
+    """
+    NVFP4 ultra grouped GEMM (SM103) with per-token activation scaling
+    and per-expert weight scaling, applied separately in the EVT epilogue.
+    """
+
+    def preprocess(self, x, w):
+        m_values = [i.shape[0] for i in x]
+        m_sizes = torch.tensor(m_values).to(dtype=torch.int64, device=x[0].device)
+        x_cat = torch.concat(x, dim=0).contiguous()
+
+        G = m_sizes.numel()
+        N_per_expert = w[0].shape[0]
+        K = w[0].shape[1]
+
+        # Per-expert weight quantization.
+        w_cat = torch.cat(w, dim=0).contiguous()
+        w_m_sizes = torch.full(
+            (G,), N_per_expert, dtype=torch.int64, device=w_cat.device
+        )
+        w_global_scale, _ = calculate_group_max(w_cat, w_m_sizes)
+        wq, w_scale_2d = nvfp4_quantize_stacked(w_m_sizes, w_cat, w_global_scale)
+
+        wq = wq.view(G, N_per_expert, K // 2)
+        padded_N = (N_per_expert + 127) // 128 * 128
+        w_scale = w_scale_2d[: G * padded_N].view(G, padded_N, -1)
+
+        offsets = torch.cumsum(m_sizes, dim=0).to(torch.int32)
+
+        w_global_scale_inv = torch.reciprocal(w_global_scale)
+
+        return x_cat, wq, w_scale, w_global_scale_inv, m_sizes, offsets
+
+    def quantize(self, x, wq, w_scale, w_global_scale_inv, m_sizes, offsets):
+        xq, x_scale, x_token_scale_inv = nvfp4_quantize_stacked_with_token_scale(
+            m_sizes, x
+        )
+
+        return (
+            xq,
+            wq,
+            x_scale,
+            w_scale,
+            x_token_scale_inv,
+            w_global_scale_inv,
+            offsets,
+        )
+
+    def compute(
+        self,
+        xq,
+        wq,
+        x_scale,
+        w_scale,
+        x_global_scale_inv,
+        w_global_scale_inv,
+        offsets,
+    ):
+        return torch.ops.mslk.f4f4bf16_ultra_grouped_mm(
+            xq,
+            wq.transpose(-2, -1),
+            x_scale,
+            w_scale,
+            offsets,
+            x_global_scale_inv,
+            w_global_scale_inv,
+        )
+
+    def quantize_and_compute(
+        self, x, wq, w_scale, w_global_scale_inv, m_sizes, offsets
+    ):
+        (
+            xq,
+            wq,
+            x_scale,
+            w_scale,
+            x_global_scale_inv,
+            w_global_scale_inv,
+            offsets,
+        ) = self.quantize(x, wq, w_scale, w_global_scale_inv, m_sizes, offsets)
+        return self.compute(
+            xq,
+            wq,
+            x_scale,
+            w_scale,
+            x_global_scale_inv,
+            w_global_scale_inv,
+            offsets,
+        )
+
+    @property
+    def supported_accelerators(self) -> set[Accelerator]:
+        return {Accelerator.NVIDIA_SM103}
 
     @property
     def supported_gemm_types(self) -> set[GemmType]:

--- a/bench/quantize/quantize_ops.py
+++ b/bench/quantize/quantize_ops.py
@@ -15,6 +15,7 @@ from mslk.quantize.triton.fp4_quantize import (
     calculate_group_max,
     mega_fp4_quantize_kernel,
     nvfp4_quantize_stacked,
+    nvfp4_quantize_stacked_with_token_scale,
     triton_quantize_nvfp4,
 )
 from mslk.quantize.triton.fp4_utils import dequantize_nvfp4, global_scale_nvfp4
@@ -294,6 +295,41 @@ class TritonNVFP4Stacked(QuantizeOpBase):
         x_global_scale: torch.Tensor = args[1]
         xq, scale = nvfp4_quantize_stacked(m_sizes, input, x_global_scale)
         return xq, scale, x_global_scale
+
+    def dequantize(self, *args: Any) -> torch.Tensor:
+        # Grouped dequant is complex due to per-segment padding; return zeros.
+        return torch.zeros(
+            self.input_shape, dtype=torch.bfloat16, device=args[0].device
+        )
+
+    @property
+    def hip(self) -> bool:
+        return False
+
+    @property
+    def cuda(self) -> bool:
+        return True
+
+
+@register_op
+class TritonNVFP4StackedTokenScale(QuantizeOpBase):
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_shape: tuple[int, ...] = (0, 0)
+
+    def preprocess(self, input: torch.Tensor, num_groups: int = 1) -> Any:
+        self.input_shape = tuple(input.shape)
+        M = input.shape[0]
+        # Split M evenly across num_groups.
+        base = M // num_groups
+        remainder = M % num_groups
+        sizes = [base + (1 if i < remainder else 0) for i in range(num_groups)]
+        m_sizes = torch.tensor(sizes, dtype=torch.int64, device=input.device)
+        return (m_sizes,)
+
+    def quantize(self, input: torch.Tensor, *args: Any) -> Any:
+        m_sizes: torch.Tensor = args[0]
+        return nvfp4_quantize_stacked_with_token_scale(m_sizes, input)
 
     def dequantize(self, *args: Any) -> torch.Tensor:
         # Grouped dequant is complex due to per-segment padding; return zeros.

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped.cu
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+#include "f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_manifest.cuh"
+#endif
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+
+Kernel_f4f4bf16_ultra_grouped
+get_ultra_kernel_via_heuristics(int M, int N, int K) {
+  if (M <= 128) {
+    return f4f4bf16_ultra_grouped_256_128_768_2_1_1;
+  }
+  return f4f4bf16_ultra_grouped_256_256_768_2_1_1;
+}
+
+at::Tensor f4f4bf16_ultra_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    std::optional<at::Tensor> output_maybe) {
+  TORCH_CHECK(offsets.dtype() == at::kInt, "offsets must be int32.");
+  TORCH_CHECK(offsets.dim() == 1, "offsets must be 1D tensor.");
+  TORCH_CHECK(XQ.is_contiguous(), "XQ must be row major.");
+  TORCH_CHECK(WQ.transpose(-2, -1).is_contiguous(), "WQ must be column major.");
+  TORCH_CHECK(XQ.dtype() == at::kFloat4_e2m1fn_x2, "XQ must be FP4.");
+  TORCH_CHECK(WQ.dtype() == at::kFloat4_e2m1fn_x2, "WQ must be FP4.");
+  TORCH_CHECK(
+      x_scale.dtype() == at::kFloat8_e4m3fn, "x_scale must be FP8 e4m3.");
+  TORCH_CHECK(
+      w_scale.dtype() == at::kFloat8_e4m3fn, "w_scale must be FP8 e4m3.");
+  TORCH_CHECK(
+      x_global_scale.dtype() == at::kFloat, "x_global_scale must be float32.");
+  TORCH_CHECK(
+      w_global_scale.dtype() == at::kFloat, "w_global_scale must be float32.");
+  TORCH_CHECK(
+      XQ.dim() == 2 && WQ.dim() == 3,
+      "Only 2D-3D grouped GEMM (MoE forward) is supported.");
+
+  int64_t G = offsets.size(0);
+  int64_t M = XQ.size(0);
+  int64_t N = WQ.size(-1);
+  int64_t K = WQ.size(-2);
+
+  TORCH_CHECK(
+      XQ.size(-1) == K && WQ.size(0) == G,
+      "XQ shape must be (total_M, K) and WQ shape must be (G, K, N).");
+  TORCH_CHECK(
+      x_global_scale.size(0) == M,
+      "x_global_scale must have total_M elements.");
+  TORCH_CHECK(
+      w_global_scale.size(0) == G, "w_global_scale must have G elements.");
+
+  at::Tensor out = output_maybe.has_value()
+      ? output_maybe.value()
+      : at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
+
+  if (out.numel() == 0) {
+    return out;
+  }
+
+  // Normalize per-group M for heuristics.
+  int M_per_group = M / G;
+
+  auto kernel = get_ultra_kernel_via_heuristics(M_per_group, N, K * 2);
+
+  return kernel(
+      XQ,
+      WQ.transpose(-2, -1), // Column-major to row-major for CUTLASS.
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      out);
+}
+
+#else
+
+at::Tensor f4f4bf16_ultra_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    std::optional<at::Tensor> output) {
+  throw std::runtime_error(
+      "f4f4bf16_ultra_grouped_mm requires CUDA 13.0+ (SM103/B300)");
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_128_256_768_1_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_128_256_768_1_1_1.cu
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f4f4bf16_ultra_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+
+at::Tensor f4f4bf16_ultra_grouped_128_256_768_1_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  return f4f4bf16_ultra_grouped_impl<128, 256, 768, 1, 1, 1>(
+      XQ,
+      WQ,
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_128_768_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_128_768_2_1_1.cu
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f4f4bf16_ultra_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+
+at::Tensor f4f4bf16_ultra_grouped_256_128_768_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  return f4f4bf16_ultra_grouped_impl<256, 128, 768, 2, 1, 1>(
+      XQ,
+      WQ,
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_256_768_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_256_768_2_1_1.cu
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f4f4bf16_ultra_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+
+at::Tensor f4f4bf16_ultra_grouped_256_256_768_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  return f4f4bf16_ultra_grouped_impl<256, 256, 768, 2, 1, 1>(
+      XQ,
+      WQ,
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_common.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_common.cuh
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define CUTLASS_NAMESPACE mslk
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cutlass/util/device_memory.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
+#include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
+#include <cutlass/gemm/dispatch_policy.hpp>                   // @manual
+#include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
+// clang-format on
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+
+namespace mslk::gemm {
+
+namespace cutlass = cutlass_mslk;
+
+// SM103 ultra builder requires cute::tuple element types, not nv_float4_t.
+using ElementData = cutlass::float_e2m1_t;
+using ElementScale = cutlass::float_ue4m3_t;
+using ElementPair = cute::tuple<ElementData, ElementScale>;
+
+inline int64_t _byte_align(int64_t offset) {
+  int64_t remainder = offset % 16;
+  if (remainder != 0) {
+    offset += (16 - remainder);
+  }
+  return offset;
+}
+
+template <
+    typename ProblemShape,
+    typename StrideA,
+    typename StrideB,
+    typename StrideC,
+    typename LayoutSFA,
+    typename LayoutSFB,
+    typename Sm1xxBlkScaledConfig>
+__global__ void set_ultra_grouped_args_kernel(
+    int64_t G,
+    int64_t N,
+    int64_t K,
+    ProblemShape* problem_shape_ptr,
+    ElementData* xq,
+    const ElementData** xq_ptr,
+    ElementData* wq,
+    const ElementData** wq_ptr,
+    ElementScale* x_scale,
+    const ElementScale** x_scale_ptr,
+    ElementScale* w_scale,
+    const ElementScale** w_scale_ptr,
+    cutlass::bfloat16_t* output,
+    cutlass::bfloat16_t** output_ptr,
+    StrideA* stride_a_ptr,
+    StrideB* stride_b_ptr,
+    StrideC* stride_c_ptr,
+    int32_t* offsets,
+    LayoutSFA* layout_SFA,
+    LayoutSFB* layout_SFB,
+    float* x_global_scale,
+    const float** x_global_scale_ptr,
+    float* w_global_scale,
+    const float** w_global_scale_ptr) {
+  uint32_t group_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (group_index >= G) {
+    return;
+  }
+
+  auto round_up = [](int64_t x, int64_t y) { return ((x + y - 1) / y) * y; };
+
+  constexpr int ele_per_quantize_group = 16; // NVFP4
+
+  int32_t M_end = offsets[group_index];
+  int32_t M_start = (group_index == 0) ? 0 : offsets[group_index - 1];
+  int32_t M_group = M_end - M_start;
+
+  if (M_group <= 0) {
+    problem_shape_ptr[group_index] = ProblemShape(0, 0, 0);
+    return;
+  }
+
+  // Problem shape is (N, M, K) due to transposed AB convention.
+  problem_shape_ptr[group_index] = ProblemShape(N, M_group, K);
+
+  // Data pointers.
+  xq_ptr[group_index] = xq + (int64_t(M_start) * K / 2);
+  wq_ptr[group_index] = wq + (int64_t(group_index) * N * K / 2);
+  output_ptr[group_index] = output + (int64_t(M_start) * N);
+
+  // Block scale offsets. Scales are padded to multiples of (128, 4).
+  int64_t K_rounded = round_up(K / ele_per_quantize_group, 4);
+  int64_t N_rounded = round_up(N, 128);
+
+  int64_t x_scale_offset = 0;
+  for (int i = 0; i < group_index; i++) {
+    int32_t prev_start = (i == 0) ? 0 : offsets[i - 1];
+    int32_t prev_M = offsets[i] - prev_start;
+    x_scale_offset += round_up(prev_M, 128) * K_rounded;
+  }
+  x_scale_ptr[group_index] = x_scale + x_scale_offset;
+  w_scale_ptr[group_index] =
+      w_scale + int64_t(group_index) * N_rounded * K_rounded;
+
+  // Strides.
+  stride_a_ptr[group_index] = cutlass::make_cute_packed_stride(
+      StrideA{}, cute::make_shape(int(M_group), int(K), 1));
+  stride_b_ptr[group_index] = cutlass::make_cute_packed_stride(
+      StrideB{}, cute::make_shape(int(N), int(K), 1));
+  stride_c_ptr[group_index] = cutlass::make_cute_packed_stride(
+      StrideC{}, cute::make_shape(int(N), int(M_group), 1));
+
+  // Scale factor layouts for block-scaled TMA.
+  layout_SFA[group_index] = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+      cute::make_shape(int(M_group), int(N), int(K), 1));
+  layout_SFB[group_index] = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+      cute::make_shape(int(M_group), int(N), int(K), 1));
+
+  // Per-token x global scale and per-expert w global scale for EVT epilogue.
+  x_global_scale_ptr[group_index] = x_global_scale + M_start;
+  w_global_scale_ptr[group_index] = w_global_scale + group_index;
+}
+
+template <
+    int TB_M,
+    int TB_N,
+    int TB_K,
+    int TBS_M,
+    int TBS_N,
+    int TBS_K>
+at::Tensor f4f4bf16_ultra_grouped_impl(
+    at::Tensor XQ, // FP4
+    at::Tensor WQ, // FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  c10::cuda::CUDAGuard deviceGuard(XQ.device());
+
+  const int64_t G = offsets.size(0);
+
+  using ProblemShape =
+      cutlass::gemm::GroupProblemShape<cute::Shape<int, int, int>>;
+  using ElementC = cutlass::bfloat16_t;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+
+  constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementData>::value;
+  constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementData>::value;
+  constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
+  using LayoutA_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutA>::type;
+  using LayoutB_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutB>::type;
+
+  using ElementAccumulator = float;
+  using ElementComputeEpilogue = float;
+  using ArchTag = cutlass::arch::Sm103;
+  using TileShape =
+      cute::Shape<cute::Int<TB_M>, cute::Int<TB_N>, cute::Int<TB_K>>;
+  using ClusterShape =
+      cute::Shape<cute::Int<TBS_M>, cute::Int<TBS_N>, cute::Int<TBS_K>>;
+
+  // SM103 ultra grouped GEMM schedules for NVFP4.
+  using KernelSchedule = cute::conditional_t<
+      (TB_M == 256) && (TBS_M % 2 == 0),
+      cutlass::gemm::
+          KernelPtrArrayTmaWarpSpecialized2SmBlockScaledMxNvf4UltraVs16Sm103,
+      cutlass::gemm::
+          KernelPtrArrayTmaWarpSpecialized1SmBlockScaledMxNvf4UltraVs16Sm103>;
+  using EpilogueSchedule = cute::conditional_t<
+      (TB_M == 256) && (TBS_M % 2 == 0),
+      cutlass::epilogue::PtrArrayTmaWarpSpecialized2Sm,
+      cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm>;
+
+  // EVT epilogue: Output = Accumulator * XGlobalScaleInv * WGlobalScaleInv
+  // Due to the transposed AB convention (CUTLASS N = our M/tokens):
+  //   RowBroadcast (along CUTLASS N) → per-token x_global_scale
+  //   ScalarBroadcastPtrArray → per-group w_global_scale scalar
+  using XGlobalScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue*,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using WGlobalScale = cutlass::epilogue::fusion::Sm90ScalarBroadcastPtrArray<
+      ElementComputeEpilogue>;
+
+  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+  using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute0 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute0, Accum, XGlobalScale>;
+
+  using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementC,
+      ElementComputeEpilogue,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute1 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute1, EVTCompute0, WGlobalScale>;
+
+  using EpilogueEVT = EVTCompute1;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          cutlass::arch::OpClassBlockScaledTensorOp,
+          TileShape,
+          ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementAccumulator,
+          void, // No source C matrix (no beta scaling).
+          typename cutlass::layout::LayoutTranspose<LayoutC>::type*,
+          AlignmentC,
+          ElementC,
+          typename cutlass::layout::LayoutTranspose<LayoutC>::type*,
+          AlignmentC,
+          EpilogueSchedule,
+          EpilogueEVT>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          cutlass::arch::OpClassBlockScaledTensorOp,
+          ElementPair, // cute::tuple<float_e2m1_t, float_ue4m3_t>
+          LayoutB_Transpose*,
+          AlignmentB,
+          ElementPair, // cute::tuple<float_e2m1_t, float_ue4m3_t>
+          LayoutA_Transpose*,
+          AlignmentA,
+          ElementAccumulator,
+          TileShape,
+          ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          KernelSchedule>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::
+      GemmUniversal<ProblemShape, CollectiveMainloop, CollectiveEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using StrideA = typename Gemm::GemmKernel::InternalStrideA;
+  using StrideB = typename Gemm::GemmKernel::InternalStrideB;
+  using StrideC = typename Gemm::GemmKernel::InternalStrideD;
+
+  using LayoutSFA =
+      typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFA;
+  using LayoutSFB =
+      typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFB;
+  using Sm1xxBlkScaledConfig =
+      typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+
+  // Allocate a single contiguous buffer for all per-group kernel arguments.
+  const int64_t problem_size_offset = 0;
+  int64_t problem_size_buffer =
+      _byte_align(G * sizeof(ProblemShape::UnderlyingProblemShape));
+
+  const int64_t xq_offset = problem_size_offset + problem_size_buffer;
+  int64_t xq_size_buffer = _byte_align(G * sizeof(ElementData**));
+
+  const int64_t wq_offset = xq_offset + xq_size_buffer;
+  int64_t wq_size_buffer = _byte_align(G * sizeof(ElementData**));
+
+  const int64_t x_scale_offset = wq_offset + wq_size_buffer;
+  int64_t x_scale_buffer = _byte_align(G * sizeof(ElementScale**));
+
+  const int64_t w_scale_offset = x_scale_offset + x_scale_buffer;
+  int64_t w_scale_buffer = _byte_align(G * sizeof(ElementScale**));
+
+  const int64_t output_offset = w_scale_offset + w_scale_buffer;
+  int64_t output_buffer = _byte_align(G * sizeof(ElementC**));
+
+  const int64_t stride_a_offset = output_offset + output_buffer;
+  int64_t stride_a_buffer = _byte_align(G * sizeof(StrideA));
+
+  const int64_t stride_b_offset = stride_a_offset + stride_a_buffer;
+  int64_t stride_b_buffer = _byte_align(G * sizeof(StrideB));
+
+  const int64_t stride_c_offset = stride_b_offset + stride_b_buffer;
+  int64_t stride_c_buffer = _byte_align(G * sizeof(StrideC));
+
+  const int64_t layout_SFA_offset = stride_c_offset + stride_c_buffer;
+  int64_t layout_SFA_buffer = _byte_align(G * sizeof(LayoutSFA));
+
+  const int64_t layout_SFB_offset = layout_SFA_offset + layout_SFA_buffer;
+  int64_t layout_SFB_buffer = _byte_align(G * sizeof(LayoutSFB));
+
+  const int64_t x_gs_offset = layout_SFB_offset + layout_SFB_buffer;
+  int64_t x_gs_buffer = _byte_align(G * sizeof(float*));
+
+  const int64_t w_gs_offset = x_gs_offset + x_gs_buffer;
+  int64_t w_gs_buffer = _byte_align(G * sizeof(float*));
+
+  int64_t total_buffer_size = w_gs_offset + w_gs_buffer;
+
+  at::TensorOptions options = XQ.options();
+  at::Tensor kernel_args =
+      at::empty({total_buffer_size}, options.dtype(at::kByte));
+
+  char* kernel_args_ptr = reinterpret_cast<char*>(kernel_args.data_ptr());
+
+  auto* problem_shape_ptr =
+      reinterpret_cast<ProblemShape::UnderlyingProblemShape*>(
+          kernel_args_ptr + problem_size_offset);
+  const ElementData** xq_ptr =
+      reinterpret_cast<const ElementData**>(kernel_args_ptr + xq_offset);
+  const ElementData** wq_ptr =
+      reinterpret_cast<const ElementData**>(kernel_args_ptr + wq_offset);
+  const ElementScale** x_scale_ptr =
+      reinterpret_cast<const ElementScale**>(kernel_args_ptr + x_scale_offset);
+  const ElementScale** w_scale_ptr =
+      reinterpret_cast<const ElementScale**>(kernel_args_ptr + w_scale_offset);
+  ElementC** output_ptr =
+      reinterpret_cast<ElementC**>(kernel_args_ptr + output_offset);
+  StrideA* stride_a_ptr =
+      reinterpret_cast<StrideA*>(kernel_args_ptr + stride_a_offset);
+  StrideB* stride_b_ptr =
+      reinterpret_cast<StrideB*>(kernel_args_ptr + stride_b_offset);
+  StrideC* stride_c_ptr =
+      reinterpret_cast<StrideC*>(kernel_args_ptr + stride_c_offset);
+  LayoutSFA* layout_SFA_ptr =
+      reinterpret_cast<LayoutSFA*>(kernel_args_ptr + layout_SFA_offset);
+  LayoutSFB* layout_SFB_ptr =
+      reinterpret_cast<LayoutSFB*>(kernel_args_ptr + layout_SFB_offset);
+  const float** x_gs_ptr =
+      reinterpret_cast<const float**>(kernel_args_ptr + x_gs_offset);
+  const float** w_gs_ptr =
+      reinterpret_cast<const float**>(kernel_args_ptr + w_gs_offset);
+
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+  // WQ is [G, N, K/2] after transpose in the top-level dispatch.
+  const int64_t N = WQ.size(-2);
+  const int64_t K = WQ.size(-1) * 2; // 2 FP4 values packed per byte
+
+  set_ultra_grouped_args_kernel<
+      ProblemShape::UnderlyingProblemShape,
+      StrideA,
+      StrideB,
+      StrideC,
+      LayoutSFA,
+      LayoutSFB,
+      Sm1xxBlkScaledConfig><<<1, G, 0, stream>>>(
+      G,
+      N,
+      K,
+      problem_shape_ptr,
+      reinterpret_cast<ElementData*>(XQ.data_ptr()),
+      xq_ptr,
+      reinterpret_cast<ElementData*>(WQ.data_ptr()),
+      wq_ptr,
+      reinterpret_cast<ElementScale*>(x_scale.data_ptr()),
+      x_scale_ptr,
+      reinterpret_cast<ElementScale*>(w_scale.data_ptr()),
+      w_scale_ptr,
+      reinterpret_cast<ElementC*>(output.data_ptr()),
+      output_ptr,
+      stride_a_ptr,
+      stride_b_ptr,
+      stride_c_ptr,
+      reinterpret_cast<int32_t*>(offsets.data_ptr()),
+      layout_SFA_ptr,
+      layout_SFB_ptr,
+      reinterpret_cast<float*>(x_global_scale.data_ptr()),
+      x_gs_ptr,
+      reinterpret_cast<float*>(w_global_scale.data_ptr()),
+      w_gs_ptr);
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.device_id = 0;
+  hw_info.sm_count =
+      min(cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
+              hw_info.device_id),
+          2147483647);
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGrouped,
+      {int(G), problem_shape_ptr, nullptr},
+      {reinterpret_cast<const ElementData**>(wq_ptr),
+       stride_b_ptr,
+       reinterpret_cast<const ElementData**>(xq_ptr),
+       stride_a_ptr,
+       reinterpret_cast<const ElementScale**>(w_scale_ptr),
+       layout_SFB_ptr,
+       reinterpret_cast<const ElementScale**>(x_scale_ptr),
+       layout_SFA_ptr},
+      {{}, nullptr, stride_c_ptr, output_ptr, stride_c_ptr},
+      hw_info};
+
+  typename Gemm::GemmKernel::TileSchedulerArguments scheduler;
+  scheduler.raster_order =
+      cutlass::gemm::kernel::detail::RasterOrderOptions::AlongM;
+  arguments.scheduler = scheduler;
+
+  // EVT epilogue arguments: Accum / XGlobalScale / WGlobalScale.
+  // Due to AB transpose, x_global_scale (per-token) goes to RowBroadcast and
+  // w_global_scale (per-expert) goes to ScalarBroadcastPtrArray.
+  // ScalarBroadcastPtrArray args: {scalars, scalar_ptrs, scalar_ptr_arrays,
+  // dScalar}
+  arguments.epilogue.thread = {
+      {
+          {}, // Accumulator
+          {x_gs_ptr}, // XGlobalScale (RowBroadcast, per-token)
+          {} // Compute0 (multiplies)
+      },
+      {{}, {}, {w_gs_ptr}}, // WGlobalScale (ScalarBroadcastPtrArray)
+      {} // Compute1 (multiplies)
+  };
+
+  Gemm gemm;
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  at::Tensor workspace = at::empty(workspace_size, options.dtype(at::kByte));
+
+  cutlass::Status status = gemm.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  status = gemm.initialize(
+      arguments, reinterpret_cast<uint8_t*>(workspace.data_ptr()));
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm(at::cuda::getCurrentCUDAStream());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot run: ") +
+        cutlass::cutlassGetStatusString(status));
+  }
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return output;
+}
+
+} // namespace mslk::gemm
+
+#endif
+
+#undef CUTLASS_NAMESPACE

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_manifest.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_manifest.cuh
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+
+at::Tensor f4f4bf16_ultra_grouped_128_256_768_1_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output);
+
+at::Tensor f4f4bf16_ultra_grouped_256_256_768_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output);
+
+at::Tensor f4f4bf16_ultra_grouped_256_128_768_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output);
+
+using Kernel_f4f4bf16_ultra_grouped = at::Tensor (*)(
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor);
+
+const std::unordered_map<std::string, Kernel_f4f4bf16_ultra_grouped>&
+get_f4f4bf16_ultra_grouped_kernels() {
+  static const std::unordered_map<std::string, Kernel_f4f4bf16_ultra_grouped>
+      kernels = {
+          {"f4f4bf16_ultra_grouped_128_256_768_1_1_1",
+           f4f4bf16_ultra_grouped_128_256_768_1_1_1},
+          {"f4f4bf16_ultra_grouped_256_256_768_2_1_1",
+           f4f4bf16_ultra_grouped_256_256_768_2_1_1},
+          {"f4f4bf16_ultra_grouped_256_128_768_2_1_1",
+           f4f4bf16_ultra_grouped_256_128_768_2_1_1},
+      };
+  return kernels;
+}
+
+#endif
+} // namespace mslk::gemm

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -61,6 +61,8 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   m.def(
       "f4f4bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None, Tensor(a!)? global_scale=None) -> Tensor");
   m.def(
+      "f4f4bf16_ultra_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor x_global_scale, Tensor w_global_scale, Tensor(a!)? output=None) -> Tensor");
+  m.def(
       "f8f8bf16(Tensor XQ, Tensor WQ, Tensor scale, bool use_fast_accum=True) -> Tensor");
   m.def(
       "f8f8bf16_groupwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale) -> Tensor");
@@ -121,6 +123,7 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
   m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
   m.impl("f4f4bf16_grouped_mm", f4f4bf16_grouped_mm);
+  m.impl("f4f4bf16_ultra_grouped_mm", f4f4bf16_ultra_grouped_mm);
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16x9_gemm", bf16x9_gemm);
@@ -171,6 +174,7 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
   m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
   m.impl("f4f4bf16_grouped_mm", f4f4bf16_grouped_mm);
+  m.impl("f4f4bf16_ultra_grouped_mm", f4f4bf16_ultra_grouped_mm);
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16x9_gemm", bf16x9_gemm);

--- a/include/mslk/gemm/gemm_torch.h
+++ b/include/mslk/gemm/gemm_torch.h
@@ -45,6 +45,17 @@ at::Tensor f4f4bf16_grouped_mm(
     std::optional<at::Tensor> output = std::nullopt,
     std::optional<at::Tensor> global_scale = std::nullopt);
 
+// FP4 ultra grouped GEMM (SM103) with per-token activation scaling.
+at::Tensor f4f4bf16_ultra_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    std::optional<at::Tensor> output = std::nullopt);
+
 // FP4 GEMM supporting NVFP4, MXFP4 (1x32 block), and MXFP4_16 (1x16 block)
 //
 // Format selection:

--- a/mslk/gemm/_meta.py
+++ b/mslk/gemm/_meta.py
@@ -254,6 +254,26 @@ if hasattr(torch.ops.mslk, "f4f4bf16"):
         return torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
 
 
+if hasattr(torch.ops.mslk, "f4f4bf16_ultra_grouped_mm"):
+
+    @torch.library.register_fake("mslk::f4f4bf16_ultra_grouped_mm")
+    def f4f4bf16_ultra_grouped_mm_meta(
+        XQ: torch.Tensor,
+        WQ: torch.Tensor,
+        x_scale: torch.Tensor,
+        w_scale: torch.Tensor,
+        offsets: torch.Tensor,
+        x_global_scale: torch.Tensor,
+        w_global_scale: torch.Tensor,
+        output: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if output is not None:
+            return output
+        total_M = XQ.shape[0]
+        N = WQ.shape[-1]
+        return torch.empty((total_M, N), dtype=torch.bfloat16, device=XQ.device)
+
+
 if hasattr(torch.ops.mslk, "mx8mx4bf16"):
 
     @torch.library.register_fake("mslk::mx8mx4bf16")

--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -2227,7 +2227,9 @@ def _nvfp4_quantize_stacked_kernel(
     FP8_E4M3_MAX = 448.0  # type: ignore[Incompatible variable type]
     FP4_E2M1_MAX: tl.constexpr = 6  # type: ignore[Incompatible variable type]
 
-    NUM_ELEM_PER_LAYOUT: tl.constexpr = 128 * 4  # type: ignore[Incompatible variable type]
+    NUM_ELEM_PER_LAYOUT: tl.constexpr = (  # type: ignore[Incompatible variable type]
+        128 * 4
+    )
     NUM_N_BLOCKS = tl.cdiv(N, 64)
 
     pid_m = tl.program_id(1)
@@ -2317,6 +2319,152 @@ def _nvfp4_quantize_stacked_kernel(
     tl.store(s_ptr + scale_offs, scales.to(tl.uint8, bitcast=True), mask=store_mask)
 
 
+@triton.jit
+def _nvfp4_quantize_stacked_token_scale_fused_row_kernel(
+    x_ptr,
+    q_ptr,
+    s_ptr,
+    token_scale_inv_ptr,
+    m_sizes_ptr,
+    stride_xm,
+    stride_xn,
+    M,
+    N,
+    NUM_GROUPS: tl.constexpr,
+    PREFIX_NUM: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SCALE_BLOCKS: tl.constexpr,
+    USE_FULL_ROW_QUANT: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+    CHUNK_SCALE_BLOCKS: tl.constexpr,
+):
+    E4M3_EPS: tl.constexpr = 1.5258789e-05  # type: ignore[Incompatible variable type]
+    FP8_E4M3_MAX = 448.0  # type: ignore[Incompatible variable type]
+    FP4_E2M1_MAX: tl.constexpr = 6  # type: ignore[Incompatible variable type]
+    MIN_NORMAL: tl.constexpr = 1.0e-8  # type: ignore[Incompatible variable type]
+
+    NUM_ELEM_PER_LAYOUT: tl.constexpr = 128 * 4  # type: ignore[Incompatible variable type]
+    NUM_N_BLOCKS = tl.cdiv(N, 64)
+
+    row = tl.program_id(0)
+    reduce_offs_n = tl.arange(0, BLOCK_K)
+    reduce_mask = (row < M) & (reduce_offs_n < N)
+    x = tl.load(
+        x_ptr + row * stride_xm + reduce_offs_n * stride_xn,
+        mask=reduce_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    row_amax = tl.max(tl.abs(x), axis=0)
+    token_scale_inv = tl.maximum(row_amax, MIN_NORMAL) / (448.0 * 6.0)
+    row_scale = tl.div_rn(1.0, token_scale_inv)
+    tl.store(token_scale_inv_ptr + row, token_scale_inv, mask=row < M)
+
+    seg_offs = tl.arange(0, PREFIX_NUM)
+    seg_mask = seg_offs < NUM_GROUPS
+    m_vals = tl.load(m_sizes_ptr + seg_offs, mask=seg_mask, other=0)
+    cumsum_inc = tl.cumsum(m_vals, axis=0)
+    padded_vals = ((m_vals + 127) // 128) * 128
+    padded_cumsum_inc = tl.cumsum(padded_vals, axis=0)
+    cumsum_exc = cumsum_inc - m_vals
+    padded_cumsum_exc = padded_cumsum_inc - padded_vals
+
+    seg_idx = tl.max(tl.where(cumsum_exc <= row, seg_offs, 0), axis=0)
+    seg_cumsum = tl.max(tl.where(seg_offs == seg_idx, cumsum_exc, 0), axis=0)
+    seg_padded_cumsum = tl.max(
+        tl.where(seg_offs == seg_idx, padded_cumsum_exc, 0), axis=0
+    )
+    padded_r = seg_padded_cumsum + (row.to(tl.int64) - seg_cumsum)
+
+    if USE_FULL_ROW_QUANT:
+        x_blocks = x.reshape(SCALE_BLOCKS, 16)
+        block_amax = tl.max(tl.abs(x_blocks), axis=1)
+        scales = tl.div_rn(block_amax, FP4_E2M1_MAX) * row_scale
+        scales = tl.clamp(scales, E4M3_EPS, FP8_E4M3_MAX)
+        scales_fp8 = scales.to(tl.float8e4nv)
+
+        total_scale = tl.div_rn(row_scale, scales_fp8.to(tl.float32)[:, None])
+        x_blocks = x_blocks * total_scale
+
+        x_fp4x2 = convert_fp32_to_fp4_packed(x_blocks.reshape(BLOCK_K // 2, 2).split())
+        fp4_offs_n = tl.arange(0, BLOCK_K // 2)
+        fp4_mask = (row < M) & (fp4_offs_n < N // 2)
+        tl.store(q_ptr + row * (N // 2) + fp4_offs_n, x_fp4x2, mask=fp4_mask)
+
+        scale_col = tl.arange(0, SCALE_BLOCKS)
+        col_block = scale_col // 4
+        col_in_block = scale_col % 4
+        offs_m_in_layout = (padded_r % 128).to(tl.int32)
+        sub_layout_idx = offs_m_in_layout % 32
+        sub_layout_row = offs_m_in_layout // 32
+        scale_offs = (
+            (padded_r // 128) * NUM_N_BLOCKS * NUM_ELEM_PER_LAYOUT
+            + col_block * NUM_ELEM_PER_LAYOUT
+            + sub_layout_idx * 16
+            + sub_layout_row * 4
+            + col_in_block
+        )
+        scale_mask = (row < M) & (scale_col < (N // 16))
+        tl.store(
+            s_ptr + scale_offs,
+            scales_fp8.to(tl.uint8, bitcast=True),
+            mask=scale_mask,
+        )
+    else:
+        chunk_offs = tl.arange(0, CHUNK_SIZE)
+        scale_offs_in_chunk = tl.arange(0, CHUNK_SCALE_BLOCKS)
+        fp4_offs_in_chunk = tl.arange(0, CHUNK_SIZE // 2)
+
+        for k_start in range(0, N, CHUNK_SIZE):
+            chunk_offs_n = k_start + chunk_offs
+            chunk_mask = (row < M) & (chunk_offs_n < N)
+            x_chunk = tl.load(
+                x_ptr + row * stride_xm + chunk_offs_n * stride_xn,
+                mask=chunk_mask,
+                other=0.0,
+            ).to(tl.float32)
+            x_blocks = x_chunk.reshape(CHUNK_SCALE_BLOCKS, 16)
+
+            block_amax = tl.max(tl.abs(x_blocks), axis=1)
+            scales = tl.div_rn(block_amax, FP4_E2M1_MAX) * row_scale
+            scales = tl.clamp(scales, E4M3_EPS, FP8_E4M3_MAX)
+            scales_fp8 = scales.to(tl.float8e4nv)
+
+            total_scale = tl.div_rn(row_scale, scales_fp8.to(tl.float32)[:, None])
+            x_blocks = x_blocks * total_scale
+
+            x_fp4x2 = convert_fp32_to_fp4_packed(
+                x_blocks.reshape(CHUNK_SIZE // 2, 2).split()
+            )
+            fp4_offs_n = k_start // 2 + fp4_offs_in_chunk
+            fp4_mask = (row < M) & (fp4_offs_n < N // 2)
+            tl.store(
+                q_ptr + row * (N // 2) + fp4_offs_n,
+                x_fp4x2,
+                mask=fp4_mask,
+            )
+
+            scale_col = k_start // 16 + scale_offs_in_chunk
+            col_block = scale_col // 4
+            col_in_block = scale_col % 4
+            offs_m_in_layout = (padded_r % 128).to(tl.int32)
+            sub_layout_idx = offs_m_in_layout % 32
+            sub_layout_row = offs_m_in_layout // 32
+            scale_offs = (
+                (padded_r // 128) * NUM_N_BLOCKS * NUM_ELEM_PER_LAYOUT
+                + col_block * NUM_ELEM_PER_LAYOUT
+                + sub_layout_idx * 16
+                + sub_layout_row * 4
+                + col_in_block
+            )
+            scale_mask = (row < M) & (scale_col < (N // 16))
+            tl.store(
+                s_ptr + scale_offs,
+                scales_fp8.to(tl.uint8, bitcast=True),
+                mask=scale_mask,
+            )
+
+
 def nvfp4_quantize_stacked(
     m_sizes: torch.Tensor,
     input: torch.Tensor,
@@ -2401,6 +2549,70 @@ def nvfp4_quantize_stacked(
     )
 
     return xq.view(torch.float4_e2m1fn_x2), scale.view(torch.float8_e4m3fn)
+
+
+def nvfp4_quantize_stacked_with_token_scale(
+    m_sizes: torch.Tensor,
+    input: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize concatenated MoE activations with reciprocal per-token scales.
+
+    Returns:
+        Tuple of (xq, scale, token_scale_inv):
+            xq: [M, K//2] packed FP4 data.
+            scale: Flattened uint8 scale buffer in padded+swizzled CUTLASS layout.
+            token_scale_inv: [M] fp32 reciprocal per-token scales.
+    """
+    assert input.ndim >= 1, f"input.ndim needs to be >= 1, but got {input.ndim}."
+    input = input.reshape(-1, input.shape[-1])
+    M, K = input.shape
+    num_segments = m_sizes.shape[0]
+    device = input.device
+
+    assert K % 16 == 0, f"K must be divisible by 16, but got {K}."
+    assert input.dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), f"input.dtype needs to be fp16 or bf16 but got {input.dtype}."
+
+    padded_total_M_ub = M + num_segments * 127
+    xq = torch.empty((M, K // 2), device=device, dtype=torch.uint8)
+    x_token_scale_inv = torch.empty((M,), device=device, dtype=torch.float32)
+
+    num_scales_per_row = K // 16
+    n_col_blocks = triton.cdiv(num_scales_per_row, 4)
+    padded_cols = n_col_blocks * 4
+    scale = torch.empty(
+        (padded_total_M_ub, padded_cols), device=device, dtype=torch.uint8
+    )
+
+    block_k = triton.next_power_of_2(K)
+    # pyre-ignore[28]
+    _nvfp4_quantize_stacked_token_scale_fused_row_kernel[(M,)](
+        input,
+        xq,
+        scale,
+        x_token_scale_inv,
+        m_sizes,
+        input.stride(0),
+        input.stride(1),
+        M,
+        K,
+        NUM_GROUPS=num_segments,  # pyre-ignore[6]
+        PREFIX_NUM=triton.next_power_of_2(num_segments),
+        BLOCK_K=block_k,  # pyre-ignore[6]
+        SCALE_BLOCKS=block_k // 16,  # pyre-ignore[6]
+        USE_FULL_ROW_QUANT=block_k == K and K <= 8192,
+        CHUNK_SIZE=2048,
+        CHUNK_SCALE_BLOCKS=2048 // 16,
+        num_warps=8,
+    )
+
+    return (
+        xq.view(torch.float4_e2m1fn_x2),
+        scale.view(torch.float8_e4m3fn),
+        x_token_scale_inv,
+    )
 
 
 @triton.jit

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -16,7 +16,10 @@ import mslk.quantize  # noqa: F401
 import torch
 import triton  # noqa: F401
 from mslk.quantize.triton.fp4_quantize import (
+    calculate_group_max,
     get_nvfp4_global_scales_naive,
+    nvfp4_quantize_stacked,
+    nvfp4_quantize_stacked_with_token_scale,
     quantize_nvfp4_naive,
     triton_quantize_mx4_unpack,
 )
@@ -115,6 +118,14 @@ def supports_nvfp4():
     return False
 
 
+def supports_nvfp4_ultra():
+    if not torch.cuda.is_available() or not torch.version.cuda:
+        return False
+    cuda_major = int(torch.version.cuda.split(".")[0])
+    major, minor = torch.cuda.get_device_capability()
+    return cuda_major >= 13 and (major, minor) >= (10, 3)
+
+
 def supports_mxfp4():
     if torch.cuda.is_available():
         if torch.version.cuda:
@@ -129,6 +140,7 @@ SUPPORTS_MXFP8 = supports_mxfp8()
 SUPPORTS_FP8_INT4 = support_fp8_int4()
 SUPPORTS_BF16_INT4 = supports_bf16_int4()
 SUPPORTS_NVFP4 = supports_nvfp4()
+SUPPORTS_NVFP4_ULTRA = supports_nvfp4_ultra()
 SUPPORTS_MXFP4 = supports_mxfp4()
 
 if torch.cuda.is_available() and supports_float8_fnuz(
@@ -2448,6 +2460,94 @@ class NVFP4Tests(unittest.TestCase):
         self.assertTrue(out_nvfp4.isfinite().all(), "output contains non-finite values")
 
         torch.testing.assert_close(out_nvfp4, out_bf16, atol=5.0e-2, rtol=6.0e-2)
+
+    @unittest.skipIf(
+        not SUPPORTS_NVFP4_ULTRA,
+        "Skip if NVFP4 ultra grouped GEMM is not supported on this device.",
+    )
+    def test_ultra_grouped_gemm_2d_3d(self) -> None:
+        G = 2
+        N = 512
+        K = 1024
+        m_sizes_list = [128, 256]
+        m_sizes = torch.tensor(m_sizes_list, dtype=torch.int64, device=self.device)
+        offsets = torch.cumsum(m_sizes, dim=0).to(torch.int32)
+
+        M = sum(m_sizes_list)
+        X = torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        W = torch.randn((G, N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+
+        w_cat = W.reshape(G * N, K).contiguous()
+        w_m_sizes = torch.full((G,), N, dtype=torch.int64, device=self.device)
+        w_global_scale, _ = calculate_group_max(w_cat, w_m_sizes)
+        wq, w_scale_2d = nvfp4_quantize_stacked(
+            w_m_sizes,
+            w_cat,
+            w_global_scale,
+        )
+        wq = wq.view(G, N, K // 2)
+        padded_N = ((N + 127) // 128) * 128
+        w_scale = w_scale_2d[: G * padded_N].view(G, padded_N, -1)
+        w_global_scale_inv = torch.reciprocal(w_global_scale)
+
+        xq, x_scale, x_token_scale_inv = nvfp4_quantize_stacked_with_token_scale(
+            m_sizes,
+            X,
+        )
+
+        out_nvfp4 = torch.ops.mslk.f4f4bf16_ultra_grouped_mm(
+            xq,
+            wq.transpose(-2, -1),
+            x_scale,
+            w_scale,
+            offsets,
+            x_token_scale_inv,
+            w_global_scale_inv,
+        )
+        self.assertTrue(out_nvfp4.isfinite().all(), "output contains non-finite values")
+
+        refs = []
+        start = 0
+        for group_idx, m_size in enumerate(m_sizes_list):
+            end = start + m_size
+            refs.append(X[start:end] @ W[group_idx].t())
+            start = end
+        out_bf16 = torch.cat(refs, dim=0).to(torch.bfloat16)
+
+        torch.testing.assert_close(out_nvfp4, out_bf16, atol=5.0e-2, rtol=6.0e-2)
+
+    @unittest.skipIf(
+        not SUPPORTS_NVFP4_ULTRA,
+        "Skip if NVFP4 ultra grouped GEMM is not supported on this device.",
+    )
+    def test_ultra_grouped_gemm_meta(self) -> None:
+        G = 2
+        M = 384
+        N = 512
+        K = 1024
+        xq = torch.empty((M, K // 2), dtype=torch.float4_e2m1fn_x2, device="meta")
+        wq = torch.empty((G, K // 2, N), dtype=torch.float4_e2m1fn_x2, device="meta")
+        x_scale = torch.empty(
+            (M + G * 127, K // 16), dtype=torch.float8_e4m3fn, device="meta"
+        )
+        w_scale = torch.empty((G, N, K // 16), dtype=torch.float8_e4m3fn, device="meta")
+        offsets = torch.empty((G,), dtype=torch.int32, device="meta")
+        x_global_scale = torch.empty((M,), dtype=torch.float32, device="meta")
+        w_global_scale = torch.empty((G,), dtype=torch.float32, device="meta")
+
+        out = torch.ops.mslk.f4f4bf16_ultra_grouped_mm(
+            xq,
+            wq,
+            x_scale,
+            w_scale,
+            offsets,
+            x_global_scale,
+            w_global_scale,
+        )
+
+        self.assertEqual(out.shape, (M, N))
+        self.assertEqual(out.dtype, torch.bfloat16)
+        self.assertEqual(out.device.type, "meta")
 
 
 @unittest.skipIf(not SUPPORTS_MXFP4, "Skip if MXFP4 is not supported")

--- a/test/quantize/triton/fp4_quantize_test.py
+++ b/test/quantize/triton/fp4_quantize_test.py
@@ -22,6 +22,7 @@ from mslk.quantize.triton.fp4_quantize import (
     FP4_MBITS,
     FP8_E4M3_MAX,
     nvfp4_quantize_stacked,
+    nvfp4_quantize_stacked_with_token_scale,
     RoundingMode,
     triton_fake_quantize_nvfp4_per_tensor,
     triton_quantize_mx4_unpack,
@@ -460,6 +461,63 @@ MOE_SHAPES = [
 ]
 
 
+TOKEN_SCALE_MOE_SHAPES = [
+    # Small K exercises scale-column padding.
+    (3, [1, 3, 2], 64),
+    # Non-power-of-two K exercises the fused kernel's chunked path.
+    (3, [1, 2, 3], 5120),
+    # Power-of-two K exercises the fused kernel's full-row path.
+    (2, [2, 1], 8192),
+]
+
+
+def _padded_cumsum(m_sizes_list: list[int]) -> list[int]:
+    padded_cumsum = [0]
+    for m in m_sizes_list:
+        padded_cumsum.append(padded_cumsum[-1] + ((m + 127) // 128) * 128)
+    return padded_cumsum
+
+
+def _cumsum(m_sizes_list: list[int]) -> list[int]:
+    cumsum = [0]
+    for m in m_sizes_list:
+        cumsum.append(cumsum[-1] + m)
+    return cumsum
+
+
+def _extract_stacked_scale_for_expert(
+    scale: torch.Tensor,
+    m_sizes_list: list[int],
+    expert_idx: int,
+    K: int,
+) -> torch.Tensor:
+    padded_cumsum = _padded_cumsum(m_sizes_list)
+    num_scales_per_row = K // 16
+    padded_cols = ((num_scales_per_row + 3) // 4) * 4
+    row_slice = slice(padded_cumsum[expert_idx], padded_cumsum[expert_idx + 1])
+    return scale[
+        row_slice,
+        :padded_cols,
+    ]
+
+
+def _dequantize_nvfp4_with_token_scale(
+    input_quantized: torch.Tensor,
+    scale: torch.Tensor,
+    token_scale_inv: torch.Tensor,
+    group_size: int = 16,
+) -> torch.Tensor:
+    M = input_quantized.shape[0]
+    N = input_quantized.shape[1] * 2
+    scale = _from_blocked(scale, (M, math.ceil(N / group_size)))
+    input_quantized_float = fp4_to_float(input_quantized)
+    true_scale = scale.to(torch.float32) * token_scale_inv.to(torch.float32)[:, None]
+    output = input_quantized_float.view(
+        -1, N // group_size, group_size
+    ) * true_scale.view(M, -1, 1)
+    return output.view(M, N).to(torch.bfloat16)
+
+
 @pytest.mark.skipif(
     not SUPPORTS_NVFP4,
     reason="Skip if TestNVFP4QuantizeStacked is not supported on this device.",
@@ -602,3 +660,112 @@ class TestNVFP4QuantizeStacked:
 
             expert_dequant = dequantize_nvfp4(expert_xq, expert_scale, global_scales[i])
             torch.testing.assert_close(expert_dequant, x[start:end], atol=1, rtol=1)
+
+    @pytest.mark.parametrize("num_experts,m_sizes_list,K", TOKEN_SCALE_MOE_SHAPES)
+    def test_token_scale_inv_matches_row_amax(
+        self,
+        num_experts: int,
+        m_sizes_list: list[int],
+        K: int,
+    ) -> None:
+        """Verify reciprocal token scales are computed from per-row amax."""
+        m_sizes = torch.tensor(m_sizes_list, dtype=torch.int64, device=self.device)
+        M = sum(m_sizes_list)
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=self.device)
+        x[0].zero_()
+
+        _, _, token_scale_inv = nvfp4_quantize_stacked_with_token_scale(m_sizes, x)
+
+        row_amax = torch.amax(torch.abs(x.to(torch.float32)), dim=1)
+        expected = torch.clamp(row_amax, min=1.0e-8) / (FP8_E4M3_MAX * FP4_E2M1_MAX)
+        torch.testing.assert_close(token_scale_inv, expected, atol=1e-12, rtol=1e-6)
+
+    @pytest.mark.parametrize("num_experts,m_sizes_list,K", TOKEN_SCALE_MOE_SHAPES)
+    def test_token_scale_matches_per_row_reference(
+        self,
+        num_experts: int,
+        m_sizes_list: list[int],
+        K: int,
+    ) -> None:
+        """Verify packed values and local scales match per-row NVFP4 quantization."""
+        m_sizes = torch.tensor(m_sizes_list, dtype=torch.int64, device=self.device)
+        M = sum(m_sizes_list)
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=self.device)
+        x[0].zero_()
+
+        xq, scale, token_scale_inv = nvfp4_quantize_stacked_with_token_scale(m_sizes, x)
+        xq_u8 = xq.view(torch.uint8)
+
+        cumsum = _cumsum(m_sizes_list)
+        for expert_idx in range(num_experts):
+            start = cumsum[expert_idx]
+            end = cumsum[expert_idx + 1]
+            expert_scale = _extract_stacked_scale_for_expert(
+                scale,
+                m_sizes_list,
+                expert_idx,
+                K,
+            )
+            expert_scale_unblocked = _from_blocked(
+                expert_scale,
+                (end - start, K // 16),
+            ).view(torch.uint8)
+
+            for row in range(start, end):
+                row_global_scale = token_scale_inv[row].reciprocal()
+                input_row = x.narrow(0, row, 1)
+                xq_ref, scale_ref = triton_quantize_nvfp4(
+                    input_row,
+                    row_global_scale,
+                )
+                scale_ref_unblocked = _from_blocked(scale_ref, (1, K // 16)).view(
+                    torch.uint8
+                )
+
+                torch.testing.assert_close(
+                    xq_u8.narrow(0, row, 1),
+                    xq_ref.view(torch.uint8),
+                )
+                torch.testing.assert_close(
+                    expert_scale_unblocked.narrow(0, row - start, 1),
+                    scale_ref_unblocked,
+                )
+
+    @pytest.mark.parametrize("num_experts,m_sizes_list,K", TOKEN_SCALE_MOE_SHAPES)
+    def test_token_scale_dequant_roundtrip(
+        self,
+        num_experts: int,
+        m_sizes_list: list[int],
+        K: int,
+    ) -> None:
+        """Verify quantize-then-dequantize quality with per-token scales."""
+        m_sizes = torch.tensor(m_sizes_list, dtype=torch.int64, device=self.device)
+        M = sum(m_sizes_list)
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=self.device)
+
+        xq, scale, token_scale_inv = nvfp4_quantize_stacked_with_token_scale(m_sizes, x)
+        xq_u8 = xq.view(torch.uint8)
+
+        cumsum = _cumsum(m_sizes_list)
+        for expert_idx in range(num_experts):
+            start = cumsum[expert_idx]
+            end = cumsum[expert_idx + 1]
+            expert_scale = _extract_stacked_scale_for_expert(
+                scale,
+                m_sizes_list,
+                expert_idx,
+                K,
+            )
+            expert_dequant = _dequantize_nvfp4_with_token_scale(
+                xq_u8[start:end],
+                expert_scale,
+                token_scale_inv[start:end],
+            )
+            torch.testing.assert_close(expert_dequant, x[start:end], atol=1, rtol=1)
+
+    def test_token_scale_invalid_inputs(self) -> None:
+        m_sizes = torch.tensor([4], dtype=torch.int64, device=self.device)
+        x = torch.randn(4, 18, dtype=torch.bfloat16, device=self.device)
+
+        with pytest.raises(AssertionError, match="K must be divisible by 16"):
+            nvfp4_quantize_stacked_with_token_scale(m_sizes, x)


### PR DESCRIPTION
Summary:
X-link: https://github.com/mslsrc/mslk/pull/7


This diff adds a new FP4 grouped gemm kernel to MSLK that leverage GB300 ultra FP4 instructions and uses rowwise scales rather than tensorwise global scales. This is both more accurate and enables more interesting routing options in e2e use cases. We add corresponding quantization kernels and tests that verify everything works as expected. Interestingly, performance is about the same as the non-ultra NVFP4 moe kernel. I'm not quite sure why, perhaps the more involved scaling is eating into our throughput. I will also run this by nvidia to see if theres more room for improvement.

Differential Revision: D104165347


