### PR TITLE
Fix ROCm Clang CI Issue

### DIFF
--- a/.github/workflows/_mslk_rocm_test.yml
+++ b/.github/workflows/_mslk_rocm_test.yml
@@ -117,9 +117,8 @@ jobs:
     - name: Create Conda Environment
       run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
 
-    - name: Install C/C++ Compilers
-      # NOTE: Need to install compilers to set up libomp for the clang case
-      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV ${{ matrix.compiler }}
+    - name: Install C/C++ Compilers for Updated LIBGCC
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV gcc
 
     - name: Install Build Tools
       # NOTE: Need to install build tools to set up libtbb

--- a/ci/scripts/utils_build.bash
+++ b/ci/scripts/utils_build.bash
@@ -197,6 +197,11 @@ __conda_install_clang () {
   # Remove the Conda activations scripts for gcc; see comments in the method for details
   __remove_gcc_activation_scripts
 
+  # shellcheck disable=SC2155,SC2086
+  local cc_path=$(conda run ${env_prefix} which clang)
+  # shellcheck disable=SC2155,SC2086
+  local cxx_path=$(conda run ${env_prefix} which clang++)
+
   # shellcheck disable=SC2086
   print_exec conda env config vars set ${env_prefix} CC="${cc_path}"
   # shellcheck disable=SC2086


### PR DESCRIPTION
## Summary

The ROCm CI started failing on the clang job (the gcc job was fine). The failure happened during the test step, where Triton compiles kernels on the fly. The problem is that the ROCm test job was using clang as the compiler at test time, but Triton/torch use gcc-specific compiler flags at runtime, so clang chokes on them.

The CUDA CI already avoids this by always using gcc at test time, regardless of which compiler was used to build the wheel. This PR brings the ROCm CI in line with that.

## Changes

- **`_mslk_rocm_test.yml`**: Install/use `gcc` for the test step instead of the matrix compiler. We still build the wheel with clang in the build job, so clang build coverage isn't lost. We just don't use clang as the runtime compiler. This mirrors the CUDA test workflow.
- **`utils_build.bash`**: Small fix so the clang setup sets `CC`/`CXX` to the actual clang paths instead of accidentally setting them to empty values (a variable-scoping bug).

## Test plan

- [ ] ROCm CI runs and the clang job passes the "Test with PyTest" step
- [ ] gcc job continues to pass