### PR TITLE
Refine test decorators (#399)

### DIFF
--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -29,12 +29,13 @@ from mslk.quantize.triton.fp8_quantize import (
     quantize_fp8_group,
     quantize_fp8_row,
 )
+from mslk.utils.device import is_cuda, is_gfx942, is_gfx950, is_rocm
 from mslk.utils.triton.fp8_utils import get_fp8_constants
 
 try:
     from tinygemm.utils import group_quantize_tensor
 
-    if torch.cuda.is_available() and torch.version.cuda:
+    if is_cuda():
         torch.ops.load_library("//tinygemm:tinygemm")
     TINYGEMM_ENABLED = True
 except ImportError:
@@ -108,15 +109,12 @@ def get_current_accelerator() -> Accelerator | None:
     if not torch.cuda.is_available():
         raise Exception("Cannot run gemm_bench without accelerator.")
 
-    if torch.version.hip is not None:
-        props = torch.cuda.get_device_properties(0)
-        gcn_arch = getattr(props, "gcnArchName", "").upper()
-        device_name = torch.cuda.get_device_name().upper()
-        if "GFX950" in gcn_arch or "GFX950" in device_name or "MI350" in device_name:
+    if is_rocm():
+        if is_gfx950():
             return Accelerator.AMD_GFX950
-        if "MI300X" in device_name or "GFX942" in gcn_arch:
+        if is_gfx942():
             return Accelerator.AMD_MI300X
-    elif torch.version.cuda is not None:
+    elif is_cuda():
         major, minor = torch.cuda.get_device_capability()
         if major == 9 and minor == 0:
             return Accelerator.NVIDIA_SM90
@@ -659,7 +657,7 @@ class FP8Rowwise(GemmOpBase):
 
     @property
     def name(self) -> str:
-        prefix = "Cutlass" if torch.version.cuda else "CK"
+        prefix = "Cutlass" if is_cuda() else "CK"
         return f"{prefix}{self.__class__.__name__}"
 
     def __init__(self):
@@ -1314,7 +1312,7 @@ class FP8RowwiseBatched(GemmOpBase):
 
     @property
     def name(self) -> str:
-        prefix = "Cutlass" if torch.version.cuda else "CK"
+        prefix = "Cutlass" if is_cuda() else "CK"
         return f"{prefix}{self.__class__.__name__}"
 
     def quantize(self, x, w):
@@ -1436,7 +1434,7 @@ class FP8Blockwise(GemmOpBase):
 
     @property
     def name(self) -> str:
-        prefix = "Cutlass" if torch.version.cuda else "CK"
+        prefix = "Cutlass" if is_cuda() else "CK"
         return f"{prefix}{self.__class__.__name__}"
 
     def quantize(self, x, w):
@@ -1954,7 +1952,7 @@ class BF16Grouped(GemmOpBase):
 
     @property
     def name(self) -> str:
-        prefix = "Cutlass" if torch.version.cuda else "CK"
+        prefix = "Cutlass" if is_cuda() else "CK"
         return f"{prefix}{self.__class__.__name__}"
 
     def preprocess(self, x, w):

--- a/bench/quantize/quantize_ops.py
+++ b/bench/quantize/quantize_ops.py
@@ -27,6 +27,7 @@ from mslk.quantize.triton.fp8_quantize import (
     triton_quantize_fp8_group,
     triton_quantize_fp8_tensor,
 )
+from mslk.utils.device import is_cuda, is_rocm
 
 
 class QuantizeOpBase(metaclass=abc.ABCMeta):
@@ -66,9 +67,9 @@ class QuantizeOpBase(metaclass=abc.ABCMeta):
     @property
     def supported(self) -> bool:
         """Whether this op will run on the current device."""
-        if torch.version.hip is not None:
+        if is_rocm():
             return self.hip
-        elif torch.version.cuda is not None:
+        elif is_cuda():
             return self.cuda
         else:
             return False

--- a/mslk/testing/device.py
+++ b/mslk/testing/device.py
@@ -6,29 +6,138 @@
 
 # pyre-strict
 
+"""Shared ``unittest`` skip decorators for gating GPU tests by device support.
+
+Two kinds of gate, combined via ``unittest``'s AND-composition of stacked
+decorators:
+
+**Platform gates (strict)** pick the platform:
+
+    @skipUnlessCuda()   # NVIDIA only
+    @skipUnlessRocm()   # AMD only
+
+**Refinements** narrow within a platform. Each is *transparent* on the other
+platform (it never gates a device it doesn't speak for):
+
+    @skipUnlessCudaCapability(min, max)   # NVIDIA compute capability
+    @skipUnlessGfxArch(*archs)            # AMD gfx arch
+
+A single-platform test stacks a platform gate with an optional refinement::
+
+    @skipUnlessCuda()                 # CUDA, SM100+
+    @skipUnlessCudaCapability(10)
+    class MXFP4Tests(unittest.TestCase): ...
+
+    @skipUnlessRocm()                 # ROCm, MI300
+    @skipUnlessGfxArch("gfx942")
+    class FooRocmTests(unittest.TestCase): ...
+
+A dual-platform test (supported on NVIDIA *or* AMD) stacks the two refinements
+instead. Because each is transparent on the other platform, AND-composition
+yields the union — runs iff (CUDA & capability) or (ROCm & arch)::
+
+    @skipUnlessGfxArch("gfx942")      # MI300, or
+    @skipUnlessCudaCapability(9, 10)  # SM90 / SM100
+    class FP8Tests(unittest.TestCase): ...
+
+Skip messages are derived from the arguments; callers do not supply one.
+"""
+
 import unittest
 from collections.abc import Callable
 from typing import Any
 
-from mslk.utils.device import compute_capability_in, is_cuda
+from mslk.utils.device import (
+    compute_capability_at_least,
+    compute_capability_in,
+    cuda_version_at_least,
+    gfx_arch_in,
+    is_cuda,
+    is_rocm,
+)
 
 
-def skip_unless_compute_capability(
+def skipUnlessCuda() -> Callable[..., Any]:
+    """Skip the test unless running on any NVIDIA CUDA device.
+
+    A strict platform gate. To narrow to a compute capability, stack with
+    :func:`skipUnlessCudaCapability`.
+    """
+    return unittest.skipIf(not is_cuda(), "requires CUDA")
+
+
+def skipUnlessRocm() -> Callable[..., Any]:
+    """Skip the test unless running on any AMD ROCm device.
+
+    A strict platform gate. To narrow to a gfx arch, stack with
+    :func:`skipUnlessGfxArch`.
+    """
+    return unittest.skipIf(not is_rocm(), "requires ROCm")
+
+
+def skipUnlessCudaCapability(
     major_min: int,
     major_max: int | None = None,
-    reason: str | None = None,
+    *,
+    minor_min: int = 0,
 ) -> Callable[..., Any]:
-    """Skip the test unless on CUDA with compute-capability major in range.
+    """Narrow a CUDA test to a compute-capability range.
 
-    ``major_max=None`` means no upper bound (e.g. ``major_min=9`` is "SM90+").
+    Runs on CUDA only when the device compute-capability major is in
+    ``[major_min, major_max]`` (``major_max=None`` means no upper bound, e.g.
+    ``major_min=9`` is "SM90+"; ``major_min == major_max`` is an exact SM).
+
+    ``minor_min`` adds a lower bound on the capability *minor*, so the gate
+    compares the full ``(major, minor)`` pair — e.g. ``major_min=10,
+    minor_min=3`` is "SM10.3+". It pairs naturally with no ``major_max``.
+
+    Transparent on ROCm so it composes with :func:`skipUnlessGfxArch` into a
+    dual-platform union. For a CUDA-only test, pair it with
+    :func:`skipUnlessCuda` instead.
     """
-    if reason is None:
-        bound = (
-            f"SM{major_min}0+"
-            if major_max is None
-            else f"SM{major_min}0-SM{major_max}0"
-        )
-        reason = f"requires CUDA {bound}"
-    return unittest.skipIf(
-        not (is_cuda() and compute_capability_in(major_min, major_max)), reason
+    cuda_supported = (
+        is_cuda()
+        and compute_capability_in(major_min, major_max)
+        and (minor_min == 0 or compute_capability_at_least(major_min, minor_min))
     )
+    if minor_min:
+        reason = f"requires CUDA SM{major_min}{minor_min}+"
+    elif major_max is None:
+        reason = f"requires CUDA SM{major_min}0+"
+    elif major_min == major_max:
+        reason = f"requires CUDA SM{major_min}0"
+    else:
+        reason = f"requires CUDA SM{major_min}0-SM{major_max}0"
+    return unittest.skipIf(not (cuda_supported or is_rocm()), reason)
+
+
+def skipUnlessCudaVersion(major_min: int) -> Callable[..., Any]:
+    """Narrow a CUDA test to a minimum CUDA toolkit major version.
+
+    Gates on the CUDA toolkit the binary was built against
+    (``torch.version.cuda``), which is distinct from the device compute
+    capability. Transparent on ROCm so it composes with the other refinements.
+    """
+    return unittest.skipIf(
+        not (is_rocm() or (is_cuda() and cuda_version_at_least(major_min))),
+        f"requires CUDA toolkit {major_min}+",
+    )
+
+
+def skipUnlessGfxArch(
+    arch: str,
+    *more_archs: str,
+) -> Callable[..., Any]:
+    """Narrow a ROCm test to one or more gfx archs.
+
+    Runs on ROCm only when the device's gfx arch matches one of the given archs
+    (e.g. ``"gfx942"`` for MI300, ``"gfx950"`` for MI350).
+
+    Transparent on CUDA so it composes with :func:`skipUnlessCudaCapability`
+    into a dual-platform union. For a ROCm-only test, pair it with
+    :func:`skipUnlessRocm` instead.
+    """
+    archs = (arch, *more_archs)
+    gfx_supported = is_rocm() and gfx_arch_in(archs)
+    reason = f"requires ROCm arch {' or '.join(archs)}"
+    return unittest.skipIf(not (gfx_supported or is_cuda()), reason)

--- a/mslk/utils/device.py
+++ b/mslk/utils/device.py
@@ -49,6 +49,30 @@ def compute_capability_in(major_min: int, major_max: int | None = None) -> bool:
     return major >= major_min and (major_max is None or major <= major_max)
 
 
+def compute_capability_at_least(major_min: int, minor_min: int = 0) -> bool:
+    """True if the device compute capability is at least ``(major_min, minor_min)``.
+
+    Unlike :func:`compute_capability_in`, this compares the full
+    ``(major, minor)`` pair, so it can express e.g. SM10.3+ (``(10, 3)``).
+    Returns ``False`` when no GPU is available.
+    """
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability() >= (major_min, minor_min)
+
+
+def cuda_version_at_least(major_min: int) -> bool:
+    """True on a CUDA build whose toolkit major version is at least ``major_min``.
+
+    This checks the CUDA *toolkit* the binary was built against
+    (``torch.version.cuda``), which is distinct from the device compute
+    capability. Returns ``False`` on ROCm or CPU-only builds.
+    """
+    if torch.version.cuda is None:
+        return False
+    return int(torch.version.cuda.split(".")[0]) >= major_min
+
+
 def get_gfx_arch_name() -> str:
     """Return the ROCm ``gcnArchName`` of the current device (e.g. ``gfx942``).
 

--- a/test/conv/conv_test.py
+++ b/test/conv/conv_test.py
@@ -12,11 +12,12 @@ import unittest
 import mslk.conv  # noqa: F401
 import torch
 from mslk.quantize.triton.fp8_quantize import quantize_fp8_tensor
-from mslk.testing.device import skip_unless_compute_capability
+from mslk.testing.device import skipUnlessCuda, skipUnlessCudaCapability
 
 
 # f8f8bf16_conv is currently only supported on CUDA (not HIP) and requires SM100+.
-@skip_unless_compute_capability(10, reason="f8f8bf16_conv requires CUDA SM100+")
+@skipUnlessCuda()
+@skipUnlessCudaCapability(10)
 class F8F8BF16ConvTest(unittest.TestCase):
     """Test f8f8bf16_conv operator for correctness, compile, and export."""
 

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -7,7 +7,6 @@
 # pyre-strict
 # pyre-ignore-all-errors[56]
 
-import os
 import unittest
 from typing import Optional, Union
 
@@ -24,15 +23,14 @@ from mslk.quantize.triton.fp4_quantize import (
     quantize_nvfp4_naive,
     triton_quantize_mx4_unpack,
 )
-from mslk.utils.device import (
-    compute_capability_in,
-    gfx_arch_in,
-    is_cuda,
-    is_gfx942,
-    is_gfx950,
-    is_rocm,
-    supports_float8_fnuz,
+from mslk.testing.device import (
+    skipUnlessCuda,
+    skipUnlessCudaCapability,
+    skipUnlessCudaVersion,
+    skipUnlessGfxArch,
+    skipUnlessRocm,
 )
+from mslk.utils.device import compute_capability_in, supports_float8_fnuz
 
 if torch.cuda.is_available():
     from mslk.gemm.triton.fp8_gemm import matmul_fp8_block, matmul_fp8_row
@@ -52,75 +50,13 @@ try:
 except ImportError:
     pass
 
-running_on_github: bool = os.getenv("GITHUB_ENV") is not None
 
-
-# Feature-support matrix for the GEMM kernels exercised in this file. These map
-# the device's arch/compute-capability (via mslk.utils.device primitives) to
-# whether a given GEMM dtype path is supported, and are specific to these tests.
-def supports_bf16():
-    if is_rocm():
-        return is_gfx942()
-    return compute_capability_in(9)
-
-
-def supports_fp8():
-    if is_rocm():
-        return is_gfx942() and supports_float8_fnuz(throw_on_hip_incompatibility=False)
-    return compute_capability_in(9, 10)
-
-
-def supports_mxfp8():
-    if is_rocm():
-        return False
-    return compute_capability_in(10)
-
-
-def supports_bf16_int4():
-    return is_cuda() and compute_capability_in(9, 9)
-
-
-def supports_fp8_int4():
-    return is_cuda() and compute_capability_in(9, 9)
-
-
-def supports_nvfp4():
-    return is_cuda() and compute_capability_in(10)
-
-
-def supports_nvfp4_ultra():
-    if not is_cuda() or torch.version.cuda is None:
-        return False
-    cuda_major = int(torch.version.cuda.split(".")[0])
-    major, minor = torch.cuda.get_device_capability()
-    return cuda_major >= 13 and (major, minor) >= (10, 3)
-
-
-def supports_mxfp4():
-    if is_rocm():
-        # TODO add AMD here later
-        return False
-    return compute_capability_in(10)
-
-
-def supports_int8():
-    """True on CUDA SM80+ or ROCm CDNA3 (gfx942) / CDNA4 (gfx950)."""
-    if is_rocm():
-        return gfx_arch_in(["gfx942", "gfx950"])
-    return compute_capability_in(8)
-
-
-SUPPORTS_BF16 = supports_bf16()
-SUPPORTS_FP8 = supports_fp8()
-SUPPORTS_MXFP8 = supports_mxfp8()
-SUPPORTS_FP8_INT4 = supports_fp8_int4()
-SUPPORTS_BF16_INT4 = supports_bf16_int4()
-SUPPORTS_NVFP4 = supports_nvfp4()
-SUPPORTS_NVFP4_ULTRA = supports_nvfp4_ultra()
-SUPPORTS_MXFP4 = supports_mxfp4()
-
+# Device gating for the GEMM kernels exercised in this file uses the shared skip
+# decorators from mslk.testing.device: the strict platform gates
+# skipUnlessCuda / skipUnlessRocm, refined by skipUnlessCudaCapability,
+# skipUnlessGfxArch, and skipUnlessCudaVersion.
 if torch.cuda.is_available() and supports_float8_fnuz(
-    throw_on_hip_incompatibility=(not running_on_github)
+    throw_on_hip_incompatibility=False
 ):
     # Supported FP8 format is different on NV and AMD.
     fp8_e4m3: torch.dtype = torch.float8_e4m3fnuz
@@ -133,9 +69,6 @@ else:
 E4M3_MAX_POS: float = torch.finfo(fp8_e4m3).max
 EPS: float = 1e-12
 FP16_MAX_POS: float = torch.finfo(torch.float16).max
-
-# pyre-fixme[16]: Module `mslk` has no attribute `open_source`.
-open_source: bool = getattr(mslk, "open_source", False)
 
 
 def int4_row_quantize(
@@ -284,15 +217,8 @@ def _fp8_batched_gemm_cases() -> list[tuple]:
     return cases
 
 
-@unittest.skipIf(
-    not torch.cuda.is_available(),
-    "Operators are only available on CUDA enabled machines",
-)
-@unittest.skipIf(open_source, "Temporarily disabled in OSS.")
-@unittest.skipIf(
-    not all((SUPPORTS_FP8, SUPPORTS_BF16_INT4, SUPPORTS_FP8_INT4)),
-    "ExportCompileTests is not supported on this device.",
-)
+@skipUnlessCuda()
+@skipUnlessCudaCapability(9, 9)
 class ExportCompileTests(unittest.TestCase):
     """Test that GEMM ops can be compiled & exported."""
 
@@ -354,19 +280,11 @@ class ExportCompileTests(unittest.TestCase):
             self.XQ, self.WQ, self.row_scale, self.col_scale, self.output
         )
 
-    @unittest.skipIf(not is_gfx942(), "Requires MI300X")
-    def test_compile_f8f8f16_rowwise(self) -> None:
-        torch.compile(torch.ops.mslk.f8f8f16_rowwise)(
-            self.XQ, self.WQ, self.row_scale, self.col_scale
-        )
-
-    @unittest.skipIf(not torch.version.cuda, "Requires CUDA")
     def test_compile_i8i8bf16(self) -> None:
         torch.compile(torch.ops.mslk.i8i8bf16)(
             self.XQ.view(torch.int8), self.WQ.view(torch.int8), 1.0, 1
         )
 
-    @unittest.skipIf(not torch.version.cuda, "Requires CUDA")
     def test_compile_f8i4bf16_rowwise(self) -> None:
         torch.compile(torch.ops.mslk.f8i4bf16_rowwise)(
             self.XQ,
@@ -376,7 +294,6 @@ class ExportCompileTests(unittest.TestCase):
             self.block_scale[0],
         )
 
-    @unittest.skipIf(not torch.version.cuda, "Requires CUDA")
     def test_compile_bf16i4bf16_rowwise(self) -> None:
         torch.compile(torch.ops.mslk.bf16i4bf16_rowwise)(
             self.X,
@@ -385,7 +302,6 @@ class ExportCompileTests(unittest.TestCase):
             self.block_scale[0].repeat(self.N).view(-1, self.N),
         )
 
-    @unittest.skipIf(not torch.version.cuda, "Requires CUDA")
     def test_compile_bf16i4bf16_rowwise_batched(self) -> None:
         torch.compile(torch.ops.mslk.bf16i4bf16_rowwise_batched)(
             self.X.view(1, self.M, self.K),
@@ -395,17 +311,32 @@ class ExportCompileTests(unittest.TestCase):
         )
 
 
-@unittest.skipIf(not SUPPORTS_FP8, "FP8Tests is not supported on this device.")
+@skipUnlessRocm()
+@skipUnlessGfxArch("gfx942")
+class F8F8F16RowwiseCompileTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.device = torch.accelerator.current_accelerator()
+        M = N = K = 256
+        cls.XQ = torch.randn(M, K, device=cls.device).to(torch.float8_e4m3fnuz)
+        cls.WQ = torch.randn(N, K, device=cls.device).to(torch.float8_e4m3fnuz)
+        cls.row_scale = torch.randn(M, device=cls.device)
+        cls.col_scale = torch.randn(N, device=cls.device)
+
+    def test_compile_f8f8f16_rowwise(self) -> None:
+        torch.compile(torch.ops.mslk.f8f8f16_rowwise)(
+            self.XQ, self.WQ, self.row_scale, self.col_scale
+        )
+
+
+@skipUnlessGfxArch("gfx942")
+@skipUnlessCudaCapability(9, 10)
 class FP8Tests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.device = torch.accelerator.current_accelerator()
 
     @parameterized.expand(_fp8_gemm_cases())
-    @unittest.skipIf(
-        torch.version.hip is not None and running_on_github,
-        "type fp8e4b8 not supported in this architecture. The supported fp8 dtypes are ('fp8e5',)",
-    )
     def test_gemm(
         self,
         M: int,
@@ -657,10 +588,7 @@ class FP8Tests(unittest.TestCase):
             (1, 0, 512, 512),  # empty (M=0)
         ]
     )
-    @unittest.skipIf(
-        not is_gfx942(),
-        "Only MI300X supports torch 3D-2D grouped gemm API",
-    )
+    @skipUnlessRocm()
     def test_grouped_gemm_3d_2d(
         self,
         G: int,
@@ -709,10 +637,7 @@ class FP8Tests(unittest.TestCase):
             (16, 2048, 1024, 512, True),  # cudagraph
         ]
     )
-    @unittest.skipIf(
-        not is_gfx942(),
-        "Only MI300X supports torch 2D-2D grouped gemm API",
-    )
+    @skipUnlessRocm()
     def test_grouped_gemm_2d_2d(
         self,
         G: int,
@@ -909,9 +834,8 @@ class FP8Tests(unittest.TestCase):
         self.bf16_loopover_validate(x_group, W, y_fp8_group, y_bf16_group)
 
 
-@unittest.skipIf(
-    not SUPPORTS_BF16_INT4, "Skip if BF16Int4Tests is not supported on this device."
-)
+@skipUnlessCuda()
+@skipUnlessCudaCapability(9, 9)
 class BF16Int4Tests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -1072,7 +996,6 @@ class BF16Int4Tests(unittest.TestCase):
             (16, 2048, 1024, 512, True),  # cudagraph
         ]
     )
