### PR TITLE
Re-skip attention tests in ROCm CI

### DIFF
--- a/ci/scripts/mslk_test.bash
+++ b/ci/scripts/mslk_test.bash
@@ -149,6 +149,7 @@ __configure_mslk_test_rocm () {
   fi
 
   export ignored_tests=(
+    ./attention/*_test.py
     ./comm/*.py
     ./moe/*.py
     ./quantize/fp8_quantize_test.py


### PR DESCRIPTION
## Summary
- Adds `./attention/*_test.py` back to the ROCm `ignored_tests` list in CI
- These tests were inadvertently un-skipped in #400
- Attention tests are broken on **both** platforms due to a relative import bug (`from .test_utils` → `from test_utils`) and additionally fail on ROCm because cutlass kernels don't exist
- They remain skipped in CUDA CI as well

## Test plan
- [ ] Verify ROCm CI no longer attempts to run attention tests