### PR TITLE
Enable per-token scaled FP4 grouped gemm on B200

### DIFF
--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -2751,8 +2751,10 @@ class CutlassNVFP4TorchGrouped(GemmOpBase):
 @register_gemm_op
 class NVFP4UltraGroupwise(GemmOpBase):
     """
-    NVFP4 ultra grouped GEMM (SM103) with per-token activation scaling
-    and per-expert weight scaling, applied separately in the EVT epilogue.
+    NVFP4 grouped GEMM with per-token activation scaling and per-expert
+    weight scaling, applied separately in the EVT epilogue. Uses the SM103
+    ultra NVFP4 schedules on B300 and the standard SM100 NVFP4 schedules
+    on B200; the appropriate kernel is selected at runtime.
     """
 
     def preprocess(self, x, w):
@@ -2841,7 +2843,7 @@ class NVFP4UltraGroupwise(GemmOpBase):
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.NVIDIA_SM103}
+        return {Accelerator.NVIDIA_SM100, Accelerator.NVIDIA_SM103}
 
     @property
     def supported_gemm_types(self) -> set[GemmType]:

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped.cu
@@ -9,20 +9,48 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 #include "f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_manifest.cuh"
 #endif
 
 namespace mslk::gemm {
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+namespace {
+
+// Returns the compute capability of the current device as major*10 + minor
+// (e.g. 100 for B200 / sm_100, 103 for B300 / sm_103). Cached on first call.
+int get_device_sm_version() {
+  static int sm = []() {
+    auto* props = at::cuda::getDeviceProperties(at::cuda::current_device());
+    return props->major * 10 + props->minor;
+  }();
+  return sm;
+}
+
+} // namespace
 
 Kernel_f4f4bf16_ultra_grouped
 get_ultra_kernel_via_heuristics(int M, int N, int K) {
-  if (M <= 128) {
-    return f4f4bf16_ultra_grouped_256_128_768_2_1_1;
+  const int sm = get_device_sm_version();
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+  // B300 (SM 10.3) ultra NVFP4 path.
+  if (sm >= 103) {
+    if (M <= 128) {
+      return f4f4bf16_ultra_grouped_256_128_768_2_1_1;
+    }
+    return f4f4bf16_ultra_grouped_256_256_768_2_1_1;
   }
-  return f4f4bf16_ultra_grouped_256_256_768_2_1_1;
+#endif
+  // B200 (SM 10.0) NVFP4 path.
+  TORCH_CHECK(
+      sm >= 100,
+      "f4f4bf16_ultra_grouped_mm requires a Blackwell (sm_100+) GPU.");
+  if (M <= 128) {
+    return f4f4bf16_ultra_grouped_256_128_256_2_1_1;
+  }
+  return f4f4bf16_ultra_grouped_256_256_256_2_1_1;
 }
 
 at::Tensor f4f4bf16_ultra_grouped_mm(
@@ -102,7 +130,7 @@ at::Tensor f4f4bf16_ultra_grouped_mm(
     at::Tensor w_global_scale,
     std::optional<at::Tensor> output) {
   throw std::runtime_error(
-      "f4f4bf16_ultra_grouped_mm requires CUDA 13.0+ (SM103/B300)");
+      "f4f4bf16_ultra_grouped_mm requires CUDA 12.8+ and a Blackwell GPU");
 }
 
 #endif

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_128_256_768_1_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_128_256_768_1_1_1.cu
@@ -21,7 +21,7 @@ at::Tensor f4f4bf16_ultra_grouped_128_256_768_1_1_1(
     at::Tensor x_global_scale,
     at::Tensor w_global_scale,
     at::Tensor output) {
-  return f4f4bf16_ultra_grouped_impl<128, 256, 768, 1, 1, 1>(
+  return f4f4bf16_ultra_grouped_impl<true, 128, 256, 768, 1, 1, 1>(
       XQ,
       WQ,
       x_scale,

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_128_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_128_256_2_1_1.cu
@@ -10,9 +10,9 @@
 
 namespace mslk::gemm {
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
-at::Tensor f4f4bf16_ultra_grouped_256_256_768_2_1_1(
+at::Tensor f4f4bf16_ultra_grouped_256_128_256_2_1_1(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
@@ -21,7 +21,7 @@ at::Tensor f4f4bf16_ultra_grouped_256_256_768_2_1_1(
     at::Tensor x_global_scale,
     at::Tensor w_global_scale,
     at::Tensor output) {
-  return f4f4bf16_ultra_grouped_impl<true, 256, 256, 768, 2, 1, 1>(
+  return f4f4bf16_ultra_grouped_impl<false, 256, 128, 256, 2, 1, 1>(
       XQ,
       WQ,
       x_scale,

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_128_768_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_128_768_2_1_1.cu
@@ -21,7 +21,7 @@ at::Tensor f4f4bf16_ultra_grouped_256_128_768_2_1_1(
     at::Tensor x_global_scale,
     at::Tensor w_global_scale,
     at::Tensor output) {
-  return f4f4bf16_ultra_grouped_impl<256, 128, 768, 2, 1, 1>(
+  return f4f4bf16_ultra_grouped_impl<true, 256, 128, 768, 2, 1, 1>(
       XQ,
       WQ,
       x_scale,

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_256_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_256_256_256_2_1_1.cu
@@ -10,9 +10,9 @@
 
 namespace mslk::gemm {
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
-at::Tensor f4f4bf16_ultra_grouped_256_256_768_2_1_1(
+at::Tensor f4f4bf16_ultra_grouped_256_256_256_2_1_1(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
@@ -21,7 +21,7 @@ at::Tensor f4f4bf16_ultra_grouped_256_256_768_2_1_1(
     at::Tensor x_global_scale,
     at::Tensor w_global_scale,
     at::Tensor output) {
-  return f4f4bf16_ultra_grouped_impl<true, 256, 256, 768, 2, 1, 1>(
+  return f4f4bf16_ultra_grouped_impl<false, 256, 256, 256, 2, 1, 1>(
       XQ,
       WQ,
       x_scale,

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_common.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_common.cuh
@@ -23,16 +23,20 @@
 #include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
 // clang-format on
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
 namespace mslk::gemm {
 
 namespace cutlass = cutlass_mslk;
 
-// SM103 ultra builder requires cute::tuple element types, not nv_float4_t.
+// Underlying element types (same for both Sm100 NVFP4 and Sm103 ultra NVFP4).
 using ElementData = cutlass::float_e2m1_t;
 using ElementScale = cutlass::float_ue4m3_t;
+// Sm103 ultra CollectiveBuilder expects the (data, scale) pair as a
+// cute::tuple, while the Sm100 NVFP4 CollectiveBuilder takes nv_float4_t
+// directly.
 using ElementPair = cute::tuple<ElementData, ElementScale>;
+using ElementNvf4 = cutlass::nv_float4_t<ElementData>;
 
 inline int64_t _byte_align(int64_t offset) {
   int64_t remainder = offset % 16;
@@ -134,7 +138,25 @@ __global__ void set_ultra_grouped_args_kernel(
   w_global_scale_ptr[group_index] = w_global_scale + group_index;
 }
 
+// Sm103 ultra schedules require CUDA 13+. Alias them to Sm100 NVFP4 schedules
+// on older toolkits so that template instantiation with UseUltra=false still
+// resolves to valid types when those CUDA 12.8 builds reach the conditional.
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+using _UltraArchTag = cutlass::arch::Sm103;
+using _UltraSchedule2Sm = cutlass::gemm::
+    KernelPtrArrayTmaWarpSpecialized2SmBlockScaledMxNvf4UltraVs16Sm103;
+using _UltraSchedule1Sm = cutlass::gemm::
+    KernelPtrArrayTmaWarpSpecialized1SmBlockScaledMxNvf4UltraVs16Sm103;
+#else
+using _UltraArchTag = cutlass::arch::Sm100;
+using _UltraSchedule2Sm =
+    cutlass::gemm::KernelPtrArrayTmaWarpSpecialized2SmNvf4Sm100;
+using _UltraSchedule1Sm =
+    cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmNvf4Sm100;
+#endif
+
 template <
+    bool UseUltra,
     int TB_M,
     int TB_N,
     int TB_K,
@@ -172,19 +194,30 @@ at::Tensor f4f4bf16_ultra_grouped_impl(
 
   using ElementAccumulator = float;
   using ElementComputeEpilogue = float;
-  using ArchTag = cutlass::arch::Sm103;
+  using ArchTag =
+      cute::conditional_t<UseUltra, _UltraArchTag, cutlass::arch::Sm100>;
   using TileShape =
       cute::Shape<cute::Int<TB_M>, cute::Int<TB_N>, cute::Int<TB_K>>;
   using ClusterShape =
       cute::Shape<cute::Int<TBS_M>, cute::Int<TBS_N>, cute::Int<TBS_K>>;
 
-  // SM103 ultra grouped GEMM schedules for NVFP4.
+  // Sm103 ultra path uses cute::tuple<data, scale>; Sm100 NVFP4 path takes
+  // nv_float4_t directly.
+  using ElementForBuilder =
+      cute::conditional_t<UseUltra, ElementPair, ElementNvf4>;
+
+  // Kernel schedule: ultra uses BlockScaledMxNvf4UltraVs16Sm103, Sm100 uses the
+  // standard Nvf4 ptr-array schedule (matching f4f4bf16_grouped).
   using KernelSchedule = cute::conditional_t<
-      (TB_M == 256) && (TBS_M % 2 == 0),
-      cutlass::gemm::
-          KernelPtrArrayTmaWarpSpecialized2SmBlockScaledMxNvf4UltraVs16Sm103,
-      cutlass::gemm::
-          KernelPtrArrayTmaWarpSpecialized1SmBlockScaledMxNvf4UltraVs16Sm103>;
+      UseUltra,
+      cute::conditional_t<
+          (TB_M == 256) && (TBS_M % 2 == 0),
+          _UltraSchedule2Sm,
+          _UltraSchedule1Sm>,
+      cute::conditional_t<
+          (TB_M == 256) && (TBS_M % 2 == 0),
+          cutlass::gemm::KernelPtrArrayTmaWarpSpecialized2SmNvf4Sm100,
+          cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmNvf4Sm100>>;
   using EpilogueSchedule = cute::conditional_t<
       (TB_M == 256) && (TBS_M % 2 == 0),
       cutlass::epilogue::PtrArrayTmaWarpSpecialized2Sm,
@@ -226,18 +259,37 @@ at::Tensor f4f4bf16_ultra_grouped_impl(
 
   using EpilogueEVT = EVTCompute1;
 
+  // Ultra (Sm103) uses OpClassBlockScaledTensorOp for the epilogue; Sm100
+  // NVFP4 uses OpClassTensorOp (matches f4f4bf16_grouped_common.cuh).
+  using EpilogueOpClass = cute::conditional_t<
+      UseUltra,
+      cutlass::arch::OpClassBlockScaledTensorOp,
+      cutlass::arch::OpClassTensorOp>;
+
+  // On Sm100, Sm90ScalarBroadcastPtrArray (used by WGlobalScale above) needs a
+  // non-void C type so its pointer-array stride layout is set up correctly.
+  // On Sm103 ultra, void C performs better, so keep the original behavior
+  // there. Source C is unused (nullptr passed in arguments, no beta) in both
+  // cases — this only affects internal stride bookkeeping.
+  using EpilogueElementC = cute::conditional_t<UseUltra, void, ElementC>;
+  using EpilogueLayoutC = cute::conditional_t<
+      UseUltra,
+      void,
+      typename cutlass::layout::LayoutTranspose<LayoutC>::type*>;
+  static constexpr int EpilogueAlignmentC = UseUltra ? 0 : AlignmentC;
+
   using CollectiveEpilogue =
       typename cutlass::epilogue::collective::CollectiveBuilder<
           ArchTag,
-          cutlass::arch::OpClassBlockScaledTensorOp,
+          EpilogueOpClass,
           TileShape,
           ClusterShape,
           cutlass::epilogue::collective::EpilogueTileAuto,
           ElementAccumulator,
           ElementAccumulator,
-          void, // No source C matrix (no beta scaling).
-          typename cutlass::layout::LayoutTranspose<LayoutC>::type*,
-          AlignmentC,
+          EpilogueElementC,
+          EpilogueLayoutC,
+          EpilogueAlignmentC,
           ElementC,
           typename cutlass::layout::LayoutTranspose<LayoutC>::type*,
           AlignmentC,
@@ -248,10 +300,10 @@ at::Tensor f4f4bf16_ultra_grouped_impl(
       typename cutlass::gemm::collective::CollectiveBuilder<
           ArchTag,
           cutlass::arch::OpClassBlockScaledTensorOp,
-          ElementPair, // cute::tuple<float_e2m1_t, float_ue4m3_t>
+          ElementForBuilder,
           LayoutB_Transpose*,
           AlignmentB,
-          ElementPair, // cute::tuple<float_e2m1_t, float_ue4m3_t>
+          ElementForBuilder,
           LayoutA_Transpose*,
           AlignmentA,
           ElementAccumulator,

--- a/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_manifest.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16_ultra_grouped/f4f4bf16_ultra_grouped_manifest.cuh
@@ -10,8 +10,31 @@
 
 namespace mslk::gemm {
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
+// SM100 (B200) NVFP4 variants. Use TileShape K = 256.
+at::Tensor f4f4bf16_ultra_grouped_256_128_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output);
+
+at::Tensor f4f4bf16_ultra_grouped_256_256_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output);
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+// SM103 (B300) NVFP4 ultra variants. Use TileShape K = 768.
 at::Tensor f4f4bf16_ultra_grouped_128_256_768_1_1_1(
     at::Tensor XQ,
     at::Tensor WQ,
@@ -41,6 +64,7 @@ at::Tensor f4f4bf16_ultra_grouped_256_128_768_2_1_1(
     at::Tensor x_global_scale,
     at::Tensor w_global_scale,
     at::Tensor output);
+#endif // CUDA >= 13.0
 
 using Kernel_f4f4bf16_ultra_grouped = at::Tensor (*)(
     at::Tensor,
@@ -56,15 +80,21 @@ const std::unordered_map<std::string, Kernel_f4f4bf16_ultra_grouped>&
 get_f4f4bf16_ultra_grouped_kernels() {
   static const std::unordered_map<std::string, Kernel_f4f4bf16_ultra_grouped>
       kernels = {
+          {"f4f4bf16_ultra_grouped_256_128_256_2_1_1",
+           f4f4bf16_ultra_grouped_256_128_256_2_1_1},
+          {"f4f4bf16_ultra_grouped_256_256_256_2_1_1",
+           f4f4bf16_ultra_grouped_256_256_256_2_1_1},
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
           {"f4f4bf16_ultra_grouped_128_256_768_1_1_1",
            f4f4bf16_ultra_grouped_128_256_768_1_1_1},
           {"f4f4bf16_ultra_grouped_256_256_768_2_1_1",
            f4f4bf16_ultra_grouped_256_256_768_2_1_1},
           {"f4f4bf16_ultra_grouped_256_128_768_2_1_1",
            f4f4bf16_ultra_grouped_256_128_768_2_1_1},
+#endif
       };
   return kernels;
 }
 
-#endif
+#endif // CUDA >= 12.8
 } // namespace mslk::gemm


### PR DESCRIPTION
Summary: Adds templating to allow per-token FP4 grouped gemm kernel to run on GB200 as well as GB300. This is done in a purely static way so it has no impact on performance. The new GB200 functionality has similar perf to the standard global scale grouped gemm.

Differential Revision: D106103018


