### PR TITLE
FA4 MXFP8 Prefill Kernel (#340)

### DIFF
--- a/mslk/attention/fmha/cute_blackwell.py
+++ b/mslk/attention/fmha/cute_blackwell.py
@@ -173,9 +173,16 @@ def _convert_input_format(
 
     if is_qkv_mxfp8 and query.ndim == 4:
         # Reshape Q/K/V to the 4D layout the kernel expects:
-        # Q: (1, B, Hq, K) → (B, 1, Hq, K)
-        _, B, Hq, K = query.shape
-        query = query.squeeze(0).unsqueeze(1).reshape(B, 1, Hq, K).contiguous()
+        # Q: (1, B*Mq, Hq, K) → (B, Mq, Hq, K)
+        _, BxMq, Hq, K = query.shape
+        # Determine B from K/V shape: K is (1, B*Mkv, Hkv, K_int32)
+        # For non-paged: seqused_k gives per-batch kv lengths
+        if seqused_k is not None:
+            B = seqused_k.shape[0]
+        else:
+            B = 1
+        Mq = BxMq // B
+        query = query.reshape(B, Mq, Hq, K).contiguous()
         if page_table is None:
             Mkv_padded = key.shape[1] // B
             Hkv = key.shape[2]
@@ -393,7 +400,11 @@ def _window_size(
 class FwOp(AttentionFwOpBase):
     OPERATOR = _get_operator("_flash_attn_fwd")
     SUPPORTED_DEVICES: Set[str] = {"cuda"}
-    SUPPORTED_DTYPES: Set[torch.dtype] = {torch.bfloat16, torch.float16}
+    SUPPORTED_DTYPES: Set[torch.dtype] = {
+        torch.bfloat16,
+        torch.float16,
+        torch.float8_e4m3fn,
+    }
     SUPPORTED_MAX_K = 128
     SUPPORTED_MIN_K = 64
     SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
@@ -481,6 +492,7 @@ class FwOp(AttentionFwOpBase):
         window_left, window_right = _window_size(inp.attn_bias)
 
         fp8_inp = inp if isinstance(inp, InputsFp8) else None
+        mxfp8_inp = inp if isinstance(inp, InputsMXFp8) else None
         if fp8_inp is not None:
             assert (
                 fp8_inp.k_fp8_scale_shift is not None
@@ -489,17 +501,28 @@ class FwOp(AttentionFwOpBase):
                 "k_fp8_scale_shift and v_fp8_scale_shift must be provided when inp is InputsFp8"
             )
 
+        # Determine scale tensors for the operator
+        if mxfp8_inp is not None:
+            k_scale = mxfp8_inp.k_fp8_scale
+            v_scale = mxfp8_inp.v_fp8_scale
+            q_scale = mxfp8_inp.q_fp8_scale
+        elif fp8_inp is not None:
+            k_scale = fp8_inp.k_fp8_scale_shift
+            v_scale = fp8_inp.v_fp8_scale_shift
+            q_scale = None
+        else:
+            k_scale = None
+            v_scale = None
+            q_scale = None
+
         if inp.query.numel() > 0 and inp.key.numel() > 0:
             out, lse = cls.OPERATOR(
                 q=inp.query,
                 k=inp.key,
                 v=inp.value,
-                k_scale_shift=fp8_inp.k_fp8_scale_shift
-                if fp8_inp is not None
-                else None,
-                v_scale_shift=fp8_inp.v_fp8_scale_shift
-                if fp8_inp is not None
-                else None,
+                k_scale_shift=k_scale,
+                v_scale_shift=v_scale,
+                q_scale_shift=q_scale,
                 cu_seqlens_q=cu_seqlens_q,
                 cu_seqlens_k=cu_seqlens_k,
                 seqlen_kv=seqused_k,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/MSLK-NV/pull/269


Adds a new CuteDSL MXFP8 prefill kernel for Blackwell. The kernel uses MXFP8 (float8_e4m3 data + float8_e8m0 block scales, with sf_vec_size = 32) for Q, K, and V tensors via tcgen05 blockscaled MMA instructions.

Numerics:
```
=== Numerics comparison (non-causal (full attention); reference: BF16 Q/K/V + BF16 kernel) ===
Config                                     Variant          max_ae    mean_ae          mse    cos_sim
---------------------------------------------------------------------------------------------------
B=1 Mq=2048 Mkv=2048 Hkv=8 G=8 K=128       fake_kv        0.018066   0.001120   2.0225e-06   0.999248
                                           fake_qkv       0.027344   0.001363   3.0019e-06   0.998884
                                           real_mxfp8     0.024414   0.001560   3.9177e-06   0.998543

B=1 Mq=4096 Mkv=4096 Hkv=8 G=8 K=128       fake_kv        0.015625   0.000789   9.9975e-07   0.999265
                                           fake_qkv       0.015625   0.000962   1.4878e-06   0.998906
                                           real_mxfp8     0.020996   0.001103   1.9491e-06   0.998566

B=1 Mq=8192 Mkv=8192 Hkv=8 G=8 K=128       fake_kv        0.010254   0.000563   5.0742e-07   0.999249
                                           fake_qkv       0.014648   0.000686   7.5274e-07   0.998886
                                           real_mxfp8     0.013916   0.000786   9.8530e-07   0.998542

B=1 Mq=16384 Mkv=16384 Hkv=8 G=8 K=128     fake_kv        0.006836   0.000397   2.5153e-07   0.999243
                                           fake_qkv       0.008301   0.000484   3.7481e-07   0.998873
                                           real_mxfp8     0.008789   0.000555   4.9144e-07   0.998521

B=1 Mq=13620 Mkv=13620 Hkv=8 G=8 K=128     fake_kv        0.007812   0.000435   3.0290e-07   0.999272
                                           fake_qkv       0.011719   0.000531   4.5107e-07   0.998916
                                           real_mxfp8     0.012207   0.000609   5.9125e-07   0.998579
```

Performance:
```
=== Performance (non-causal (full attention); warmup=20 iters=100 rounds=3) ===
Config                                        BF16 ms   MXFP8 ms   BF16 TF/s  MXFP8 TF/s  Speedup
-----------------------------------------------------------------------------------------------------------------
B=1 Mq=2048 Mkv=2048 Hkv=8 G=8 K=128           0.2016     0.2160      681.85      636.34    0.93x
B=1 Mq=4096 Mkv=4096 Hkv=8 G=8 K=128           0.4444     0.4525     1237.16     1214.90    0.98x
B=1 Mq=8192 Mkv=8192 Hkv=8 G=8 K=128           1.6754     1.7489     1312.50     1257.35    0.96x
B=1 Mq=16384 Mkv=16384 Hkv=8 G=8 K=128         6.5416     6.9570     1344.64     1264.36    0.94x
B=1 Mq=13620 Mkv=13620 Hkv=8 G=8 K=128         4.5631     4.9130     1332.13     1237.26    0.93x
```

Reviewed By: jwfromm

Differential Revision: D101210355


