### PR TITLE
[ROCm] Add Triton FP8 groupwise (grouped/non-grouped) GEMM kernels

### DIFF
--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -31,6 +31,12 @@ from mslk.quantize.triton.fp8_quantize import (
 )
 from mslk.utils.device import is_cuda, is_gfx942, is_gfx950, is_rocm
 from mslk.utils.triton.fp8_utils import get_fp8_constants
+from mslk.utils.device import (
+    is_cuda,
+    is_gfx942,
+    is_gfx950,
+    is_rocm,
+)
 
 try:
     from tinygemm.utils import group_quantize_tensor
@@ -87,7 +93,7 @@ class Accelerator(Enum):
     NVIDIA_SM90 = auto()
     NVIDIA_SM100 = auto()
     NVIDIA_SM103 = auto()
-    AMD_MI300X = auto()
+    AMD_GFX942 = auto()
     AMD_GFX950 = auto()
 
 
@@ -113,7 +119,7 @@ def get_current_accelerator() -> Accelerator | None:
         if is_gfx950():
             return Accelerator.AMD_GFX950
         if is_gfx942():
-            return Accelerator.AMD_MI300X
+            return Accelerator.AMD_GFX942
     elif is_cuda():
         major, minor = torch.cuda.get_device_capability()
         if major == 9 and minor == 0:
@@ -724,7 +730,7 @@ class FP8Rowwise(GemmOpBase):
             Accelerator.NVIDIA_SM90,
             Accelerator.NVIDIA_SM100,
             Accelerator.NVIDIA_SM103,
-            Accelerator.AMD_MI300X,
+            Accelerator.AMD_GFX942,
         }
 
     @property
@@ -753,7 +759,7 @@ class FP8RowwisePreshuffle(FP8Rowwise):
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.AMD_MI300X}
+        return {Accelerator.AMD_GFX942}
 
     @property
     def supported_gemm_types(self) -> set[GemmType]:
@@ -1167,7 +1173,7 @@ class FP8RowwiseGrouped(GemmOpBase):
             Accelerator.NVIDIA_SM90,
             Accelerator.NVIDIA_SM100,
             Accelerator.NVIDIA_SM103,
-            Accelerator.AMD_MI300X,
+            Accelerator.AMD_GFX942,
         }
 
     @property
@@ -1201,7 +1207,7 @@ class FP8RowwiseGrouped2D3D(FP8RowwiseGrouped):
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.AMD_MI300X}
+        return {Accelerator.AMD_GFX942}
 
     @property
     def supported_gemm_types(self) -> set[GemmType]:
@@ -1245,7 +1251,7 @@ class TorchFP8RowwiseGrouped(FP8RowwiseGrouped2D3D):
     def supported_accelerators(self) -> set[Accelerator]:
         return {
             Accelerator.NVIDIA_SM90,
-            Accelerator.AMD_MI300X,
+            Accelerator.AMD_GFX942,
         }
 
     @property
@@ -1258,7 +1264,7 @@ class TorchFP8RowwiseGrouped(FP8RowwiseGrouped2D3D):
 
 
 @register_gemm_op
-class CutlassFP8GroupwiseGrouped(GemmOpBase):
+class FP8GroupwiseGrouped(GemmOpBase):
     """
     FP8 grouped matmul with groupwise scaling.
     """
@@ -1293,7 +1299,7 @@ class CutlassFP8GroupwiseGrouped(GemmOpBase):
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.NVIDIA_SM90}
+        return {Accelerator.NVIDIA_SM90, Accelerator.AMD_GFX950, Accelerator.AMD_GFX942}
 
     @property
     def supported_gemm_types(self) -> set[GemmType]:
@@ -1337,7 +1343,7 @@ class FP8RowwiseBatched(GemmOpBase):
             Accelerator.NVIDIA_SM90,
             Accelerator.NVIDIA_SM100,
             Accelerator.NVIDIA_SM103,
-            Accelerator.AMD_MI300X,
+            Accelerator.AMD_GFX942,
         }
 
     @property
@@ -1456,7 +1462,7 @@ class FP8Blockwise(GemmOpBase):
     def supported_accelerators(self) -> set[Accelerator]:
         return {
             Accelerator.NVIDIA_SM90,
-            Accelerator.AMD_MI300X,
+            Accelerator.AMD_GFX942,
         }
 
     @property
@@ -1469,7 +1475,7 @@ class FP8Blockwise(GemmOpBase):
 
 
 @register_gemm_op
-class CutlassFP8Groupwise(GemmOpBase):
+class FP8Groupwise(GemmOpBase):
     """
     FP8 matmul with groupwise scaling.
     """
@@ -1496,7 +1502,7 @@ class CutlassFP8Groupwise(GemmOpBase):
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.NVIDIA_SM90}
+        return {Accelerator.NVIDIA_SM90, Accelerator.AMD_GFX950, Accelerator.AMD_GFX942}
 
     @property
     def supported_gemm_types(self) -> set[GemmType]:
@@ -1982,7 +1988,7 @@ class BF16Grouped(GemmOpBase):
             Accelerator.NVIDIA_SM90,
             Accelerator.NVIDIA_SM100,
             Accelerator.NVIDIA_SM103,
-            Accelerator.AMD_MI300X,
+            Accelerator.AMD_GFX942,
         }
 
     @property
@@ -2055,7 +2061,7 @@ class TritonBF16Int4Rowwise(CutlassBF16Int4Rowwise):
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.AMD_MI300X}
+        return {Accelerator.AMD_GFX942}
 
 
 @register_gemm_op

--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -31,12 +31,6 @@ from mslk.quantize.triton.fp8_quantize import (
 )
 from mslk.utils.device import is_cuda, is_gfx942, is_gfx950, is_rocm
 from mslk.utils.triton.fp8_utils import get_fp8_constants
-from mslk.utils.device import (
-    is_cuda,
-    is_gfx942,
-    is_gfx950,
-    is_rocm,
-)
 
 try:
     from tinygemm.utils import group_quantize_tensor

