### PR TITLE
Add pyre-strict to mslk/mslk/conv/_meta.py

### DIFF
--- a/mslk/conv/_meta.py
+++ b/mslk/conv/_meta.py
@@ -1,3 +1,4 @@
+# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #


### PR DESCRIPTION
Summary: Enables strict Pyre type checking for `fbcode/mslk/mslk/conv/_meta.py` by adding the `# pyre-strict` directive. The file contains Meta (shape inference) implementations for Conv ops that were previously registered in C++. The code already fully satisfies strict mode requirements with no type errors, so only the directive annotation was needed. This improves code quality by opting the module into stricter type safety guarantees going forward.

Differential Revision: D105271984


