### PR TITLE
Stub SM90 CUTLASS GEMM kernels on Blackwell builds (#364)

### DIFF
--- a/csrc/gemm/cutlass/bf16bf16bf16_grouped/bf16bf16bf16_grouped_common.cuh
+++ b/csrc/gemm/cutlass/bf16bf16bf16_grouped/bf16bf16bf16_grouped_common.cuh
@@ -221,6 +221,21 @@ at::Tensor bf16bf16bf16_grouped_impl(
     int sm_count,
     std::optional<at::Tensor> zero_start_index_M,
     std::optional<at::Tensor> M_sizes) {
+#ifdef MSLK_DISABLE_SM90_CUTLASS
+  // Blackwell-only build: this SM90 grouped-GEMM is never dispatched (the
+  // runtime arch selector uses the SM100 path). Skip the CUTLASS SM90
+  // instantiation to cut build time; the symbol is preserved for linking.
+  (void)X;
+  (void)W;
+  (void)output;
+  (void)sm_count;
+  (void)zero_start_index_M;
+  (void)M_sizes;
+  TORCH_CHECK(
+      false,
+      "bf16bf16bf16_grouped SM90 kernel invoked in a Blackwell-only build");
+  return at::Tensor();
+#else
   int64_t G;
   at::TensorOptions options;
   at::ScalarType dtype;
@@ -518,6 +533,7 @@ at::Tensor bf16bf16bf16_grouped_impl(
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return output;
+#endif // MSLK_DISABLE_SM90_CUTLASS
 }
 
 // Helper function to dispatch based on dtype

--- a/csrc/gemm/cutlass/f8f8bf16_rowwise/f8f8bf16_rowwise_common.cuh
+++ b/csrc/gemm/cutlass/f8f8bf16_rowwise/f8f8bf16_rowwise_common.cuh
@@ -48,281 +48,301 @@ at::Tensor f8f8bf16_rowwise_impl(
     at::Tensor w_scale,
     std::optional<at::Tensor> bias,
     std::optional<at::Tensor> output) {
-  c10::cuda::CUDAGuard deviceGuard(XQ.device());
-
-  // XQ: M x K
-  // WQ: N x K
-  // output: M x N
-  int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
-  int N = WQ.size(0);
-  int K = WQ.size(1);
-  // 1. If the input tensor is {M, K}, the output tensor is {M, N}.
-  // 2. If the input tensor is {b, M, K}, the output tensor is {b, M, N}.
-  auto out_sizes = XQ.sizes().vec();
-  out_sizes.back() = N;
-  // Handle case where there is a zero dimension, we simply return an empty
-  // tensor.
-  if (M == 0 || N == 0 || K == 0) {
-    // Use zeros instead of empty for special case where K=0.
-    return at::zeros(out_sizes, XQ.options().dtype(at::kBFloat16));
+#ifdef MSLK_DISABLE_SM90_CUTLASS
+  // Blackwell-only build: the SM90 instantiation (ARCH != 10) is never
+  // dispatched at runtime (the SM100 path is selected). Skip its CUTLASS body
+  // to cut build time; the function symbol is preserved for linking.
+  if constexpr (ARCH != 10) {
+    (void)XQ;
+    (void)WQ;
+    (void)x_scale;
+    (void)w_scale;
+    (void)bias;
+    (void)output;
+    TORCH_CHECK(
+        false,
+        "f8f8bf16_rowwise SM90 kernel invoked in a Blackwell-only build");
+    return at::Tensor();
   }
+  if constexpr (ARCH == 10)
+#endif
+  {
+    c10::cuda::CUDAGuard deviceGuard(XQ.device());
 
-  TORCH_CHECK(XQ.size(-1) == K);
-  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
-  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
+    // XQ: M x K
+    // WQ: N x K
+    // output: M x N
+    int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
+    int N = WQ.size(0);
+    int K = WQ.size(1);
+    // 1. If the input tensor is {M, K}, the output tensor is {M, N}.
+    // 2. If the input tensor is {b, M, K}, the output tensor is {b, M, N}.
+    auto out_sizes = XQ.sizes().vec();
+    out_sizes.back() = N;
+    // Handle case where there is a zero dimension, we simply return an empty
+    // tensor.
+    if (M == 0 || N == 0 || K == 0) {
+      // Use zeros instead of empty for special case where K=0.
+      return at::zeros(out_sizes, XQ.options().dtype(at::kBFloat16));
+    }
 
-  at::Tensor Y;
-  if (output.has_value()) {
-    Y = output.value();
-    // Make sure the provided output has the proper shape and dtype.
-    TORCH_CHECK(Y.sizes().vec() == out_sizes);
-    TORCH_CHECK(Y.dtype() == at::kBFloat16);
-  } else {
-    Y = at::empty(out_sizes, XQ.options().dtype(at::kBFloat16));
+    TORCH_CHECK(XQ.size(-1) == K);
+    TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
+    TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
+
+    at::Tensor Y;
+    if (output.has_value()) {
+      Y = output.value();
+      // Make sure the provided output has the proper shape and dtype.
+      TORCH_CHECK(Y.sizes().vec() == out_sizes);
+      TORCH_CHECK(Y.dtype() == at::kBFloat16);
+    } else {
+      Y = at::empty(out_sizes, XQ.options().dtype(at::kBFloat16));
+    }
+
+    using ElementA = cutlass::float_e4m3_t;
+    using LayoutA = cutlass::layout::RowMajor;
+    constexpr int AlignmentInputA = 16 / sizeof(ElementA);
+
+    using ElementB = cutlass::float_e4m3_t;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    constexpr int AlignmentInputB = 16 / sizeof(ElementB);
+
+    // Use implicit transpose to enable more flexible configurations.
+    using LayoutA_Transpose =
+        typename cutlass::layout::LayoutTranspose<LayoutA>::type;
+    using LayoutB_Transpose =
+        typename cutlass::layout::LayoutTranspose<LayoutB>::type;
+
+    using ElementBias = BIAS_DTYPE;
+
+    using ElementOutput = cutlass::bfloat16_t;
+    using LayoutOutput = cutlass::layout::RowMajor;
+    constexpr int AlignmentOutput = 16 / sizeof(ElementOutput);
+
+    using ElementAccumulator = float;
+    using ElementComputeEpilogue = float;
+    using ArchTag = cute::conditional_t<
+        ARCH == 10,
+        cutlass::arch::Sm100,
+        cutlass::arch::Sm90>; // Tag indicating the minimum SM that
+                              // supports the intended feature
+    using OperatorClass = cutlass::arch::OpClassTensorOp;
+    using TileShape = cute::Shape<
+        cute::Int<TB_M>,
+        cute::Int<TB_N>,
+        cute::Int<TB_K>>; // Threadblock-level
+                          // tile size
+    using ClusterShape = cute::Shape<
+        cute::Int<TBS_M>,
+        cute::Int<TBS_N>,
+        cute::Int<TBS_K>>; // Shape of the
+                           // threadblocks in a
+                           // cluster
+    using StageCountType =
+        cutlass::gemm::collective::StageCountAuto; // Stage count maximized
+                                                   // based on the tile size
+    using KernelSchedule = cutlass::gemm::collective::
+        KernelScheduleAuto; // Kernel to launch based on the default setting in
+                            // the Collective Builder
+
+    // Implement rowwise scaling epilogue.
+    using XScale = cutlass::epilogue::fusion::Sm90ColBroadcast<
+        0,
+        TileShape,
+        ElementComputeEpilogue,
+        ElementComputeEpilogue,
+        cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
+
+    using WScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
+        0,
+        TileShape,
+        ElementComputeEpilogue,
+        ElementComputeEpilogue,
+        cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+    using Bias = cutlass::epilogue::fusion::Sm90ColBroadcast<
+        0,
+        TileShape,
+        ElementBias,
+        ElementBias,
+        cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
+
+    using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+    using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
+        cutlass::multiplies,
+        ElementComputeEpilogue, // First stage output type.
+        ElementComputeEpilogue, // First stage input types.
+        cutlass::FloatRoundStyle::round_to_nearest>;
+
+    using EVTCompute0 =
+        cutlass::epilogue::fusion::Sm90EVT<Compute0, WScale, Accum>;
+
+    using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
+        cutlass::multiplies,
+        ElementBias, // Second stage output type.
+        ElementComputeEpilogue, // Second stage input types.
+        cutlass::FloatRoundStyle::round_to_nearest>;
+
+    using EVTCompute1 =
+        cutlass::epilogue::fusion::Sm90EVT<Compute1, XScale, EVTCompute0>;
+
+    using ComputeBias = cutlass::epilogue::fusion::Sm90Compute<
+        cutlass::plus,
+        ElementOutput, // Final (optional) stage output type.
+        ElementBias, // Final stage input types.
+        cutlass::FloatRoundStyle::round_to_nearest>;
+
+    using EpilogueEVT =
+        cutlass::epilogue::fusion::Sm90EVT<ComputeBias, Bias, EVTCompute1>;
+
+    using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
+    using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
+    using SlowAccum = cute::conditional_t<PONG, PongSchedule, DefaultSchedule>;
+    using FastAccum = cute::conditional_t<
+        COOP,
+        cutlass::gemm::KernelTmaWarpSpecializedCooperativeFP8FastAccum,
+        cute::conditional_t<
+            PONG,
+            cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum,
+            cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum>>;
+
+    using MainLoopScheduleSM100 = cutlass::gemm::collective::KernelScheduleAuto;
+    using EpilogueScheduleSM100 =
+        cutlass::epilogue::collective::EpilogueScheduleAuto;
+
+    using MainLoopSchedule = cute::conditional_t<
+        ARCH == 10,
+        MainLoopScheduleSM100,
+        cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>>;
+    using EpilogueSchedule = cute::conditional_t<
+        ARCH == 10,
+        EpilogueScheduleSM100,
+        cute::conditional_t<
+            COOP,
+            cutlass::epilogue::TmaWarpSpecializedCooperative,
+            cutlass::epilogue::TmaWarpSpecialized>>;
+
+    using CollectiveEpilogue =
+        typename cutlass::epilogue::collective::CollectiveBuilder<
+            ArchTag,
+            cutlass::arch::OpClassTensorOp,
+            TileShape,
+            ClusterShape,
+            cutlass::epilogue::collective::EpilogueTileAuto,
+            ElementAccumulator,
+            ElementComputeEpilogue,
+            void,
+            typename cutlass::layout::LayoutTranspose<LayoutOutput>::type,
+            AlignmentOutput,
+            ElementOutput,
+            typename cutlass::layout::LayoutTranspose<LayoutOutput>::type,
+            AlignmentOutput,
+            EpilogueSchedule,
+            EpilogueEVT>::CollectiveOp;
+
+    using CollectiveMainloop =
+        typename cutlass::gemm::collective::CollectiveBuilder<
+            ArchTag,
+            OperatorClass,
+            ElementB,
+            LayoutB_Transpose,
+            AlignmentInputA,
+            ElementA,
+            LayoutA_Transpose,
+            AlignmentInputB,
+            ElementAccumulator,
+            TileShape,
+            ClusterShape,
+            cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+                sizeof(typename CollectiveEpilogue::SharedStorage))>,
+            MainLoopSchedule>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        cute::Shape<int, int, int>,
+        CollectiveMainloop,
+        CollectiveEpilogue>;
+
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+    using StrideInputA = typename Gemm::GemmKernel::StrideA;
+    using StrideInputB = typename Gemm::GemmKernel::StrideB;
+    using StrideOutput = typename Gemm::GemmKernel::StrideC;
+
+    StrideInputA stride_a = cutlass::make_cute_packed_stride(
+        StrideInputA{}, cute::make_shape(M, K, 1));
+    StrideInputB stride_b = cutlass::make_cute_packed_stride(
+        StrideInputB{}, cute::make_shape(N, K, 1));
+    StrideOutput stride_output = cutlass::make_cute_packed_stride(
+        StrideOutput{}, cute::make_shape(N, M, 1));
+
+    typename Gemm::Arguments arguments{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {N, M, K},
+        {reinterpret_cast<ElementB*>(WQ.data_ptr()),
+         stride_b,
+         reinterpret_cast<ElementA*>(XQ.data_ptr()),
+         stride_a},
+        {{}, // Epilogue thread we populate below.
+         nullptr,
+         stride_output,
+         (ElementOutput*)Y.data_ptr<at::BFloat16>(),
+         stride_output}};
+
+    arguments.epilogue.thread = {
+        {bias.has_value()
+             ? reinterpret_cast<ElementBias*>(bias.value().data_ptr())
+             : nullptr}, // bias. Note Cutlass EVT will skip node if argument is
+                         // nullptr
+        // compute_1
+        {
+            {reinterpret_cast<ElementComputeEpilogue*>(
+                w_scale.data_ptr())}, // x_scale
+            // compute_0
+            {
+                {reinterpret_cast<ElementComputeEpilogue*>(
+                    x_scale.data_ptr())}, // w_scale
+                {}, // Accumulator
+                {} // Multiplies
+            },
+            {}, // Multiplies
+        },
+        {}, // Plus
+    };
+
+    Gemm gemm;
+
+    // Using the arguments, query for extra workspace required for matrix
+    // multiplication computation
+    size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+    // Allocate workspace memory
+    at::Tensor workspace =
+        at::empty(workspace_size, XQ.options().dtype(at::kByte));
+
+    // Check the problem size is supported or not
+    cutlass::Status status = gemm.can_implement(arguments);
+    if (status != cutlass::Status::kSuccess) {
+      throw std::runtime_error("cutlass cannot implement");
+    }
+
+    // Initialize CUTLASS kernel with arguments and workspace pointer
+    status = gemm.initialize(arguments, workspace.data_ptr());
+    if (status != cutlass::Status::kSuccess) {
+      throw std::runtime_error("cutlass cannot initialize");
+    }
+
+    status = gemm(at::cuda::getCurrentCUDAStream());
+    if (status != cutlass::Status::kSuccess) {
+      throw std::runtime_error(
+          std::string("cutlass cannot run") +
+          cutlass::cutlassGetStatusString(status));
+    }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    return Y;
   }
-
-  using ElementA = cutlass::float_e4m3_t;
-  using LayoutA = cutlass::layout::RowMajor;
-  constexpr int AlignmentInputA = 16 / sizeof(ElementA);
-
-  using ElementB = cutlass::float_e4m3_t;
-  using LayoutB = cutlass::layout::ColumnMajor;
-  constexpr int AlignmentInputB = 16 / sizeof(ElementB);
-
-  // Use implicit transpose to enable more flexible configurations.
-  using LayoutA_Transpose =
-      typename cutlass::layout::LayoutTranspose<LayoutA>::type;
-  using LayoutB_Transpose =
-      typename cutlass::layout::LayoutTranspose<LayoutB>::type;
-
-  using ElementBias = BIAS_DTYPE;
-
-  using ElementOutput = cutlass::bfloat16_t;
-  using LayoutOutput = cutlass::layout::RowMajor;
-  constexpr int AlignmentOutput = 16 / sizeof(ElementOutput);
-
-  using ElementAccumulator = float;
-  using ElementComputeEpilogue = float;
-  using ArchTag = cute::conditional_t<
-      ARCH == 10,
-      cutlass::arch::Sm100,
-      cutlass::arch::Sm90>; // Tag indicating the minimum SM that
-                            // supports the intended feature
-  using OperatorClass = cutlass::arch::OpClassTensorOp;
-  using TileShape = cute::Shape<
-      cute::Int<TB_M>,
-      cute::Int<TB_N>,
-      cute::Int<TB_K>>; // Threadblock-level
-                        // tile size
-  using ClusterShape = cute::Shape<
-      cute::Int<TBS_M>,
-      cute::Int<TBS_N>,
-      cute::Int<TBS_K>>; // Shape of the
-                         // threadblocks in a
-                         // cluster
-  using StageCountType =
-      cutlass::gemm::collective::StageCountAuto; // Stage count maximized
-                                                 // based on the tile size
-  using KernelSchedule = cutlass::gemm::collective::
-      KernelScheduleAuto; // Kernel to launch based on the default setting in
-                          // the Collective Builder
-
-  // Implement rowwise scaling epilogue.
-  using XScale = cutlass::epilogue::fusion::Sm90ColBroadcast<
-      0,
-      TileShape,
-      ElementComputeEpilogue,
-      ElementComputeEpilogue,
-      cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
-
-  using WScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
-      0,
-      TileShape,
-      ElementComputeEpilogue,
-      ElementComputeEpilogue,
-      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
-
-  using Bias = cutlass::epilogue::fusion::Sm90ColBroadcast<
-      0,
-      TileShape,
-      ElementBias,
-      ElementBias,
-      cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
-
-  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
-
-  using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiplies,
-      ElementComputeEpilogue, // First stage output type.
-      ElementComputeEpilogue, // First stage input types.
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EVTCompute0 =
-      cutlass::epilogue::fusion::Sm90EVT<Compute0, WScale, Accum>;
-
-  using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiplies,
-      ElementBias, // Second stage output type.
-      ElementComputeEpilogue, // Second stage input types.
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EVTCompute1 =
-      cutlass::epilogue::fusion::Sm90EVT<Compute1, XScale, EVTCompute0>;
-
-  using ComputeBias = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::plus,
-      ElementOutput, // Final (optional) stage output type.
-      ElementBias, // Final stage input types.
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EpilogueEVT =
-      cutlass::epilogue::fusion::Sm90EVT<ComputeBias, Bias, EVTCompute1>;
-
-  using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
-  using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
-  using SlowAccum = cute::conditional_t<PONG, PongSchedule, DefaultSchedule>;
-  using FastAccum = cute::conditional_t<
-      COOP,
-      cutlass::gemm::KernelTmaWarpSpecializedCooperativeFP8FastAccum,
-      cute::conditional_t<
-          PONG,
-          cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum,
-          cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum>>;
-
-  using MainLoopScheduleSM100 = cutlass::gemm::collective::KernelScheduleAuto;
-  using EpilogueScheduleSM100 =
-      cutlass::epilogue::collective::EpilogueScheduleAuto;
-
-  using MainLoopSchedule = cute::conditional_t<
-      ARCH == 10,
-      MainLoopScheduleSM100,
-      cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>>;
-  using EpilogueSchedule = cute::conditional_t<
-      ARCH == 10,
-      EpilogueScheduleSM100,
-      cute::conditional_t<
-          COOP,
-          cutlass::epilogue::TmaWarpSpecializedCooperative,
-          cutlass::epilogue::TmaWarpSpecialized>>;
-
-  using CollectiveEpilogue =
-      typename cutlass::epilogue::collective::CollectiveBuilder<
-          ArchTag,
-          cutlass::arch::OpClassTensorOp,
-          TileShape,
-          ClusterShape,
-          cutlass::epilogue::collective::EpilogueTileAuto,
-          ElementAccumulator,
-          ElementComputeEpilogue,
-          void,
-          typename cutlass::layout::LayoutTranspose<LayoutOutput>::type,
-          AlignmentOutput,
-          ElementOutput,
-          typename cutlass::layout::LayoutTranspose<LayoutOutput>::type,
-          AlignmentOutput,
-          EpilogueSchedule,
-          EpilogueEVT>::CollectiveOp;
-
-  using CollectiveMainloop =
-      typename cutlass::gemm::collective::CollectiveBuilder<
-          ArchTag,
-          OperatorClass,
-          ElementB,
-          LayoutB_Transpose,
-          AlignmentInputA,
-          ElementA,
-          LayoutA_Transpose,
-          AlignmentInputB,
-          ElementAccumulator,
-          TileShape,
-          ClusterShape,
-          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
-              sizeof(typename CollectiveEpilogue::SharedStorage))>,
-          MainLoopSchedule>::CollectiveOp;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int, int, int>,
-      CollectiveMainloop,
-      CollectiveEpilogue>;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-
-  using StrideInputA = typename Gemm::GemmKernel::StrideA;
-  using StrideInputB = typename Gemm::GemmKernel::StrideB;
-  using StrideOutput = typename Gemm::GemmKernel::StrideC;
-
-  StrideInputA stride_a = cutlass::make_cute_packed_stride(
-      StrideInputA{}, cute::make_shape(M, K, 1));
-  StrideInputB stride_b = cutlass::make_cute_packed_stride(
-      StrideInputB{}, cute::make_shape(N, K, 1));
-  StrideOutput stride_output = cutlass::make_cute_packed_stride(
-      StrideOutput{}, cute::make_shape(N, M, 1));
-
-  typename Gemm::Arguments arguments{
-      cutlass::gemm::GemmUniversalMode::kGemm,
-      {N, M, K},
-      {reinterpret_cast<ElementB*>(WQ.data_ptr()),
-       stride_b,
-       reinterpret_cast<ElementA*>(XQ.data_ptr()),
-       stride_a},
-      {{}, // Epilogue thread we populate below.
-       nullptr,
-       stride_output,
-       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
-       stride_output}};
-
-  arguments.epilogue.thread = {
-      {bias.has_value()
-           ? reinterpret_cast<ElementBias*>(bias.value().data_ptr())
-           : nullptr}, // bias. Note Cutlass EVT will skip node if argument is
-                       // nullptr
-      // compute_1
-      {
-          {reinterpret_cast<ElementComputeEpilogue*>(
-              w_scale.data_ptr())}, // x_scale
-          // compute_0
-          {
-              {reinterpret_cast<ElementComputeEpilogue*>(
-                  x_scale.data_ptr())}, // w_scale
-              {}, // Accumulator
-              {} // Multiplies
-          },
-          {}, // Multiplies
-      },
-      {}, // Plus
-  };
-
-  Gemm gemm;
-
-  // Using the arguments, query for extra workspace required for matrix
-  // multiplication computation
-  size_t workspace_size = Gemm::get_workspace_size(arguments);
-
-  // Allocate workspace memory
-  at::Tensor workspace =
-      at::empty(workspace_size, XQ.options().dtype(at::kByte));
-
-  // Check the problem size is supported or not
-  cutlass::Status status = gemm.can_implement(arguments);
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot implement");
-  }
-
-  // Initialize CUTLASS kernel with arguments and workspace pointer
-  status = gemm.initialize(arguments, workspace.data_ptr());
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot initialize");
-  }
-
-  status = gemm(at::cuda::getCurrentCUDAStream());
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error(
-        std::string("cutlass cannot run") +
-        cutlass::cutlassGetStatusString(status));
-  }
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-  return Y;
 }
 
 template <

