### PR TITLE
Fix `f8f8bf16` meta to support 3D activations

### DIFF
--- a/mslk/gemm/_meta.py
+++ b/mslk/gemm/_meta.py
@@ -330,9 +330,20 @@ if hasattr(torch.ops.mslk, "f8f8bf16"):
         scale: torch.Tensor,
         use_fast_accum: bool = True,
     ) -> torch.Tensor:
-        M = X.shape[0]
-        N = W.shape[0]
-        return torch.empty((M, N), dtype=torch.bfloat16, device=X.device)
+        x_dims = X.dim()
+        w_dims = W.dim()
+        assert (x_dims == 2 or x_dims == 3) and (w_dims == 2), (
+            "The dim of X must be 2 or 3, and dim of W must be 2"
+        )
+        if x_dims == 2:
+            M = X.shape[0]
+            N = W.shape[0]
+            return torch.empty((M, N), dtype=torch.bfloat16, device=X.device)
+        else:
+            B = X.shape[0]
+            M = X.shape[1]
+            N = W.shape[0]
+            return torch.empty((B, M, N), dtype=torch.bfloat16, device=X.device)
 
 
 if hasattr(torch.ops.mslk, "f8f8bf16_groupwise"):


### PR DESCRIPTION
### Summary

The bare `f8f8bf16_meta` in `mslk/gemm/_meta.py` only handles 2D inputs — it returns `(M, N)` regardless of input rank. Every other `f8f8bf16_*` meta in the same file (`_rowwise`, `_blockwise`, `_tensorwise`, `_rowwise_batched`) already handles both 2D and 3D via a `dim()` check. This PR brings `f8f8bf16_meta` in line with that convention so callers passing a 3D `X` of shape `(B, M, K)` get back a correctly-shaped meta tensor `(B, M, N)` instead of `(M, N)`.

### Change

```diff
 if hasattr(torch.ops.mslk, "f8f8bf16"):

     @torch.library.register_fake("mslk::f8f8bf16")
     def f8f8bf16_meta(
         X: torch.Tensor,
         W: torch.Tensor,
         scale: torch.Tensor,
         use_fast_accum: bool = True,
     ) -> torch.Tensor:
-        M = X.shape[0]
-        N = W.shape[0]
-        return torch.empty((M, N), dtype=torch.bfloat16, device=X.device)
+        x_dims = X.dim()
+        w_dims = W.dim()
+        assert (x_dims == 2 or x_dims == 3) and (w_dims == 2), (
+            "The dim of X must be 2 or 3, and dim of W must be 2"
+        )
+        if x_dims == 2:
+            M = X.shape[0]
+            N = W.shape[0]
+            return torch.empty((M, N), dtype=torch.bfloat16, device=X.device)
+        else:
+            B = X.shape[0]
+            M = X.shape[1]
+            N = W.shape[0]
+            return torch.empty((B, M, N), dtype=torch.bfloat16, device=X.device)
```

### Rationale

- Matches the established pattern of the three sibling metas immediately above (`f8f8bf16_rowwise_meta`, `f8f8bf16_blockwise_meta`, `f8f8bf16_tensorwise_meta`) — same assert, same branching, same shape contract.
- In practice `F.linear` flattens 3D activations to 2D before the underlying matmul, so torchao + `nn.Linear` callers don't hit the wrong-shape return today. This PR is a correctness / convention fix for direct callers under `torch.compile` / `torch.export`, not a fix for a user-visible bug.
- Risk is low: the 2D code path is unchanged; the 3D path is new but mirrors the proven pattern from the sibling metas.

### Note on other 2D-only metas

Several other metas in this file are also 2D-only and follow the same `M = X.shape[0]; N = W.shape[0]; return (M, N)` pattern: `i8i8bf16`, `i8i8bf16_dynamic`, `f4f4bf16`, `mx8mx4bf16`, `f8f8bf16_groupwise`, `f8f8bf16_cublas`, `bf16x9_gemm`, `f8i4bf16_shuffled`, `f8f8f16_rowwise`, `f8f8f16_rowwise_preshuffle`. I left them untouched in this PR because I don't have empirical evidence that their C++ kernels accept 3D inputs — happy to file a follow-up PR if you confirm which ones should be brought in line with the 2D/3D convention.

### Testing

Verified locally on H100 + CUDA 13.2 + PyTorch 2.12 + torchao (current main with `import mslk.gemm` added):

```python
import torch
import mslk.gemm  # registers fakes

X = torch.empty(2, 8, 16, dtype=torch.float8_e4m3fn, device="meta")
W = torch.empty(32, 16, dtype=torch.float8_e4m3fn, device="meta")
s = torch.empty(1, dtype=torch.float32, device="meta")
out = torch.ops.mslk.f8f8bf16(X, W, s)
assert tuple(out.shape) == (2, 8, 32)   # before this PR: (2, 32) — wrong
```

cc @jwfromm @janeyx99