### PR TITLE
Enable Pyrefly for fbcode/mslk

### DIFF
--- a/bench/quantize/quantize_ops.py
+++ b/bench/quantize/quantize_ops.py
@@ -43,11 +43,13 @@ class QuantizeOpBase(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractproperty
+    # pyrefly: ignore [bad-return]
     def hip(self) -> bool:
         """Whether this operator supports AMD or not."""
         pass
 
     @abc.abstractproperty
+    # pyrefly: ignore [bad-return]
     def cuda(self) -> bool:
         """Whether this operator supports Nvidia or not."""
         pass

--- a/mslk/attention/cutlass_blackwell_fmha/__init__.py
+++ b/mslk/attention/cutlass_blackwell_fmha/__init__.py
@@ -16,6 +16,7 @@ load_library_buck(
 # by default in OSS PyTorch.
 import torch._utils_internal  # noqa: E402
 
+# pyrefly: ignore [missing-attribute]
 torch._utils_internal.REQUIRES_SET_PYTHON_MODULE = False
 
 from . import _meta, cutlass_blackwell_fmha_custom_op  # noqa: F401, E402

--- a/mslk/attention/fmha/__init__.py
+++ b/mslk/attention/fmha/__init__.py
@@ -178,6 +178,7 @@ class _fMHA(torch.autograd.Function):
 
     @staticmethod
     @torch.autograd.function.once_differentiable
+    # pyrefly: ignore [bad-override]
     def backward(ctx, grad, grad_lse):
         # Re-create context
         query, key, value, out, lse = ctx.saved_tensors

--- a/mslk/attention/fmha/_triton/splitk_kernels.py
+++ b/mslk/attention/fmha/_triton/splitk_kernels.py
@@ -166,6 +166,7 @@ def _fwd_kernel_splitK(  # noqa: C901
         f"Only row-wise fp8 quantization is supported, but got {N_GROUPS=} > 1.",
     )
     FP8_QUANTIZED: tl.constexpr = K_fp8_scale_shift is not None
+    # pyrefly: ignore [bad-assignment]
     INT4_QUANTIZED: tl.constexpr = PACKED_PER_VAL > 1 and not FP8_QUANTIZED
     PACKED_D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // PACKED_PER_VAL // N_GROUPS
     D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // N_GROUPS
@@ -361,6 +362,7 @@ def _fwd_kernel_splitK(  # noqa: C901
     # This is a solution for Triton native lack of support for lists of tensors.
     acc: "VAR_ARGS_ARRAY"  # noqa: F821
 
+    # pyrefly: ignore [unbound-name]
     for i in range(len(acc)):  # noqa: F821
         acc[i] = tl.zeros([BLOCK_M, D_PER_GROUP], dtype=internal_dtype)  # noqa: F821
     # scale sm_scale by log_2(e) and use
@@ -402,10 +404,12 @@ def _fwd_kernel_splitK(  # noqa: C901
             q_scale = tl.load(
                 tl.advance(q_scale_block_ptr, (0, i * D_PER_GROUP)), boundary_check=(0,)
             )
+            # pyrefly: ignore [unbound-name]
             q[i] = q_quantized.to(Q.dtype.element_ty)  # noqa: F821
     else:
         # Regular query loading
         for i in range(len(acc)):  # noqa: F821
+            # pyrefly: ignore [unbound-name]
             q[i] = tl.load(  # noqa: F821
                 tl.advance(Q_block_ptr, (0, i * D_PER_GROUP)), boundary_check=(0,)
             )
@@ -430,10 +434,12 @@ def _fwd_kernel_splitK(  # noqa: C901
     for start_n in range(lo, hi, BLOCK_N):
         if PAGE_SIZE > 0:
             # Offset in integer blocks from the beginning of the page
+            # pyrefly: ignore [unbound-name]
             block_offset_in_page = logical_block_idx % BLOCKS_IN_PAGE
             # Offset in integer pages
             logical_page_idx = logical_block_idx // BLOCKS_IN_PAGE
             physical_page_idx = tl.load(
+                # pyrefly: ignore [unbound-name]
                 block_table + stride_blocktablesl * logical_page_idx
             ).to(tl.int32)
             offset = physical_page_idx * PAGE_SIZE + block_offset_in_page * BLOCK_N
@@ -483,6 +489,7 @@ def _fwd_kernel_splitK(  # noqa: C901
                 )
             elif FP8_QUANTIZED:
                 K_scale_shift_block_ptr = tl.make_block_ptr(
+                    # pyrefly: ignore [bad-argument-type]
                     base=k_fp8_scale_shift_base,
                     shape=(1, offset + current_block_size),
                     strides=(1, stride_k_fp8_scale_shift_n),
@@ -491,6 +498,7 @@ def _fwd_kernel_splitK(  # noqa: C901
                     order=(0, 1),
                 )
                 V_scale_shift_block_ptr = tl.make_block_ptr(
+                    # pyrefly: ignore [bad-argument-type]
                     base=v_fp8_scale_shift_base,
                     shape=(offset + current_block_size, 1),
                     strides=(stride_v_fp8_scale_shift_n, 1),
@@ -513,9 +521,13 @@ def _fwd_kernel_splitK(  # noqa: C901
         for i in range(len(acc)):  # noqa: F821
             # Load and dequantize K/V with appropriate return values based on quantization flags
             result = load_dequantize_k_v_group(  # noqa: F821
+                # pyrefly: ignore [unbound-name]
                 K_block_ptr,
+                # pyrefly: ignore [unbound-name]
                 V_block_ptr,
+                # pyrefly: ignore [unbound-name]
                 K_scale_shift_block_ptr,
+                # pyrefly: ignore [unbound-name]
                 V_scale_shift_block_ptr,
                 BOUNDS_CHECKS_N,
                 PACKED_PER_VAL,
@@ -532,26 +544,33 @@ def _fwd_kernel_splitK(  # noqa: C901
 
             # Unpack results based on quantization configuration
             if QUANTIZE_PV_TO_FP8 and QUANTIZE_QK_TO_FP8:
+                # pyrefly: ignore [unbound-name]
                 k[i], v[i], v_scale, k_scale = result  # noqa: F821
             elif QUANTIZE_PV_TO_FP8:
+                # pyrefly: ignore [unbound-name]
                 k[i], v[i], v_scale = result  # noqa: F821
             elif QUANTIZE_QK_TO_FP8:
+                # pyrefly: ignore [unbound-name]
                 k[i], v[i], k_scale = result  # noqa: F821
             else:
+                # pyrefly: ignore [unbound-name]
                 k[i], v[i] = result  # noqa: F821
         # -- compute qk ---
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
         for i in range(len(acc)):  # noqa: F821
+            # pyrefly: ignore [unbound-name]
             qk += tl.dot(q[i], k[i])  # noqa: F821
 
         if QUANTIZE_QK_TO_FP8:
             # Reshape k_scale for proper broadcasting with qk
             # k_scale has shape (BLOCK_N,), we need to reshape it to (1, BLOCK_N)
             # for proper broadcasting with qk of shape (BLOCK_M, BLOCK_N)
+            # pyrefly: ignore [unbound-name]
             k_scale_reshaped = tl.reshape(k_scale, (1, BLOCK_N))
 
             # Apply k_scale to qk
             qk = qk * k_scale_reshaped
+            # pyrefly: ignore [unbound-name]
             qk = qk * tl.reshape(q_scale, (BLOCK_M, 1))  # noqa: F821
 
         # Apply qk_scale (scalar)
@@ -564,6 +583,7 @@ def _fwd_kernel_splitK(  # noqa: C901
 
         if HAS_ADDITIVE_BIAS:
             loaded_bias = tl.load(
+                # pyrefly: ignore [unbound-name]
                 additive_bias_block_ptr,
                 boundary_check=(0, 1) if BOUNDS_CHECKS_N else (0,),
             )
@@ -576,10 +596,12 @@ def _fwd_kernel_splitK(  # noqa: C901
             qk = tl.where(tl.arange(0, BLOCK_N) < hi - start_n, qk, float("-inf"))
         if IS_CAUSAL:
             # -- apply the causal mask --
+            # pyrefly: ignore [unbound-name]
             qk = tl.where(diag_idx_shifted >= start_n - start_kv_idx, qk, float("-inf"))
         if IS_LOCAL:
             # -- apply the local window size mask --
             qk = tl.where(
+                # pyrefly: ignore [unbound-name]
                 diag_idx_shifted < start_n - start_kv_idx + WINDOW_LEFT + 1,
                 qk,
                 float("-inf"),
@@ -608,6 +630,7 @@ def _fwd_kernel_splitK(  # noqa: C901
             p = p.to(v_dtype)
         else:
             # Apply v-scale to P
+            # pyrefly: ignore [unbound-name]
             p = p * tl.trans(v_scale)
 
             # Quantize P to FP8
@@ -624,9 +647,11 @@ def _fwd_kernel_splitK(  # noqa: C901
         for i in range(len(acc)):  # noqa: F821
             acc[i] *= alpha[:, None]  # noqa: F821
             if not QUANTIZE_PV_TO_FP8:
+                # pyrefly: ignore [unbound-name]
                 acc[i] += tl.dot(p, v[i])  # noqa: F821
             else:
                 # Re-scale PV using p_scale
+                # pyrefly: ignore [unbound-name]
                 acc[i] += tl.dot(p, v[i]) * p_scale[:, None]  # noqa: F821
 
         if not PAGE_SIZE:
@@ -869,12 +894,15 @@ def load_dequantize_k_v_group(
     # Return appropriate values based on quantization flags
     if QUANTIZE_PV_TO_FP8 and QUANTIZE_QK_TO_FP8:
         # Return both v_scale and k_scale for applying to P and K
+        # pyrefly: ignore [unbound-name]
         return k, v, v_scale, k_scale
     elif QUANTIZE_PV_TO_FP8:
         # Return v_scale for applying v_scale to P
+        # pyrefly: ignore [unbound-name]
         return k, v, v_scale
     elif QUANTIZE_QK_TO_FP8:
         # Return k_scale for applying k_scale to K
+        # pyrefly: ignore [unbound-name]
         return k, v, k_scale
     else:
         return k, v
@@ -1109,6 +1137,7 @@ def dequantize(
     shift,
     PACKED_PER_VAL: tl.constexpr,
     IS_HIP: tl.constexpr,
+    # pyrefly: ignore [bad-function-definition]
     USE_FP32_SCALES: tl.constexpr = False,
 ):
     """PACKED_PER_VAL is the number of values packed into each element x_.
@@ -1324,6 +1353,7 @@ def _splitK_reduce_varargs(
 
     out_splitk_offset: "VAR_ARGS_ARRAY"  # noqa: F821
     for i in range(len(Out_splitK)):
+        # pyrefly: ignore [unbound-name]
         out_splitk_offset[i] = (  # noqa: F821
             stride_osk_z[i] * off_z  # type: ignore # noqa: F821
             + stride_osk_g[i] * off_g
@@ -1333,6 +1363,7 @@ def _splitK_reduce_varargs(
         )
     lse_splitk_offset: "VAR_ARGS_ARRAY"  # noqa: F821
     for i in range(len(Out_splitK)):
+        # pyrefly: ignore [unbound-name]
         lse_splitk_offset[i] = (  # noqa: F821
             stride_lsek_z[i] * off_z  # type: ignore # noqa: F821
             + stride_lsek_g[i] * off_g

--- a/mslk/attention/fmha/_triton/vararg_kernel.py
+++ b/mslk/attention/fmha/_triton/vararg_kernel.py
@@ -253,6 +253,7 @@ def unroll_varargs(kernel, N: int, mode: VarargMode = VarargMode.UNROLL):
     jitted_fn = triton.jit(fn)
     if not hasattr(jitted_fn, "_unsafe_update_src"):
         # Triton older than 3.2
+        # pyrefly: ignore [bad-argument-count]
         jitted_fn.src = new_src
     return jitted_fn
 

--- a/mslk/attention/fmha/attn_bias_utils.py
+++ b/mslk/attention/fmha/attn_bias_utils.py
@@ -183,6 +183,7 @@ def create_attn_bias(  # noqa: C901
                 window_size=min(window_size, min(k)),
             )
         elif bias_type is fmha.attn_bias.BlockDiagonalLocalAttentionPaddedKeysMask:
+            # pyrefly: ignore [missing-attribute]
             g_block_diag = block_diag_type.from_seqlens_local(
                 q_seqlen=q,
                 kv_padding=kv_len,

--- a/mslk/attention/fmha/ck_decoder.py
+++ b/mslk/attention/fmha/ck_decoder.py
@@ -24,6 +24,7 @@ class FwOp(AttentionFwOpBase):
     OPERATOR = get_operator("xformers", "efficient_attention_forward_decoder_ck")
     SUPPORTED_DEVICES: Set[str] = {"cuda"}
     SUPPORTED_DTYPES: Set[torch.dtype] = {torch.half, torch.bfloat16, torch.float}
+    # pyrefly: ignore [bad-override-mutable-attribute]
     SUPPORTED_MAX_K: int = 256
     SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
         type(None),

--- a/mslk/attention/fmha/common.py
+++ b/mslk/attention/fmha/common.py
@@ -60,6 +60,7 @@ class ScaledTensor(torch.Tensor):
     __slots__ = ["scale", "dequant_func", "original_dtype"]
 
     # Disabling custom torch function handling for this class
+    # pyrefly: ignore [bad-override]
     __torch_function__ = torch._C._disabled_torch_function_impl
 
     @staticmethod
@@ -116,6 +117,7 @@ class ScaledTensor(torch.Tensor):
         """
         return self.data, self.scale  # type: ignore
 
+    # pyrefly: ignore [bad-override]
     def __repr__(self):
         """
         Custom string representation for ScaledTensor.
@@ -135,6 +137,7 @@ def pack_fp8_tensorwise_per_head(
     def dequant_func(x, scale):
         return x * scale[:, None, :, None]
 
+    # pyrefly: ignore [no-matching-overload]
     return ScaledTensor(
         data=x,
         scale=scale,

--- a/mslk/attention/fmha/cute_blackwell.py
+++ b/mslk/attention/fmha/cute_blackwell.py
@@ -235,7 +235,9 @@ def _convert_input_format(
             output_dtype=inp.output_dtype,
             is_partial=inp.is_partial,
             # We want k_fp8_scale_shift and v_fp8_scale_shift to be in the same shape as key and value[:-1]
+            # pyrefly: ignore [missing-attribute]
             k_fp8_scale_shift=key_scale.view(key.shape[:-1]),
+            # pyrefly: ignore [missing-attribute]
             v_fp8_scale_shift=value_scale.view(value.shape[:-1]),
             use_fp32_scales=inp.use_fp32_scales,
         )
@@ -258,9 +260,11 @@ def _convert_input_format(
         else:
             key = key.view(torch.float8_e4m3fn)
             value = value.view(torch.float8_e4m3fn)
+            # pyrefly: ignore [missing-attribute]
             key_scale = key_scale.view(torch.float8_e8m0fnu)
             key_scale = key_scale.view(*key.shape[:-1], key.shape[-1] // 32)
 
+            # pyrefly: ignore [missing-attribute]
             value_scale = value_scale.view(torch.float8_e8m0fnu)
             value_scale = value_scale.view(*value.shape[:-1], value.shape[-1] // 32)
 

--- a/mslk/attention/fmha/dispatch.py
+++ b/mslk/attention/fmha/dispatch.py
@@ -119,6 +119,7 @@ def _dispatch_fw_priority_list(
                 ck.FwOp,
             ]
         )
+    # pyrefly: ignore [bad-argument-type]
     priority_list_ops.append(triton_splitk.FwOp)
     if not needs_gradient:
         mqa_or_gqa = (
@@ -140,21 +141,27 @@ def _dispatch_fw_priority_list(
                 and not torch.mtia.is_available()
             ):
                 # priority_list_ops.appendleft(ck_splitk.FwOp)
+                # pyrefly: ignore [bad-argument-type]
                 priority_list_ops.remove(triton_splitk.FwOp)
+                # pyrefly: ignore [bad-argument-type]
                 priority_list_ops.appendleft(triton_splitk.FwOp)
                 # Without variable seqlen flash is fastest
                 if torch.version.cuda and not isinstance(
                     inp.attn_bias, attn_bias.BlockDiagonalMask
                 ):
                     if _get_use_fa3():
+                        # pyrefly: ignore [bad-argument-type]
                         priority_list_ops.remove(flash3.FwOp)
+                    # pyrefly: ignore [bad-argument-type]
                     priority_list_ops.remove(flash.FwOp)
+                    # pyrefly: ignore [bad-argument-type]
                     priority_list_ops.appendleft(flash.FwOp)
 
     # torch.mtia.is_available() cannot be called here because it isn't supported
     # when tracing with PT2, so we simply add flash_mtia to the end if the MTIA
     # dynamic library can be loaded
     if _USE_MTIA_FLASH_ATTENTION:
+        # pyrefly: ignore [bad-argument-type]
         priority_list_ops.append(flash_mtia.FwOp)
 
     return priority_list_ops

--- a/mslk/attention/fmha/flash3_compatibility_check.py
+++ b/mslk/attention/fmha/flash3_compatibility_check.py
@@ -21,6 +21,7 @@ def _flash_attention3_incompatible_reason() -> Optional[str]:
             "- is your Flash-Attention version recent enough?"
         )
     _fwd_schema = torch.ops.flash_attn_3.fwd.default._schema  # type: ignore
+    # pyrefly: ignore [missing-attribute]
     if not _fwd_schema.is_backward_compatible_with(
         parse_schema(
             "flash_attn_3::fwd("
@@ -106,9 +107,12 @@ def _flash_attention3_incompatible_reason() -> Optional[str]:
         "int sm_margin=0) "
         "-> (Tensor, Tensor, Tensor, Tensor, Tensor)"
     )
-    if not _bwd_schema.is_backward_compatible_with(
-        _bwd_expected
-    ) and not _bwd_schema.is_backward_compatible_with(_bwd_expected_alt):
+    if (
+        # pyrefly: ignore [missing-attribute]
+        not _bwd_schema.is_backward_compatible_with(_bwd_expected)
+        # pyrefly: ignore [missing-attribute]
+        and not _bwd_schema.is_backward_compatible_with(_bwd_expected_alt)
+    ):
         return "flash_attn_3::bwd operator is not compatible"
     return None
 

--- a/mslk/attention/fmha/torch_attention_compat.py
+++ b/mslk/attention/fmha/torch_attention_compat.py
@@ -27,6 +27,7 @@ def is_pt_cutlass_compatible(force: bool = False) -> bool:
     expected_fwd_schema = parse_schema(fwd_schema_str)
 
     current_schema = torch.ops.aten._efficient_attention_forward.default._schema
+    # pyrefly: ignore [missing-attribute]
     if not current_schema.is_backward_compatible_with(expected_fwd_schema):
         compatible = False
 
@@ -48,6 +49,7 @@ def is_pt_cutlass_compatible(force: bool = False) -> bool:
     expected_bwd_schema = parse_schema(bwd_schema_str)
 
     current_schema = torch.ops.aten._efficient_attention_backward.default._schema
+    # pyrefly: ignore [missing-attribute]
     if not current_schema.is_backward_compatible_with(expected_bwd_schema):
         compatible = False
 
@@ -96,6 +98,7 @@ def ensure_pt_flash_ok() -> None:
     expected_fwd_schema = parse_schema(fwd_schema_str)
 
     current_schema = torch.ops.aten._flash_attention_forward.default._schema  # noqa: E501
+    # pyrefly: ignore [missing-attribute]
     if not current_schema.is_backward_compatible_with(expected_fwd_schema):
         raise ImportError(
             "Current Torch with Flash-Attention "
@@ -122,6 +125,7 @@ def ensure_pt_flash_ok() -> None:
     expected_bwd_schema = parse_schema(bwd_schema_str)
 
     current_schema = torch.ops.aten._flash_attention_backward.default._schema  # noqa: E501
+    # pyrefly: ignore [missing-attribute]
     if not current_schema.is_backward_compatible_with(expected_bwd_schema):
         raise ImportError(
             "Current Torch with Flash-Attention "

--- a/mslk/attention/fmha/tree_attention.py
+++ b/mslk/attention/fmha/tree_attention.py
@@ -633,10 +633,18 @@ def tree_attention(
             torch.bfloat16,
         )
         packed_k = pack_fp8_tensorwise_per_head(
-            cache_k.view(1, Bkv * Mk, G, H, D), cache_k.scale, torch.bfloat16
+            # pyrefly: ignore [missing-attribute]
+            cache_k.view(1, Bkv * Mk, G, H, D),
+            # pyrefly: ignore [missing-attribute]
+            cache_k.scale,
+            torch.bfloat16,
         )
         packed_v = pack_fp8_tensorwise_per_head(
-            cache_v.view(1, Bkv * Mk, G, H, D), cache_v.scale, torch.bfloat16
+            # pyrefly: ignore [missing-attribute]
+            cache_v.view(1, Bkv * Mk, G, H, D),
+            # pyrefly: ignore [missing-attribute]
+            cache_v.scale,
+            torch.bfloat16,
         )
         attn_prefix, lse_prefix = memory_efficient_attention_partial(
             packed_q,

--- a/mslk/attention/fmha/triton_splitk.py
+++ b/mslk/attention/fmha/triton_splitk.py
@@ -1101,17 +1101,27 @@ def merge_attentions(
         lse_split,
         attn_out,
         lse_out,
+        # pyrefly: ignore [bad-argument-type]
         split_k=split_k,
         splitK_pow2=splitK_pow2,
+        # pyrefly: ignore [bad-argument-type]
         **_strides(attn_split, "osk_z", "osk_g", "osk_h", "osk_s", "osk_m", "osk_k"),
+        # pyrefly: ignore [bad-argument-type]
         **_strides(lse_split, "lsek_z", "lsek_g", "lsek_h", "lsek_s", "lsek_m"),
+        # pyrefly: ignore [bad-argument-type]
         **_strides(attn_out, "oz", "om", "og", "oh", "ok"),
+        # pyrefly: ignore [bad-argument-type]
         **_strides(lse_out, "lse_z", "lse_g", "lse_h", "lse_m"),
+        # pyrefly: ignore [bad-argument-type]
         head_dim=head_dim,
         head_dim_pow_2=triton.next_power_of_2(head_dim),
+        # pyrefly: ignore [bad-argument-type]
         G=G,
+        # pyrefly: ignore [bad-argument-type]
         H=H,
+        # pyrefly: ignore [bad-argument-type]
         WRITE_LSE=lse_out is not None,
+        # pyrefly: ignore [unexpected-keyword]
         num_warps=num_warps,
     )
 
@@ -1299,6 +1309,7 @@ def _prepare_reduce_kernel_params(
     attn_split_strides = {}
     lse_split_strides = {}
     for i in range(len(attn_split)):
+        # pyrefly: ignore [no-matching-overload]
         attn_split_strides.update(
             _strides(
                 attn_split[i],
@@ -1309,6 +1320,7 @@ def _prepare_reduce_kernel_params(
                 "osk_k" + str(i),
             )
         )
+        # pyrefly: ignore [no-matching-overload]
         lse_split_strides.update(
             _strides(
                 lse_split[i],
@@ -1329,10 +1341,14 @@ def _prepare_reduce_kernel_params(
         **attn_split_strides,
         **lse_split_strides,
     }
+    # pyrefly: ignore [no-matching-overload]
     kernel_args.update(_strides(attn_out, "oz", "om", "og", "oh", "ok"))
+    # pyrefly: ignore [no-matching-overload]
     kernel_args.update(_strides(lse_out, "lse_z", "lse_g", "lse_h", "lse_m"))
     if grad_attn is not None:
+        # pyrefly: ignore [no-matching-overload]
         kernel_args.update(_strides(grad_attn, "doz", "dom", "dog", "doh", "dok"))
+        # pyrefly: ignore [no-matching-overload]
         kernel_args.update(_strides(grad_lse, "dlse_z", "dlse_g", "dlse_h", "dlse_m"))
     return kernel_args, grid
 

--- a/mslk/conv/__init__.py
+++ b/mslk/conv/__init__.py
@@ -14,6 +14,7 @@ load_library_buck("//mslk/csrc/conv:conv_ops")
 # by default in OSS PyTorch.
 import torch._utils_internal  # noqa: E402
 
+# pyrefly: ignore [missing-attribute]
 torch._utils_internal.REQUIRES_SET_PYTHON_MODULE = False
 
 from . import _meta  # noqa: F401, E402

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -21,6 +21,7 @@ for op in gemm_ops:
 # by default in OSS PyTorch.
 import torch._utils_internal  # noqa: E402
 
+# pyrefly: ignore [missing-attribute]
 torch._utils_internal.REQUIRES_SET_PYTHON_MODULE = False
 
 from . import _meta  # noqa: F401, E402

--- a/mslk/gemm/triton/grouped_gemm.py
+++ b/mslk/gemm/triton/grouped_gemm.py
@@ -303,6 +303,7 @@ def _mslk_grouped_gemm(
             if USE_TMA_STORE:
                 c_desc_ptr = tl.make_tensor_descriptor(
                     c_ptr + M_start_offset * N,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, n_size],
                     # pyre-ignore
                     strides=[n_size, 1],
@@ -477,6 +478,7 @@ def _mslk_grouped_gemm_ws(
             if USE_TMA_STORE:
                 c_desc_ptr = tl.make_tensor_descriptor(
                     c_ptr + M_start_offset * N,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, N],
                     # pyre-ignore
                     strides=[N, 1],
@@ -628,6 +630,7 @@ def _mslk_grouped_gemm_fp8_rowwise(
             if USE_TMA_STORE:
                 c_desc_ptr = tl.make_tensor_descriptor(
                     c_ptr + M_start_offset * N,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, n_size],
                     # pyre-ignore
                     strides=[n_size, 1],
@@ -783,6 +786,7 @@ def _mslk_grouped_gemm_fp8_rowwise_ws(
             if USE_TMA_STORE:
                 c_desc_ptr = tl.make_tensor_descriptor(
                     c_ptr + M_start_offset * N,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, N],
                     # pyre-ignore
                     strides=[N, 1],

--- a/mslk/moe/__init__.py
+++ b/mslk/moe/__init__.py
@@ -20,6 +20,7 @@ if torch.cuda.is_available():
 # by default in OSS PyTorch.
 import torch._utils_internal  # noqa: E402
 
+# pyrefly: ignore [missing-attribute]
 torch._utils_internal.REQUIRES_SET_PYTHON_MODULE = False
 
 from . import _meta  # noqa: F401, E402

--- a/mslk/moe/layers.py
+++ b/mslk/moe/layers.py
@@ -1040,6 +1040,7 @@ class MetaShufflingMoE(BaselineMoE):
         scores = torch.sigmoid(scores)
         assert scores.shape == (B * T, self.E)
 
+        # pyrefly: ignore [not-callable]
         token_counts, expert_indices, token_indices = index_shuffling(
             scores,  # num_tokens
         )

--- a/mslk/quantize/triton/fp8_quantize.py
+++ b/mslk/quantize/triton/fp8_quantize.py
@@ -1232,6 +1232,7 @@ def _kernel_quantize_fp8_tensor(
         chunk_id += num_sms
 
     # Atomically update global max using integer atomics on float bits
+    # pyrefly: ignore [missing-attribute]
     local_max_int = local_max.to(tl.float32, bitcast=False).to(tl.int32, bitcast=True)
     tl.atomic_max(global_max_ptr, local_max_int)
 

--- a/mslk/quantize/triton/legacy/fake_quantize.py
+++ b/mslk/quantize/triton/legacy/fake_quantize.py
@@ -29,6 +29,7 @@ def _fake_quantize_nvfp4_kernel(
     pid = tl.program_id(0)
     FP8_E4M3_MAX = 448.0
     FLT_MIN: tl.constexpr = (  # type: ignore[Incompatible variable type]
+        # pyrefly: ignore [bad-assignment]
         1.175494350822287508e-38  # C FLT_MIN
     )
 

--- a/mslk/quantize/triton/legacy/naive.py
+++ b/mslk/quantize/triton/legacy/naive.py
@@ -59,4 +59,5 @@ def quantize_nvfp4_naive(
         )
     )
 
+    # pyrefly: ignore [bad-return]
     return xqs, x_scales

--- a/mslk/quantize/triton/legacy/quantize_stacked.py
+++ b/mslk/quantize/triton/legacy/quantize_stacked.py
@@ -65,6 +65,7 @@ def _nvfp4_quantize_stacked_kernel(
     FP4_E2M1_MAX: tl.constexpr = 6  # type: ignore[Incompatible variable type]
 
     NUM_ELEM_PER_LAYOUT: tl.constexpr = (  # type: ignore[Incompatible variable type]
+        # pyrefly: ignore [bad-assignment]
         128 * 4
     )
     NUM_N_BLOCKS = tl.cdiv(N, 64)
@@ -380,8 +381,10 @@ def nvfp4_quantize_stacked(
         # pyre-ignore[6]
         NUM_GROUPS=num_segments,
         PREFIX_NUM=triton.next_power_of_2(num_segments),
+        # pyrefly: ignore [bad-argument-type]
         BSEARCH_ITERS=max(1, (num_segments - 1).bit_length()),
         M_PER_BLOCK=m_per_block,  # pyre-ignore[6]
+        # pyrefly: ignore [unexpected-keyword]
         num_stages=n_stages,
     )
 
@@ -439,9 +442,13 @@ def nvfp4_quantize_stacked_with_token_scale(
         PREFIX_NUM=triton.next_power_of_2(num_segments),
         BLOCK_K=block_k,  # pyre-ignore[6]
         SCALE_BLOCKS=block_k // 16,  # pyre-ignore[6]
+        # pyrefly: ignore [bad-argument-type]
         USE_FULL_ROW_QUANT=block_k == K and K <= 8192,
+        # pyrefly: ignore [bad-argument-type]
         CHUNK_SIZE=2048,
+        # pyrefly: ignore [bad-argument-type]
         CHUNK_SCALE_BLOCKS=2048 // 16,
+        # pyrefly: ignore [unexpected-keyword]
         num_warps=8,
     )
 

--- a/test/attention/bert_padding.py
+++ b/test/attention/bert_padding.py
@@ -29,6 +29,7 @@ class IndexFirstAxis(torch.autograd.Function):
         ).reshape(-1, *other_shape)
 
     @staticmethod
+    # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         (indices,) = ctx.saved_tensors
         assert grad_output.ndim >= 2
@@ -65,6 +66,7 @@ class IndexPutFirstAxis(torch.autograd.Function):
         return output
 
     @staticmethod
+    # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         (indices,) = ctx.saved_tensors
         # TD [2022-03-04] For some reason torch.gather is a bit faster than indexing.

--- a/test/attention/blackwell_fmha_test.py
+++ b/test/attention/blackwell_fmha_test.py
@@ -561,7 +561,9 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
         # Compare outputs
         if is_paged:
             # Compare paged output with both reference and non paged output
+            # pyrefly: ignore [bad-argument-type]
             self._allclose(out_paged, out_ref, out_pt)
+            # pyrefly: ignore [bad-argument-type]
             self._allclose(out_paged, out, out_pt)
         else:
             self._allclose(out, out_ref, out_pt)
@@ -615,6 +617,7 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
                 dq_d,
                 dk_d,
                 dv_d,
+                # pyrefly: ignore [no-matching-overload]
             ) = torch.autograd.grad(out_d, (q, k, v), g)
             assert torch.equal(dq, dq_d)
             assert torch.equal(dk, dk_d)
@@ -771,7 +774,9 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
         # Compare outputs
         if is_paged:
             # Compare paged output with both reference and non paged output
+            # pyrefly: ignore [bad-argument-type]
             self._allclose(out_paged, out_ref, out_pt)
+            # pyrefly: ignore [bad-argument-type]
             self._allclose(out_paged, out, out_pt)
         else:
             self._allclose(out, out_ref, out_pt)
@@ -817,6 +822,7 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
 
         if deterministic:
             # Rerun the test. The outputs must be bit-wise exact
+            # pyrefly: ignore [no-matching-overload]
             dq_unpad_d, dk_unpad_d, dv_unpad_d = torch.autograd.grad(
                 out_unpad_d, (q_unpad, k_unpad, v_unpad), g_unpad
             )

--- a/test/attention/fmha/utils.py
+++ b/test/attention/fmha/utils.py
@@ -465,6 +465,7 @@ compute_capability = (0, 0)
 if torch.cuda.is_available():
     compute_capability = torch.cuda.get_device_capability("cuda")
 sm75_or_better_only = wrong_hardware(
+    # pyrefly: ignore [unsupported-operation]
     torch.version.cuda is not None and compute_capability < (7, 5),
     reason="requires sm75+",
 )


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/MSLK-NV/pull/346

Migrates fbcode/mslk from Pyre to Pyrefly by removing the root set_pyrefly(False) opt-out so the tree inherits set_pyrefly(True) from the fbcode root default. Suppressed 106 pre-existing type errors that Pyrefly surfaces but Pyre did not, with annotation-only # pyrefly: ignore comments; no runtime changes.

Differential Revision: D108818855


