### PR TITLE
Add Windows python-only wheel builds for CUDA variants

### DIFF
--- a/.github/scripts/nova_dir_windows.bash
+++ b/.github/scripts/nova_dir_windows.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+################################################################################
+# Windows builds are python-only — no C++/CUDA compilation is performed.
+# The native kernels are not needed because the CUDA-compiled .so libraries
+# are Linux-only; Windows users get the Python layer (triton kernels, python
+# utilities, etc.) while the heavy lifting happens on Linux GPU servers.
+################################################################################
+export MSLK_PYTHON_ONLY=1
+export BUILD_FROM_NOVA=1
+
+## Set MSLK_REPO path for other scripts to use.
+## Windows Nova runners do not use Docker, so the checkout path differs from
+## the Linux /__w/... convention.
+export MSLK_REPO="${GITHUB_WORKSPACE}/${REPOSITORY}"
+
+## Overwrite existing ENV VAR in Nova
+if [[ "$CONDA_ENV" != "" ]]; then export CONDA_RUN="conda run --no-capture-output -p ${CONDA_ENV}" && echo "$CONDA_RUN"; fi
+
+if [[ "$CU_VERSION" == "cu"* ]]; then
+    echo "[NOVA] Windows python-only build for CUDA variant: ${CU_VERSION}"
+fi

