### PR TITLE
Fix Windows wheel build: avoid legacy wheel.bdist_wheel pkg_resources… (#401)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -641,7 +641,13 @@ def main(argv: List[str]) -> None:
 
         python_only_plat = os.environ.get("MSLK_PYTHON_ONLY_PLAT", "")
         if python_only_plat:
-            from wheel.bdist_wheel import bdist_wheel as _BdistWheel
+            try:
+                # setuptools >= 70.1 vendors bdist_wheel; prefer it so we
+                # avoid the legacy ``wheel`` module, which imports
+                # ``pkg_resources`` at load time (removed in setuptools >= 81).
+                from setuptools.command.bdist_wheel import bdist_wheel as _BdistWheel
+            except ImportError:
+                from wheel.bdist_wheel import bdist_wheel as _BdistWheel
 
             class _PlatBdistWheel(_BdistWheel):
                 def get_tag(self):


### PR DESCRIPTION
Summary:
… import

The Windows wheel build fails on trunk for all Python/CUDA matrix jobs with ModuleNotFoundError: No module named 'pkg_resources'. setup.py imports bdist_wheel from the legacy 'wheel' package, whose bdist_wheel module imports pkg_resources at load time; recent setuptools (>= 81) no longer provides it.

Prefer setuptools' vendored bdist_wheel (available since setuptools 70.1), falling back to the legacy import only on older setuptools. Only the Windows build sets MSLK_PYTHON_ONLY_PLAT, which is why this path was Windows-only.


Reviewed By: cthi

Differential Revision: D109581021

Pulled By: bottler