--- a/csrc/gemm/ck/fp8_blockwise_gemm.hip
+++ b/csrc/gemm/ck/fp8_blockwise_gemm.hip
@@ -245,9 +245,8 @@ at::Tensor f8f8bf16_blockwise(
     int64_t block_k = 128) {
   // Check that input datatypes are valid.
   TORCH_CHECK(
-      (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
-          (WQ.dtype() == at::kFloat8_e4m3fnuz),
-      "Inputs must be type float8_e4m3fnuz.");
+      XQ.dtype() == WQ.dtype(),
+      "XQ and WQ dtypes must match, got ", XQ.dtype(), " vs ", WQ.dtype());
   TORCH_CHECK(
       (x_scale.dtype() == at::kFloat) && (w_scale.dtype() == at::kFloat),
       "Scales must be float32.");

--- a/csrc/gemm/ck/fp8_rowwise/fp8fp8bf16_rowwise_gemm.hip
+++ b/csrc/gemm/ck/fp8_rowwise/fp8fp8bf16_rowwise_gemm.hip
@@ -506,9 +506,8 @@ at::Tensor f8f8_rowwise_wrapper(
     std::optional<at::Tensor> output = std::nullopt) {
   // Check that input datatypes are valid.
   TORCH_CHECK(
-      (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
-          (WQ.dtype() == at::kFloat8_e4m3fnuz),
-      "Inputs must be type float8_e4m3fnuz.");
+      XQ.dtype() == WQ.dtype(),
+      "XQ and WQ dtypes must match, got ", XQ.dtype(), " vs ", WQ.dtype());
   TORCH_CHECK(
       (x_scale.dtype() == at::kFloat) && (w_scale.dtype() == at::kFloat),
       "Scales must be float32.");

--- a/csrc/gemm/ck/fp8_rowwise/fp8fp8fp16_rowwise_gemm.hip
+++ b/csrc/gemm/ck/fp8_rowwise/fp8fp8fp16_rowwise_gemm.hip
@@ -74,9 +74,8 @@ at::Tensor f8f8_rowwise_wrapper(
     std::optional<at::Tensor> output = std::nullopt) {
   // Check that input datatypes are valid.
   TORCH_CHECK(
-      (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
-          (WQ.dtype() == at::kFloat8_e4m3fnuz),
-      "Inputs must be type float8_e4m3fnuz.");
+      XQ.dtype() == WQ.dtype(),
+      "XQ and WQ dtypes must match, got ", XQ.dtype(), " vs ", WQ.dtype());
   TORCH_CHECK(
       (x_scale.dtype() == at::kFloat) && (w_scale.dtype() == at::kFloat),
       "Scales must be float32.");

--- a/csrc/gemm/ck/fp8_rowwise_batched/fp8_rowwise_batched_gemm.hip
+++ b/csrc/gemm/ck/fp8_rowwise_batched/fp8_rowwise_batched_gemm.hip
@@ -210,9 +210,8 @@ at::Tensor f8f8bf16_rowwise_batched(
       XQ.dim() == 3 && WQ.dim() == 3,
       "Inputs must have 3 dimensions, with the first being batch.");
   TORCH_CHECK(
-      (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
-          (WQ.dtype() == at::kFloat8_e4m3fnuz),
-      "Inputs must be type float8_e4m3fnuz.");
+      XQ.dtype() == WQ.dtype(),
+      "XQ and WQ dtypes must match, got ", XQ.dtype(), " vs ", WQ.dtype());
   TORCH_CHECK(
       (x_scale.dtype() == at::kFloat) && (w_scale.dtype() == at::kFloat),
       "Scales must be float32.");

--- a/csrc/gemm/ck/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/csrc/gemm/ck/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -478,17 +478,6 @@ void set_dynamic_kernel_args(
   }
 }
 
-static std::pair<at::ScalarType, std::string> get_float8_e4m3_dtype() {
-  if (at::detail::getCUDAHooks().isGPUArch({"gfx942"})) {
-    return std::make_pair(at::kFloat8_e4m3fnuz, "float8_e4m3fnuz");
-  } else if (at::detail::getCUDAHooks().isGPUArch({"gfx950"})) {
-    return std::make_pair(at::kFloat8_e4m3fn, "float8_e4m3fn");
-  } else {
-    std::string gcn_arch_name = at::cuda::getCurrentDeviceProperties()->gcnArchName;
-    TORCH_CHECK(false, "Unsupported GPU architecture for FP8: ", gcn_arch_name);
-  }
-}
-
 template <typename OutputType>
 OutputType _f8f8bf16_rowwise_grouped(
     at::TensorList XQ,
@@ -497,7 +486,6 @@ OutputType _f8f8bf16_rowwise_grouped(
     at::TensorList w_scale) {
   // Check that input datatypes are valid.
   // First confirm that there are the same number of groups in all inputs.
-  static auto float8_dtype = get_float8_e4m3_dtype();
   TORCH_CHECK(
       XQ.size() == WQ.size() && XQ.size() == x_scale.size() &&
           XQ.size() == w_scale.size(),
@@ -507,16 +495,13 @@ OutputType _f8f8bf16_rowwise_grouped(
   for (at::Tensor x : XQ) {
     TORCH_CHECK(x.is_cuda() && x.is_contiguous());
     TORCH_CHECK(x.dim() == 2, "Inputs must be 2D.");
-    TORCH_CHECK(
-        x.dtype() == float8_dtype.first,
-        "Inputs must be type ", float8_dtype.second);
   }
   for (at::Tensor w : WQ) {
     TORCH_CHECK(w.is_cuda() && w.is_contiguous());
     TORCH_CHECK(w.dim() == 2, "Inputs must be 2D.");
     TORCH_CHECK(
-        w.dtype() == float8_dtype.first,
-        "Inputs must be type ", float8_dtype.second);
+        XQ[0].dtype() == w.dtype(),
+        "XQ and WQ dtypes must match, got ", XQ[0].dtype(), " vs ", w.dtype());
     TORCH_CHECK(
         w.size(0) >= 512 && w.size(1) >= 512,
         "N and K must be at least 512 for grouped gemm. For smaller inputs, consider unrolling.");
@@ -584,13 +569,9 @@ void validate_inputs_common(
   TORCH_CHECK(x_scale.is_cuda());
   TORCH_CHECK(w_scale.is_cuda());
 
-  static auto float8_dtype = get_float8_e4m3_dtype();
   TORCH_CHECK(
-      XQ.dtype() == float8_dtype.first,
-      "Input XQ must be type ", float8_dtype.second);
-  TORCH_CHECK(
-      WQ.dtype() == float8_dtype.first,
-      "Input WQ must be type ", float8_dtype.second);
+      XQ.dtype() == WQ.dtype(),
+      "XQ and WQ dtypes must match, got ", XQ.dtype(), " vs ", WQ.dtype());
 
   TORCH_CHECK(x_scale.dtype() == at::kFloat, "Scales must be float32.");
   TORCH_CHECK(w_scale.dtype() == at::kFloat, "Scales must be float32.");

--- a/csrc/gemm/ck/fp8_rowwise_preshuffle/fp8_rowwise_preshuffle_gemm.hip
+++ b/csrc/gemm/ck/fp8_rowwise_preshuffle/fp8_rowwise_preshuffle_gemm.hip
@@ -102,9 +102,8 @@ at::Tensor f8f8_rowwise_preshuffle_wrapper(
     std::optional<at::Tensor> output = std::nullopt) {
   // Check that input datatypes are valid.
   TORCH_CHECK(
-      (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
-          (WQ.dtype() == at::kFloat8_e4m3fnuz),
-      "Inputs must be type float8_e4m3fnuz.");
+      XQ.dtype() == WQ.dtype(),
+      "XQ and WQ dtypes must match, got ", XQ.dtype(), " vs ", WQ.dtype());
   TORCH_CHECK(
       (x_scale.dtype() == at::kFloat) && (w_scale.dtype() == at::kFloat),
       "Scales must be float32.");

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -55,6 +55,14 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   // mx8mx8_gemm.py via torch.library.impl.
   m.def(
       "mx8mx8bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None, int? actual_num_tokens=None) -> Tensor");
+  // FP8 groupwise GEMM: shared schema; CUDA uses CUTLASS, ROCm uses the
+  // Triton implementation registered by fp8_groupwise_gemm.py.
+  m.def(
+      "f8f8bf16_groupwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale) -> Tensor");
+  // FP8 groupwise grouped GEMM: shared schema; CUDA uses CUTLASS, ROCm uses
+  // the Triton implementation registered by fp8_groupwise_grouped_gemm.py.
+  m.def(
+      "f8f8bf16_groupwise_grouped(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes) -> Tensor");
 #ifdef USE_ROCM
   m.def(
       "f8f8f16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? bias=None, bool use_fast_accum=True) -> Tensor");
@@ -90,10 +98,6 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
       "f4f4bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None, Tensor(a!)? global_scale=None) -> Tensor");
   m.def(
       "f4f4bf16_ultra_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor x_global_scale, Tensor w_global_scale, Tensor(a!)? output=None) -> Tensor");
-  m.def(
-      "f8f8bf16_groupwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale) -> Tensor");
-  m.def(
-      "f8f8bf16_groupwise_grouped(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes) -> Tensor");
   m.def("bf16x9_gemm(Tensor A, Tensor B, Tensor(a!)? output=None) -> Tensor");
   m.def(
       "f8i4bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor");

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -29,12 +29,13 @@ import torch  # noqa: E402
 from . import _meta  # noqa: F401, E402
 
 if torch.version.hip is not None:
-    # Register the Triton implementation of mx8mx4bf16 for ROCm.  This import
-    # triggers the @torch.library.impl("mslk::mx8mx4bf16", "CUDA") decoration
-    # in mx8mx4_gemm.py, which overrides the default (non-existent) CUDA impl
-    # so that torch.ops.mslk.mx8mx4bf16/_grouped dispatches to the Triton
-    # kernel on AMD.
+    # Register the Triton ROCm implementations for mx8mx4bf16, mx8mx8bf16, and
+    # f8f8bf16_groupwise(_grouped).  Each import triggers a
+    # @torch.library.impl(..., "CUDA") decoration that overrides the default
+    # (non-existent) CUDA impl so the ops dispatch to the Triton kernels on AMD.
     from .triton import (  # noqa: F401
+        fp8_groupwise_gemm,
+        fp8_groupwise_grouped_gemm,
         grouped_gemm as _grouped_gemm,
         mx8mx4_gemm,
         mx8mx8_gemm,

--- a/mslk/gemm/triton/fp8_groupwise_gemm.py
+++ b/mslk/gemm/triton/fp8_groupwise_gemm.py
@@ -1,0 +1,291 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+FP8 (E4M3) x FP8 (E4M3) groupwise-scaled GEMM for ROCm/AMD.
+
+This is the ROCm Triton counterpart of the NVIDIA CUTLASS implementation in
+csrc/gemm/cutlass/f8f8bf16_groupwise.cu.
+
+Scaling scheme ("groupwise"):
+  x_scale : [K // 128, M]         float32 -- one scale per (K-group-of-128, row)
+  w_scale : [K // 128, N // 128]  float32 -- one scale per (K-group, N-group-of-128)
+
+Both scales use k_major=False layout (K dimension is outermost), matching the
+output of quantize_fp8_group(x, k_major=False) and
+quantize_fp8_block(w, block_m=128, block_k=128, k_major=False).
+
+FP8 dtype (hardware-native formats):
+  gfx942 (MI300X, CDNA3) -- tl.float8e4b8  (torch.float8_e4m3fnuz, bias=8, AMD fnuz)
+  gfx950 (MI350X, CDNA4) -- tl.float8e4nv  (torch.float8_e4m3fn,   bias=7, OCP)
+  CUDA                   -- tl.float8e4nv  (torch.float8_e4m3fn,   bias=7, OCP)
+
+The Triton kernel infers the FP8 pointer type from the input tensor dtype, so it
+automatically uses the correct hardware format as long as the caller supplies
+tensors produced by quantize_fp8_group / quantize_fp8_block, which call
+get_fp8_constants() to select the right dtype per device.
+"""
+
+from typing import List, Optional
+
+import torch
+import triton  # @manual
+import triton.language as tl  # @manual
+from triton import Config  # @manual
+
+# Scale group size in K: must match the quantize_fp8_group/block group_size.
+_SCALE_GROUP_K: int = 128
+
+
+# ---------------------------------------------------------------------------
+# Autotuning configs
+# ---------------------------------------------------------------------------
+
+
+def _get_configs() -> List[Config]:
+    """
+    Tile configs for the groupwise FP8 GEMM kernel.
+
+    BLOCK_K is fixed to 128 to match the scale group size: each K tile maps
+    to exactly one scale group, avoiding partial-scale complexity.
+    BLOCK_M and BLOCK_N are autotuned.
+    """
+    configs = []
+    for bm in [16, 32, 64, 128, 256]:
+        for bn in [16, 32, 64, 128, 256]:
+            for nw in [4, 8]:
+                for ns in [2, 3, 4]:
+                    configs.append(
+                        Config(
+                            {"BLOCK_M": bm, "BLOCK_N": bn, "BLOCK_K": 128},
+                            num_warps=nw,
+                            num_stages=ns,
+                        )
+                    )
+    return configs
+
+
+def _prune_configs(configs, named_args, **kwargs):
+    """Drop configs whose tile exceeds the problem in M or N."""
+    M = named_args["M"]
+    N = named_args["N"]
+    pruned = []
+    for cfg in configs:
+        bm = cfg.kwargs["BLOCK_M"]
+        bn = cfg.kwargs["BLOCK_N"]
+        if bm > M or bn > N:
+            continue
+        if M <= 16 and bm > 16:
+            continue
+        if M <= 32 and bm > 32:
+            continue
+        pruned.append(cfg)
+    return pruned if pruned else configs
+
+
+# ---------------------------------------------------------------------------
+# Triton kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.autotune(
+    configs=_get_configs(),
+    key=["M", "N", "K"],
+    prune_configs_by={"early_config_prune": _prune_configs},
+)
+@triton.jit
+def _f8f8bf16_groupwise_kernel(
+    XQ_ptr,  # [M, K]           FP8 activations
+    WQ_ptr,  # [N, K]           FP8 weights (W already transposed)
+    XS_ptr,  # [K//128, M]      float32 x_scale
+    WS_ptr,  # [K//128, N//128] float32 w_scale
+    Out_ptr,  # [M, N]           bfloat16 output
+    M,
+    N,
+    K,
+    stride_xm,
+    stride_xk,
+    stride_wn,
+    stride_wk,
+    stride_xs_k,
+    stride_xs_m,  # x_scale strides: [K//128, M]
+    stride_ws_k,
+    stride_ws_n,  # w_scale strides: [K//128, N//128]
+    stride_om,
+    stride_on,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,  # fixed to 128 = scale group size
+) -> None:
+    """
+    Computes Out[M, N] = dequant(XQ) @ dequant(WQ).T in bfloat16.
+
+    Scale application: for each K-group g of 128 elements:
+      combined_scale[m, n] = x_scale[g, m] * w_scale[g, n // 128]
+      contribution = dot(XQ[:, g*128:(g+1)*128], WQ[:, g*128:(g+1)*128].T)
+                   * combined_scale
+    """
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    # Number of scale groups in K and N.
+    # N-group index for each column in this tile (for w_scale indexing).
+    # w_scale has shape [K//128, N//128]; all columns in [pid_n*BLOCK_N, (pid_n+1)*BLOCK_N)
+    # map to N-group indices offs_n // 128.  We compute the w_scale pointer offsets
+    # per column using the N-group stride.
+    n_group_offs = offs_n // 128  # [BLOCK_N] int, each in [0, N//128)
+
+    acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+
+    num_k_groups = tl.cdiv(K, BLOCK_K)  # = K // 128 when K % 128 == 0
+
+    for k_g in tl.range(0, num_k_groups):
+        k_start = k_g * BLOCK_K
+        offs_k = k_start + tl.arange(0, BLOCK_K)
+
+        # Load XQ tile [BLOCK_M, BLOCK_K] in FP8.
+        # Triton infers the element type from the pointer dtype (FP8), so no
+        # explicit cast is needed.
+        xq = tl.load(
+            XQ_ptr + offs_m[:, None] * stride_xm + offs_k[None, :] * stride_xk,
+            mask=(offs_m[:, None] < M) & (offs_k[None, :] < K),
+            other=0.0,
+        )
+
+        # Load WQ tile [BLOCK_N, BLOCK_K] in FP8; transposed inside dot.
+        wq = tl.load(
+            WQ_ptr + offs_n[:, None] * stride_wn + offs_k[None, :] * stride_wk,
+            mask=(offs_n[:, None] < N) & (offs_k[None, :] < K),
+            other=0.0,
+        )
+
+        # Dot product for this K group: [BLOCK_M, BLOCK_N] float32.
+        tmp = tl.dot(xq, tl.trans(wq), out_dtype=tl.float32)
+
+        # Load x_scale[k_g, offs_m]: one float32 per row in this tile.
+        x_sc = tl.load(
+            XS_ptr + k_g * stride_xs_k + offs_m * stride_xs_m,
+            mask=offs_m < M,
+            other=1.0,
+        )  # [BLOCK_M]
+
+        # Load w_scale[k_g, offs_n // 128]: one float32 per N-group-of-128.
+        w_sc = tl.load(
+            WS_ptr + k_g * stride_ws_k + n_group_offs * stride_ws_n,
+            mask=offs_n < N,
+            other=1.0,
+        )  # [BLOCK_N]
+
+        # Combined scale: [BLOCK_M, BLOCK_N].
+        combined = x_sc[:, None] * w_sc[None, :]
+        acc += tmp * combined
+
+    # Store output as bfloat16.
+    tl.store(
+        Out_ptr + offs_m[:, None] * stride_om + offs_n[None, :] * stride_on,
+        acc.to(tl.bfloat16),
+        mask=(offs_m[:, None] < M) & (offs_n[None, :] < N),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python wrapper
+# ---------------------------------------------------------------------------
+
+
+def matmul_f8f8bf16_groupwise(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    output: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    FP8 (E4M3) groupwise-scaled GEMM -> BFloat16.
+
+    Matches the CUDA CUTLASS API contract for f8f8bf16_groupwise.
+
+    Args:
+        XQ      : [M, K]         torch.float8_e4m3fnuz (ROCm) or float8_e4m3fn (CUDA)
+        WQ      : [N, K]         same FP8 dtype, W already transposed by caller
+        x_scale : [K//128, M]   float32 -- per-row, per-K-group activation scales
+        w_scale : [K//128, N//128] float32 -- per-K-group, per-N-group weight scales
+        output  : [M, N]         optional pre-allocated bfloat16 output
+
+    Returns:
+        [M, N] bfloat16 tensor.
+    """
+    assert XQ.ndim == 2, f"XQ must be 2D, got shape {XQ.shape}"
+    assert WQ.ndim == 2, f"WQ must be 2D [N, K], got shape {WQ.shape}"
+
+    M, K = XQ.shape
+    N = WQ.shape[0]
+    assert WQ.shape[1] == K, f"WQ K dim mismatch: WQ.shape={WQ.shape}, XQ K={K}"
+    assert K % _SCALE_GROUP_K == 0, (
+        f"K={K} must be a multiple of scale group size {_SCALE_GROUP_K}"
+    )
+
+    if output is None:
+        output = torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
+
+    if M == 0 or N == 0 or K == 0:
+        return output
+
+    grid = lambda meta: (  # noqa: E731
+        triton.cdiv(M, meta["BLOCK_M"]),
+        triton.cdiv(N, meta["BLOCK_N"]),
+    )
+
+    _f8f8bf16_groupwise_kernel[grid](
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        output,
+        M,
+        N,
+        K,
+        XQ.stride(0),
+        XQ.stride(1),
+        WQ.stride(0),
+        WQ.stride(1),
+        x_scale.stride(0),
+        x_scale.stride(1),
+        w_scale.stride(0),
+        w_scale.stride(1),
+        output.stride(0),
+        output.stride(1),
+    )
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Register as the ROCm implementation of mslk::f8f8bf16_groupwise
+# ---------------------------------------------------------------------------
+# The C++ schema is declared in gemm_ops.cpp (shared between CUDA and ROCm).
+# On ROCm the CUDA C++ implementation is absent; this module registers the
+# Triton kernel above as the dispatch target via torch.library.impl.
+
+if torch.version.hip is not None and hasattr(torch.ops, "mslk"):
+    if hasattr(torch.ops.mslk, "f8f8bf16_groupwise"):
+        try:
+
+            @torch.library.impl("mslk::f8f8bf16_groupwise", "CUDA")
+            def _f8f8bf16_groupwise_rocm(
+                XQ: torch.Tensor,
+                WQ: torch.Tensor,
+                x_scale: torch.Tensor,
+                w_scale: torch.Tensor,
+            ) -> torch.Tensor:
+                return matmul_f8f8bf16_groupwise(XQ, WQ, x_scale, w_scale)
+
+        except RuntimeError:
+            pass  # already registered (e.g. module imported more than once)

--- a/mslk/gemm/triton/fp8_groupwise_grouped_gemm.py
+++ b/mslk/gemm/triton/fp8_groupwise_grouped_gemm.py
@@ -1,0 +1,322 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+FP8 (E4M3) x FP8 (E4M3) groupwise-scaled grouped GEMM for ROCm/AMD.
+
+This is the ROCm Triton counterpart of the NVIDIA CUTLASS implementation of
+f8f8bf16_groupwise_grouped.
+
+Tensor layout:
+  XQ      : [TotalM, K]         FP8 -- all groups concatenated along M
+  WQ      : [G, N, K]           FP8 -- one weight matrix per group
+  x_scale : [TotalM, K//128]    float32 -- row-major activation scales (matches CUTLASS layout)
+  w_scale : [G, K//128, N//128] float32 -- per-group, per-K-group, per-N-group weight scales
+  M_sizes : [G]                 int64   -- number of rows per group
+  Output  : [TotalM, N]         bfloat16
+
+FP8 dtype (hardware-native formats):
+  gfx942 (MI300X, CDNA3) -- tl.float8e4b8  (torch.float8_e4m3fnuz, bias=8, AMD fnuz)
+  gfx950 (MI350X, CDNA4) -- tl.float8e4nv  (torch.float8_e4m3fn,   bias=7, OCP)
+
+The kernel infers the FP8 pointer type from the input tensor dtype, so it
+automatically uses the correct hardware format as long as the caller supplies
+tensors produced by quantize_fp8_group / quantize_fp8_block.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import triton  # @manual
+import triton.language as tl  # @manual
+from triton import Config  # @manual
+
+# Scale group size in K: must match the quantize_fp8_group/block group_size.
+_SCALE_GROUP_K: int = 128
+
+# Module-level cache for CPU-side precomputed values (M_starts, max_M).
+# Keyed by (M_sizes.data_ptr(), G, N, K) so the cache is invalidated if
+# M_sizes changes.  Populated on the first (non-capturing) call; reused
+# inside CUDA graph capture without device-to-host transfers.
+_grouped_precomp_cache: Dict[Tuple, Tuple] = {}
+
+
+# ---------------------------------------------------------------------------
+# Autotuning configs
+# ---------------------------------------------------------------------------
+
+
+def _get_configs() -> List[Config]:
+    """
+    Tile configs for the grouped groupwise FP8 GEMM kernel.
+
+    BLOCK_K is fixed to 128 to match the scale group size.
+    BLOCK_M and BLOCK_N are autotuned.
+    """
+    configs = []
+    for bm in [16, 32, 64, 128, 256]:
+        for bn in [16, 32, 64, 128, 256]:
+            for nw in [4, 8]:
+                for ns in [2, 3, 4]:
+                    configs.append(
+                        Config(
+                            {"BLOCK_M": bm, "BLOCK_N": bn, "BLOCK_K": 128},
+                            num_warps=nw,
+                            num_stages=ns,
+                        )
+                    )
+    return configs
+
+
+def _prune_configs(configs, named_args, **kwargs):
+    """Drop configs whose tile exceeds the problem in N."""
+    N = named_args["N"]
+    pruned = [cfg for cfg in configs if cfg.kwargs["BLOCK_N"] <= N]
+    return pruned if pruned else configs
+
+
+# ---------------------------------------------------------------------------
+# Triton kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.autotune(
+    configs=_get_configs(),
+    key=["G", "N", "K"],
+    prune_configs_by={"early_config_prune": _prune_configs},
+)
+@triton.jit
+def _f8f8bf16_groupwise_grouped_kernel(
+    XQ_ptr,  # [TotalM, K]           FP8 activations (all groups)
+    WQ_ptr,  # [G, N, K]             FP8 weights (one matrix per group)
+    XS_ptr,  # [TotalM, K//128]      float32 x_scale, row-major (CUTLASS layout)
+    WS_ptr,  # [G, K//128, N//128]   float32 w_scale
+    Out_ptr,  # [TotalM, N]           bfloat16 output
+    M_sizes_ptr,  # [G]  int64 -- rows per group
+    M_starts_ptr,  # [G]  int64 -- cumulative M offset per group
+    G,
+    N,
+    K,
+    stride_xm,
+    stride_xk,
+    stride_wg,
+    stride_wn,
+    stride_wk,
+    stride_xs_m,
+    stride_xs_k,
+    stride_ws_g,
+    stride_ws_k,
+    stride_ws_n,
+    stride_om,
+    stride_on,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,  # fixed to 128 = scale group size
+) -> None:
+    """
+    Computes Out[M_start:M_start+M_g, N] = dequant(XQ[group]) @ dequant(WQ[g]).T
+
+    Grid: (G, ceil(max_M / BLOCK_M), ceil(N / BLOCK_N))
+    Programs whose pid_m tile falls outside the group's M are discarded early.
+    """
+    pid_g = tl.program_id(0)
+    pid_m = tl.program_id(1)
+    pid_n = tl.program_id(2)
+
+    # Load this group's row count and starting global row index.
+    M_g = tl.load(M_sizes_ptr + pid_g)
+    M_start = tl.load(M_starts_ptr + pid_g)
+
+    # Discard tiles that exceed this group's M dimension.
+    if pid_m * BLOCK_M >= M_g:
+        return
+
+    # Global row indices into XQ, x_scale, and Out.
+    offs_m = M_start + pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    # N-group index for w_scale [G, K//128, N//128].
+    n_group_offs = offs_n // 128  # [BLOCK_N]
+
+    acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+
+    num_k_groups = tl.cdiv(K, BLOCK_K)  # = K // 128 when K % 128 == 0
+    row_limit = M_start + M_g  # exclusive upper bound for this group
+
+    for k_g in tl.range(0, num_k_groups):
+        k_start = k_g * BLOCK_K
+        offs_k = k_start + tl.arange(0, BLOCK_K)
+
+        # Load XQ tile [BLOCK_M, BLOCK_K] from the concatenated activation tensor.
+        xq = tl.load(
+            XQ_ptr + offs_m[:, None] * stride_xm + offs_k[None, :] * stride_xk,
+            mask=(offs_m[:, None] < row_limit) & (offs_k[None, :] < K),
+            other=0.0,
+        )
+
+        # Load WQ tile [BLOCK_N, BLOCK_K] from group g's weight matrix.
+        wq = tl.load(
+            WQ_ptr
+            + pid_g * stride_wg
+            + offs_n[:, None] * stride_wn
+            + offs_k[None, :] * stride_wk,
+            mask=(offs_n[:, None] < N) & (offs_k[None, :] < K),
+            other=0.0,
+        )
+
+        # Dot product for this K group: [BLOCK_M, BLOCK_N] float32.
+        tmp = tl.dot(xq, tl.trans(wq), out_dtype=tl.float32)
+
+        local_m = offs_m - M_start  # [BLOCK_M] row index within this group
+        x_sc = tl.load(
+            XS_ptr + M_start * stride_xs_m + local_m * stride_xs_k + k_g * M_g,
+            mask=offs_m < row_limit,
+            other=1.0,
+        )  # [BLOCK_M]
+
+        # Load w_scale[g, k_g, offs_n // 128]: one float32 per N-group.
+        w_sc = tl.load(
+            WS_ptr
+            + pid_g * stride_ws_g
+            + k_g * stride_ws_k
+            + n_group_offs * stride_ws_n,
+            mask=offs_n < N,
+            other=1.0,
+        )  # [BLOCK_N]
+
+        # Combined scale: [BLOCK_M, BLOCK_N].
+        acc += tmp * x_sc[:, None] * w_sc[None, :]
+
+    # Store output as bfloat16.
+    tl.store(
+        Out_ptr + offs_m[:, None] * stride_om + offs_n[None, :] * stride_on,
+        acc.to(tl.bfloat16),
+        mask=(offs_m[:, None] < row_limit) & (offs_n[None, :] < N),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python wrapper
+# ---------------------------------------------------------------------------
+
+
+def matmul_f8f8bf16_groupwise_grouped(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    M_sizes: torch.Tensor,
+    output: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    FP8 (E4M3) grouped groupwise-scaled GEMM -> BFloat16.
+
+    Args:
+        XQ      : [TotalM, K]         FP8 -- all groups concatenated
+        WQ      : [G, N, K]           FP8 -- one weight matrix per group
+        x_scale : [TotalM, K//128]    float32 -- activation scales, row-major (matches CUTLASS)
+        w_scale : [G, K//128, N//128] float32 -- weight scales per group
+        M_sizes : [G]                 int64 -- rows per group (must sum to TotalM)
+        output  : [TotalM, N]         optional pre-allocated bfloat16 output
+
+    Returns:
+        [TotalM, N] bfloat16 tensor.
+    """
+    assert XQ.ndim == 2, f"XQ must be 2D [TotalM, K], got {XQ.shape}"
+    assert WQ.ndim == 3, f"WQ must be 3D [G, N, K], got {WQ.shape}"
+    assert M_sizes.ndim == 1, f"M_sizes must be 1D [G], got {M_sizes.shape}"
+
+    TotalM, K = XQ.shape
+    G, N, Kw = WQ.shape
+    assert Kw == K, f"WQ K mismatch: WQ.shape={WQ.shape}, XQ K={K}"
+    assert K % _SCALE_GROUP_K == 0, (
+        f"K={K} must be a multiple of scale group size {_SCALE_GROUP_K}"
+    )
+    assert M_sizes.shape[0] == G, f"M_sizes length {M_sizes.shape[0]} must equal G={G}"
+
+    if output is None:
+        output = torch.empty((TotalM, N), dtype=torch.bfloat16, device=XQ.device)
+
+    if TotalM == 0 or N == 0 or K == 0 or G == 0:
+        return output
+
+    # Precompute M_starts (cumulative row offsets) and max_M on CPU.
+    # Results are cached so CUDA graph capture (which forbids device-to-host
+    # transfers) can reuse the values computed on the first non-capturing call.
+    cache_key = (M_sizes.data_ptr(), G, N, K)
+    if cache_key not in _grouped_precomp_cache:
+        m_sizes_cpu = M_sizes.cpu()
+        m_starts_cpu = torch.zeros(G, dtype=torch.int64)
+        if G > 1:
+            m_starts_cpu[1:] = m_sizes_cpu[:-1].cumsum(0)
+        max_M = int(m_sizes_cpu.max().item())
+        _grouped_precomp_cache[cache_key] = (
+            m_starts_cpu.to(XQ.device),
+            max_M,
+        )
+
+    M_starts, max_M = _grouped_precomp_cache[cache_key]
+
+    grid = lambda meta: (  # noqa: E731
+        G,
+        triton.cdiv(max_M, meta["BLOCK_M"]),
+        triton.cdiv(N, meta["BLOCK_N"]),
+    )
+
+    _f8f8bf16_groupwise_grouped_kernel[grid](
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        output,
+        M_sizes,
+        M_starts,
+        G,
+        N,
+        K,
+        XQ.stride(0),
+        XQ.stride(1),
+        WQ.stride(0),
+        WQ.stride(1),
+        WQ.stride(2),
+        x_scale.stride(0),  # stride_xs_m: [TotalM, K//128] row stride
+        x_scale.stride(1),  # stride_xs_k: column stride (=1 for contiguous)
+        w_scale.stride(0),
+        w_scale.stride(1),
+        w_scale.stride(2),
+        output.stride(0),
+        output.stride(1),
+    )
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Register as the ROCm implementation of mslk::f8f8bf16_groupwise_grouped
+# ---------------------------------------------------------------------------
+# The C++ schema is declared in gemm_ops.cpp (shared between CUDA and ROCm).
+# On ROCm the CUDA C++ implementation is absent; this module registers the
+# Triton kernel above as the dispatch target via torch.library.impl.
+
+if torch.version.hip is not None and hasattr(torch.ops, "mslk"):
+    if hasattr(torch.ops.mslk, "f8f8bf16_groupwise_grouped"):
+        try:
+
+            @torch.library.impl("mslk::f8f8bf16_groupwise_grouped", "CUDA")
+            def _f8f8bf16_groupwise_grouped_rocm(
+                XQ: torch.Tensor,
+                WQ: torch.Tensor,
+                x_scale: torch.Tensor,
+                w_scale: torch.Tensor,
+                M_sizes: torch.Tensor,
+            ) -> torch.Tensor:
+                return matmul_f8f8bf16_groupwise_grouped(
+                    XQ, WQ, x_scale, w_scale, M_sizes
+                )
+
+        except RuntimeError:
+            pass  # already registered (e.g. module imported more than once)

--- a/mslk/gemm/triton/fp8_groupwise_grouped_gemm.py
+++ b/mslk/gemm/triton/fp8_groupwise_grouped_gemm.py
@@ -29,7 +29,7 @@ automatically uses the correct hardware format as long as the caller supplies
 tensors produced by quantize_fp8_group / quantize_fp8_block.
 """
 
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional
 
 import torch
 import triton  # @manual
@@ -38,12 +38,6 @@ from triton import Config  # @manual
 
 # Scale group size in K: must match the quantize_fp8_group/block group_size.
 _SCALE_GROUP_K: int = 128
-
-# Module-level cache for CPU-side precomputed values (M_starts, max_M).
-# Keyed by (M_sizes.data_ptr(), G, N, K) so the cache is invalidated if
-# M_sizes changes.  Populated on the first (non-capturing) call; reused
-# inside CUDA graph capture without device-to-host transfers.
-_grouped_precomp_cache: Dict[Tuple, Tuple] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -245,26 +239,18 @@ def matmul_f8f8bf16_groupwise_grouped(
     if TotalM == 0 or N == 0 or K == 0 or G == 0:
         return output
 
-    # Precompute M_starts (cumulative row offsets) and max_M on CPU.
-    # Results are cached so CUDA graph capture (which forbids device-to-host
-    # transfers) can reuse the values computed on the first non-capturing call.
-    cache_key = (M_sizes.data_ptr(), G, N, K)
-    if cache_key not in _grouped_precomp_cache:
-        m_sizes_cpu = M_sizes.cpu()
-        m_starts_cpu = torch.zeros(G, dtype=torch.int64)
-        if G > 1:
-            m_starts_cpu[1:] = m_sizes_cpu[:-1].cumsum(0)
-        max_M = int(m_sizes_cpu.max().item())
-        _grouped_precomp_cache[cache_key] = (
-            m_starts_cpu.to(XQ.device),
-            max_M,
-        )
+    # Derive M_starts (cumulative row offsets) on the GPU -- no device-to-host
+    # sync, so this captures cleanly inside a CUDA graph.
+    # M_starts[g] = sum of M_sizes[:g] = (0, M_sizes[0], M_sizes[0]+M_sizes[1], ...)
+    M_starts = M_sizes.cumsum(0) - M_sizes
 
-    M_starts, max_M = _grouped_precomp_cache[cache_key]
-
+    # The M dimension of the grid is bounded by TotalM (a host int already in
+    # hand) rather than max group size, avoiding a .item() sync.  Tiles that
+    # fall outside their group's M are discarded early in the kernel, so the
+    # extra launches for uneven groups are cheap no-ops.
     grid = lambda meta: (  # noqa: E731
         G,
-        triton.cdiv(max_M, meta["BLOCK_M"]),
+        triton.cdiv(TotalM, meta["BLOCK_M"]),
         triton.cdiv(N, meta["BLOCK_N"]),
     )
 

--- a/mslk/quantize/triton/fp8_quantize.py
+++ b/mslk/quantize/triton/fp8_quantize.py
@@ -905,13 +905,18 @@ def _kernel_quantize_fp8_group(
         scale_chunk_offset = scale_k_offset + k * GROUP_LOAD
 
         if USE_M_MAJOR and G > 0:
+            # Cast scale_chunk_offset to int64 to match group_M's dtype (a
+            # tl.tensor loaded from m_sizes), preventing a type mismatch in
+            # the pointer arithmetic that causes a Triton compilation
+            # error ("cannot convert int32[] tensor to tensor").
+            sco = scale_chunk_offset.to(group_M.dtype)
             tl.store(
                 A_scale
                 + group_offset
                 + (pid - group_cumsum) * stride_a_scale_k
-                + (scale_chunk_offset * group_M),
+                + (sco * group_M),
                 1.0 / a_scale,
-                mask=scale_chunk_offset < NUM_GROUPS,
+                mask=sco < NUM_GROUPS,
             )
         else:
             if USE_M_MAJOR:

--- a/mslk/quantize/triton/fp8_quantize.py
+++ b/mslk/quantize/triton/fp8_quantize.py
@@ -905,18 +905,20 @@ def _kernel_quantize_fp8_group(
         scale_chunk_offset = scale_k_offset + k * GROUP_LOAD
 
         if USE_M_MAJOR and G > 0:
-            # Cast scale_chunk_offset to int64 to match group_M's dtype (a
-            # tl.tensor loaded from m_sizes), preventing a type mismatch in
-            # the pointer arithmetic that causes a Triton compilation
-            # error ("cannot convert int32[] tensor to tensor").
-            sco = scale_chunk_offset.to(group_M.dtype)
+            # Recompute the 1-D mask from tl.arange + Python ints to avoid a
+            # Triton compilation error: the SSA merge of group_M (a 0-D
+            # loaded tensor) into scale_chunk_offset causes the type resolver
+            # to infer a 0-D type for scale_chunk_offset in this branch, which
+            # makes "scale_chunk_offset < NUM_GROUPS" a 0-D mask that tl.store
+            # cannot use. Using tl.arange directly guarantees a 1-D mask.
+            valid = tl.arange(0, GROUP_LOAD) + k * GROUP_LOAD < NUM_GROUPS
             tl.store(
                 A_scale
                 + group_offset
                 + (pid - group_cumsum) * stride_a_scale_k
-                + (sco * group_M),
+                + (scale_chunk_offset * group_M),
                 1.0 / a_scale,
-                mask=sco < NUM_GROUPS,
+                mask=valid,
             )
         else:
             if USE_M_MAJOR:

--- a/mslk/quantize/triton/fp8_quantize.py
+++ b/mslk/quantize/triton/fp8_quantize.py
@@ -862,7 +862,7 @@ def _kernel_quantize_fp8_group(
     scale_row_offset = pid * stride_a_scale_m
     k_offset = tl.arange(0, GROUP_LOAD * GROUP_SIZE)
     scale_k_offset = tl.arange(0, GROUP_LOAD)
-    NUM_GROUPS: tl.constexpr = K // GROUP_SIZE
+    NUM_GROUPS = K // GROUP_SIZE
 
     # When dealing with an M-major grouped gemm, we need to figure out
     # which group this thread corresponds to and figure out the corresponding
@@ -903,15 +903,8 @@ def _kernel_quantize_fp8_group(
         # Scale and quantize.
         a_scale = MAX_FP8 / group_max
         scale_chunk_offset = scale_k_offset + k * GROUP_LOAD
-
+        valid = tl.arange(0, GROUP_LOAD) + k * GROUP_LOAD < NUM_GROUPS
         if USE_M_MAJOR and G > 0:
-            # Recompute the 1-D mask from tl.arange + Python ints to avoid a
-            # Triton compilation error: the SSA merge of group_M (a 0-D
-            # loaded tensor) into scale_chunk_offset causes the type resolver
-            # to infer a 0-D type for scale_chunk_offset in this branch, which
-            # makes "scale_chunk_offset < NUM_GROUPS" a 0-D mask that tl.store
-            # cannot use. Using tl.arange directly guarantees a 1-D mask.
-            valid = tl.arange(0, GROUP_LOAD) + k * GROUP_LOAD < NUM_GROUPS
             tl.store(
                 A_scale
                 + group_offset
@@ -927,13 +920,13 @@ def _kernel_quantize_fp8_group(
                     + pid * stride_a_scale_k
                     + scale_chunk_offset * stride_a_scale_m,
                     1.0 / a_scale,
-                    mask=scale_chunk_offset < NUM_GROUPS,
+                    mask=valid,
                 )
             else:
                 tl.store(
                     A_scale + scale_row_offset + scale_chunk_offset * stride_a_scale_k,
                     1.0 / a_scale,
-                    mask=scale_chunk_offset < NUM_GROUPS,
+                    mask=valid,
                 )
         # Apply scale to input.
         a_fp8 = a_grouped * a_scale[:, None]

--- a/mslk/quantize/triton/fp8_quantize.py
+++ b/mslk/quantize/triton/fp8_quantize.py
@@ -903,7 +903,7 @@ def _kernel_quantize_fp8_group(
         # Scale and quantize.
         a_scale = MAX_FP8 / group_max
         scale_chunk_offset = scale_k_offset + k * GROUP_LOAD
-        valid = tl.arange(0, GROUP_LOAD) + k * GROUP_LOAD < NUM_GROUPS
+        valid = scale_chunk_offset < NUM_GROUPS
         if USE_M_MAJOR and G > 0:
             tl.store(
                 A_scale

--- a/mslk/utils/device.py
+++ b/mslk/utils/device.py
@@ -20,6 +20,7 @@ feature-support flags), see ``mslk.testing.device``.
 
 import functools
 import logging
+import os
 from collections.abc import Iterable
 
 import torch
@@ -105,6 +106,17 @@ def is_gfx950() -> bool:
     return is_rocm() and gfx_arch_in(["gfx950"])
 
 
+# When set to "1" / "true" / "yes", forces MSLK to use AMD fnuz FP8
+# (torch.float8_e4m3fnuz / tl.float8e4b8) even on gfx950 (MI350X), which
+# natively uses OCP FP8 (torch.float8_e4m3fn).  Useful for debugging or when
+# interoperating with code that always produces fnuz tensors.
+_FORCE_FP8_FNUZ: bool = os.getenv("MSLK_ROCM_FORCE_FP8FNUZ_TYPE", "0").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+
 @functools.lru_cache
 def supports_float8_fnuz(throw_on_hip_incompatibility: bool = True) -> bool:
     """Whether the current device uses the FP8 ``fnuz`` format (ROCm only).
@@ -120,8 +132,11 @@ def supports_float8_fnuz(throw_on_hip_incompatibility: bool = True) -> bool:
         return False
 
     # gfx942 (MI300) reports (9, 4) and gfx950 (MI350) reports (9, 5).
-    if torch.cuda.get_device_capability() >= (9, 4):
-        return True
+    device_capability = torch.cuda.get_device_capability()
+    if device_capability >= (9, 4):
+        if _FORCE_FP8_FNUZ or device_capability == (9, 4):
+            return True
+        return False
 
     msg = f"Unsupported GPU arch: {get_gfx_arch_name()} for FP8"
     if throw_on_hip_incompatibility:

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -203,7 +203,7 @@ def _fp8_gemm_cases() -> list[tuple]:
 
 
 def _fp8_batched_gemm_cases() -> list[tuple]:
-    modes = ["default"] + (["torch_3d3d"] if torch.version.hip else [])
+    modes = ["default", "torch_3d3d"]
     cases = []
     for mode in modes:
         for use_loopover in (True, False):
@@ -223,7 +223,13 @@ class ExportCompileTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        fp8_dtype = torch.float8_e4m3fnuz if torch.version.hip else torch.float8_e4m3fn
+        fp8_dtype = (
+            torch.float8_e4m3fnuz
+            if supports_float8_fnuz(
+                throw_on_hip_incompatibility=(not running_on_github)
+            )
+            else torch.float8_e4m3fn
+        )
         cls.device = torch.accelerator.current_accelerator()
         cls.M = 256
         cls.N = 256
@@ -255,7 +261,7 @@ class ExportCompileTests(unittest.TestCase):
         model = TestModule().cuda()
         M, N, K = 256, 256, 256
         fp8_dtype = torch.float8_e4m3fn
-        if torch.version.hip:
+        if supports_float8_fnuz(throw_on_hip_incompatibility=(not running_on_github)):
             fp8_dtype = torch.float8_e4m3fnuz
         xq = torch.randn(M, K).to(fp8_dtype).cuda()
         wq = torch.randn(N, K).to(fp8_dtype).cuda()
@@ -328,7 +334,7 @@ class F8F8F16RowwiseCompileTests(unittest.TestCase):
         )
 
 
-@skipUnlessGfxArch("gfx942")
+@skipUnlessGfxArch("gfx942", "gfx950")
 @skipUnlessCudaCapability(9, 10)
 class FP8Tests(unittest.TestCase):
     @classmethod
@@ -832,6 +838,106 @@ class FP8Tests(unittest.TestCase):
         # BF16 loopover gemm reference
         self.bf16_loopover_validate(x_group, W, y_fp8_group, y_bf16_group)
 
+
+@skipUnlessGfxArch("gfx942", "gfx950")
+@skipUnlessCudaCapability(9, 10)
+class FP8GroupwiseTests(unittest.TestCase):
+    """Correctness tests for the FP8 groupwise GEMM kernel (f8f8bf16_groupwise).
+
+    On CUDA the CUTLASS implementation is exercised; on ROCm the Triton kernel.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.device = torch.accelerator.current_accelerator()
+
+    @parameterized.expand(
+        [
+            (128, 128, 256),  # small
+            (512, 1024, 2048),  # medium
+            (1, 128, 256),  # M=1 decode
+            (2048, 6144, 3584),  # large
+        ]
+    )
+    def test_f8f8bf16_groupwise(self, M: int, N: int, K: int) -> None:
+        from mslk.quantize.triton.fp8_quantize import (
+            quantize_fp8_block,
+            quantize_fp8_group,
+        )
+
+        x = torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        w = torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+
+        # Quantize: x_scale [K//128, M], w_scale [K//128, N//128]
+        xq, x_scale = quantize_fp8_group(x, k_major=False)
+        wq, w_scale = quantize_fp8_block(w, block_m=128, block_k=128, k_major=False)
+
+        out = torch.ops.mslk.f8f8bf16_groupwise(xq, wq, x_scale, w_scale)
+        ref = (x @ w.t()).to(torch.bfloat16)
+
+        self.assertFalse(out.isnan().any().item(), "Output contains NaN")
+        self.assertFalse(out.isinf().any().item(), "Output contains Inf")
+        torch.testing.assert_close(out, ref, atol=8.0e-2, rtol=8.0e-2)
+
+    @parameterized.expand(
+        [
+            # (m_values, N, K)
+            ([128, 64], 128, 256),  # small, 2 groups
+            ([512, 256, 128], 256, 512),  # medium, 3 groups
+            ([1, 128, 256], 128, 256),  # decode + prefill mix
+            ([2048, 1024], 512, 512),  # large, 2 groups
+        ]
+    )
+    def test_f8f8bf16_groupwise_grouped(self, m_values: list, N: int, K: int) -> None:
+        from mslk.quantize.triton.fp8_quantize import (
+            quantize_fp8_block,
+            quantize_fp8_group,
+        )
+
+        G = len(m_values)
+        device = self.device
+        m_sizes = torch.tensor(m_values, dtype=torch.int64, device=device)
+        TotalM = sum(m_values)
+
+        x = torch.randn((TotalM, K), dtype=torch.bfloat16, device=device) * 0.1
+        ws = [
+            torch.randn((N, K), dtype=torch.bfloat16, device=device) * 0.01
+            for _ in range(G)
+        ]
+
+        # Quantize weights: each [N, K] -> wq [N, K], w_scale [K//128, N//128].
+        wq_list, ws_list = zip(
+            *[
+                quantize_fp8_block(w, block_m=128, block_k=128, k_major=False)
+                for w in ws
+            ]
+        )
+        wq = torch.stack(wq_list, dim=0).contiguous()  # [G, N, K]
+        w_scale = torch.stack(ws_list, dim=0).contiguous()  # [G, K//128, N//128]
+
+        # Quantize activations: xq [TotalM, K], x_scale [K//128, TotalM].
+        xq, x_scale = quantize_fp8_group(x, m_sizes=m_sizes)
+
+        out = torch.ops.mslk.f8f8bf16_groupwise_grouped(
+            xq, wq, x_scale, w_scale, m_sizes
+        )
+
+        # BF16 reference: compute per group and concatenate.
+        ref_parts = []
+        row = 0
+        for g, m_g in enumerate(m_values):
+            ref_parts.append((x[row : row + m_g] @ ws[g].t()).to(torch.bfloat16))
+            row += m_g
+        ref = torch.cat(ref_parts, dim=0)
+
+        self.assertFalse(out.isnan().any().item(), "Output contains NaN")
+        self.assertFalse(out.isinf().any().item(), "Output contains Inf")
+        torch.testing.assert_close(out, ref, atol=8.0e-2, rtol=8.0e-2)
+
+
+@unittest.skipIf(
+    not SUPPORTS_BF16_INT4, "Skip if BF16Int4Tests is not supported on this device."
+)
 
 @skipUnlessCuda()
 @skipUnlessCudaCapability(9, 9)

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -7,6 +7,7 @@
 # pyre-strict
 # pyre-ignore-all-errors[56]
 
+import os
 import unittest
 from typing import Optional, Union
 
@@ -49,6 +50,8 @@ try:
         MARLIN_ENABLED = True
 except ImportError:
     pass
+
+running_on_github: bool = os.getenv("GITHUB_ENV") is not None
 
 # Device gating for the GEMM kernels exercised in this file uses the shared skip
 # decorators from mslk.testing.device: the strict platform gates
@@ -934,10 +937,6 @@ class FP8GroupwiseTests(unittest.TestCase):
         self.assertFalse(out.isinf().any().item(), "Output contains Inf")
         torch.testing.assert_close(out, ref, atol=8.0e-2, rtol=8.0e-2)
 
-
-@unittest.skipIf(
-    not SUPPORTS_BF16_INT4, "Skip if BF16Int4Tests is not supported on this device."
-)
 
 @skipUnlessCuda()
 @skipUnlessCudaCapability(9, 9)


### PR DESCRIPTION
## Summary

1. New: f8f8bf16_groupwise. ROCm Triton FP8xFP8 GEMM with groupwise scaling, matching the CUDA CUTLASS schema. Registered automatically for ROCm via mslk/gemm/__init__.py.

2. New: f8f8bf16_groupwise_grouped. ROCm Triton grouped variant with 2D input and 3D weights. CUDA-graph-safe via a  recompute cache keyed on tensor pointer.

3. Fix: CK dtype checks in blockwise, rowwise, rowwise-batched, rowwise-grouped, and rowwise-preshuffle kernels hardcoded float8_e4m3fnuz. Relaxed to XQ.dtype() == WQ.dtype() so gfx950 OCP FP8 (float8_e4m3fn) tensors no longer fail the assertion.

4. Fix: supports_float8_fnuz() previously returned True for all capability >= (9,4), making gfx950 (MI350X) use fnuz which is the slow emulation path. Fixed to return False for (9,5)+. Env var MSLK_ROCM_FORCE_FP8FNUZ_TYPE=1 provided as an escape hatch for debugging and interop.

## Test plan

- [x] Run pytest test/gemm/gemm_test.py -k test_f8f8bf16_groupwise on gfx942 and gfx950.
- [x] Run pytest test/gemm/gemm_test.py -k test_f8f8bf16_groupwise_grouped on gfx942 and gfx950.
- [x] Verify existing FP8 rowwise and blockwise tests pass on gfx950 with OCP tensors.
- [x] Verify MSLK_ROCM_FORCE_FP8FNUZ_TYPE=1 restores the fnuz path on gfx950.