--- a/.github/scripts/nova_postscript_windows.bash
+++ b/.github/scripts/nova_postscript_windows.bash
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+################################################################################
+# Post-script for validating MSLK python-only wheels on Windows.
+#
+# Installs the built wheel and verifies that the package can be imported.
+# No GPU tests are run since this is a python-only build.
+################################################################################
+
+echo "[NOVA] Current working directory: $(pwd)"
+cd "${MSLK_REPO}" || echo "[NOVA] Failed to cd to ${MSLK_REPO}"
+
+export BUILD_FROM_NOVA=1
+
+echo "[NOVA] Installing the built wheel ..."
+$CONDA_RUN pip install dist/*.whl
+
+echo "[NOVA] Verifying import ..."
+$CONDA_RUN python -c "
+import mslk
+print(f'MSLK version:  {mslk.__version__}')
+print(f'MSLK variant:  {mslk.__variant__}')
+print(f'MSLK target:   {mslk.__target__}')
+assert mslk.__variant__ == 'python_only', f'Expected python_only variant, got {mslk.__variant__}'
+print('Import verification passed')
+"
+
+echo "[NOVA] MSLK python-only post-build validation completed"

--- a/.github/scripts/nova_prescript_windows.bash
+++ b/.github/scripts/nova_prescript_windows.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+################################################################################
+# Pre-script for building MSLK python-only wheels on Windows.
+#
+# Unlike the Linux pre-script, this does not invoke the full C++/CUDA build
+# pipeline.  It only needs setuptools to package the Python source tree.
+################################################################################
+
+echo "[NOVA] Current working directory: $(pwd)"
+cd "${MSLK_REPO}" || exit 1
+
+# Reset BUILD_FROM_NOVA to allow setup.py to run the build
+export BUILD_FROM_NOVA=0
+
+# Force the wheel platform tag to win_amd64 so it is only installable on
+# Windows and cannot accidentally become a fallback for Linux users whose
+# Python/CUDA/Torch version doesn't match any native wheel.
+export MSLK_PYTHON_ONLY_PLAT="win_amd64"
+
+# Build MSLK nightly by default
+if [[ -z "${CHANNEL}" ]]; then
+    export CHANNEL="nightly"
+fi
+
+echo "[NOVA] Installing build dependencies ..."
+$CONDA_RUN pip install build wheel setuptools 'setuptools_git_versioning>=3.0.0' numpy
+
+echo "[NOVA] Building MSLK python-only wheel ..."
+echo "[NOVA]   MSLK_PYTHON_ONLY=${MSLK_PYTHON_ONLY}"
+echo "[NOVA]   CHANNEL=${CHANNEL}"
+echo "[NOVA]   CU_VERSION=${CU_VERSION}"
+$CONDA_RUN python -m build --wheel --no-isolation
+
+echo "[NOVA] Enumerating the built wheels ..."
+ls -lth dist/*.whl || exit 1
+
+echo "[NOVA] Enumerating the wheel SHAs ..."
+sha256sum dist/*.whl 2>/dev/null || certutil -hashfile dist/*.whl SHA256 2>/dev/null || true
+
+echo "[NOVA] MSLK python-only build completed"

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -1,0 +1,86 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+name: Build MSLK Windows Wheels
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+    tags:
+      # Release candidate tag look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-matrix:
+    if: ${{ github.repository_owner == 'meta-pytorch' }}
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: windows
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-cuda: enable
+      with-rocm: disable
+      with-cpu: disable
+
+  filter-matrix:
+    if: ${{ github.repository_owner == 'meta-pytorch' }}
+    needs: generate-matrix
+    runs-on: linux.24_04.4x
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+    - uses: actions/setup-python@v4
+    - name: Checkout MSLK repository
+      uses: actions/checkout@v4
+      with:
+        repository: meta-pytorch/MSLK
+    - name: Filter Generated Built Matrix
+      id: filter
+      env:
+        MAT: ${{ needs.generate-matrix.outputs.matrix }}
+      # Nova Coordinate Filters:
+      # cuda/12.6: No longer supported in MSLK
+      run: |
+        set -ex
+        pwd
+        ls
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'desired_cuda:cu126' )"
+        echo "${MATRIX_BLOB}"
+        echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
+
+  build:
+    if: ${{ github.repository_owner == 'meta-pytorch' }}
+    needs: filter-matrix
+    name: meta-pytorch/MSLK
+    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
+    with:
+      repository: meta-pytorch/MSLK
+      ref: ""
+      pre-script: .github/scripts/nova_prescript_windows.bash
+      post-script: .github/scripts/nova_postscript_windows.bash
+      smoke-test-script: ""
+      env-var-script: .github/scripts/nova_dir_windows.bash
+      package-name: mslk
+      build-target: default
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
+      trigger-event: ${{ github.event_name }}
+      # Python-only builds are fast; no C++ compilation needed
+      timeout: 60

--- a/setup.py
+++ b/setup.py
@@ -605,9 +605,50 @@ def main(argv: List[str]) -> None:
 
     if _PYTHON_ONLY:
         print("[SETUP.PY] MSLK_PYTHON_ONLY=1 — skipping C++/CUDA build")
-        package_name = "mslk"
-        package_version = "0.0.0"
+
+        if str(os.environ.get("BUILD_FROM_NOVA", "")) == "1":
+            print(
+                "[SETUP.PY] Running under Nova workflow context"
+                " (non-prebuild step) ... exiting"
+            )
+            sys.exit(0)
+
+        package_name = os.environ.get("MSLK_PACKAGE_NAME", "mslk")
+
+        channel = os.environ.get("CHANNEL", "")
+        version_override = os.environ.get("MSLK_VERSION_OVERRIDE", "")
+
+        if version_override:
+            pkg_version = version_override
+        elif channel == "nightly":
+            today = date.today()
+            pkg_version = f"{today.year}.{today.month}.{today.day}"
+        elif channel in ("test", "release"):
+            import setuptools_git_versioning as gitversion
+
+            pkg_version = gitversion.version_from_git().base_version
+        else:
+            pkg_version = "0.0.0"
+
+        cu_version = os.environ.get("CU_VERSION", "")
+        if cu_version:
+            pkg_vver = f"+{cu_version}"
+        else:
+            pkg_vver = ""
+
+        package_version = f"{pkg_version}{pkg_vver}"
         _write_version_file(package_version, "default", "python_only")
+
+        python_only_plat = os.environ.get("MSLK_PYTHON_ONLY_PLAT", "")
+        if python_only_plat:
+            from wheel.bdist_wheel import bdist_wheel as _BdistWheel
+
+            class _PlatBdistWheel(_BdistWheel):
+                def get_tag(self):
+                    python, abi, _ = super().get_tag()
+                    return python, abi, python_only_plat
+
+            extra_kwargs["cmdclass"] = {"bdist_wheel": _PlatBdistWheel}
 
     else:
         # Handle command line args before passing to main setup() method.


### PR DESCRIPTION
Summary:
MSLK currently only publishes Linux wheels (x86 and aarch64) to downloads.pytorch.org. This adds a Windows wheel build that packages the Python layer only (`MSLK_PYTHON_ONLY=1`) — no C++/CUDA compilation — and tags the wheel as `py3-none-win_amd64` so it is only installable on Windows and cannot become an accidental fallback for Linux users with a mismatched Python/CUDA/Torch version.

This is needed for xformers users.

Changes:
- `setup.py`: Enhanced the `MSLK_PYTHON_ONLY` code path with proper Nova versioning (nightly date stamps, release git tags, `+cuXXX` variant suffixes), a `BUILD_FROM_NOVA=1` early-exit check matching the native build path, and an `MSLK_PYTHON_ONLY_PLAT` env var that overrides the wheel platform tag via a custom `bdist_wheel.get_tag()`.
- `.github/workflows/build_wheels_windows.yml`: Nova workflow generating a Windows CUDA-only matrix (no ROCm, no CPU) with the same `cu126` filter as the Linux workflow.
- `.github/scripts/nova_dir_windows.bash`: Env-var script setting `MSLK_PYTHON_ONLY=1`, `BUILD_FROM_NOVA=1`, and the Windows-compatible `MSLK_REPO` path.
- `.github/scripts/nova_prescript_windows.bash`: Lightweight pre-script that installs minimal build deps and runs `python -m build --wheel --no-isolation` with `MSLK_PYTHON_ONLY_PLAT=win_amd64`.
- `.github/scripts/nova_postscript_windows.bash`: Installs the wheel and verifies `import mslk` with `variant == "python_only"`.

Differential Revision: D107273307


