### PR TITLE
Drop unused NCCL link from gpu_cpp_library

### DIFF
--- a/cmake/GpuCppLibrary.cmake
+++ b/cmake/GpuCppLibrary.cmake
@@ -285,7 +285,6 @@ function(gpu_cpp_library)
     # Collect external libraries for linking
     set(library_dependencies
         ${TORCH_LIBRARIES}
-        ${NCCL_LIBRARIES}
         ${CUDA_DRIVER_LIBRARIES}
         ${args_DEPS})
 
@@ -300,9 +299,6 @@ function(gpu_cpp_library)
         ""
         "TORCH_LIBRARIES"
         "${TORCH_LIBRARIES}"
-        ""
-        "NCCL_LIBRARIES"
-        "${NCCL_LIBRARIES}"
         ""
         "CUDA_DRIVER_LIBRARIES"
         "${CUDA_DRIVER_LIBRARIES}"


### PR DESCRIPTION
Summary:
This diff removes `${NCCL_LIBRARIES}` from the `gpu_cpp_library` link line so mslk's GPU shared objects no longer carry a `NEEDED libnccl.so.2`. mslk references no NCCL symbols: its sources call no nccl APIs and include no nccl headers, and the built `mslk.so` has zero undefined nccl symbols (libnccl is also absent from its `.gnu.version_r`). The link is vestigial lineage from fbgemm_gpu's `gpu_cpp_library`, which links NCCL for its custom all-reduce operator that mslk does not have.

Because the link is vestigial, this is a cleanup, not a fix for any particular build layout. mslk*.so genuinely links libtorch and libcublas/libcublasLt/libcudart, which — in build layouts that install libraries as separate Python wheels — live under site-packages rather than a shared lib dir, so the mslk `$ORIGIN/../../..` RPATH still needs widening to the wheel dirs (handled by a companion RPATH change) to resolve them. libnccl sat in that same set, but unlike the genuine deps mslk never used it, so the spurious `NEEDED` only tied the mslk import to libnccl being resolvable for nothing. Removing it drops that coupling at the root, so the RPATH no longer needs to locate a libnccl that mslk does not link against, and clears the bogus `NEEDED` regardless of build layout.

Differential Revision: D109887454


