### PR TITLE
Fix QAT carry-over bugs in fake_quantize_nvfp4

### DIFF
--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -5967,6 +5967,10 @@ def triton_fake_quantize_nvfp4_per_tensor(
     assert input.numel() != 0
     assert input.dim() >= 2
     assert input.dtype == torch.bfloat16
+    if scale_ub is not None and scale_ub.numel() != 1:
+        raise AssertionError(
+            f"scale_ub must be a scalar (numel == 1); got shape {tuple(scale_ub.shape)}"
+        )
 
     output = torch.empty_like(input)
 


### PR DESCRIPTION
Summary:
Production-code fixes for the four B-side defects (#B10 / #B11 / #B12 /
#B13) added by Diff 1 of `~/.llms/plans/fix_b_test_carryover_semantics.plan.md`.
Closes the QAT path's three carry-over bugs (#45 / #47 / #48) and removes
a dead-code legacy file. After this diff lands, B has 0 silent-wrong-output
defects in its QAT path.

## Production fixes

### #B10 / #45 — int64 indexing in QAT kernel
`fake_quantize_nvfp4_kernel` now accepts a `USE_INT64_INDEXING:
tl.constexpr` and promotes `pid` to int64 when set, mirroring the gate
already present in `quantize_fp4_kernel`. The wrapper computes
`numel > 2**31 - 1` and forwards. Closes the silent address-overflow
on tensors > 2³¹ elements (~4 GB at bf16) — production-blocking for
QAT on large LLM checkpoints.

### #B11 / #48 — STE / autograd.Function
`fake_quantize_nvfp4` is now backed by `_FakeQuantNVFP4` (a
`torch.autograd.Function` subclass) whose backward returns
`(grad_out, None, None)` — straight-through estimator on `x`, no
gradient on the (non-learnable) `global_amax` or `scale_ub`
buffers. Honors the docstring's pre-existing claim of STE that the
implementation did not previously provide.

### #B12 / #47 — Shape assertion on scale_ub
Both A and B add `assert scale_ub is None or scale_ub.numel() == 1`:
- B: `fake_quantize_nvfp4` (Step 2.3).
- A: `triton_fake_quantize_nvfp4_per_tensor` (Step 2.3 mirror).
Replaces the confusing `RuntimeError` (B: from `.reshape(1)`; A:
from `.item()`) with a clear contract violation up front.

### #B13 — Delete legacy fp4_primitives.py
The legacy single-file copy of `fp4_primitives` has been
superseded by the `fp4_primitives/` package. The single file was
not built (BUCK glob picks only `fp4_primitives/**/*.py`) but
retained pre-refactor versions of helpers, posing a hazard for
future contributors. Verified no module-level imports rely on the
single file (all imports go through the package or its submodules).

## Test follow-ups

- Dropped `unittest.expectedFailure` from
  `test_bug_45/47/48::test_b_impl`. Assertions now pass for real.
- Added `"47"` to `EXPECTED_PASS` in
  `bugs/run_test_a_impl_loop.sh` (A-side now also clean for #47
  via the Step 2.3 mirror).
- New `tests/test_fake_quantize.py::FakeQuantizeNvfp4STETest` end-to-
  end coverage:
  - `test_ste_passthrough` — `loss.backward()` propagates a
    non-None, identity-shaped gradient.
  - `test_no_grad_on_global_amax` — STE returns None for the buffer.
  - `test_scale_ub_shape_assertion` — non-scalar `scale_ub` raises
    `AssertionError`.

## Status reports

- New file `~/.llms/plans/tritonfp4/14_bug_status_at_diff2.md`
  capturing the post-fix scorecard: 46/48 = 96% bugs FIXED+AVOIDED in B;
  0 silent-wrong-output defects remain in B's QAT path.
- `06_bugs_B.md`: marked #B10 / #B11 / #B12 / #B13 as ✅ FIXED.

## Test plan

```
cd /data/users/bensonma415/fbsource/fbcode
bash ai_codesign/nonprod/bensonma415/triton/bugs/run_test_a_impl_loop.sh
bash ai_codesign/nonprod/bensonma415/triton/bugs/run_test_b_impl_loop.sh

buck2 test mode/opt -c fbcode.nvcc_arch=b200 \
  fbcode//ai_codesign/nonprod/bensonma415/triton:test_fake_quantize \
  -- -k test_ste_passthrough
```

Both loops exit 0; `test_bug_45/47/48::test_b_impl` now pass for real
(no longer reported as "expected failures"). `test_ste_passthrough`
passes.

`arc lint -a` clean across all edited files.

## Stack

This diff stacks on the "Add #43–#48 repros + harden FP4 bug-repro test
suite" diff (Diff 1 of `fix_b_test_carryover_semantics.plan.md`),
which stacks on D104627296. Diff 1's `expectedFailure` decorators
flip from "expected failure" → "pass" automatically against this
diff's production code; the decorator-removal in this diff is the
final clean-up.

Reviewed By: henrylhtsang

Differential Revision: D104712387


