### PR TITLE
Fix flash_attn_bench crash on the flash_attn.cute (FA4) backend: pass window_size=(-1, -1) instead of None

### DIFF
--- a/bench/attn/flash_attn_bench.py
+++ b/bench/attn/flash_attn_bench.py
@@ -126,7 +126,7 @@ def benchmark(
     ws = (window_size, 0) if window_size > 0 else None
 
     def fn():
-        flash_attn_func(Q, K, V, causal=causal, window_size=ws)
+        flash_attn_func(Q, K, V, causal=causal, window_size=ws if ws is not None else (-1, -1))
 
     ms = do_bench(fn, (), opts)
 


### PR DESCRIPTION
## Summary

`mslk.bench.attn.flash_attn_bench` crashes with `TypeError: 'NoneType' object is
not subscriptable` on every non-windowed configuration when the OSS
`flash_attn.cute` (FlashAttention-4) backend is used. The benchmark passes
`window_size=None`, but the FA4 interface expects a `(left, right)` tuple and
subscripts it unconditionally.

## Reproduction

Environment:
- `nvcr.io/nvidia/pytorch:26.05-py3` (PyTorch 2.12.0a0, CUDA 13.2)
- `flash-attn-4==4.0.0b18`, `nvidia-cutlass-dsl>=4.5.2`, `quack-kernels>=0.5.0`
- NVIDIA B300 (Blackwell, sm_103)

```
python -m mslk.bench.attn.flash_attn_bench
Benchmarking B=2, N=1024, H=32, H_kv=8, D=128

...

File ".../flash_attn/cute/interface.py", line 2003, in forward

window_size_left=window_size[0],

~~~~~~~~~~~^^^

TypeError: 'NoneType' object is not subscriptable
```

## Root cause

In `mslk/bench/attn/flash_attn_bench.py`, the timed call is:

```python
flash_attn_func(Q, K, V, causal=causal, window_size=ws)
```

where `ws` is `None` when no sliding window is requested. On the OSS path,
`mslk.attention.flash_attn.flash_attn_func` resolves (via
`mslk/attention/flash_attn/interface.py`) to
`flash_attn.cute.interface.flash_attn_func`. FA4's `forward` reads
`window_size_left=window_size[0]` / `window_size_right=window_size[1]` — it
expects the standard flash-attention tuple and subscripts it unconditionally.
The flash-attention "no window" sentinel is `(-1, -1)`, not `None`.

The internal `mslk.fb...` backend appears to accept `window_size=None`, so this
only surfaces on the public `flash_attn.cute` backend.

## Fix

Pass `(-1, -1)` when no window is requested:

```diff
-        flash_attn_func(Q, K, V, causal=causal, window_size=ws)
+        flash_attn_func(Q, K, V, causal=causal, window_size=ws if ws is not None else (-1, -1))
```

(applied to each `flash_attn_func` call site in the file).

## Testing

With the fix, the non-windowed causal configs run to completion across sequence
lengths from 1K to 64K on NVIDIA B300, confirming the `flash_attn.cute` (FA4)
backend dispatches and executes on Blackwell. Throughput increases with sequence
length as expected for causal attention. Windowed configs (where `ws` is a real
tuple) are unaffected.

## Output after fix

```
Flash Attention Bench
-------------------------------------------------------------------
   B        N    H  H_kv    D Causal Window |         Ms     TFLOPS
-------------------------------------------------------------------
   2     1024   32     8  128      Y      - |      0.020    1706.25
   2     2048   32     8  128      Y      - |      0.067    2057.07
   2     4096   32     8  128      Y      - |      0.226    2431.70
   2     8192   32     8  128      Y      - |      0.820    2682.49
   2    16384   32     8  128      Y      - |      3.109    2829.64
   2    32768   32     8  128      Y      - |     12.034    2923.72
   2    65536   32     8  128      Y      - |     47.520    2961.67

Hardware: NVIDIA B300 SXM6 PC

Benchmark Settings:
    CUDA graph: True
    Causal: True
```