--- a/csrc/gemm/cutlass/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_common.cuh
+++ b/csrc/gemm/cutlass/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_common.cuh
@@ -45,265 +45,285 @@ at::Tensor f8f8bf16_rowwise_batched_impl(
     at::Tensor w_scale,
     std::optional<at::Tensor> bias,
     std::optional<at::Tensor> output) {
-  c10::cuda::CUDAGuard deviceGuard(XQ.device());
-
-  int B, M, N, K;
-  B = XQ.size(0);
-  M = XQ.size(1);
-  N = WQ.size(1);
-  K = WQ.size(2);
-
-  auto out_sizes = XQ.sizes().vec();
-  out_sizes.back() = N;
-  // Handle case where there is a zero dimension, we simply return an empty
-  // tensor.
-  if (M == 0 || N == 0 || K == 0) {
-    // Use zeros instead of empty for special case where K=0.
-    return at::zeros(out_sizes, XQ.options().dtype(at::kBFloat16));
+#ifdef MSLK_DISABLE_SM90_CUTLASS
+  // Blackwell-only build: the SM90 instantiation (ARCH != 10) is never
+  // dispatched at runtime (the SM100 path is selected). Skip its CUTLASS body
+  // to cut build time; the function symbol is preserved for linking.
+  if constexpr (ARCH != 10) {
+    (void)XQ;
+    (void)WQ;
+    (void)x_scale;
+    (void)w_scale;
+    (void)bias;
+    (void)output;
+    TORCH_CHECK(
+        false,
+        "f8f8bf16_rowwise_batched SM90 kernel invoked in a Blackwell-only build");
+    return at::Tensor();
   }
+  if constexpr (ARCH == 10)
+#endif
+  {
+    c10::cuda::CUDAGuard deviceGuard(XQ.device());
 
-  TORCH_CHECK(XQ.size(-1) == K);
+    int B, M, N, K;
+    B = XQ.size(0);
+    M = XQ.size(1);
+    N = WQ.size(1);
+    K = WQ.size(2);
 
-  at::Tensor Y;
-  if (output.has_value()) {
-    Y = output.value();
-    TORCH_CHECK(Y.dtype() == at::kBFloat16);
-  } else {
-    Y = at::empty({B, M, N}, XQ.options().dtype(at::kBFloat16));
+    auto out_sizes = XQ.sizes().vec();
+    out_sizes.back() = N;
+    // Handle case where there is a zero dimension, we simply return an empty
+    // tensor.
+    if (M == 0 || N == 0 || K == 0) {
+      // Use zeros instead of empty for special case where K=0.
+      return at::zeros(out_sizes, XQ.options().dtype(at::kBFloat16));
+    }
+
+    TORCH_CHECK(XQ.size(-1) == K);
+
+    at::Tensor Y;
+    if (output.has_value()) {
+      Y = output.value();
+      TORCH_CHECK(Y.dtype() == at::kBFloat16);
+    } else {
+      Y = at::empty({B, M, N}, XQ.options().dtype(at::kBFloat16));
+    }
+
+    using ElementInputA = cutlass::float_e4m3_t;
+    using LayoutInputA = cutlass::layout::RowMajor;
+    constexpr int AlignmentInputA = 16 / sizeof(ElementInputA);
+
+    using ElementInputB = cutlass::float_e4m3_t;
+    using LayoutInputB = cutlass::layout::ColumnMajor;
+    constexpr int AlignmentInputB = 16 / sizeof(ElementInputB);
+
+    using ElementBias = float;
+
+    using ElementOutput = cutlass::bfloat16_t;
+    using LayoutOutput = cutlass::layout::RowMajor;
+    constexpr int AlignmentOutput = 16 / sizeof(ElementOutput);
+
+    using ElementAccumulator = float;
+    using ElementComputeEpilogue = float;
+    using ArchTag = cute::conditional_t<
+        ARCH == 10,
+        cutlass::arch::Sm100,
+        cutlass::arch::Sm90>; // Tag indicating the minimum SM that
+                              // supports the intended feature
+    using OperatorClass = cutlass::arch::OpClassTensorOp;
+    using TileShape = cute::Shape<
+        cute::Int<TB_M>,
+        cute::Int<TB_N>,
+        cute::Int<TB_K>>; // Threadblock-level
+                          // tile size
+    using ClusterShape = cute::Shape<
+        cute::Int<TBS_M>,
+        cute::Int<TBS_N>,
+        cute::Int<TBS_K>>; // Shape of the
+                           // threadblocks in a
+                           // cluster
+    using StageCountType =
+        cutlass::gemm::collective::StageCountAuto; // Stage count maximized
+                                                   // based on the tile size
+    using KernelSchedule = cutlass::gemm::collective::
+        KernelScheduleAuto; // Kernel to launch based on the default setting in
+                            // the Collective Builder
+
+    // Implement rowwise scaling epilogue.
+    using XScale = cutlass::epilogue::fusion::Sm90ColBroadcast<
+        0,
+        TileShape,
+        ElementComputeEpilogue,
+        ElementComputeEpilogue,
+        cute::Stride<cute::Int<1>, cute::Int<0>, int32_t>>;
+
+    using WScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
+        0,
+        TileShape,
+        ElementComputeEpilogue,
+        ElementComputeEpilogue,
+        cute::Stride<cute::Int<0>, cute::Int<1>, int32_t>>;
+
+    using Bias = cutlass::epilogue::fusion::Sm90RowBroadcast<
+        0,
+        TileShape,
+        ElementBias,
+        ElementBias,
+        cute::Stride<cute::Int<0>, cute::Int<1>, int32_t>>;
+
+    using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+    using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
+        cutlass::multiplies,
+        ElementComputeEpilogue, // First stage output type.
+        ElementComputeEpilogue, // First stage input types.
+        cutlass::FloatRoundStyle::round_to_nearest>;
+
+    using EVTCompute0 =
+        cutlass::epilogue::fusion::Sm90EVT<Compute0, WScale, Accum>;
+
+    using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
+        cutlass::multiplies,
+        ElementBias, // Second stage output type.
+        ElementComputeEpilogue, // Second stage input types.
+        cutlass::FloatRoundStyle::round_to_nearest>;
+
+    using EVTCompute1 =
+        cutlass::epilogue::fusion::Sm90EVT<Compute1, XScale, EVTCompute0>;
+
+    using ComputeBias = cutlass::epilogue::fusion::Sm90Compute<
+        cutlass::plus,
+        ElementOutput, // Final (optional) stage output type.
+        ElementBias, // Final stage input types.
+        cutlass::FloatRoundStyle::round_to_nearest>;
+
+    using EpilogueEVT =
+        cutlass::epilogue::fusion::Sm90EVT<ComputeBias, Bias, EVTCompute1>;
+
+    using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
+    using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
+    using FastDefaultSchedule =
+        cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum;
+    using FastPongSchedule =
+        cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
+    using FastAccum =
+        cute::conditional_t<PONG, FastPongSchedule, FastDefaultSchedule>;
+
+    using MainLoopScheduleSM100 = cutlass::gemm::collective::KernelScheduleAuto;
+    using EpilogueScheduleSM100 =
+        cutlass::epilogue::collective::EpilogueScheduleAuto;
+
+    using MainLoopSchedule =
+        cute::conditional_t<ARCH == 10, MainLoopScheduleSM100, FastAccum>;
+    using EpilogueSchedule = cute::conditional_t<
+        ARCH == 10,
+        EpilogueScheduleSM100,
+        cutlass::epilogue::TmaWarpSpecialized>;
+
+    using CollectiveEpilogue =
+        typename cutlass::epilogue::collective::CollectiveBuilder<
+            ArchTag,
+            cutlass::arch::OpClassTensorOp,
+            TileShape,
+            ClusterShape,
+            cutlass::epilogue::collective::EpilogueTileAuto,
+            ElementAccumulator,
+            ElementComputeEpilogue,
+            void, // No C input - we are doing C = A @ B, not C = A @ B + beta*C
+            void,
+            0,
+            ElementOutput,
+            LayoutOutput,
+            AlignmentOutput,
+            EpilogueSchedule,
+            EpilogueEVT>::CollectiveOp;
+
+    using CollectiveMainloop =
+        typename cutlass::gemm::collective::CollectiveBuilder<
+            ArchTag,
+            OperatorClass,
+            ElementInputA,
+            LayoutInputA,
+            AlignmentInputA,
+            ElementInputB,
+            LayoutInputB,
+            AlignmentInputB,
+            ElementAccumulator,
+            TileShape,
+            ClusterShape,
+            cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+                sizeof(typename CollectiveEpilogue::SharedStorage))>,
+            MainLoopSchedule>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        cute::Shape<int, int, int, int>,
+        CollectiveMainloop,
+        CollectiveEpilogue>;
+
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+    using StrideInputA = typename Gemm::GemmKernel::StrideA;
+    using StrideInputB = typename Gemm::GemmKernel::StrideB;
+    using StrideOutput = typename Gemm::GemmKernel::StrideC;
+
+    StrideInputA stride_a = cutlass::make_cute_packed_stride(
+        StrideInputA{}, cute::make_shape(M, K, B));
+    StrideInputB stride_b = cutlass::make_cute_packed_stride(
+        StrideInputB{}, cute::make_shape(N, K, B));
+    StrideOutput stride_output = cutlass::make_cute_packed_stride(
+        StrideOutput{}, cute::make_shape(M, N, B));
+
+    typename Gemm::Arguments arguments{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {M, N, K, B},
+        {reinterpret_cast<ElementInputA*>(XQ.data_ptr()),
+         stride_a,
+         reinterpret_cast<ElementInputB*>(WQ.data_ptr()),
+         stride_b},
+        {{}, // Epilogue thread we populate below.
+         (ElementOutput*)Y.data_ptr<at::BFloat16>(),
+         stride_output,
+         (ElementOutput*)Y.data_ptr<at::BFloat16>(),
+         stride_output}};
+
+    arguments.epilogue.thread = {
+        {bias.has_value()
+             ? reinterpret_cast<ElementBias*>(bias.value().data_ptr())
+             : nullptr,
+         ElementBias(0),
+         {cute::Int<0>(), cute::Int<1>(), int32_t(N)}}, // bias
+        // compute_1
+        {
+            {reinterpret_cast<ElementComputeEpilogue*>(x_scale.data_ptr()),
+             ElementComputeEpilogue(0),
+             {cute::Int<1>(), cute::Int<0>(), int32_t(M)}}, // x_scale
+            // compute_0
+            {
+                {reinterpret_cast<ElementComputeEpilogue*>(w_scale.data_ptr()),
+                 ElementComputeEpilogue(0),
+                 {cute::Int<0>(), cute::Int<1>(), int32_t(N)}}, // w_scale
+                {}, // Accumulator
+                {} // Multiplies
+            },
+            {}, // Multiplies
+        },
+        {}, // Plus
+    };
+
+    Gemm gemm;
+
+    // Using the arguments, query for extra workspace required for matrix
+    // multiplication computation
+    size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+    // Allocate workspace memory
+    at::Tensor workspace =
+        at::empty(workspace_size, XQ.options().dtype(at::kByte));
+
+    // Check the problem size is supported or not
+    cutlass::Status status = gemm.can_implement(arguments);
+    if (status != cutlass::Status::kSuccess) {
+      throw std::runtime_error("cutlass cannot implement");
+    }
+
+    // Initialize CUTLASS kernel with arguments and workspace pointer
+    status = gemm.initialize(arguments, workspace.data_ptr());
+    if (status != cutlass::Status::kSuccess) {
+      throw std::runtime_error("cutlass cannot initialize");
+    }
+
+    status = gemm(at::cuda::getCurrentCUDAStream());
+    if (status != cutlass::Status::kSuccess) {
+      throw std::runtime_error(
+          std::string("cutlass cannot run") +
+          cutlass::cutlassGetStatusString(status));
+    }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    return Y;
   }
-
-  using ElementInputA = cutlass::float_e4m3_t;
-  using LayoutInputA = cutlass::layout::RowMajor;
-  constexpr int AlignmentInputA = 16 / sizeof(ElementInputA);
-
-  using ElementInputB = cutlass::float_e4m3_t;
-  using LayoutInputB = cutlass::layout::ColumnMajor;
-  constexpr int AlignmentInputB = 16 / sizeof(ElementInputB);
-
-  using ElementBias = float;
-
-  using ElementOutput = cutlass::bfloat16_t;
-  using LayoutOutput = cutlass::layout::RowMajor;
-  constexpr int AlignmentOutput = 16 / sizeof(ElementOutput);
-
-  using ElementAccumulator = float;
-  using ElementComputeEpilogue = float;
-  using ArchTag = cute::conditional_t<
-      ARCH == 10,
-      cutlass::arch::Sm100,
-      cutlass::arch::Sm90>; // Tag indicating the minimum SM that
-                            // supports the intended feature
-  using OperatorClass = cutlass::arch::OpClassTensorOp;
-  using TileShape = cute::Shape<
-      cute::Int<TB_M>,
-      cute::Int<TB_N>,
-      cute::Int<TB_K>>; // Threadblock-level
-                        // tile size
-  using ClusterShape = cute::Shape<
-      cute::Int<TBS_M>,
-      cute::Int<TBS_N>,
-      cute::Int<TBS_K>>; // Shape of the
-                         // threadblocks in a
-                         // cluster
-  using StageCountType =
-      cutlass::gemm::collective::StageCountAuto; // Stage count maximized
-                                                 // based on the tile size
-  using KernelSchedule = cutlass::gemm::collective::
-      KernelScheduleAuto; // Kernel to launch based on the default setting in
-                          // the Collective Builder
-
-  // Implement rowwise scaling epilogue.
-  using XScale = cutlass::epilogue::fusion::Sm90ColBroadcast<
-      0,
-      TileShape,
-      ElementComputeEpilogue,
-      ElementComputeEpilogue,
-      cute::Stride<cute::Int<1>, cute::Int<0>, int32_t>>;
-
-  using WScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
-      0,
-      TileShape,
-      ElementComputeEpilogue,
-      ElementComputeEpilogue,
-      cute::Stride<cute::Int<0>, cute::Int<1>, int32_t>>;
-
-  using Bias = cutlass::epilogue::fusion::Sm90RowBroadcast<
-      0,
-      TileShape,
-      ElementBias,
-      ElementBias,
-      cute::Stride<cute::Int<0>, cute::Int<1>, int32_t>>;
-
-  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
-
-  using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiplies,
-      ElementComputeEpilogue, // First stage output type.
-      ElementComputeEpilogue, // First stage input types.
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EVTCompute0 =
-      cutlass::epilogue::fusion::Sm90EVT<Compute0, WScale, Accum>;
-
-  using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiplies,
-      ElementBias, // Second stage output type.
-      ElementComputeEpilogue, // Second stage input types.
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EVTCompute1 =
-      cutlass::epilogue::fusion::Sm90EVT<Compute1, XScale, EVTCompute0>;
-
-  using ComputeBias = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::plus,
-      ElementOutput, // Final (optional) stage output type.
-      ElementBias, // Final stage input types.
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EpilogueEVT =
-      cutlass::epilogue::fusion::Sm90EVT<ComputeBias, Bias, EVTCompute1>;
-
-  using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
-  using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
-  using FastDefaultSchedule =
-      cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum;
-  using FastPongSchedule =
-      cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
-  using FastAccum =
-      cute::conditional_t<PONG, FastPongSchedule, FastDefaultSchedule>;
-
-  using MainLoopScheduleSM100 = cutlass::gemm::collective::KernelScheduleAuto;
-  using EpilogueScheduleSM100 =
-      cutlass::epilogue::collective::EpilogueScheduleAuto;
-
-  using MainLoopSchedule =
-      cute::conditional_t<ARCH == 10, MainLoopScheduleSM100, FastAccum>;
-  using EpilogueSchedule = cute::conditional_t<
-      ARCH == 10,
-      EpilogueScheduleSM100,
-      cutlass::epilogue::TmaWarpSpecialized>;
-
-  using CollectiveEpilogue =
-      typename cutlass::epilogue::collective::CollectiveBuilder<
-          ArchTag,
-          cutlass::arch::OpClassTensorOp,
-          TileShape,
-          ClusterShape,
-          cutlass::epilogue::collective::EpilogueTileAuto,
-          ElementAccumulator,
-          ElementComputeEpilogue,
-          void, // No C input - we are doing C = A @ B, not C = A @ B + beta*C
-          void,
-          0,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
-          EpilogueSchedule,
-          EpilogueEVT>::CollectiveOp;
-
-  using CollectiveMainloop =
-      typename cutlass::gemm::collective::CollectiveBuilder<
-          ArchTag,
-          OperatorClass,
-          ElementInputA,
-          LayoutInputA,
-          AlignmentInputA,
-          ElementInputB,
-          LayoutInputB,
-          AlignmentInputB,
-          ElementAccumulator,
-          TileShape,
-          ClusterShape,
-          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
-              sizeof(typename CollectiveEpilogue::SharedStorage))>,
-          MainLoopSchedule>::CollectiveOp;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int, int, int, int>,
-      CollectiveMainloop,
-      CollectiveEpilogue>;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-
-  using StrideInputA = typename Gemm::GemmKernel::StrideA;
-  using StrideInputB = typename Gemm::GemmKernel::StrideB;
-  using StrideOutput = typename Gemm::GemmKernel::StrideC;
-
-  StrideInputA stride_a = cutlass::make_cute_packed_stride(
-      StrideInputA{}, cute::make_shape(M, K, B));
-  StrideInputB stride_b = cutlass::make_cute_packed_stride(
-      StrideInputB{}, cute::make_shape(N, K, B));
-  StrideOutput stride_output = cutlass::make_cute_packed_stride(
-      StrideOutput{}, cute::make_shape(M, N, B));
-
-  typename Gemm::Arguments arguments{
-      cutlass::gemm::GemmUniversalMode::kGemm,
-      {M, N, K, B},
-      {reinterpret_cast<ElementInputA*>(XQ.data_ptr()),
-       stride_a,
-       reinterpret_cast<ElementInputB*>(WQ.data_ptr()),
-       stride_b},
-      {{}, // Epilogue thread we populate below.
-       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
-       stride_output,
-       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
-       stride_output}};
-
-  arguments.epilogue.thread = {
-      {bias.has_value()
-           ? reinterpret_cast<ElementBias*>(bias.value().data_ptr())
-           : nullptr,
-       ElementBias(0),
-       {cute::Int<0>(), cute::Int<1>(), int32_t(N)}}, // bias
-      // compute_1
-      {
-          {reinterpret_cast<ElementComputeEpilogue*>(x_scale.data_ptr()),
-           ElementComputeEpilogue(0),
-           {cute::Int<1>(), cute::Int<0>(), int32_t(M)}}, // x_scale
-          // compute_0
-          {
-              {reinterpret_cast<ElementComputeEpilogue*>(w_scale.data_ptr()),
-               ElementComputeEpilogue(0),
-               {cute::Int<0>(), cute::Int<1>(), int32_t(N)}}, // w_scale
-              {}, // Accumulator
-              {} // Multiplies
-          },
-          {}, // Multiplies
-      },
-      {}, // Plus
-  };
-
-  Gemm gemm;
-
-  // Using the arguments, query for extra workspace required for matrix
-  // multiplication computation
-  size_t workspace_size = Gemm::get_workspace_size(arguments);
-
-  // Allocate workspace memory
-  at::Tensor workspace =
-      at::empty(workspace_size, XQ.options().dtype(at::kByte));
-
-  // Check the problem size is supported or not
-  cutlass::Status status = gemm.can_implement(arguments);
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot implement");
-  }
-
-  // Initialize CUTLASS kernel with arguments and workspace pointer
-  status = gemm.initialize(arguments, workspace.data_ptr());
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot initialize");
-  }
-
-  status = gemm(at::cuda::getCurrentCUDAStream());
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error(
-        std::string("cutlass cannot run") +
-        cutlass::cutlassGetStatusString(status));
-  }
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-  return Y;
 }
 
 #else

