### PR TITLE
Fix fp8 rowwise TMA persistent path on Triton 3.x

### DIFF
--- a/mslk/gemm/triton/fp8_gemm.py
+++ b/mslk/gemm/triton/fp8_gemm.py
@@ -784,8 +784,24 @@ def _kernel_matmul_fp8_row_tma_persistent(
 
     num_pid_in_group = GROUP_M * num_pid_n
 
-    dtype_fp8 = tl.float8e4nv
-    scale_dtype = tl.float32
+    a_desc = tl.make_tensor_descriptor(
+        A_ptr,
+        shape=[M, K],
+        strides=[K, 1],
+        block_shape=[BLOCK_M, BLOCK_K],
+    )
+    b_desc = tl.make_tensor_descriptor(
+        B_ptr,
+        shape=[N, K],
+        strides=[K, 1],
+        block_shape=[BLOCK_N, BLOCK_K],
+    )
+    c_desc = tl.make_tensor_descriptor(
+        C_ptr,
+        shape=[M, N],
+        strides=[N, 1],
+        block_shape=[BLOCK_M, BLOCK_N],
+    )
 
     # Outer loop over tiles assigned to this SM
     for tile_id in range(start_pid, num_tiles, NUM_SMS):
@@ -807,12 +823,8 @@ def _kernel_matmul_fp8_row_tma_persistent(
         for ki in range(0, k_tiles):
             offs_k = ki * BLOCK_K
 
-            a = tl._experimental_descriptor_load(
-                A_ptr, [offs_am, offs_k], [BLOCK_M, BLOCK_K], dtype_fp8
-            )
-            b = tl._experimental_descriptor_load(
-                B_ptr, [offs_bn, offs_k], [BLOCK_N, BLOCK_K], dtype_fp8
-            )
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
 
             if fp8_fast_accum:
                 acc = tl.dot(
@@ -822,24 +834,20 @@ def _kernel_matmul_fp8_row_tma_persistent(
                 acc += tl.dot(a, b.T, out_dtype=dot_out_dtype, allow_tf32=allow_tf32)
 
         # Invert scaling.
-        a_scale = tl._experimental_descriptor_load(
-            A_scale, [offs_am], [BLOCK_M], scale_dtype
-        )
-        b_scale = tl._experimental_descriptor_load(
-            B_scale, [offs_bn], [BLOCK_N], scale_dtype
-        )
+        offs_scale_m = offs_am + tl.arange(0, BLOCK_M)
+        offs_scale_n = offs_bn + tl.arange(0, BLOCK_N)
+        a_scale = tl.load(A_scale + offs_scale_m, mask=offs_scale_m < M, other=0.0)
+        b_scale = tl.load(B_scale + offs_scale_n, mask=offs_scale_n < N, other=0.0)
         scale = a_scale[:, None] * b_scale[None, :]
         acc *= scale
 
         # Load and add bias if specified.
         if USE_BIAS:
-            bias = tl._experimental_descriptor_load(
-                Bias, [offs_bn], [BLOCK_N], bias_dtype
-            )
+            bias = tl.load(Bias + offs_scale_n, mask=offs_scale_n < N, other=0.0)
             acc += bias[None, :]
 
         acc = acc.to(c_dtype)
-        tl._experimental_descriptor_store(C_ptr, acc, [offs_am, offs_bn])
+        c_desc.store([offs_am, offs_bn], acc)
 
 
 has_warp_specialization = hasattr(tl, "async_task")
@@ -1197,6 +1205,10 @@ def matmul_fp8_row(
 
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
 
+    # Device-side TMA needs a 16-byte-aligned innermost global stride (K bytes for
+    # fp8 A/B, N*elem_size for C); smaller shapes fall back to the non-TMA kernels.
+    tma_aligned = (K * a.element_size()) % 16 == 0 and (N * c.element_size()) % 16 == 0
+
     def persistent_grid(META: Dict[str, int]) -> Tuple[int]:
         return (
             min(
@@ -1308,8 +1320,6 @@ def matmul_fp8_row(
         desc_a = desc_helper.get_tma_descriptor_kernel_param("a")
         desc_b = desc_helper.get_tma_descriptor_kernel_param("b")
         desc_c = desc_helper.get_tma_descriptor_kernel_param("c")
-        desc_a_scale = desc_helper.get_tma_descriptor_kernel_param("a_scale")
-        desc_b_scale = desc_helper.get_tma_descriptor_kernel_param("b_scale")
         desc_bias = desc_helper.get_tma_descriptor_kernel_param("bias")
 
         bias_dtype_triton = None
@@ -1348,82 +1358,12 @@ def matmul_fp8_row(
             NUM_SMS=NUM_SMS,
             USE_BIAS=bias is not None,
         )
-    elif tma_persistent:
-        # used by TMA persistent kernel
-        desc_helper = TmaAutoTuneHelper()
-        desc_helper.init_tma_descriptor("a")
-        desc_helper.init_tma_descriptor("b")
-        desc_helper.init_tma_descriptor("c")
-        desc_helper.init_tma_descriptor("a_scale")
-        desc_helper.init_tma_descriptor("b_scale")
-        desc_helper.init_tma_descriptor("bias")
+    elif tma_persistent and tma_aligned:
+        # Descriptors are built in-kernel; just register an allocator for them.
+        def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+            return torch.empty(size, device=a.device, dtype=torch.int8)
 
-        def persistent_grid_tma(META: Dict[str, int]) -> Tuple[int]:
-            nonlocal desc_helper  # noqa: F824
-            assert a_scale is not None  # Type narrowing for Pyre
-            desc_helper.fill_2d_tma_descriptor(
-                "a",
-                a.data_ptr(),
-                M,
-                K,
-                META["BLOCK_M"],
-                META["BLOCK_K"],
-                a.element_size(),
-            )
-
-            desc_helper.fill_2d_tma_descriptor(
-                "b",
-                b.data_ptr(),
-                N,
-                K,
-                META["BLOCK_N"],
-                META["BLOCK_K"],
-                b.element_size(),
-            )
-            desc_helper.fill_2d_tma_descriptor(
-                "c",
-                c.data_ptr(),
-                M,
-                N,
-                META["BLOCK_M"],
-                META["BLOCK_N"],
-                c.element_size(),
-            )
-            desc_helper.fill_1d_tma_descriptor(
-                "a_scale",
-                a_scale.data_ptr(),
-                M,
-                META["BLOCK_M"],
-                a_scale.element_size(),
-            )
-            desc_helper.fill_1d_tma_descriptor(
-                "b_scale",
-                b_scale.data_ptr(),
-                N,
-                META["BLOCK_N"],
-                b_scale.element_size(),
-            )
-            if bias is not None:
-                desc_helper.fill_1d_tma_descriptor(
-                    "bias",
-                    bias.data_ptr(),
-                    N,
-                    META["BLOCK_N"],
-                    bias.element_size(),
-                )
-            return (
-                min(
-                    NUM_SMS,
-                    triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
-                ),
-            )
-
-        desc_a = desc_helper.get_tma_descriptor_kernel_param("a")
-        desc_b = desc_helper.get_tma_descriptor_kernel_param("b")
-        desc_c = desc_helper.get_tma_descriptor_kernel_param("c")
-        desc_a_scale = desc_helper.get_tma_descriptor_kernel_param("a_scale")
-        desc_b_scale = desc_helper.get_tma_descriptor_kernel_param("b_scale")
-        desc_bias = desc_helper.get_tma_descriptor_kernel_param("bias")
+        triton.set_allocator(alloc_fn)
 
         bias_dtype_triton = None
         if bias is not None:
@@ -1431,20 +1371,20 @@ def matmul_fp8_row(
 
         # pyre-ignore
         torch._library.capture_triton(_kernel_matmul_fp8_row_tma_persistent)[
-            persistent_grid_tma
+            persistent_grid
         ](
-            desc_a,
-            desc_b,
-            desc_c,
+            a,
+            b,
+            c,
             M,
             N,
             K,
             m_key,
             n_key,
             k_key,
-            desc_a_scale,
-            desc_b_scale,
-            desc_bias,
+            a_scale,
+            b_scale,
+            bias,
             a.stride(0),
             a.stride(1),
             b.stride(0),

--- a/test/gemm/triton/fp8_gemm_test.py
+++ b/test/gemm/triton/fp8_gemm_test.py
@@ -102,6 +102,44 @@ class TestFp8Matmul(unittest.TestCase):
         _test_matmul_fp8_row((3, 4, 5), torch.device("cpu"), False)
         _test_matmul_fp8_row((3, 4, 5), torch.device("cpu"), False, True)
 
+    @unittest.skipIf(
+        not torch.cuda.is_available()
+        or torch.version.hip is not None
+        or torch.cuda.get_device_properties(torch.cuda.current_device()).major < 9,
+        "Device-side TMA persistent path is CUDA-only (Hopper+)",
+    )
+    def test_matmul_fp8_row_tma_persistent(self) -> None:
+        # Aligned shapes (K % 16 == 0, N % 8 == 0) take the device-side TMA path;
+        # the tiny shapes in test_matmul_fp8_row only hit the fallback. Compare to
+        # a dequantized-fp8 reference to isolate the kernel from quant noise.
+        for M, N, K, fast_accum, use_bias in [
+            (128, 256, 128, True, False),
+            (256, 256, 256, False, False),
+            (512, 512, 256, True, True),
+        ]:
+            a = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+            b = torch.randn(N, K, dtype=torch.bfloat16, device="cuda")
+            bias = (
+                torch.randn(N, dtype=torch.float32, device="cuda") if use_bias else None
+            )
+            a_fp8, a_scale = quantize_fp8_row(a)
+            b_fp8, b_scale = quantize_fp8_row(b)
+            ref = (a_fp8.to(torch.float32) * a_scale[:, None]) @ (
+                b_fp8.to(torch.float32) * b_scale[:, None]
+            ).T
+            if use_bias:
+                ref = ref + bias
+            out = matmul_fp8_row(
+                a_fp8,
+                b_fp8,
+                a_scale,
+                b_scale,
+                bias=bias,
+                fp8_fast_accum=fast_accum,
+                tma_persistent=True,
+            )
+            torch.testing.assert_close(out.to(torch.float32), ref, atol=1e-1, rtol=2e-2)
+
     def test_matmul_fp8_row_skip_scaling(self) -> None:
         def _fp8_clamp(x: torch.Tensor) -> torch.Tensor:
             fp8_dtype = torch.float8_e4m3fn


### PR DESCRIPTION
## Summary

On Triton 3.x, `matmul_fp8_row(..., tma_persistent=True)` — the **default Nvidia fp8-rowwise path** — is hard-broken: `_kernel_matmul_fp8_row_tma_persistent` calls `tl._experimental_descriptor_load/_store` and the host builds descriptors via `TmaAutoTuneHelper` → `triton.runtime.driver.active.utils.fill_*_tma_descriptor`. **All of these were removed in Triton 3.x.** This PR migrates the non-warp-specialized TMA persistent kernel to the stable device-side `tl.make_tensor_descriptor` API, mirroring the grouped-GEMM migration (FBGEMM #4866 store path / #5937 load path).

## Root cause

On Triton 3.6 the persistent fp8 path fails at launch:

```
AttributeError: 'CudaUtils' object has no attribute 'fill_1d_tma_descriptor'
```

- kernel side: `tl._experimental_descriptor_load` / `_experimental_descriptor_store` — removed.
- host side: `TmaAutoTuneHelper.fill_{1d,2d}_tma_descriptor` → `driver.active.utils.fill_*_tma_descriptor` — removed.

So the entire `tma_persistent` branch cannot run (not merely TMA-off).

## What this PR does

- **`_kernel_matmul_fp8_row_tma_persistent`**: build A/B/C descriptors in-kernel with `tl.make_tensor_descriptor`; load via `a_desc.load(...)` and store via `c_desc.store(...)`. Per-row scales and bias move to plain `tl.load` (they are 1-D and tiny — same pattern already used by `grouped_gemm.py`).
- **`matmul_fp8_row`**: drop the `TmaAutoTuneHelper` descriptor build for this branch; pass the raw `a`/`b`/`c`/scale/bias tensors and register a `triton.set_allocator` for the device-side descriptor scratch.
- **Alignment guard**: device-side TMA requires the innermost global stride to be 16-byte aligned (`K` bytes for fp8 A/B, `N*elem_size` for the output). Shapes that violate this (e.g. tiny `K`/`N`) now fall back to the existing non-TMA persistent kernels, so they stay correct.

## What this PR does NOT do (and why)

- The **warp-specialized** kernel (`_kernel_matmul_fp8_row_tma_persistent_ws_cooperative`) is **not** migrated. It requires `tl.async_task` (the WS Triton fork), which is unavailable on stock Triton 3.x (`hasattr(tl, "async_task")` is `False`), so the branch is unreachable here and I can't exercise it. Migrating it is a follow-up — same scope boundary as #5937.

## Testing

H100, Triton 3.6.0 / torch 2.11:

- `test/gemm/triton/fp8_gemm_test.py::TestFp8Matmul::test_matmul_fp8_row` — **fails before this PR** (the `AttributeError` above), **passes after**.
- New `test_matmul_fp8_row_tma_persistent` exercises the device-side TMA path on aligned shapes (the pre-existing test only uses tiny shapes, which now take the fallback) and checks against a dequantized-fp8 reference — kernel rel-err ~3e-3.

Related: FBGEMM #4866 (store-path migration), #5937 (grouped-GEMM load-path migration this mirrors).
