### PR TITLE
MXFP4 Quantization Fixes

### DIFF
--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -295,12 +295,16 @@ def _kernel_quantize_mx4_unpack(
             pack=1,
         )
 
+        row = exp_offset // GROUPS_PER_ROW
+        col = exp_offset % GROUPS_PER_ROW
+        padded_exp_offset = row * SCALE_K + col
+
         n_col_blocks = SCALE_K // 4
-        first_dim = exp_offset // (512 * n_col_blocks)
-        second_dim = (exp_offset % (512 * n_col_blocks)) // (128 * n_col_blocks)
-        third_dim = (exp_offset % (128 * n_col_blocks)) // (4 * n_col_blocks)
-        fourth_dim = (exp_offset % (4 * n_col_blocks)) // 4
-        fifth_dim = exp_offset % 4
+        first_dim = padded_exp_offset // (512 * n_col_blocks)
+        second_dim = (padded_exp_offset % (512 * n_col_blocks)) // (128 * n_col_blocks)
+        third_dim = (padded_exp_offset % (128 * n_col_blocks)) // (4 * n_col_blocks)
+        fourth_dim = (padded_exp_offset % (4 * n_col_blocks)) // 4
+        fifth_dim = padded_exp_offset % 4
         actual_offset = (
             first_dim * (512 * n_col_blocks)
             + fourth_dim * (512)
@@ -460,7 +464,13 @@ def triton_quantize_mx4_unpack(
     rounded_M = round_up(M, 128)
     scale_K = K // block_size
     rounded_K = round_up(scale_K, 4)
-    scale = torch.empty((rounded_M, rounded_K), device=device, dtype=torch.int8)
+    # E8M0 scale byte 127 is 2^0, the neutral scale for rounded tail slots.
+    scale = torch.full(
+        (rounded_M, rounded_K),
+        127,
+        device=device,
+        dtype=torch.int8,
+    )
 
     # In this kernel, we want each row to be divisible by group_size.
     # If the rows are not, then we will pad them. Find the number of

--- a/test/quantize/triton/fp4_quantize_test.py
+++ b/test/quantize/triton/fp4_quantize_test.py
@@ -92,7 +92,16 @@ class TestFp4Quantize:
     def setup(self):
         torch.manual_seed(0)
 
-    @pytest.mark.parametrize("shape", [(1, 128), (3, 512), (128, 1024), (4096, 10240)])
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (1, 128),
+            (129, 192),
+            (3, 512),
+            (128, 1024),
+            (4096, 10240),
+        ],
+    )
     def test_quantize_fp4(self, shape: Tuple[int, int]) -> None:
         device = "cuda"
         M, N = shape


### PR DESCRIPTION
Summary:
Applies the D103267566 scale-layout fix to MX4/NVFP4 quantization, including the MSLK MX4 unpack kernel used by the ads_mkl wrapper. These kernels allocate scale tensors in the padded MMA layout (rounded_M x rounded_K) but generate exponent offsets using the logical GROUPS_PER_ROW stride; when GROUPS_PER_ROW != SCALE_K, the old code swizzled scale bytes as if rows were unpadded. The fix converts each logical (row, col) to padded row * SCALE_K + col before the MMA-D swizzle, so scale bytes line up with the padded layout.

Also initializes padded scale tails deterministically: neutral E8M0 (127) for regular MX4/NVFP4 paths and zero/min-scale for RHT tail slots, avoiding garbage scale bytes that can decode to huge/invalid values and cause Inf/NaN in dot_scaled. This is valid for MX4 for the same reason as D103267566's MXFP8 fix: the scale tensor format and swizzle are shared; only the element packing differs.

Mast job: (with D102073625 incl.) https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-V40316_fp8mx4_opt_ne-0eb853c077?job_attempt=1&version=0&tab=summary&env=PRODUCTION

Baseline: https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-V40316_fp8mx4_opt_ne-16cf951438?job_attempt=7&version=0&tab=summary&env=PRODUCTION

 {F1989495724}

Reviewed By: jsisometa, hx2224

Differential Revision: D104318374


