### PR TITLE
Make MX4 quantize ops opaque to keep batch dim dynamic

### DIFF
--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -37,6 +37,7 @@ from mslk.quantize.triton.legacy.primitives import (  # noqa: F401
     RoundingMode,
 )
 from mslk.quantize.triton.legacy.quantize import (  # noqa: F401
+    _detect_gfx950,
     _kernel_quantize_mx4_unpack,
     triton_quantize_mx4_unpack,
     triton_quantize_nvfp4,


### PR DESCRIPTION
Summary:
Reland of D107990672.

D107990672 was reverted because it broke tests at import time, e.g. `apf/utils/tests:activation_hook_utils_test` failed with:

```
ImportError: cannot import name '_detect_gfx950' from 'mslk.quantize.triton.fp4_quantize'
```

Root cause of that breakage: the original diff's V7 CI fix added `IS_GFX950=_detect_gfx950()` to the `_kernel_quantize_mx4_unpack` launch and imported `_detect_gfx950` from the `mslk.quantize.triton.fp4_quantize` shim, but that shim does not re-export `_detect_gfx950` (it lives in `mslk.quantize.triton.legacy.quantize`, alongside the `_kernel_quantize_mx4_unpack` the shim already re-exports). Any module importing `ads_mkl.ops.triton.fp4_quantize` therefore failed to import.

This reland is identical to D107990672 plus one line: add `_detect_gfx950` to the mslk `fp4_quantize` shim's `legacy.quantize` re-export block, so the kernel and its launch-arg helper are both reachable through the shim and `ads_mkl` resolves the import. This is a pure additive re-export consistent with the shim's stated purpose ("same-object re-exports for internal consumers"). cc mslk owners (oncall mslk_dev).

--- Original summary (D107990672) ---

With mxfp4 linear layers enabled, the `SimpleDHENLayer.forward` compiled region hit the Dynamo `recompile_limit` (48) and fell back to eager; the bf16 baseline did not. RCA (tlparse `dynamo_cpp_guards_str` diff between the two jobs) showed the region recompiles once per distinct `input_embs` batch size x ~8 architecture sub-configs = 48 compiles: with mxfp4 the batch dim is specialized static (`[2487, 992, 256]`) vs dynamic in the baseline (`[None, 992, 256]`).

Root cause: the MX4 activation-quantize ops were registered via `custom_triton_op` (`torch._library.triton_op`), which torch.compile traces through so Inductor can fuse the Triton kernel. That tracing evaluates the launch heuristic `num_threads = math.ceil(math.sqrt(input.numel()))`; `math.sqrt`/`math.ceil` cannot operate on a `SymInt`, so tracing forces `input.numel()` to a concrete value and pins the batch dimension.

Fix: register `triton_quantize_mx4_unpack` and `triton_quantize_mx4_unpack_rht` as fully opaque `torch.library.custom_op`s. Dynamo then treats them as black boxes and uses their existing symbolic `register_fake` impls (`..._meta`) for shape propagation, so the batch dim stays dynamic. The kernel launches switch from `torch._library.capture_triton(_kernel...)[grid](...)` to a direct `_kernel...[grid](...)`, matching the other opaque quantize ops already in this file (`quantize_fp32_to_mx4`, `dequantize_mx4_to_fp32`). These ops only run inside `LinearFunction.forward` (a `torch.autograd.Function`, forward runs grad-disabled), so no op-level autograd registration is needed.

Trade-off: Inductor can no longer fuse these two Triton kernels (they become extern black-box calls) -- functionally identical, minor potential perf cost on the quantize kernels, in exchange for keeping the batch dimension dynamic and staying under the recompile limit.

Adds a CPU unit test guarding the opaque registration.

Differential Revision: D108363424


