### PR TITLE
Fix hot loop in heuristic selection for ROCm triton splitK (#394)

### DIFF
--- a/mslk/attention/fmha/triton_splitk.py
+++ b/mslk/attention/fmha/triton_splitk.py
@@ -320,8 +320,8 @@ class FwOp(AttentionFwOpBase):
             split_k = max(Mk + bh - 1, 1024) // bh
             max_chunk_size = 64
             split_k_stop_val = max(1024 / (B * G * H), 1)
-            while split_k > 1 and Mk / (split_k - 1) < max_chunk_size:
-                split_k = split_k - 1
+            # Largest split_k whose chunk is still >= max_chunk_size keys
+            split_k = max(min(split_k, Mk // max_chunk_size + 1), 1)
 
             while split_k > split_k_stop_val:
                 split_k = split_k // 2


### PR DESCRIPTION
Summary:

There was some code here that was decrementing the splitK by 1 for ROCm. For large initial value of splitK this can lead to massive CPU overhead (~ms) in Python. Convert this to closed form formula. Thanks to RichardChamberlain1 from AMD for helping identify this performance issue.

The key thing is we start at:

```
split_k = max(Mk + bh - 1, 1024) // bh
```

which for large KV sequence (`Mk`) would mean split_k starts at, say 64K. Then we are stuck decrementing by 1 for a long time.

```
  Before/after get_split_k() benchmark (ms/call):
    B  G   H     Mk  init_sk     before      after   speedup
  ----------------------------------------------------------
    1  1   1   1024     1024     0.1022    0.00067      152x
    1  1   1   4096     4096     0.4473    0.00065      690x
    1  1   1   8192     8192     0.9018    0.00064     1399x
    1  1   1  16384    16384     1.8050    0.00067     2685x
    1  1   1  32768    32768     3.6158    0.00069     5213x
    1  1   1  65536    65536     7.2117    0.00076     9521x
    8  1   8   2048       32     0.0006    0.00065        1x
```

Differential Revision: D109022205


