### PR TITLE
[ROCm] Add Triton BF16×INT4 shuffled GEMM and preshuffle_i4

### DIFF
--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -64,6 +64,16 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   m.def("i8i8bf16(Tensor XQ, Tensor WQ, float scale, int split_k=1) -> Tensor");
   m.def(
       "i8i8bf16_dynamic(Tensor XQ, Tensor WQ, Tensor scale, int split_k=1) -> Tensor");
+  // BF16xINT4 shuffled GEMMs: schema only on ROCm; implementations are
+  // registered by mslk.gemm.triton.int4_gemm via torch.library.impl at
+  // Python import time.
+  m.def(
+      "bf16i4bf16_shuffled(Tensor X, Tensor W, Tensor w_scale_group, Tensor w_zero_group) -> Tensor");
+  m.def(
+      "bf16i4bf16_shuffled_grouped(Tensor X, Tensor WQ, Tensor w_scale_group, Tensor w_zero_group, Tensor M_sizes) -> Tensor");
+  m.def(
+      "bf16i4bf16_shuffled_batched(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
+  m.def("preshuffle_i4(Tensor WQ, Tensor w_scale) -> (Tensor, Tensor)");
 #else
   m.def("i8i8bf16(Tensor XQ, Tensor WQ, float scale, int split_k=1) -> Tensor");
   m.def(

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -35,3 +35,6 @@ if torch.version.hip is not None:
     # so that torch.ops.mslk.mx8mx4bf16/_grouped dispatches to the Triton
     # kernel on AMD.
     from .triton import mx8mx4_gemm  # noqa: F401
+
+    # Register BF16xINT4 rowwise, shuffled, and preshuffle_i4 Triton impls.
+    from .triton import int4_gemm  # noqa: F401

--- a/mslk/gemm/triton/int4_gemm.py
+++ b/mslk/gemm/triton/int4_gemm.py
@@ -42,7 +42,6 @@ import triton  # @manual
 import triton.language as tl  # @manual
 from triton import Config  # @manual
 
-
 # ---------------------------------------------------------------------------
 # Autotuning configs
 # ---------------------------------------------------------------------------
@@ -216,12 +215,14 @@ def matmul_bf16i4_rowwise(
     K2 = K // 2
 
     assert W.shape == (N, K2), f"W must be [N, K//2], got {W.shape}"
-    assert w_scale_group.shape == (num_groups, N), (
-        f"w_scale_group must be [num_groups, N]={num_groups, N}, got {w_scale_group.shape}"
-    )
-    assert w_zero_group.shape == (num_groups, N), (
-        f"w_zero_group must be [num_groups, N]={num_groups, N}, got {w_zero_group.shape}"
-    )
+    assert w_scale_group.shape == (
+        num_groups,
+        N,
+    ), f"w_scale_group must be [num_groups, N]={num_groups, N}, got {w_scale_group.shape}"
+    assert w_zero_group.shape == (
+        num_groups,
+        N,
+    ), f"w_zero_group must be [num_groups, N]={num_groups, N}, got {w_zero_group.shape}"
     group_size = K // num_groups
     assert group_size % 64 == 0, (
         f"group_size={group_size} must be divisible by 64 (2 * BLOCK_K_min=32); "
@@ -286,9 +287,9 @@ def matmul_bf16i4_rowwise_batched(
     B, M, K = X.shape
     _, N, _ = W.shape
     num_groups_total = w_scale.shape[0]
-    assert num_groups_total % B == 0, (
-        f"w_scale.shape[0]={num_groups_total} must be divisible by B={B}"
-    )
+    assert (
+        num_groups_total % B == 0
+    ), f"w_scale.shape[0]={num_groups_total} must be divisible by B={B}"
     num_groups = num_groups_total // B
 
     outs = []
@@ -297,6 +298,155 @@ def matmul_bf16i4_rowwise_batched(
         zp_b = w_zp[b * num_groups : (b + 1) * num_groups]
         outs.append(matmul_bf16i4_rowwise(X[b], W[b], scale_b, zp_b))
     return torch.stack(outs, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# BF16 preshuffle / unshuffle helpers
+# ---------------------------------------------------------------------------
+#
+# CUTLASS preshuffle_i4 (BF16 variant) reorders INT4 values within each
+# group of 8 along K using the permutation [0,2,4,6,1,3,5,7].  The CUDA
+# implementation uses cutlass::reorder_tensor; here we replicate it with
+# vectorised bitwise ops so it works on ROCm without CUTLASS headers.
+#
+# Input layout (rowwise): each byte packs (lo=even_K, hi=odd_K).
+#   Bytes [b0, b1, b2, b3] hold nibbles [n0,n1,n2,n3,n4,n5,n6,n7].
+# After preshuffle [0,2,4,6,1,3,5,7]:
+#   out_byte0 = lo(n0) | hi(n2)  — lo nibbles of b0 and b1
+#   out_byte1 = lo(n4) | hi(n6)  — lo nibbles of b2 and b3
+#   out_byte2 = lo(n1) | hi(n3)  — hi nibbles of b0 and b1
+#   out_byte3 = lo(n5) | hi(n7)  — hi nibbles of b2 and b3
+# This separates even-K (lo) nibbles into bytes 0-1 and odd-K (hi)
+# nibbles into bytes 2-3, which is a pure bitwise rearrangement.
+
+
+def _bf16_preshuffle_i4(WQ: torch.Tensor) -> torch.Tensor:
+    N, K2 = WQ.shape
+    assert (K2 * 2) % 8 == 0, f"K={K2 * 2} must be divisible by 8 for preshuffle"
+    b = WQ.view(torch.uint8).view(N, K2 // 4, 4).to(torch.int32)
+    lo = b & 0x0F
+    hi = (b >> 4) & 0x0F
+    out = torch.stack(
+        [
+            lo[:, :, 0] | (lo[:, :, 1] << 4),
+            lo[:, :, 2] | (lo[:, :, 3] << 4),
+            hi[:, :, 0] | (hi[:, :, 1] << 4),
+            hi[:, :, 2] | (hi[:, :, 3] << 4),
+        ],
+        dim=-1,
+    )
+    return out.to(torch.uint8).view(torch.int8).view(N, K2).contiguous()
+
+
+@triton.jit
+def _unshuffle_i4_kernel(
+    src_ptr,
+    dst_ptr,
+    num_elements,
+    BLOCK: tl.constexpr,
+) -> None:
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < num_elements
+
+    # Load 4 bytes as int32 — one group of 8 INT4 values in shuffled layout
+    val = tl.load(src_ptr + offs, mask=mask).to(tl.int32)
+
+    # Shuffled layout: lo nibbles in bytes 0-1, hi nibbles in bytes 2-3
+    # Extract each byte
+    b0 = val & 0xFF
+    b1 = (val >> 8) & 0xFF
+    b2 = (val >> 16) & 0xFF
+    b3 = (val >> 24) & 0xFF
+
+    # Reconstruct original rowwise bytes: byte_i = lo_nibble_i | (hi_nibble_i << 4)
+    out0 = (b0 & 0x0F) | ((b2 & 0x0F) << 4)
+    out1 = ((b0 >> 4) & 0x0F) | ((b2 >> 4) << 4)
+    out2 = (b1 & 0x0F) | ((b3 & 0x0F) << 4)
+    out3 = ((b1 >> 4) & 0x0F) | ((b3 >> 4) << 4)
+
+    result = out0 | (out1 << 8) | (out2 << 16) | (out3 << 24)
+    tl.store(dst_ptr + offs, result.to(tl.int32), mask=mask)
+
+
+def _bf16_unshuffle_i4(WQ_shuffled: torch.Tensor) -> torch.Tensor:
+    N, K2 = WQ_shuffled.shape
+    assert (K2 * 2) % 8 == 0, f"K={K2 * 2} must be divisible by 8 for unshuffle"
+    src = WQ_shuffled.view(torch.int32).contiguous()
+    dst = torch.empty_like(src)
+    num_elements = src.numel()
+    BLOCK = 1024
+    grid = (triton.cdiv(num_elements, BLOCK),)
+    _unshuffle_i4_kernel[grid](src, dst, num_elements, BLOCK)
+    return dst.view(torch.int8).view(N, K2)
+
+
+def preshuffle_i4_bf16(
+    WQ: torch.Tensor,
+    w_scale: torch.Tensor,
+) -> "tuple[torch.Tensor, torch.Tensor]":
+    WQ_shuffled = _bf16_preshuffle_i4(WQ)
+    return WQ_shuffled, w_scale
+
+
+# ---------------------------------------------------------------------------
+# Shuffled wrappers — unshuffle then delegate to rowwise kernel
+# ---------------------------------------------------------------------------
+
+
+def matmul_bf16i4_shuffled(
+    X: torch.Tensor,
+    W_shuffled: torch.Tensor,
+    w_scale_group: torch.Tensor,
+    w_zero_group: torch.Tensor,
+) -> torch.Tensor:
+    W = _bf16_unshuffle_i4(W_shuffled)
+    return matmul_bf16i4_rowwise(X, W, w_scale_group, w_zero_group)
+
+
+def matmul_bf16i4_shuffled_grouped(
+    X: torch.Tensor,
+    WQ: torch.Tensor,
+    w_scale_group: torch.Tensor,
+    w_zero_group: torch.Tensor,
+    M_sizes: torch.Tensor,
+) -> torch.Tensor:
+    G = M_sizes.shape[0]
+    N = WQ.shape[1]
+    K2 = WQ.shape[2]
+    M = X.shape[0]
+
+    W_unshuffled = torch.stack([_bf16_unshuffle_i4(WQ[g]) for g in range(G)])
+
+    m_list = M_sizes.cpu().tolist()
+    x_groups = torch.split(X, m_list, dim=0)
+
+    outs = []
+    for g in range(G):
+        if m_list[g] == 0:
+            outs.append(X.new_empty((0, N)))
+            continue
+        num_groups = w_scale_group.shape[1]
+        outs.append(
+            matmul_bf16i4_rowwise(
+                x_groups[g],
+                W_unshuffled[g],
+                w_scale_group[g],
+                w_zero_group[g],
+            )
+        )
+    return torch.cat(outs, dim=0)
+
+
+def matmul_bf16i4_shuffled_batched(
+    X: torch.Tensor,
+    WQ: torch.Tensor,
+    w_scale: torch.Tensor,
+    w_zp: torch.Tensor,
+) -> torch.Tensor:
+    B = X.shape[0]
+    W_unshuffled = torch.stack([_bf16_unshuffle_i4(WQ[b]) for b in range(B)])
+    return matmul_bf16i4_rowwise_batched(X, W_unshuffled, w_scale, w_zp)
 
 
 # ---------------------------------------------------------------------------
@@ -329,3 +479,52 @@ if torch.version.hip is not None and hasattr(torch.ops, "mslk"):
             w_zp: torch.Tensor,
         ) -> torch.Tensor:
             return matmul_bf16i4_rowwise_batched(X, W, w_scale, w_zp)
+
+    if hasattr(torch.ops.mslk, "bf16i4bf16_shuffled"):
+
+        @torch.library.impl("mslk::bf16i4bf16_shuffled", "CUDA")
+        def _bf16i4bf16_shuffled_rocm(
+            X: torch.Tensor,
+            W: torch.Tensor,
+            w_scale_group: torch.Tensor,
+            w_zero_group: torch.Tensor,
+        ) -> torch.Tensor:
+            return matmul_bf16i4_shuffled(X, W, w_scale_group, w_zero_group)
+
+    if hasattr(torch.ops.mslk, "bf16i4bf16_shuffled_grouped"):
+
+        @torch.library.impl("mslk::bf16i4bf16_shuffled_grouped", "CUDA")
+        def _bf16i4bf16_shuffled_grouped_rocm(
+            X: torch.Tensor,
+            WQ: torch.Tensor,
+            w_scale_group: torch.Tensor,
+            w_zero_group: torch.Tensor,
+            M_sizes: torch.Tensor,
+        ) -> torch.Tensor:
+            return matmul_bf16i4_shuffled_grouped(
+                X, WQ, w_scale_group, w_zero_group, M_sizes
+            )
+
+    if hasattr(torch.ops.mslk, "bf16i4bf16_shuffled_batched"):
+
+        @torch.library.impl("mslk::bf16i4bf16_shuffled_batched", "CUDA")
+        def _bf16i4bf16_shuffled_batched_rocm(
+            X: torch.Tensor,
+            WQ: torch.Tensor,
+            w_scale: torch.Tensor,
+            w_zp: torch.Tensor,
+        ) -> torch.Tensor:
+            return matmul_bf16i4_shuffled_batched(X, WQ, w_scale, w_zp)
+
+    if hasattr(torch.ops.mslk, "preshuffle_i4"):
+
+        @torch.library.impl("mslk::preshuffle_i4", "CUDA")
+        def _preshuffle_i4_rocm(
+            WQ: torch.Tensor,
+            w_scale: torch.Tensor,
+        ) -> "tuple[torch.Tensor, torch.Tensor]":
+            if w_scale.dtype == torch.bfloat16:
+                return preshuffle_i4_bf16(WQ, w_scale)
+            raise NotImplementedError(
+                f"ROCm preshuffle_i4 only supports BF16 scales, got {w_scale.dtype}"
+            )

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -1225,6 +1225,121 @@ class BF16Int4TritonROCmTests(unittest.TestCase):
         y_direct = self.matmul_rowwise(x, wq, w_scale, w_zp)
         torch.testing.assert_close(y_op, y_direct, atol=0.0, rtol=0.0)
 
+    @parameterized.expand(
+        [
+            (256, 256, 128, 128),  # small (matches Meta BF16Int4Tests)
+            (2048, 4096, 2048, 128),  # medium
+            (4096, 8192, 4096, 128),  # large
+        ]
+    )
+    def test_shuffled_accuracy(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        group_size: int,
+    ) -> None:
+        from mslk.gemm.triton.int4_gemm import (
+            matmul_bf16i4_shuffled,
+            preshuffle_i4_bf16,
+        )
+
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        w = torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.01
+
+        wq, w_scale, w_zp = int4_row_quantize(w, group_size)
+        wq = pack_int4(wq).contiguous().to(device=self.device)
+        w_scale = w_scale.contiguous().to(device=self.device)
+        w_zp = w_zp.contiguous().to(device=self.device)
+
+        y_rowwise = self.matmul_rowwise(x, wq, w_scale, w_zp)
+
+        wq_shuffled, _ = preshuffle_i4_bf16(wq, w_scale)
+        y_shuffled = matmul_bf16i4_shuffled(x, wq_shuffled, w_scale, w_zp)
+
+        torch.testing.assert_close(y_shuffled, y_rowwise, atol=0.0, rtol=0.0)
+
+    @parameterized.expand(
+        [
+            (1, 256, 1024, 512),  # small (matches Meta BF16Int4Tests)
+            (16, 2048, 1024, 512),  # medium
+            (64, 3584, 6144, 3584),  # large
+            (1, 0, 1024, 512),  # empty (M=0 edge case)
+        ]
+    )
+    def test_shuffled_grouped_accuracy(
+        self,
+        G: int,
+        M: int,
+        N: int,
+        K: int,
+    ) -> None:
+        from mslk.gemm.triton.int4_gemm import (
+            matmul_bf16i4_shuffled_grouped,
+            preshuffle_i4_bf16,
+        )
+
+        group_size = 128
+        if M > 0:
+            ms = torch.randint(1, (M // 64) + 1, (G,), dtype=torch.int) * 64
+        else:
+            ms = torch.zeros((G,), dtype=torch.int)
+        M_sizes = ms.to(device=self.device, dtype=torch.int64)
+
+        x_parts = []
+        w_list = []
+        wq_list = []
+        scale_list = []
+        zp_list = []
+        for g in range(G):
+            m = ms[g].item()
+            x_g = torch.randn(m, K, dtype=torch.bfloat16, device=self.device) * 0.1
+            w_g = torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.01
+            wq_g, s_g, z_g = int4_row_quantize(w_g, group_size)
+            wq_g = pack_int4(wq_g).contiguous().to(device=self.device)
+            s_g = s_g.contiguous().to(device=self.device, dtype=torch.bfloat16)
+            z_g = z_g.contiguous().to(device=self.device, dtype=torch.bfloat16)
+            x_parts.append(x_g)
+            w_list.append(w_g)
+            wq_shuffled_g, _ = preshuffle_i4_bf16(wq_g, s_g)
+            wq_list.append(wq_shuffled_g)
+            scale_list.append(s_g)
+            zp_list.append(z_g)
+
+        x_cat = torch.cat(x_parts, dim=0)
+        wq_stacked = torch.stack(wq_list)
+        scales_stacked = torch.stack(scale_list)
+        zp_stacked = torch.stack(zp_list)
+
+        y = matmul_bf16i4_shuffled_grouped(
+            x_cat, wq_stacked, scales_stacked, zp_stacked, M_sizes
+        )
+
+        y_ref_parts = []
+        for g in range(G):
+            y_ref_parts.append(
+                (x_parts[g].float() @ w_list[g].float().T).to(torch.bfloat16)
+            )
+        y_ref = torch.cat(y_ref_parts, dim=0)
+
+        torch.testing.assert_close(y, y_ref, atol=1.0e-1, rtol=8.0e-2)
+
+    def test_preshuffle_roundtrip(self) -> None:
+        from mslk.gemm.triton.int4_gemm import (
+            _bf16_preshuffle_i4,
+            _bf16_unshuffle_i4,
+        )
+
+        N, K = 256, 512
+        w = torch.randn(N, K, dtype=torch.bfloat16, device=self.device)
+        wq, w_scale, w_zp = int4_row_quantize(w, 128)
+        wq = pack_int4(wq).contiguous().to(device=self.device)
+
+        wq_shuffled = _bf16_preshuffle_i4(wq)
+        wq_roundtrip = _bf16_unshuffle_i4(wq_shuffled)
+
+        self.assertTrue(torch.equal(wq, wq_roundtrip))
+
 
 @skipUnlessCuda()
 @skipUnlessCudaCapability(9, 9)
@@ -2723,7 +2838,7 @@ class MX8MX4Tests(unittest.TestCase):
         B = torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
 
         # Quantize A to MX8 with blocked scale layout
-        (a_scale_raw, aq) = to_mxfp8(A)
+        a_scale_raw, aq = to_mxfp8(A)
         a_scale = _to_blocked(a_scale_raw.view(torch.int8).reshape(M, -1)).view(
             torch.uint8
         )
@@ -2884,7 +2999,7 @@ class MX8MX6Tests(unittest.TestCase):
         B = torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
 
         # Quantize A to MX8 with blocked scale layout
-        (a_scale_raw, aq) = to_mxfp8(A)
+        a_scale_raw, aq = to_mxfp8(A)
         a_scale = _to_blocked(a_scale_raw.view(torch.int8).reshape(M, -1)).view(
             torch.uint8
         )
@@ -2893,7 +3008,7 @@ class MX8MX6Tests(unittest.TestCase):
         # then create E2M3 weight data from the MX8 data.
         # E2M3 is stored as 1 byte per element (6-bit value in uint8).
         # We use the FP8 data masked to 6 bits as a proxy for E2M3.
-        (b_scale_raw, bq_fp8) = to_mxfp8(B)
+        b_scale_raw, bq_fp8 = to_mxfp8(B)
         b_scale = _to_blocked(b_scale_raw.view(torch.int8).reshape(N, -1)).view(
             torch.uint8
         )


### PR DESCRIPTION
## Motivation

Add ROCm Triton implementations for the CUTLASS-only BF16×INT4 shuffled weight GEMM ops (`bf16i4bf16_shuffled`, `bf16i4bf16_shuffled_grouped`, `bf16i4bf16_shuffled_batched`) and the `preshuffle_i4` weight preprocessing op. These ops exist on CUDA via CUTLASS but have no ROCm implementation. The shuffled layout is used by quantized inference pipelines that pre-process INT4 weights with `quantize_int4_preshuffle()` for efficient CUTLASS MMA tile access.

The CUTLASS preshuffle applies a `[0,2,4,6,1,3,5,7]` nibble permutation within each group of 8 INT4 values along K, separating even-K and odd-K nibbles into contiguous byte pairs. The CUDA implementation depends on `cutlass::reorder_tensor` and `cutlass::compute_memory_reordering_atom` which are unavailable on ROCm.

## Technical Details

**`mslk/gemm/triton/int4_gemm.py`** — Extended with:
- **`_bf16_preshuffle_i4()`**: Pure-PyTorch BF16 preshuffle using vectorized bitwise ops on uint8→int32 views. Separates lo/hi nibbles from each byte, then repacks into the shuffled layout. One-time cost at model load (~34μs for 4K×4K weights).
- **`_unshuffle_i4_kernel`**: Triton JIT kernel for inverse permutation. Loads 4-byte groups as int32, rearranges nibbles with bitwise ops in registers, stores result. Single kernel launch, ~34μs fixed cost independent of weight size.
- **`_bf16_unshuffle_i4()`**: Python wrapper launching the Triton unshuffle kernel.
- **`matmul_bf16i4_shuffled()`**: Unshuffles weights via Triton kernel, then delegates to the existing `_bf16i4_rowwise_kernel`. The activation pre-split strategy (even/odd K columns) and dual-dot dequantization are reused unchanged.
- **`matmul_bf16i4_shuffled_grouped()`**: Iterates over G expert groups using `M_sizes`, unshuffles each expert's weights, delegates per-group to `matmul_bf16i4_rowwise`.
- **`matmul_bf16i4_shuffled_batched()`**: Loop-over-batch variant, same pattern.
- **`torch.library.impl` registrations**: `mslk::bf16i4bf16_shuffled`, `mslk::bf16i4bf16_shuffled_grouped`, `mslk::bf16i4bf16_shuffled_batched`, `mslk::preshuffle_i4` — all dispatch to "CUDA" (ROCm uses CUDA dispatch key via HIP).

**`csrc/gemm/gemm_ops.cpp`** — Op schemas added to `#ifdef USE_ROCM` block. Previously only defined in `#else` (CUDA/CUTLASS).

**`mslk/gemm/__init__.py`** — Import `int4_gemm` on ROCm (alongside existing `mx8mx4_gemm`) to trigger `torch.library.impl` registration at module load.

**`test/gemm/gemm_test.py`** — New tests added to existing `BF16Int4TritonROCmTests` class:
- `test_shuffled_accuracy`: 3 sizes, verifies bit-exact match vs rowwise kernel
- `test_shuffled_grouped_accuracy`: 4 sizes (G=1/16/64, including M=0 edge case)
- `test_preshuffle_roundtrip`: preshuffle → unshuffle = identity

Test dimensions aligned with Meta's CUDA `BF16Int4Tests`.

## Test Plan

```
pytest test/gemm/gemm_test.py::BF16Int4TritonROCmTests -v
```

## Test Result

All 14 tests passed on MI300X (gfx942), 3 skipped (torch.ops dispatch — expected in python-only install).

| Test | Pass | Skip | Notes |
|---|---|---|---|
| `test_shuffled_accuracy` (3 sizes) | **3** | 0 | Bit-exact match vs rowwise |
| `test_shuffled_grouped_accuracy` (4 sizes) | **4** | 0 | G=64 large + M=0 edge case |
| `test_preshuffle_roundtrip` | **1** | 0 | shuffle → unshuffle = identity |
| `test_rowwise_*` (existing, 6 tests) | **6** | 0 | No regressions |
| `test_torch_op_dispatch` (3 tests) | 0 | 3 | Expected: python-only, no C++ lib |
| **Total** | **14** | **3** | |

### Performance (MI300X gfx942, shuffled GEMM end-to-end)

| Shape (M, N, K) | Latency (ms) | TFLOPS | % of BF16 peak |
|---|---|---|---|
| 1, 4096, 4096 | 0.147 | 0.2 | 0.0% |
| 64, 4096, 4096 | 0.143 | 15.0 | 1.1% |
| 256, 4096, 4096 | 0.154 | 55.7 | 4.3% |
| 1024, 4096, 4096 | 0.171 | 201.1 | 15.4% |
| 2048, 4096, 4096 | 0.268 | 256.1 | 19.6% |
| 4096, 4096, 4096 | 0.515 | 266.8 | **20.4%** |
| 8192, 4096, 4096 | 1.058 | 259.9 | 19.9% |
| 16384, 4096, 4096 | 2.443 | 225.0 | 17.2% |

**Analysis:** Peak 267 TFLOPS = 20% of MI300X BF16 spec (1,307 TFLOPS), or 47% of achievable `torch.mm` BF16 throughput (566 TFLOPS). Memory-bandwidth bound at small M (≤256). Plateaus at ~260 TFLOPS for M≥2048 — the dual-dot dequantization strategy (two `tl.dot` per K-tile for even/odd nibbles) and per-group scale loads cap compute utilization. This matches the underlying rowwise kernel; the Triton unshuffle adds a fixed ~34μs overhead.

### Design decision: unshuffle-then-rowwise vs dedicated shuffled kernel

The current approach unshuffles preshuffled weights then reuses the existing rowwise GEMM kernel. An alternative is a dedicated kernel that reads shuffled weights natively with modified nibble unpacking. The unshuffle approach was chosen because:
1. The Triton unshuffle is ~34μs fixed — negligible vs GEMM time at production sizes
2. Zero code duplication — reuses the proven rowwise kernel and its autotuning configs
3. Simpler to maintain — one kernel path, not two

If profiling shows the unshuffle overhead matters for small-batch inference, a dedicated shuffled kernel can be added later without API changes.