### PR TITLE
Enable MX8xMX4 grouped GEMM

### DIFF
--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -3154,6 +3154,94 @@ class CutlassMXFP8GroupwiseGrouped2D3D(GemmOpBase):
 
 
 @register_gemm_op
+class CutlassMX8MX4GroupwiseGrouped2D3D(GemmOpBase):
+    """
+    MXFP8 activation x MXFP4 weight grouped GEMM with 2D inputs and 3D weights.
+    """
+
+    def preprocess(self, x, w):
+        assert isinstance(x, list)
+        assert isinstance(w, list)
+        x = torch.cat(x, dim=0).contiguous()
+        w = torch.stack(w, dim=0).contiguous()
+        return x, w
+
+    def quantize(self, x, w):
+        block_size = 32
+        G, _, K = w.shape
+        total_M = x.shape[0]
+        group_size = total_M // G
+        input_group_end_offsets = torch.arange(
+            group_size, total_M + 1, group_size, dtype=torch.int32, device=x.device
+        )
+
+        wq_list = []
+        w_scale_list = []
+        for i in range(G):
+            wq, w_scale = triton_quantize_mx4_unpack(w[i])
+            wq_list.append(wq.view(torch.float4_e2m1fn_x2))
+            w_scale_list.append(w_scale)
+        wq = torch.stack(wq_list, dim=0).contiguous()
+        w_scale = torch.stack(w_scale_list, dim=0).contiguous()
+
+        xq_list = []
+        x_scale_list = []
+        for i in range(G):
+            prev_group_end = 0 if i == 0 else input_group_end_offsets[i - 1]
+            curr_group_end = input_group_end_offsets[i]
+            x_slice = x[prev_group_end:curr_group_end, :]
+            x_scale, xq = to_mxfp8(x_slice)
+            x_scale = _to_blocked(
+                x_scale.view(torch.int8).reshape(x_slice.shape[0], -1)
+            ).view(torch.uint8)
+            xq_list.append(xq)
+            x_scale_list.append(x_scale)
+        xq = torch.cat(xq_list, dim=0).contiguous()
+        x_scale = torch.cat(x_scale_list, dim=0).contiguous()
+        x_scale = x_scale.reshape(-1, K // block_size)
+        return xq, wq, x_scale, w_scale, input_group_end_offsets
+
+    def compute(self, xq, wq, x_scale, w_scale, input_group_end_offsets):
+        return torch.ops.mslk.mx8mx4bf16_grouped_mm(
+            xq,
+            wq.transpose(-2, -1),
+            x_scale,
+            w_scale,
+            input_group_end_offsets,
+        )
+
+    def quantize_and_compute(self, x, w):
+        xq, wq, x_scale, w_scale, input_group_end_offsets = self.quantize(x, w)
+        return self.compute(
+            xq,
+            wq,
+            x_scale,
+            w_scale,
+            input_group_end_offsets,
+        )
+
+    @property
+    def supported_accelerators(self) -> set[Accelerator]:
+        return {Accelerator.NVIDIA_SM100, Accelerator.NVIDIA_SM103}
+
+    @property
+    def supported_gemm_types(self) -> set[GemmType]:
+        return {GemmType.GROUPED}
+
+    @property
+    def compute_dtype(self) -> ComputeDtype:
+        return ComputeDtype.FP8
+
+    @property
+    def input_bytes_per_element(self) -> float:
+        return 1.0
+
+    @property
+    def weight_bytes_per_element(self) -> float:
+        return 0.5
+
+
+@register_gemm_op
 class CutlassMXFP8GroupwiseGrouped2D2D(GemmOpBase):
     """
     MXFP8 grouped GEMM with 2D inputs and 2D weights.

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped.cu
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <mslk/utils/utils.h>
+#include <mslk/utils/tuning_cache.cuh>
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+#include "mx8mx4bf16_grouped/mx8mx4bf16_grouped_manifest.cuh"
+#endif
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+namespace {
+
+Kernel_mx8mx4bf16_grouped
+get_mx8mx4_grouped_kernel_via_heuristics(int M, int N, int K) {
+  if (M <= 64) {
+    if (N <= 1024) {
+      return mx8mx4bf16_grouped_128_64_256_1_1_1;
+    } else if (N >= 4096 && K <= 4096) {
+      return mx8mx4bf16_grouped_256_64_128_2_1_1;
+    } else {
+      return mx8mx4bf16_grouped_256_64_256_2_1_1;
+    }
+  } else if (M <= 128) {
+    if (N >= 4096 && K <= 4096) {
+      return mx8mx4bf16_grouped_256_128_128_2_1_1;
+    } else {
+      return mx8mx4bf16_grouped_256_128_256_2_1_1;
+    }
+  } else {
+    if (N >= 4096 && K <= 4096) {
+      return mx8mx4bf16_grouped_256_256_128_2_1_1;
+    } else {
+      return mx8mx4bf16_grouped_256_256_256_2_1_1;
+    }
+  }
+}
+
+Kernel_mx8mx4bf16_grouped get_mx8mx4_grouped_kernel_via_tuning(
+    int M,
+    int N,
+    int K,
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  static TuningCache cache("mx8mx4bf16_grouped");
+
+  M = nextPowerOf2OrRoundUp(M, 1024, 1024);
+  N = nextPowerOf2OrRoundUp(N, 1024, 1024);
+  K = nextPowerOf2OrRoundUp(K, 1024, 1024);
+
+  const std::string shape_key =
+      std::to_string(M) + "_" + std::to_string(N) + "_" + std::to_string(K);
+
+  const auto& kernels = get_mx8mx4bf16_grouped_kernels();
+  return cache.findBestKernelMaybeAutotune(
+      shape_key, kernels, XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+} // namespace
+
+at::Tensor mx8mx4bf16_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    std::optional<at::Tensor> output_maybe) {
+  TORCH_CHECK(
+      XQ.is_cuda() && XQ.is_contiguous(), "XQ must be contiguous CUDA.");
+  TORCH_CHECK(WQ.is_cuda(), "WQ must be CUDA.");
+  TORCH_CHECK(WQ.transpose(-2, -1).is_contiguous(), "WQ must be column major.");
+  TORCH_CHECK(x_scale.is_cuda() && x_scale.is_contiguous());
+  TORCH_CHECK(w_scale.is_cuda() && w_scale.is_contiguous());
+  TORCH_CHECK(offsets.is_cuda(), "offsets must be CUDA.");
+  TORCH_CHECK(offsets.dtype() == at::kInt, "offsets must be int32.");
+  TORCH_CHECK(offsets.dim() == 1, "offsets must be 1D.");
+
+  TORCH_CHECK(XQ.dtype() == at::kFloat8_e4m3fn, "XQ must be MXFP8 E4M3.");
+  TORCH_CHECK(WQ.dtype() == at::kFloat4_e2m1fn_x2, "WQ must be MXFP4 E2M1.");
+
+  TORCH_CHECK(
+      XQ.dim() == 2 && WQ.dim() == 3,
+      "mx8mx4bf16_grouped_mm currently supports only 2D-3D inputs.");
+
+  const int64_t G = offsets.size(0);
+  TORCH_CHECK(
+      G > 0 && G <= 1024, "mx8mx4bf16_grouped_mm supports 1 to 1024 groups.");
+  const int64_t total_M = XQ.size(0);
+  const int64_t N = WQ.size(-1);
+  const int64_t K_storage = WQ.size(-2);
+  const int64_t K = K_storage * 2;
+
+  TORCH_CHECK(WQ.size(0) == G, "WQ group dimension must match offsets.");
+  TORCH_CHECK(
+      XQ.size(1) == K,
+      "XQ shape must be [total_M, K] and WQ shape must be [G, K/2, N].");
+  TORCH_CHECK(K % 32 == 0, "K must be a multiple of 32.");
+
+  at::Tensor output = output_maybe.has_value()
+      ? output_maybe.value()
+      : at::empty({total_M, N}, XQ.options().dtype(at::kBFloat16));
+  TORCH_CHECK(
+      output.dim() == 2 && output.size(0) == total_M && output.size(1) == N,
+      "output must have shape [total_M, N].");
+
+  if (output.numel() == 0) {
+    return output;
+  }
+
+  at::Tensor WQ_contig = WQ.transpose(-2, -1);
+  const int64_t heuristic_M = total_M / G;
+  auto kernel = [&]() {
+    if (std::getenv("MSLK_AUTOTUNE_ENABLE")) {
+      return get_mx8mx4_grouped_kernel_via_tuning(
+          heuristic_M,
+          N,
+          K,
+          XQ,
+          WQ_contig,
+          x_scale,
+          w_scale,
+          output,
+          G,
+          offsets);
+    }
+    return get_mx8mx4_grouped_kernel_via_heuristics(heuristic_M, N, K);
+  }();
+
+  return kernel(XQ, WQ_contig, x_scale, w_scale, output, G, offsets);
+}
+
+#else
+
+at::Tensor mx8mx4bf16_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    std::optional<at::Tensor> output) {
+  throw std::runtime_error("CUDA version is older than 12.8");
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_128_128_256_1_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_128_128_256_1_1_1.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_128_128_256_1_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx4bf16_grouped_impl<128, 128, 256, 1, 1, 1>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_128_256_256_1_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_128_256_256_1_1_1.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_128_256_256_1_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx4bf16_grouped_impl<128, 256, 256, 1, 1, 1>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_128_64_256_1_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_128_64_256_1_1_1.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_128_64_256_1_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx4bf16_grouped_impl<128, 64, 256, 1, 1, 1>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_128_128_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_128_128_2_1_1.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_256_128_128_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx4bf16_grouped_impl<256, 128, 128, 2, 1, 1>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_128_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_128_256_2_1_1.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_256_128_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx4bf16_grouped_impl<256, 128, 256, 2, 1, 1>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_256_128_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_256_128_2_1_1.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_256_256_128_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx4bf16_grouped_impl<256, 256, 128, 2, 1, 1>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_256_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_256_256_2_1_1.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_256_256_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx4bf16_grouped_impl<256, 256, 256, 2, 1, 1>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_64_128_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_64_128_2_1_1.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_256_64_128_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx4bf16_grouped_impl<256, 64, 128, 2, 1, 1>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_64_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_256_64_256_2_1_1.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx8mx4bf16_grouped_common.cuh"
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_256_64_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  return mx8mx4bf16_grouped_impl<256, 64, 256, 2, 1, 1>(
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
+}
+
+#endif
+
+} // namespace mslk::gemm

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_common.cuh
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_common.cuh
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define CUTLASS_NAMESPACE mslk
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cutlass/util/device_memory.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
+#include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
+#include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
+// clang-format on
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+namespace mslk::gemm {
+
+namespace cutlass = cutlass_mslk;
+
+inline int64_t _mx8mx4_grouped_byte_align(int64_t offset) {
+  int64_t remainder = offset % 16;
+  if (remainder != 0) {
+    offset += (16 - remainder);
+  }
+  return offset;
+}
+
+template <
+    typename ProblemShape,
+    typename ElementA,
+    typename ElementB,
+    typename ElementC,
+    typename ScaleDtype,
+    typename StrideA,
+    typename StrideB,
+    typename StrideC,
+    typename LayoutSFA,
+    typename LayoutSFB,
+    typename Sm1xxBlkScaledConfig>
+__global__ void set_mx8mx4_grouped_2d3d_args_kernel(
+    int64_t G,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    ProblemShape* problem_shape_ptr,
+    ElementA* xq,
+    const ElementA** xq_ptr,
+    ElementB* wq,
+    const ElementB** wq_ptr,
+    ScaleDtype* x_scale,
+    const ScaleDtype** x_scale_ptr,
+    ScaleDtype* w_scale,
+    const ScaleDtype** w_scale_ptr,
+    ElementC* output,
+    ElementC** output_ptr,
+    StrideA* stride_a_ptr,
+    StrideB* stride_b_ptr,
+    StrideC* stride_c_ptr,
+    int32_t* offsets,
+    LayoutSFA* layout_SFA,
+    LayoutSFB* layout_SFB) {
+  const uint32_t group_index = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (group_index >= G) {
+    return;
+  }
+
+  __shared__ int non_zero_counter;
+  if (threadIdx.x == 0) {
+    non_zero_counter = 0;
+  }
+
+  problem_shape_ptr[group_index] = ProblemShape(0, 0, 0);
+  __syncthreads();
+
+  const int32_t prev_group_end_offset =
+      (group_index == 0) ? 0 : offsets[group_index - 1];
+  const int32_t curr_group_end_offset = offsets[group_index];
+  const int32_t M_group_size = curr_group_end_offset - prev_group_end_offset;
+
+  if (M_group_size <= 0) {
+    return;
+  }
+
+  CUDA_KERNEL_ASSERT(
+      curr_group_end_offset <= M &&
+      "for mx8mx4 2d-3d grouped GEMM, group end offsets must be <= M\n");
+
+  auto round_up = [](int64_t x, int64_t y) { return ((x + y - 1) / y) * y; };
+
+  constexpr int64_t kScaleFactorBlockSize = 32;
+  const int64_t K_scale_rounded = round_up(K / kScaleFactorBlockSize, 4);
+  const int64_t N_rounded = round_up(N, 128);
+
+  int64_t scale_group_offset_M = 0;
+  for (int i = 0; i < group_index; i++) {
+    const int64_t group_i_size =
+        (i == 0) ? offsets[i] : offsets[i] - offsets[i - 1];
+    scale_group_offset_M += round_up(group_i_size, 128);
+  }
+
+  const int64_t group_offset_M = prev_group_end_offset;
+  const int non_zero_idx = atomicAdd(&non_zero_counter, 1);
+
+  // A is MXFP8: one byte per logical K element.
+  const int64_t xq_offset = group_offset_M * K;
+  // B is MXFP4: two logical K elements packed into one storage element.
+  const int64_t wq_offset = group_index * N * K / 2;
+  const int64_t output_offset = group_offset_M * N;
+  const int64_t x_scale_offset = scale_group_offset_M * K_scale_rounded;
+  const int64_t w_scale_offset = group_index * N_rounded * K_scale_rounded;
+
+  // The mixed MX8xMX4 kernel uses the transposed problem form:
+  //   D^T = W @ X^T, with logical output still stored as [M, N].
+  problem_shape_ptr[non_zero_idx] = ProblemShape(N, M_group_size, K);
+
+  xq_ptr[non_zero_idx] = xq + xq_offset;
+  wq_ptr[non_zero_idx] = wq + wq_offset;
+  x_scale_ptr[non_zero_idx] = x_scale + x_scale_offset;
+  w_scale_ptr[non_zero_idx] = w_scale + w_scale_offset;
+  output_ptr[non_zero_idx] = output + output_offset;
+
+  stride_a_ptr[non_zero_idx] = cutlass::make_cute_packed_stride(
+      StrideA{}, cute::make_shape(int(M_group_size), int(K), 1));
+  stride_b_ptr[non_zero_idx] = cutlass::make_cute_packed_stride(
+      StrideB{}, cute::make_shape(int(N), int(K), 1));
+  stride_c_ptr[non_zero_idx] = cutlass::make_cute_packed_stride(
+      StrideC{}, cute::make_shape(int(N), int(M_group_size), 1));
+
+  layout_SFA[non_zero_idx] = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+      cute::make_shape(int(M_group_size), int(N), int(K), 1));
+  layout_SFB[non_zero_idx] = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+      cute::make_shape(int(M_group_size), int(N), int(K), 1));
+}
+
+template <int TB_M, int TB_N, int TB_K, int TBS_M, int TBS_N, int TBS_K>
+at::Tensor mx8mx4bf16_grouped_impl(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets) {
+  c10::cuda::CUDAGuard deviceGuard(XQ.device());
+
+  using ProblemShape =
+      cutlass::gemm::GroupProblemShape<cute::Shape<int, int, int>>;
+  using ElementA = cutlass::mx_float8_t<cutlass::float_e4m3_t>;
+  using ElementB = cutlass::mx_float4_t<cutlass::float_e2m1_t>;
+  using ElementC = cutlass::bfloat16_t;
+
+  using LayoutA = typename cutlass::layout::LayoutTranspose<
+      cutlass::layout::RowMajor>::type;
+  using LayoutB = typename cutlass::layout::LayoutTranspose<
+      cutlass::layout::ColumnMajor>::type;
+  using LayoutC = typename cutlass::layout::LayoutTranspose<
+      cutlass::layout::RowMajor>::type;
+
+  constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+  constexpr int AlignmentB = 128;
+  constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
+  using ElementAccumulator = float;
+  using ArchTag = cutlass::arch::Sm100;
+  using TileShape =
+      cute::Shape<cute::Int<TB_M>, cute::Int<TB_N>, cute::Int<TB_K>>;
+  using ClusterShape =
+      cute::Shape<cute::Int<TBS_M>, cute::Int<TBS_N>, cute::Int<TBS_K>>;
+
+  using KernelSchedule = cute::conditional_t<
+      (TB_M == 256) && (TBS_M % 2 == 0),
+      cutlass::gemm::KernelPtrArrayTmaWarpSpecialized2SmMxf8f6f4Sm100,
+      cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmMxf8f6f4Sm100>;
+  using EpilogueSchedule = cute::conditional_t<
+      (TB_M == 256) && (TBS_M % 2 == 0),
+      cutlass::epilogue::PtrArrayTmaWarpSpecialized2Sm,
+      cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm>;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          cutlass::arch::OpClassTensorOp,
+          TileShape,
+          ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementAccumulator,
+          void,
+          void,
+          0,
+          ElementC,
+          LayoutC*,
+          AlignmentC,
+          EpilogueSchedule>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          cutlass::arch::OpClassBlockScaledTensorOp,
+          ElementB,
+          LayoutB*,
+          AlignmentB,
+          ElementA,
+          LayoutA*,
+          AlignmentA,
+          ElementAccumulator,
+          TileShape,
+          ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          KernelSchedule>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::
+      GemmUniversal<ProblemShape, CollectiveMainloop, CollectiveEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using StrideA = typename Gemm::GemmKernel::InternalStrideA;
+  using StrideB = typename Gemm::GemmKernel::InternalStrideB;
+  using StrideC = typename Gemm::GemmKernel::InternalStrideD;
+
+  using ScaleDtype = typename ElementA::ScaleFactorType;
+  using DataTypeA = typename ElementA::DataType;
+  using DataTypeB = typename ElementB::DataType;
+
+  using LayoutSFA =
+      typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFA;
+  using LayoutSFB =
+      typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFB;
+  using Sm1xxBlkScaledConfig =
+      typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+
+  const int64_t problem_size_offset = 0;
+  int64_t problem_size_buffer = _mx8mx4_grouped_byte_align(
+      G * sizeof(ProblemShape::UnderlyingProblemShape));
+
+  const int64_t xq_offset = problem_size_offset + problem_size_buffer;
+  int64_t xq_size_buffer = _mx8mx4_grouped_byte_align(G * sizeof(ElementA**));
+
+  const int64_t wq_offset = xq_offset + xq_size_buffer;
+  int64_t wq_size_buffer = _mx8mx4_grouped_byte_align(G * sizeof(ElementB**));
+
+  const int64_t x_scale_offset = wq_offset + wq_size_buffer;
+  int64_t x_scale_buffer = _mx8mx4_grouped_byte_align(G * sizeof(ScaleDtype**));
+
+  const int64_t w_scale_offset = x_scale_offset + x_scale_buffer;
+  int64_t w_scale_buffer = _mx8mx4_grouped_byte_align(G * sizeof(ScaleDtype**));
+
+  const int64_t output_offset = w_scale_offset + w_scale_buffer;
+  int64_t output_buffer = _mx8mx4_grouped_byte_align(G * sizeof(ElementC**));
+
+  const int64_t stride_a_offset = output_offset + output_buffer;
+  int64_t stride_a_buffer = _mx8mx4_grouped_byte_align(G * sizeof(StrideA));
+
+  const int64_t stride_b_offset = stride_a_offset + stride_a_buffer;
+  int64_t stride_b_buffer = _mx8mx4_grouped_byte_align(G * sizeof(StrideB));
+
+  const int64_t stride_c_offset = stride_b_offset + stride_b_buffer;
+  int64_t stride_c_buffer = _mx8mx4_grouped_byte_align(G * sizeof(StrideC));
+
+  const int64_t layout_SFA_offset = stride_c_offset + stride_c_buffer;
+  int64_t layout_SFA_buffer = _mx8mx4_grouped_byte_align(G * sizeof(LayoutSFA));
+
+  const int64_t layout_SFB_offset = layout_SFA_offset + layout_SFA_buffer;
+  int64_t layout_SFB_buffer = _mx8mx4_grouped_byte_align(G * sizeof(LayoutSFB));
+
+  int64_t total_buffer_size = layout_SFB_offset + layout_SFB_buffer;
+  at::Tensor kernel_args =
+      at::empty({total_buffer_size}, XQ.options().dtype(at::kByte));
+  char* kernel_args_ptr = reinterpret_cast<char*>(kernel_args.data_ptr());
+
+  auto* problem_shape_ptr =
+      reinterpret_cast<ProblemShape::UnderlyingProblemShape*>(
+          kernel_args_ptr + problem_size_offset);
+  const ElementA** xq_ptr =
+      reinterpret_cast<const ElementA**>(kernel_args_ptr + xq_offset);
+  const ElementB** wq_ptr =
+      reinterpret_cast<const ElementB**>(kernel_args_ptr + wq_offset);
+  const ScaleDtype** x_scale_ptr =
+      reinterpret_cast<const ScaleDtype**>(kernel_args_ptr + x_scale_offset);
+  const ScaleDtype** w_scale_ptr =
+      reinterpret_cast<const ScaleDtype**>(kernel_args_ptr + w_scale_offset);
+  ElementC** output_ptr =
+      reinterpret_cast<ElementC**>(kernel_args_ptr + output_offset);
+  StrideA* stride_a_ptr =
+      reinterpret_cast<StrideA*>(kernel_args_ptr + stride_a_offset);
+  StrideB* stride_b_ptr =
+      reinterpret_cast<StrideB*>(kernel_args_ptr + stride_b_offset);
+  StrideC* stride_c_ptr =
+      reinterpret_cast<StrideC*>(kernel_args_ptr + stride_c_offset);
+  LayoutSFA* layout_SFA =
+      reinterpret_cast<LayoutSFA*>(kernel_args_ptr + layout_SFA_offset);
+  LayoutSFB* layout_SFB =
+      reinterpret_cast<LayoutSFB*>(kernel_args_ptr + layout_SFB_offset);
+
+  const int64_t M = XQ.size(0);
+  const int64_t N = WQ.size(-2);
+  const int64_t K = WQ.size(-1) * 2;
+
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  set_mx8mx4_grouped_2d3d_args_kernel<
+      ProblemShape::UnderlyingProblemShape,
+      ElementA,
+      ElementB,
+      ElementC,
+      ScaleDtype,
+      StrideA,
+      StrideB,
+      StrideC,
+      LayoutSFA,
+      LayoutSFB,
+      Sm1xxBlkScaledConfig><<<1, G, 0, stream>>>(
+      G,
+      M,
+      N,
+      K,
+      problem_shape_ptr,
+      reinterpret_cast<ElementA*>(XQ.data_ptr()),
+      xq_ptr,
+      reinterpret_cast<ElementB*>(WQ.data_ptr()),
+      wq_ptr,
+      reinterpret_cast<ScaleDtype*>(x_scale.data_ptr()),
+      x_scale_ptr,
+      reinterpret_cast<ScaleDtype*>(w_scale.data_ptr()),
+      w_scale_ptr,
+      reinterpret_cast<ElementC*>(output.data_ptr()),
+      output_ptr,
+      stride_a_ptr,
+      stride_b_ptr,
+      stride_c_ptr,
+      reinterpret_cast<int32_t*>(offsets.data_ptr()),
+      layout_SFA,
+      layout_SFB);
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.device_id = 0;
+  hw_info.sm_count =
+      min(cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
+              hw_info.device_id),
+          2147483647);
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGrouped,
+      {int(G), problem_shape_ptr, nullptr},
+      {reinterpret_cast<const DataTypeB**>(wq_ptr),
+       stride_b_ptr,
+       reinterpret_cast<const DataTypeA**>(xq_ptr),
+       stride_a_ptr,
+       reinterpret_cast<const ScaleDtype**>(w_scale_ptr),
+       layout_SFB,
+       reinterpret_cast<const ScaleDtype**>(x_scale_ptr),
+       layout_SFA},
+      {{}, nullptr, stride_c_ptr, output_ptr, stride_c_ptr},
+      hw_info};
+
+  Gemm gemm;
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  at::Tensor workspace =
+      at::empty(workspace_size, XQ.options().dtype(at::kByte));
+
+  cutlass::Status status = gemm.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement mx8mx4 grouped");
+  }
+
+  status = gemm.initialize(
+      arguments, reinterpret_cast<uint8_t*>(workspace.data_ptr()));
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize mx8mx4 grouped");
+  }
+
+  status = gemm(at::cuda::getCurrentCUDAStream());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot run mx8mx4 grouped: ") +
+        cutlass::cutlassGetStatusString(status));
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return output;
+}
+
+} // namespace mslk::gemm
+
+#endif
+
+#undef CUTLASS_NAMESPACE

--- a/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_manifest.cuh
+++ b/csrc/gemm/cutlass/mx8mx4bf16_grouped/mx8mx4bf16_grouped_manifest.cuh
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+
+namespace mslk::gemm {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor mx8mx4bf16_grouped_128_64_256_1_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx4bf16_grouped_128_128_256_1_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx4bf16_grouped_128_256_256_1_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx4bf16_grouped_256_64_128_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx4bf16_grouped_256_64_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx4bf16_grouped_256_128_128_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx4bf16_grouped_256_128_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx4bf16_grouped_256_256_128_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+at::Tensor mx8mx4bf16_grouped_256_256_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor output,
+    int64_t G,
+    at::Tensor offsets);
+
+using Kernel_mx8mx4bf16_grouped = at::Tensor (*)(
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    int64_t,
+    at::Tensor);
+
+const std::unordered_map<std::string, Kernel_mx8mx4bf16_grouped>&
+get_mx8mx4bf16_grouped_kernels() {
+  static const std::unordered_map<std::string, Kernel_mx8mx4bf16_grouped>
+      kernels = {
+          {"mx8mx4bf16_grouped_128_64_256_1_1_1",
+           mx8mx4bf16_grouped_128_64_256_1_1_1},
+          {"mx8mx4bf16_grouped_128_128_256_1_1_1",
+           mx8mx4bf16_grouped_128_128_256_1_1_1},
+          {"mx8mx4bf16_grouped_128_256_256_1_1_1",
+           mx8mx4bf16_grouped_128_256_256_1_1_1},
+          {"mx8mx4bf16_grouped_256_64_128_2_1_1",
+           mx8mx4bf16_grouped_256_64_128_2_1_1},
+          {"mx8mx4bf16_grouped_256_64_256_2_1_1",
+           mx8mx4bf16_grouped_256_64_256_2_1_1},
+          {"mx8mx4bf16_grouped_256_128_128_2_1_1",
+           mx8mx4bf16_grouped_256_128_128_2_1_1},
+          {"mx8mx4bf16_grouped_256_128_256_2_1_1",
+           mx8mx4bf16_grouped_256_128_256_2_1_1},
+          {"mx8mx4bf16_grouped_256_256_128_2_1_1",
+           mx8mx4bf16_grouped_256_256_128_2_1_1},
+          {"mx8mx4bf16_grouped_256_256_256_2_1_1",
+           mx8mx4bf16_grouped_256_256_256_2_1_1},
+      };
+  return kernels;
+}
+
+#endif
+} // namespace mslk::gemm

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -55,6 +55,8 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   m.def(
       "mx8mx4bf16(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? output=None) -> Tensor");
   m.def(
+      "mx8mx4bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None) -> Tensor");
+  m.def(
       "mx8mx6bf16(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? output=None) -> Tensor");
   m.def(
       "mx6mx6bf16(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? output=None) -> Tensor");
@@ -124,6 +126,7 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("i8i8bf16", i8i8bf16);
   m.impl("f4f4bf16", f4f4bf16);
   m.impl("mx8mx4bf16", mx8mx4bf16);
+  m.impl("mx8mx4bf16_grouped_mm", mx8mx4bf16_grouped_mm);
   m.impl("mx8mx6bf16", mx8mx6bf16);
   m.impl("mx6mx6bf16", mx6mx6bf16);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
@@ -177,6 +180,7 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("i8i8bf16", i8i8bf16);
   m.impl("f4f4bf16", f4f4bf16);
   m.impl("mx8mx4bf16", mx8mx4bf16);
+  m.impl("mx8mx4bf16_grouped_mm", mx8mx4bf16_grouped_mm);
   m.impl("mx8mx6bf16", mx8mx6bf16);
   m.impl("mx6mx6bf16", mx6mx6bf16);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);

--- a/include/mslk/gemm/gemm_torch.h
+++ b/include/mslk/gemm/gemm_torch.h
@@ -56,6 +56,17 @@ at::Tensor f4f4bf16_ultra_grouped_mm(
     at::Tensor w_global_scale,
     std::optional<at::Tensor> output = std::nullopt);
 
+// Torch compliant MXFP8 activation x MXFP4 weight grouped GEMM.
+// Supports 2D-3D MoE forward inputs:
+//   XQ: [total_M, K], WQ: [G, K / 2, N], offsets: [G].
+at::Tensor mx8mx4bf16_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    std::optional<at::Tensor> output = std::nullopt);
+
 // FP4 GEMM supporting NVFP4, MXFP4 (1x32 block), and MXFP4_16 (1x16 block)
 //
 // Format selection:

--- a/mslk/gemm/_meta.py
+++ b/mslk/gemm/_meta.py
@@ -306,6 +306,24 @@ if hasattr(torch.ops.mslk, "mx8mx4bf16"):
         return torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
 
 
+if hasattr(torch.ops.mslk, "mx8mx4bf16_grouped_mm"):
+
+    @torch.library.register_fake("mslk::mx8mx4bf16_grouped_mm")
+    def mx8mx4bf16_grouped_mm_meta(
+        XQ: torch.Tensor,
+        WQ: torch.Tensor,
+        x_scale: torch.Tensor,
+        w_scale: torch.Tensor,
+        offsets: torch.Tensor,
+        output: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if output is not None:
+            return output
+        total_M = XQ.shape[0]
+        N = WQ.shape[-1]
+        return torch.empty((total_M, N), dtype=torch.bfloat16, device=XQ.device)
+
+
 if hasattr(torch.ops.mslk, "mx6mx6bf16"):
 
     @torch.library.register_fake("mslk::mx6mx6bf16")

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -2632,6 +2632,123 @@ class MXFP4Tests(unittest.TestCase):
     @settings(deadline=None)
     @given(
         G=st.sampled_from([1, 4, 16]),
+        M=st.sampled_from([1, 4, 32, 128]),
+        N=st.sampled_from([256, 1024, 4096]),
+        K=st.sampled_from([512, 2048]),
+    )
+    def test_mx8mx4_grouped_gemm_2d_3d(
+        self,
+        G: int,
+        M: int,
+        N: int,
+        K: int,
+    ) -> None:
+        from mslk.gemm.triton.fp8_gemm import to_mxfp8
+
+        XS = [
+            torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+            for _ in range(G)
+        ]
+        WS = [
+            torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+            for _ in range(G)
+        ]
+        offsets = torch.arange(
+            M,
+            G * M + 1,
+            M,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        xqs = []
+        x_scales = []
+        wqs = []
+        w_scales = []
+        for x, w in zip(XS, WS):
+            x_scale, xq = to_mxfp8(x)
+            x_scale = _to_blocked(
+                x_scale.view(torch.int8).reshape(x.shape[0], -1)
+            ).view(torch.uint8)
+            wq, w_scale = triton_quantize_mx4_unpack(w)
+
+            xqs.append(xq)
+            x_scales.append(x_scale)
+            wqs.append(wq.view(torch.float4_e2m1fn_x2))
+            w_scales.append(w_scale)
+
+        xq = torch.cat(xqs, dim=0).contiguous()
+        x_scale = torch.cat(x_scales, dim=0).contiguous().reshape(-1, K // 32)
+        wq = torch.stack(wqs, dim=0).contiguous()
+        w_scale = torch.stack(w_scales, dim=0).contiguous()
+
+        X = torch.cat(XS, dim=0)
+        W = torch.stack(WS, dim=0)
+
+        out_bf16 = torch._grouped_mm(
+            X, W.transpose(-2, -1), offs=offsets, out_dtype=torch.bfloat16
+        )
+        out_mx8mx4 = torch.ops.mslk.mx8mx4bf16_grouped_mm(
+            xq, wq.transpose(-2, -1), x_scale, w_scale, offsets
+        )
+        self.assertTrue(out_mx8mx4.isfinite().all(), "output has non-finite values")
+
+        torch.testing.assert_close(out_mx8mx4, out_bf16, atol=5.0e-2, rtol=6.0e-2)
+
+    def test_mx8mx4_grouped_gemm_2d_3d_empty_groups(self) -> None:
+        from mslk.gemm.triton.fp8_gemm import to_mxfp8
+
+        G = 8
+        N = 1024
+        K = 2048
+        m_sizes_list = [0, 1, 4, 0, 32, 0, 8, 16]
+        offsets = torch.tensor(
+            m_sizes_list, dtype=torch.int32, device=self.device
+        ).cumsum(0, dtype=torch.int32)
+
+        XS = [
+            torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+            for M in m_sizes_list
+        ]
+        WS = [
+            torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+            for _ in range(G)
+        ]
+
+        xqs = []
+        x_scales = []
+        wqs = []
+        w_scales = []
+        refs = []
+        for x, w in zip(XS, WS):
+            if x.numel() > 0:
+                x_scale, xq = to_mxfp8(x)
+                x_scale = _to_blocked(
+                    x_scale.view(torch.int8).reshape(x.shape[0], -1)
+                ).view(torch.uint8)
+                xqs.append(xq)
+                x_scales.append(x_scale)
+                refs.append(x @ w.t())
+            wq, w_scale = triton_quantize_mx4_unpack(w)
+            wqs.append(wq.view(torch.float4_e2m1fn_x2))
+            w_scales.append(w_scale)
+
+        xq = torch.cat(xqs, dim=0).contiguous()
+        x_scale = torch.cat(x_scales, dim=0).contiguous().reshape(-1, K // 32)
+        wq = torch.stack(wqs, dim=0).contiguous()
+        w_scale = torch.stack(w_scales, dim=0).contiguous()
+
+        out_bf16 = torch.cat(refs, dim=0).to(torch.bfloat16)
+        out_mx8mx4 = torch.ops.mslk.mx8mx4bf16_grouped_mm(
+            xq, wq.transpose(-2, -1), x_scale, w_scale, offsets
+        )
+        self.assertTrue(out_mx8mx4.isfinite().all(), "output has non-finite values")
+
+        torch.testing.assert_close(out_mx8mx4, out_bf16, atol=5.0e-2, rtol=6.0e-2)
+
+    @settings(deadline=None)
+    @given(
+        G=st.sampled_from([1, 4, 16]),
         M=st.sampled_from([250, 500, 3500]),
         N=st.sampled_from([256, 1024, 6144]),
         K=st.sampled_from([2048, 3584]),


### PR DESCRIPTION
Summary: Adds a CUTLASS-backed `mx8mx4bf16_grouped_mm` operator for 2D x 3D grouped GEMM with MXFP8 activations and MXFP4 weights. The new path includes SM100 kernel instances, heuristic/tuning-cache based kernel selection, PyTorch op binding and fake/meta registration, `gemm_bench` coverage, and a Hypothesis correctness test against `torch._grouped_mm`.

Reviewed By: cthi, jiawenliu64

Differential Revision: D106246194