-    @unittest.skipIf(not torch.version.cuda, "Currently not supported on AMD.")
     def test_shuffled_grouped_gemm(
         self,
         G: int,
@@ -1178,7 +1101,7 @@ class BF16Int4Tests(unittest.TestCase):
             )
 
 
-@unittest.skipIf(torch.version.hip is None, "ROCm-only: BF16xINT4 Triton rowwise GEMM")
+@skipUnlessRocm()
 class BF16Int4TritonROCmTests(unittest.TestCase):
     """
     Tests for the Triton BF16xINT4 rowwise GEMM running on AMD GPUs.
@@ -1303,9 +1226,8 @@ class BF16Int4TritonROCmTests(unittest.TestCase):
         torch.testing.assert_close(y_op, y_direct, atol=0.0, rtol=0.0)
 
 
-@unittest.skipIf(
-    not SUPPORTS_FP8_INT4, "Skip if FP8Int4Tests is not supported on this device."
-)
+@skipUnlessCuda()
+@skipUnlessCudaCapability(9, 9)
 class FP8Int4Tests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -1487,9 +1409,8 @@ class FP8Int4Tests(unittest.TestCase):
             )
 
 
-@unittest.skipIf(
-    not SUPPORTS_MXFP8, "Skip if MXFP8Tests is not supported on this device."
-)
+@skipUnlessCuda()
+@skipUnlessCudaCapability(10)
 class MXFP8Tests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -1813,9 +1734,8 @@ class MXFP8Tests(unittest.TestCase):
         )
 
 
-@unittest.skipIf(
-    not SUPPORTS_BF16, "Skip if BF16Tests is not supported on this device."
-)
+@skipUnlessGfxArch("gfx942")
+@skipUnlessCudaCapability(9)
 class BF16Tests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -1854,10 +1774,7 @@ class BF16Tests(unittest.TestCase):
             ]
         ]
     )
-    @unittest.skipIf(
-        not torch.version.cuda,
-        "Skip on AMD: test_grouped_gemm_wgrad not yet supported.",
-    )
+    @skipUnlessCuda()
     def test_grouped_gemm_wgrad(
         self,
         G: int,
@@ -1965,10 +1882,7 @@ class BF16Tests(unittest.TestCase):
             ]
         ]
     )
-    @unittest.skipIf(
-        not torch.version.cuda,
-        "Skip on AMD: test_grouped_gemm_dgrad not yet supported.",
-    )
+    @skipUnlessCuda()
     def test_grouped_gemm_dgrad(
         self,
         G: int,
@@ -2048,10 +1962,7 @@ class BF16Tests(unittest.TestCase):
             ]
         ]
     )
-    @unittest.skipIf(
-        not torch.version.cuda,
-        "Skip on AMD: test_grouped_gemm_fprop not yet supported.",
-    )
+    @skipUnlessCuda()
     def test_grouped_gemm_fprop(
         self,
         G: int,
@@ -2122,10 +2033,7 @@ class BF16Tests(unittest.TestCase):
             ]
         ]
     )
-    @unittest.skipIf(
-        not torch.version.cuda,
-        "Skip on AMD: test not yet supported.",
-    )
+    @skipUnlessCuda()
     def test_grouped_gemm_wgrad_zero_token_experts(
         self,
         N: int,
@@ -2241,9 +2149,8 @@ class BF16Tests(unittest.TestCase):
             )
 
 
-@unittest.skipIf(
-    not SUPPORTS_NVFP4, "Skip if NVFP4Tests is not supported on this device."
-)
+@skipUnlessCuda()
+@skipUnlessCudaCapability(10)
 class NVFP4Tests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -2373,10 +2280,8 @@ class NVFP4Tests(unittest.TestCase):
 
         torch.testing.assert_close(out_nvfp4, out_bf16, atol=5.0e-2, rtol=6.0e-2)
 
-    @unittest.skipIf(
-        not SUPPORTS_NVFP4_ULTRA,
-        "Skip if NVFP4 ultra grouped GEMM is not supported on this device.",
-    )
+    @skipUnlessCudaVersion(13)
+    @skipUnlessCudaCapability(10, minor_min=3)
     def test_ultra_grouped_gemm_2d_3d(self) -> None:
         G = 2
         N = 512
@@ -2428,10 +2333,8 @@ class NVFP4Tests(unittest.TestCase):
 
         torch.testing.assert_close(out_nvfp4, out_bf16, atol=5.0e-2, rtol=6.0e-2)
 
-    @unittest.skipIf(
-        not SUPPORTS_NVFP4_ULTRA,
-        "Skip if NVFP4 ultra grouped GEMM is not supported on this device.",
-    )
+    @skipUnlessCudaVersion(13)
+    @skipUnlessCudaCapability(10, minor_min=3)
     def test_ultra_grouped_gemm_meta(self) -> None:
         G = 2
         M = 384
@@ -2462,7 +2365,8 @@ class NVFP4Tests(unittest.TestCase):
         self.assertEqual(out.device.type, "meta")
 
 
-@unittest.skipIf(not SUPPORTS_MXFP4, "Skip if MXFP4 is not supported")
+@skipUnlessCuda()
+@skipUnlessCudaCapability(10)
 class MXFP4Tests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -2601,7 +2505,8 @@ class MXFP4Tests(unittest.TestCase):
         torch.testing.assert_close(out_mxfp4, out_bf16, atol=8.0e-2, rtol=8.0e-2)
 
 
-@unittest.skipIf(not SUPPORTS_MXFP4, "Skip if MXFP4 is not supported")
+@skipUnlessCuda()
+@skipUnlessCudaCapability(10)
 class MXFP4BlockSize16Tests(unittest.TestCase):
     """
     Tests for MXFP4_16 format: MXFP4 with 1x16 block size