--- a/csrc/gemm/cutlass/f8f8bf16_rowwise_grouped/f8f8bf16_rowwise_grouped_common.cuh
+++ b/csrc/gemm/cutlass/f8f8bf16_rowwise_grouped/f8f8bf16_rowwise_grouped_common.cuh
@@ -230,6 +230,22 @@ at::Tensor f8f8bf16_rowwise_grouped_impl(
     at::Tensor output,
     std::optional<at::Tensor> zero_start_index_M,
     std::optional<at::Tensor> M_sizes) {
+#ifdef MSLK_DISABLE_SM90_CUTLASS
+  // Blackwell-only build: this SM90 grouped-GEMM kernel is never dispatched
+  // (the runtime arch selector uses the SM100 path). Skip the expensive CUTLASS
+  // SM90 instantiation to cut build time; the symbol is preserved for linking.
+  (void)XQ;
+  (void)WQ;
+  (void)x_scale;
+  (void)w_scale;
+  (void)output;
+  (void)zero_start_index_M;
+  (void)M_sizes;
+  TORCH_CHECK(
+      false,
+      "f8f8bf16_rowwise_grouped SM90 kernel invoked in a Blackwell-only build");
+  return at::Tensor();
+#else
   int64_t G;
   at::TensorOptions options;
   if constexpr (std::is_same_v<InputType, at::TensorList>) {
@@ -600,6 +616,7 @@ at::Tensor f8f8bf16_rowwise_grouped_impl(
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return output;
+#endif // MSLK_DISABLE_SM90_CUTLASS
 }
 
 #endif


### PR DESCRIPTION
Summary:

Build-time optimization for the Blackwell LLM predictor fbpkg (smart.inference_platform_sp.llm_predictor_gpu_vllm.persistent.blackwell, nvcc_arch=b200a,b300a_native).

Several CUTLASS GEMM families in mslk/csrc/gemm/cutlass/ ship both an SM90 (Hopper, the *_9_*.cu kernels) and an SM100 (Blackwell, the *_10_*.cu kernels) variant, selected at runtime by getDeviceArch(), which returns the GPU compute-capability major version (getDeviceProperties()->major). Both GB200 (sm_100) and GB300 (sm_103) report major == 10, so on Blackwell the dispatcher always takes the arch == 10 (SM100) branch and the SM90 kernels are never invoked. They are nonetheless compiled from source on every Blackwell build, and each *_9_* file is a full CUTLASS SM90 GEMM template instantiation, which is among the most expensive nvcc compilations in the build.

This diff adds an is_blackwell_only() helper to mslk/build_utils.bzl (true only when every requested fbcode.nvcc_arch is a Blackwell arch; handles comma-separated lists such as b200a,b300a_native) and, for pure-Blackwell builds, passes -DMSLK_DISABLE_SM90_CUTLASS to four grouped/rowwise CUTLASS targets. Under that define the SM90 kernel body is #ifdef-stubbed to a TORCH_CHECK(false): the function symbol is preserved so the dispatcher's else-branch references still link, only the heavy CUTLASS instantiation is skipped. This stubs ~82 SM90 .cu on the Blackwell build.

Targets gated:
- cutlass_f8f8bf16_rowwise_grouped (~36 SM90 .cu) and cutlass_bf16bf16bf16_grouped (~33 SM90 .cu): pure-SM90 impl function (ArchTag = Sm90), so the whole impl body is stubbed.
- cutlass_f8f8bf16_rowwise (9 SM90 .cu) and cutlass_f8f8bf16_rowwise_batched (4 SM90 .cu): one impl template with ArchTag = conditional_t<ARCH == 10, Sm100, Sm90>, so the SM90 path is stubbed with an if constexpr (ARCH != 10) guard and the SM100 (ARCH == 10) body is preserved.

Mixed/Hopper fleets (e.g. nvcc_arch=a100,h100a,b200a) have is_blackwell_only() == False, so the define is not set and the SM90 kernels are compiled and used exactly as before.

Correctness: the SM90 stub can only be reached if a non-major-10 GPU runs a Blackwell-only-compiled binary, which cannot happen, since this fbpkg is nvcc-targeted at sm_100/sm_103 and deployed only on GB200/GB300. Verified that (a) getDeviceArch() returns the CC major version, (b) every dispatcher's arch == 10 branch returns only _10_ kernels while the else branch returns only _9_ kernels (all _10_ returns precede all _9_ returns, no interleaving), and (c) the SM90 GEMM symbols have no caller anywhere other than the dispatcher's else branch.

Differential Revision: D107047414


