### PR TITLE
Add native MX6 GEMM kernel (mx6mx6bf16)

### DIFF
--- a/bench/gemm/mx6mx6_bench.py
+++ b/bench/gemm/mx6mx6_bench.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Benchmark: symmetric MX6×MX6 CUTLASS block-scaled GEMM kernel (mx6mx6bf16)
+# Compares against BF16 matmul, MX8×MX8, MX8×MX6, MX8×MX4, and native NVFP4 (f4f4bf16).
+# Throughput/latency only — no SQNR (no Python MX6 quantizer for the A operand).
+
+from __future__ import annotations
+
+import time
+
+import mslk.gemm  # noqa: F401
+import mslk.quantize  # noqa: F401
+import torch
+from mslk.gemm.triton.fp8_gemm import to_mxfp8
+from mslk.quantize.triton.fp4_quantize import _to_blocked, triton_quantize_mx4_unpack
+
+
+def benchmark_fn(fn, warmup: int = 5, iters: int = 20) -> float:
+    """Benchmark a function, return median time in ms."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        elapsed = (time.perf_counter() - start) * 1000  # ms
+        times.append(elapsed)
+
+    times.sort()
+    return times[len(times) // 2]  # median
+
+
+def tflops(M: int, N: int, K: int, time_ms: float) -> float:
+    """Compute TFLOPS from GEMM dimensions and time."""
+    flops = 2 * M * N * K
+    return flops / (time_ms * 1e-3) / 1e12
+
+
+def main() -> None:
+    device = torch.accelerator.current_accelerator()
+    N = 16384
+    K = 16384
+    num_iters = 20
+    M_values = [1, 16, 64, 128, 256, 512, 1024]
+
+    print(
+        f"Benchmark on {torch.cuda.get_device_name()}, N=K={N}, num_iters={num_iters}"
+    )
+    print()
+
+    print(
+        f"{'M':>6} | {'bf16_mm':>10} | {'mx8mx8':>8} | {'mx8mx6':>8} | {'mx6mx6':>8} | {'mx8mx4':>8} | {'f4f4':>8}"
+    )
+    print(
+        f"{'':>6} | {'(TFLOPS)':>10} | {'(TFLOPS)':>8} | {'(TFLOPS)':>8} | {'(TFLOPS)':>8} | {'(TFLOPS)':>8} | {'(TFLOPS)':>8}"
+    )
+    print("-" * 84)
+
+    for M in M_values:
+        # BF16 matmul reference
+        A_bf16 = torch.randn((M, K), dtype=torch.bfloat16, device=device)
+        B_bf16 = torch.randn((N, K), dtype=torch.bfloat16, device=device)
+
+        t_bf16 = benchmark_fn(
+            lambda _a=A_bf16, _b=B_bf16: _a @ _b.t(),
+            iters=num_iters,
+        )
+        tflops_bf16 = tflops(M, N, K, t_bf16)
+
+        # Quantize A to MX8 (used as activation for mx8mx8/mx8mx6/mx8mx4)
+        A_small = A_bf16 * 0.1
+        B_small = B_bf16 * 0.01
+        (a_scale_raw, aq) = to_mxfp8(A_small)
+        a_scale = _to_blocked(a_scale_raw.view(torch.int8).reshape(M, -1)).view(
+            torch.uint8
+        )
+
+        # MX8×MX8 via grouped_mm (single group)
+        (b_scale_raw_8, bq_8) = to_mxfp8(B_small)
+        b_scale_8 = _to_blocked(b_scale_raw_8.view(torch.int8).reshape(N, -1)).view(
+            torch.uint8
+        )
+        bq_8_col = bq_8.t()
+        offsets = torch.tensor([K], dtype=torch.int32, device=device)
+        out_mx8 = torch.empty((1, M, N), dtype=torch.bfloat16, device=device)
+        a_scale_2d = (
+            a_scale.reshape(-1, a_scale.shape[-1]) if a_scale.ndim != 2 else a_scale
+        )
+        b_scale_8_2d = (
+            b_scale_8.reshape(-1, b_scale_8.shape[-1])
+            if b_scale_8.ndim != 2
+            else b_scale_8
+        )
+
+        if hasattr(torch.ops.mslk, "mx8mx8bf16_grouped_mm"):
+            t_mx8 = benchmark_fn(
+                lambda _aq=aq,
+                _bq=bq_8_col,
+                _as=a_scale_2d,
+                _bs=b_scale_8_2d,
+                _off=offsets,
+                _out=out_mx8: torch.ops.mslk.mx8mx8bf16_grouped_mm(
+                    _aq, _bq, _as, _bs, _off, _out
+                ),
+                iters=num_iters,
+            )
+            tflops_mx8 = tflops(M, N, K, t_mx8)
+        else:
+            tflops_mx8 = float("nan")
+
+        # MX8×MX4 (B quantized to MX4 via triton)
+        bq_4, b_scale_4 = triton_quantize_mx4_unpack(B_small)
+        bq_4_cast = bq_4.view(torch.float4_e2m1fn_x2)
+
+        if hasattr(torch.ops.mslk, "mx8mx4bf16"):
+            t_mx4 = benchmark_fn(
+                lambda _aq=aq,
+                _bq=bq_4_cast,
+                _as=a_scale,
+                _bs=b_scale_4: torch.ops.mslk.mx8mx4bf16(_aq, _bq, _as, _bs),
+                iters=num_iters,
+            )
+            tflops_mx4 = tflops(M, N, K, t_mx4)
+        else:
+            tflops_mx4 = float("nan")
+
+        # MX8×MX6 (raw uint8 packed-6 weights; reuse MX4-style block scales).
+        # The mx8mx6bf16 op is optional — it only exists once D103697749 lands.
+        wq_6 = torch.randint(0, 256, (N, K * 6 // 8), dtype=torch.uint8, device=device)
+
+        if hasattr(torch.ops.mslk, "mx8mx6bf16"):
+            t_mx8mx6 = benchmark_fn(
+                lambda _aq=aq,
+                _wq=wq_6,
+                _as=a_scale,
+                _bs=b_scale_4: torch.ops.mslk.mx8mx6bf16(_aq, _wq, _as, _bs),
+                iters=num_iters,
+            )
+            tflops_mx8mx6 = tflops(M, N, K, t_mx8mx6)
+        else:
+            tflops_mx8mx6 = float("nan")
+
+        # MX6×MX6 (both A and B raw uint8 packed-6; reuse MX4-style block scales)
+        aq_6 = torch.randint(0, 256, (M, K * 6 // 8), dtype=torch.uint8, device=device)
+        # Build a placeholder MX4-style A scale to match the kernel scale layout.
+        _, a_scale_6 = triton_quantize_mx4_unpack(A_small)
+
+        t_mx6mx6 = benchmark_fn(
+            lambda _aq=aq_6,
+            _wq=wq_6,
+            _as=a_scale_6,
+            _bs=b_scale_4: torch.ops.mslk.mx6mx6bf16(_aq, _wq, _as, _bs),
+            iters=num_iters,
+        )
+        tflops_mx6mx6 = tflops(M, N, K, t_mx6mx6)
+
+        # f4f4bf16 (native NVFP4 — both operands MX4)
+        aq_4, a_scale_4 = triton_quantize_mx4_unpack(A_small)
+        aq_4_cast = aq_4.view(torch.float4_e2m1fn_x2)
+
+        if hasattr(torch.ops.mslk, "f4f4bf16"):
+            t_f4f4 = benchmark_fn(
+                lambda _aq=aq_4_cast,
+                _bq=bq_4_cast,
+                _as=a_scale_4,
+                _bs=b_scale_4: torch.ops.mslk.f4f4bf16(_aq, _bq, _as, _bs),
+                iters=num_iters,
+            )
+            tflops_f4f4 = tflops(M, N, K, t_f4f4)
+        else:
+            tflops_f4f4 = float("nan")
+
+        print(
+            f"{M:>6} | {tflops_bf16:>10.1f} | {tflops_mx8:>8.1f} | {tflops_mx8mx6:>8.1f} | {tflops_mx6mx6:>8.1f} | {tflops_mx4:>8.1f} | {tflops_f4f4:>8.1f}"
+        )
+
+    print()
+    print(
+        "Note: SQNR omitted — no Python MX6 quantizer is wired up, so MX6 weights "
+        "and (for mx6mx6) MX6 activations are random uint8."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/gemm/cutlass/mx6mx6bf16.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16.cu
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cutlass/util/device_memory.h>
+#include <mslk/utils/utils.h>
+#include <mslk/utils/tuning_cache.cuh>
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+#include "mx6mx6bf16/mx6mx6bf16_manifest.cuh"
+#endif
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+namespace {
+
+// Tile selector tuned on B200 via autotune sweep + 10-rep production bench.
+Kernel_mx6mx6bf16 get_kernel_via_heuristics(int M, int N, int K) {
+  if (M <= 16 && (N == 9216 || N == 10240)) {
+    return mx6mx6bf16_256_128_4_1_1;
+  }
+  if (M <= 192) {
+    return mx6mx6bf16_256_128_2_1_1;
+  }
+  if (M <= 256) {
+    if (N >= 10240) {
+      return mx6mx6bf16_256_256_2_1_1;
+    }
+    // Tested but dropped
+    //   if ((N == 7168 || N == 8192) && K >= 12288) {
+    //     return mx6mx6bf16_256_128_2_2_1;
+    //   }
+    return mx6mx6bf16_256_128_2_1_1;
+  }
+  if (M <= 512) {
+    if (N >= 5120 && K >= 4096) {
+      return mx6mx6bf16_256_256_2_1_1;
+    }
+    return mx6mx6bf16_256_128_2_1_1;
+  }
+  return mx6mx6bf16_256_256_2_1_1;
+}
+
+const std::unordered_map<std::string, Kernel_mx6mx6bf16>&
+get_mx6mx6bf16_kernels() {
+  static const std::unordered_map<std::string, Kernel_mx6mx6bf16> kernels = {
+      {"mx6mx6bf16_128_128_1_1_1", mx6mx6bf16_128_128_1_1_1},
+      {"mx6mx6bf16_128_128_2_2_1", mx6mx6bf16_128_128_2_2_1},
+      {"mx6mx6bf16_128_128_4_1_1", mx6mx6bf16_128_128_4_1_1},
+      {"mx6mx6bf16_256_128_2_1_1", mx6mx6bf16_256_128_2_1_1},
+      {"mx6mx6bf16_256_128_2_2_1", mx6mx6bf16_256_128_2_2_1},
+      {"mx6mx6bf16_256_128_4_1_1", mx6mx6bf16_256_128_4_1_1},
+      {"mx6mx6bf16_256_256_2_1_1", mx6mx6bf16_256_256_2_1_1},
+      {"mx6mx6bf16_256_256_2_4_1", mx6mx6bf16_256_256_2_4_1},
+  };
+  return kernels;
+}
+
+Kernel_mx6mx6bf16 get_kernel_via_tuning(
+    int M,
+    int N,
+    int K,
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  static TuningCache cache("mx6mx6bf16");
+
+  M = nextPowerOf2OrRoundUp(M, 1024, 1024);
+  N = nextPowerOf2OrRoundUp(N, 1024, 1024);
+  K = nextPowerOf2OrRoundUp(K, 1024, 1024);
+
+  const std::string shape_key =
+      std::to_string(M) + "_" + std::to_string(N) + "_" + std::to_string(K);
+
+  const auto& kernels = get_mx6mx6bf16_kernels();
+
+  auto kernel = cache.findBestKernelMaybeAutotune(
+      shape_key, kernels, XQ, WQ, x_scale, w_scale, output);
+  return kernel;
+}
+
+} // namespace
+
+at::Tensor mx6mx6bf16(
+    at::Tensor XQ, // MX FP6 (e2m3)
+    at::Tensor WQ, // MX FP6 (e2m3)
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    std::optional<at::Tensor> output) {
+  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
+  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
+  TORCH_CHECK(x_scale.is_cuda() && x_scale.is_contiguous());
+  TORCH_CHECK(w_scale.is_cuda() && w_scale.is_contiguous());
+
+  const auto M = XQ.size(0);
+  const auto N = WQ.size(0);
+  // XQ is packed 6-bit: K elements occupy K*6/8 = K*3/4 bytes, so K = bytes * 4
+  // / 3.
+  const auto K = XQ.size(1) * 4 / 3;
+  TORCH_CHECK(
+      K % 32 == 0,
+      "K must be a multiple of block size 32 for MX block-scaled GEMM");
+
+  if (M == 0 || N == 0 || K == 0) {
+    return at::zeros({M, N}, XQ.options().dtype(at::kBFloat16));
+  }
+
+  at::Tensor out = output.has_value()
+      ? output.value()
+      : at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
+
+  auto kernel = [&]() {
+    if (std::getenv("MSLK_AUTOTUNE_ENABLE")) {
+      return get_kernel_via_tuning(M, N, K, XQ, WQ, x_scale, w_scale, out);
+    }
+    return get_kernel_via_heuristics(M, N, K);
+  }();
+  return kernel(XQ, WQ, x_scale, w_scale, out);
+}
+
+#else
+
+at::Tensor mx6mx6bf16(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    std::optional<at::Tensor> output) {
+  throw std::runtime_error("CUDA version is older than 12.8");
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_128_128_1_1_1.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_128_128_1_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx6mx6bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx6mx6bf16_128_128_1_1_1(
+    at::Tensor XQ, // MX FP6
+    at::Tensor WQ, // MX FP6
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx6mx6bf16<128, 128, 1, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_128_128_2_2_1.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_128_128_2_2_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx6mx6bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx6mx6bf16_128_128_2_2_1(
+    at::Tensor XQ, // MX FP6
+    at::Tensor WQ, // MX FP6
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx6mx6bf16<128, 128, 2, 2, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_128_128_4_1_1.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_128_128_4_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx6mx6bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx6mx6bf16_128_128_4_1_1(
+    at::Tensor XQ, // MX FP6
+    at::Tensor WQ, // MX FP6
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx6mx6bf16<128, 128, 4, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_128_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_128_2_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx6mx6bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx6mx6bf16_256_128_2_1_1(
+    at::Tensor XQ, // MX FP6
+    at::Tensor WQ, // MX FP6
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx6mx6bf16<256, 128, 2, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_128_2_2_1.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_128_2_2_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx6mx6bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx6mx6bf16_256_128_2_2_1(
+    at::Tensor XQ, // MX FP6
+    at::Tensor WQ, // MX FP6
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx6mx6bf16<256, 128, 2, 2, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_128_4_1_1.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_128_4_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx6mx6bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx6mx6bf16_256_128_4_1_1(
+    at::Tensor XQ, // MX FP6
+    at::Tensor WQ, // MX FP6
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx6mx6bf16<256, 128, 4, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_256_2_1_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx6mx6bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx6mx6bf16_256_256_2_1_1(
+    at::Tensor XQ, // MX FP6
+    at::Tensor WQ, // MX FP6
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx6mx6bf16<256, 256, 2, 1, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_256_2_4_1.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_256_256_2_4_1.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx6mx6bf16_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx6mx6bf16_256_256_2_4_1(
+    at::Tensor XQ, // MX FP6
+    at::Tensor WQ, // MX FP6
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  return _mx6mx6bf16<256, 256, 2, 4, 1>(XQ, WQ, x_scale, w_scale, output);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_common.cuh
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_common.cuh
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define CUTLASS_NAMESPACE mslk
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cutlass/util/device_memory.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
+#include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
+#include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
+// clang-format on
+
+namespace mslk::gemm {
+
+namespace cutlass = cutlass_mslk;
+
+using MXFP6 = cutlass::mx_float6_t<cutlass::float_e2m3_t>;
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+template <
+    int TB_M,
+    int TB_N,
+    int TBS_M,
+    int TBS_N,
+    int TBS_K>
+at::Tensor _mx6mx6bf16(
+    at::Tensor XQ, // MX FP6 (e2m3)
+    at::Tensor WQ, // MX FP6 (e2m3)
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output) {
+  c10::cuda::CUDAGuard deviceGuard(XQ.device());
+
+  const int M = XQ.size(0);
+  const int N = WQ.size(0);
+  // XQ is packed 6-bit: K elements occupy K*6/8 = K*3/4 bytes, so K = bytes * 4
+  // / 3.
+  const int K = XQ.size(1) * 4 / 3;
+
+  using ElementA = MXFP6;
+  using LayoutATag = cutlass::layout::RowMajor;
+  using LayoutATag_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutATag>::type;
+  constexpr int AlignmentA = 128;
+
+  using ElementB = MXFP6;
+  using LayoutBTag = cutlass::layout::ColumnMajor;
+  using LayoutBTag_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutBTag>::type;
+  constexpr int AlignmentB = 128;
+
+  using ElementScale = float;
+  using ElementCompute = float;
+  using ElementAccumulator = float;
+
+  using ElementOutput = cutlass::bfloat16_t;
+  using LayoutOutputTag = cutlass::layout::RowMajor;
+  using LayoutOutputTag_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutOutputTag>::type;
+  constexpr int AlignmentOutput =
+      128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+  using ArchTag = cutlass::arch::Sm100;
+  using OperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+
+  constexpr int TileShapeK = 128;
+
+  using MmaTileShape =
+      cute::Shape<cute::Int<TB_M>, cute::Int<TB_N>, cute::Int<TileShapeK>>;
+  using ClusterShape =
+      cute::Shape<cute::Int<TBS_M>, cute::Int<TBS_N>, cute::Int<TBS_K>>;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          MmaTileShape,
+          ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementAccumulator,
+          void,
+          void,
+          0,
+          ElementOutput,
+          LayoutOutputTag_Transpose,
+          AlignmentOutput,
+          cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          ElementB,
+          LayoutBTag_Transpose,
+          AlignmentB,
+          ElementA,
+          LayoutATag_Transpose,
+          AlignmentA,
+          ElementAccumulator,
+          MmaTileShape,
+          ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      cute::Shape<int, int, int, int>,
+      CollectiveMainloop,
+      CollectiveEpilogue,
+      void>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using LayoutA =
+      decltype(cute::make_layout(cute::make_shape(0, 0, 0), StrideA{}));
+  using LayoutSFA = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using LayoutB =
+      decltype(cute::make_layout(cute::make_shape(0, 0, 0), StrideB{}));
+  using LayoutSFB = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFB;
+  using StrideOutput = typename Gemm::GemmKernel::StrideC;
+  using LayoutOutput =
+      decltype(cute::make_layout(cute::make_shape(0, 0, 0), StrideOutput{}));
+
+  using Sm1xxBlkScaledConfig =
+      typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+
+  StrideA stride_A =
+      cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, 1));
+  StrideB stride_B =
+      cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N, K, 1));
+  StrideOutput stride_output = cutlass::make_cute_packed_stride(
+      StrideOutput{}, cute::make_shape(N, M, 1));
+
+  LayoutA layout_A = make_layout(cute::make_shape(M, K, 1), stride_A);
+  LayoutB layout_B = make_layout(cute::make_shape(N, K, 1), stride_B);
+  LayoutOutput layout_output =
+      make_layout(cute::make_shape(N, M, 1), stride_output);
+  LayoutSFA layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+      cute::make_shape(M, N, K, 1));
+  LayoutSFB layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+      cute::make_shape(M, N, K, 1));
+
+  using DataTypeA = typename ElementA::DataType;
+  using DataTypeB = typename ElementB::DataType;
+  using SFTypeA = typename ElementA::ScaleFactorType;
+  using SFTypeB = typename ElementB::ScaleFactorType;
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {N, M, K, 1},
+      {// Mainloop arguments
+       reinterpret_cast<DataTypeB*>(WQ.data_ptr()),
+       stride_B,
+       reinterpret_cast<DataTypeA*>(XQ.data_ptr()),
+       stride_A,
+       reinterpret_cast<SFTypeB*>(w_scale.data_ptr()),
+       layout_SFB,
+       reinterpret_cast<SFTypeA*>(x_scale.data_ptr()),
+       layout_SFA},
+      {// Epilogue arguments
+       {1, 0},
+       reinterpret_cast<ElementOutput*>(output.data_ptr()),
+       stride_output,
+       reinterpret_cast<ElementOutput*>(output.data_ptr()),
+       stride_output}};
+
+  Gemm gemm;
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  at::Tensor workspace =
+      at::empty(workspace_size, XQ.options().dtype(at::kByte));
+
+  cutlass::Status status = gemm.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  status = gemm.initialize(arguments, workspace.data_ptr());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm(at::cuda::getCurrentCUDAStream());
+
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot run") +
+        cutlass::cutlassGetStatusString(status));
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return output;
+}
+
+#endif
+
+} // namespace mslk::gemm
+
+#undef CUTLASS_NAMESPACE

--- a/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_manifest.cuh
+++ b/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_manifest.cuh
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx6mx6bf16_128_128_1_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+at::Tensor mx6mx6bf16_128_128_2_2_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+at::Tensor mx6mx6bf16_256_128_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+at::Tensor mx6mx6bf16_256_128_2_2_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+at::Tensor mx6mx6bf16_256_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+at::Tensor mx6mx6bf16_256_256_2_4_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+at::Tensor mx6mx6bf16_256_128_4_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+at::Tensor mx6mx6bf16_128_128_4_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output);
+
+using Kernel_mx6mx6bf16 =
+    at::Tensor (*)(at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor);
+
+#endif
+} // namespace mslk::gemm

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -57,6 +57,8 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   m.def(
       "mx8mx6bf16(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? output=None) -> Tensor");
   m.def(
+      "mx6mx6bf16(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? output=None) -> Tensor");
+  m.def(
       "f4f4bf16_grouped_stacked(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes, Tensor? global_scale=None, Tensor? starting_row_after_padding=None, bool use_mx=True) -> Tensor");
   m.def(
       "mx8mx8bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None, int? actual_num_tokens=None) -> Tensor");
@@ -123,6 +125,7 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("f4f4bf16", f4f4bf16);
   m.impl("mx8mx4bf16", mx8mx4bf16);
   m.impl("mx8mx6bf16", mx8mx6bf16);
+  m.impl("mx6mx6bf16", mx6mx6bf16);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
   m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
   m.impl("f4f4bf16_grouped_mm", f4f4bf16_grouped_mm);
@@ -175,6 +178,7 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("f4f4bf16", f4f4bf16);
   m.impl("mx8mx4bf16", mx8mx4bf16);
   m.impl("mx8mx6bf16", mx8mx6bf16);
+  m.impl("mx6mx6bf16", mx6mx6bf16);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
   m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
   m.impl("f4f4bf16_grouped_mm", f4f4bf16_grouped_mm);

--- a/include/mslk/gemm/gemm.h
+++ b/include/mslk/gemm/gemm.h
@@ -249,4 +249,13 @@ at::Tensor mx8mx6bf16(
     at::Tensor w_scale,
     std::optional<at::Tensor> output = std::nullopt);
 
+// Symmetric MX6 x MX6 GEMM using mxf8f6f4 block-scaled tensor core instruction
+// ElementA = ElementB = mx_float6_t<float_e2m3_t>
+at::Tensor mx6mx6bf16(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    std::optional<at::Tensor> output = std::nullopt);
+
 } // namespace mslk::gemm

--- a/mslk/gemm/_meta.py
+++ b/mslk/gemm/_meta.py
@@ -306,6 +306,21 @@ if hasattr(torch.ops.mslk, "mx8mx4bf16"):
         return torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
 
 
+if hasattr(torch.ops.mslk, "mx6mx6bf16"):
+
+    @torch.library.register_fake("mslk::mx6mx6bf16")
+    def mx6mx6bf16_meta(
+        XQ: torch.Tensor,
+        WQ: torch.Tensor,
+        x_scale: torch.Tensor,
+        w_scale: torch.Tensor,
+        output: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        M = XQ.shape[0]
+        N = WQ.shape[0]
+        return torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
+
+
 if hasattr(torch.ops.mslk, "f8f8bf16"):
 
     @torch.library.register_fake("mslk::f8f8bf16")

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -2965,5 +2965,48 @@ class MX8MX6Tests(unittest.TestCase):
         self.assertEqual(out_mx8mx6.shape, (M, N))
 
 
+@unittest.skipIf(not SUPPORTS_MXFP4, "Skip if block-scaled GEMM is not supported")
+class MX6MX6Tests(unittest.TestCase):
+    """Tests for the symmetric MX6 x MX6 CUTLASS GEMM kernel (mx6mx6bf16)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.device = torch.accelerator.current_accelerator()
+
+    @settings(deadline=None)
+    @given(
+        M=st.sampled_from([1, 64, 256]),
+        N=st.sampled_from([256, 1024]),
+        K=st.sampled_from([2048, 4096]),
+    )
+    def test_gemm(self, M: int, N: int, K: int) -> None:
+        # Both A and B are random uint8 bytes packed at 6 bits/element. The
+        # mx6mx6bf16 kernel derives K = XQ.size(1) * 4 / 3 from packed bytes,
+        # so passing unpacked (M, K)-shape uint8 (e.g. via to_mxfp8(...) & 0x3F
+        # like the asymmetric mx8mx6 test) would silently corrupt K. No Python
+        # MX6 quantizer is wired up, so this test only validates dispatch +
+        # kernel execution (no NaN/Inf, correct shape/dtype).
+        A_bf16 = torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        B_bf16 = torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+
+        # MX6 packed weights for A and B: K elements at 6 bits each = K*6/8 bytes.
+        aq_6 = torch.randint(
+            0, 256, (M, K * 6 // 8), dtype=torch.uint8, device=self.device
+        )
+        bq_6 = torch.randint(
+            0, 256, (N, K * 6 // 8), dtype=torch.uint8, device=self.device
+        )
+        # Reuse MX4 block-scale layout (E8M0, block size 32) for both operands.
+        _, a_scale = triton_quantize_mx4_unpack(A_bf16)
+        _, b_scale = triton_quantize_mx4_unpack(B_bf16)
+
+        out_mx6mx6 = torch.ops.mslk.mx6mx6bf16(aq_6, bq_6, a_scale, b_scale)
+
+        self.assertFalse(out_mx6mx6.isnan().any().item(), "Output contains NaN")
+        self.assertFalse(out_mx6mx6.isinf().any().item(), "Output contains Inf")
+        self.assertEqual(out_mx6mx6.shape, torch.Size([M, N]))
+        self.assertEqual(out_mx6mx6.dtype, torch.bfloat16)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Adds a symmetric MX6×MX6 → BF16 CUTLASS GEMM kernel (`torch.ops.mslk.mx6mx6bf16`) for Blackwell (SM100, `CUDA` ≥ `12.8`), filling the symmetric-FP6 slot in the existing `mxf8f6f4` precision sweep (mx8mx8 → mx8mx6 → **mx6mx6** → mx8mx4 → f4f4). Both operands are `cutlass::mx_float6_t<float_e2m3_t>`; A and B are bit-packed (K elements ↔ K·6/8 bytes). Block-scaled with E8M0 scales, block size 32. Mirrors the structure of the asymmetric `mx8mx6bf16` kernel from D103697749 — top-level dispatch + 8 per-tile shims + manifest + heuristic + autotune-via-`MSLK_AUTOTUNE_ENABLE`.

# What's added

- `mslk/csrc/gemm/cutlass/mx6mx6bf16.cu` — top-level dispatch with a B200-tuned heuristic plus the existing `TuningCache` autotune path.
- `mslk/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_common.cuh` — templated `_mx6mx6bf16<TB_M, TB_N, TBS_M, TBS_N, TBS_K>` (`AlignmentA = AlignmentB = 128` literal, `TileShapeK = 128`, `OpClassBlockScaledTensorOp`, TN layout, BF16 epilogue).
- `mslk/csrc/gemm/cutlass/mx6mx6bf16/mx6mx6bf16_manifest.cuh` + 8 per-tile shims (`128_128_{1_1_1, 2_2_1, 4_1_1}`, `256_128_{2_1_1, 2_2_1, 4_1_1}`, `256_256_{2_1_1, 2_4_1}`).
- BUCK: new `cutlass_mx6mx6bf16` `gpu_cpp_library`; wired into `gemm_ops_cutlass`; new `mx6mx6_bench` `python_binary`.
- Op registration in `gemm_ops.cpp` (CUDA + CPU `m.impl`s) and a declaration in `mslk/include/mslk/gemm/gemm.h`.
- Python Meta dispatch in `mslk/gemm/_meta.py` via `torch.library.register_fake("mslk::mx6mx6bf16")` (matches the post- D102010050 pattern; not the older C++ `TORCH_LIBRARY_IMPL(mslk, Meta, m)` pattern that D103697749 uses).
- Hypothesis test `MX6MX6Tests` in `mslk/test/gemm/gemm_test.py`.
- Throughput-only bench `mslk/bench/gemm/mx6mx6_bench.py` comparing bf16 / mx8mx8 / mx8mx6 / mx6mx6 / mx8mx4 / f4f4 (each comparison kernel is `hasattr`-guarded so the bench runs against any subset of the family being available.

# Heuristic

`get_kernel_via_heuristics` was tuned on B200 (`devgpu031.snb3`, `CUDA 12.8`) via an autotune sweep, then verified against a 10-rep validation bench. The tree uses 3 of the 8 available tiles (`256_128_2_1_1`, `256_128_4_1_1`, `256_256_2_1_1`); the other 5 are reachable only via runtime autotune through `MSLK_AUTOTUNE_ENABLE`.

# Notes / caveats

- **Packed-K derivation:** `K = XQ.size(1) * 4 / 3` because A is bit-packed at 6 bits/element. Both `mx6mx6bf16.cu` and `mx6mx6bf16_common.cuh` derive K this way and `TORCH_CHECK(K % 32 == 0)` for the block-scale alignment. This is the one place the kernel deviates from the D103697749 `mx8mx6bf16` template, which treats A as unpacked MX8 (`K = XQ.size(1)`) — the packed-A handling is borrowed from `f4f4bf16` instead.
- **N alignment:** kernel requires `N % 8 == 0` (CUTLASS scale-factor layout); discovered by probe and observed by the test/bench shape choices.
- **No Python MX6 quantizer is wired up**, so the test inputs and bench A/B operands are random uint8 packed bytes — the test asserts only no-NaN / no-Inf / shape / dtype, no `assert_close` against an unrelated `A @ B.t()` reference.
- **Architectural ceiling:** there is no `MXF6F6` block-scaled MMA on Blackwell — `cute/arch/mma_sm100_desc.hpp` exposes only `MXF8F6F4Format` and `MXF4Format`. mx6mx6, mx8mx6, and mx8mx8 all emit the same `mxf8f6f4` instruction, so at large M they converge to the same TFLOPS; mx6mx6's win is bandwidth on A at small M.

Differential Revision: D104892225