@@ -2795,10 +2700,8 @@ class MXFP4BlockSize16Tests(unittest.TestCase):
         )
 
 
-@unittest.skipIf(
-    not SUPPORTS_MXFP4 and not is_gfx950(),
-    "Skip if MXFP4 is not supported (ROCm requires gfx950+)",
-)
+@skipUnlessGfxArch("gfx950")
+@skipUnlessCudaCapability(10)
 class MX8MX4Tests(unittest.TestCase):
     """Tests for the mixed MX8 x MX4 GEMM kernel (mx8mx4bf16)."""
 
@@ -2958,7 +2861,8 @@ class MX8MX4Tests(unittest.TestCase):
         torch.testing.assert_close(out_mx8mx4, out_bf16, atol=6.0e-2, rtol=6.0e-2)
 
 
-@unittest.skipIf(not SUPPORTS_MXFP4, "Skip if MXFP4 is not supported")
+@skipUnlessCuda()
+@skipUnlessCudaCapability(10)
 class MX8MX6Tests(unittest.TestCase):
     """Tests for the mixed MX8 x MX6 CUTLASS GEMM kernel (mx8mx6bf16)."""
 
@@ -3004,7 +2908,8 @@ class MX8MX6Tests(unittest.TestCase):
         self.assertEqual(out_mx8mx6.shape, (M, N))
 
 
-@unittest.skipIf(not SUPPORTS_MXFP4, "Skip if block-scaled GEMM is not supported")
+@skipUnlessCuda()
+@skipUnlessCudaCapability(10)
 class MX6MX6Tests(unittest.TestCase):
     """Tests for the symmetric MX6 x MX6 CUTLASS GEMM kernel (mx6mx6bf16)."""
 
@@ -3048,7 +2953,8 @@ class MX6MX6Tests(unittest.TestCase):
         self.assertEqual(out_mx6mx6.dtype, torch.bfloat16)
 
 
-@unittest.skipIf(not supports_int8(), "Requires CUDA SM80+ or ROCm")
+@skipUnlessGfxArch("gfx942", "gfx950")
+@skipUnlessCudaCapability(8)
 class RocmInt8GemmTests(unittest.TestCase):
     """Correctness tests for the Triton INT8 GEMM kernel.
 
@@ -3145,7 +3051,7 @@ class RocmInt8GemmTests(unittest.TestCase):
     # Parity with CUDA CUTLASS path (CUDA only)
     # ------------------------------------------------------------------
 
-    @unittest.skipIf(not torch.version.cuda, "CUTLASS parity only tested on CUDA")
+    @skipUnlessCuda()
     def test_parity_with_cutlass_static(self) -> None:
         M, N, K = 128, 2048, 4096
         scale = 0.01
@@ -3154,7 +3060,7 @@ class RocmInt8GemmTests(unittest.TestCase):
         triton_out = self.i8i8bf16_triton(XQ, WQ, scale)
         torch.testing.assert_close(cutlass_out, triton_out, atol=1e-2, rtol=1e-2)
 
-    @unittest.skipIf(not torch.version.cuda, "CUTLASS parity only tested on CUDA")
+    @skipUnlessCuda()
     def test_parity_with_cutlass_dynamic(self) -> None:
         M, N, K = 128, 2048, 4096
         scale = 0.01
@@ -3168,7 +3074,7 @@ class RocmInt8GemmTests(unittest.TestCase):
     # torch.ops.mslk dispatch on ROCm
     # ------------------------------------------------------------------
 
-    @unittest.skipIf(not torch.version.hip, "Op dispatch only tested on ROCm")
+    @skipUnlessRocm()
     def test_ops_dispatch_static(self) -> None:
         M, N, K = 128, 1024, 1024
         scale = 0.01
@@ -3178,7 +3084,7 @@ class RocmInt8GemmTests(unittest.TestCase):
         self.assertEqual(out.dtype, torch.bfloat16)
         torch.testing.assert_close(out, ref, atol=1.0, rtol=1e-2)
 
-    @unittest.skipIf(not torch.version.hip, "Op dispatch only tested on ROCm")
+    @skipUnlessRocm()
     def test_ops_dispatch_dynamic(self) -> None:
         M, N, K = 128, 1024, 1024
         scale = 0.01


### PR DESCRIPTION
Summary:

Consolidate GPU test gating onto shared, self-documenting skip decorators, and align hardware checks on the canonical `mslk.utils.device` helpers.

- Add shared decorators in `mslk/testing/device.py`: strict platform gates `skipUnlessCuda()` / `skipUnlessRocm()`, plus refinements `skipUnlessCudaCapability(min, max)` / `skipUnlessGfxArch(*archs)`. The refinements are transparent on the other platform so stacking them expresses a dual-platform union; skip messages are derived from the arguments (callers do not pass one).
- Migrate `gemm_test.py` class/method gating from ad-hoc `SUPPORTS_*` flags and raw `torch.version.*` checks to these decorators. `supports_nvfp4_ultra` is kept as a dedicated helper (it needs minor-version + CUDA-toolkit granularity beyond the major-only decorators).
- Migrate `conv_test.py` to the same decorators.
- Migrate the bench `gemm_ops.py` / `quantize_ops.py` hardware detection to `mslk.utils.device` (`is_cuda`/`is_rocm`/`is_gfx942`/`is_gfx950`); add the `//mslk:python_utils` dep to the quantize bench target.
- Re-enable `ExportCompileTests` in OSS (drop the `open_source` gate): the ops it exercises are core and the class is hardware-gated to CUDA SM90.
- `f8f8f16_rowwise` is a ROCm-only CK kernel (registered only under `#ifdef USE_ROCM`, absent on CUDA builds). Its compile test was stranded in the CUDA-only `ExportCompileTests` and never ran; extract it into a dedicated MI300X-gated `F8F8F16RowwiseCompileTests` so it actually runs on gfx942.
- Remove redundant method-level skips already implied by class-level gates.

Differential Revision: D109155281


