### PR TITLE
[ROCm] Fix get_clock_rate_in_khz() and _fp8_clamp() functions

### DIFF
--- a/mslk/gemm/triton/matmul_perf_model.py
+++ b/mslk/gemm/triton/matmul_perf_model.py
@@ -33,6 +33,12 @@ def get_clock_rate_in_khz():
     try:
         return nvsmi(["clocks.max.sm"])[0] * 1e3
     except FileNotFoundError:
+        # `nvidia-smi` is unavailable (e.g. on ROCm). On AMD there is no NVML, so
+        # read the clock directly from the torch device properties (in kHz).
+        if torch.version.hip is not None:
+            return torch.cuda.get_device_properties(
+                torch.cuda.current_device()
+            ).clock_rate
         import pynvml  # @manual=fbsource//third-party/pypi/pynvml:pynvml
 
         pynvml.nvmlInit()

--- a/test/gemm/triton/fp8_gemm_test.py
+++ b/test/gemm/triton/fp8_gemm_test.py
@@ -14,6 +14,7 @@ import torch
 if torch.cuda.is_available():
     from mslk.gemm.triton.fp8_gemm import matmul_fp8_block, matmul_fp8_row
     from mslk.quantize.triton.fp8_quantize import quantize_fp8_block, quantize_fp8_row
+    from mslk.utils.triton.fp8_utils import get_fp8_constants
 
 
 @unittest.skipIf(
@@ -142,8 +143,7 @@ class TestFp8Matmul(unittest.TestCase):
 
     def test_matmul_fp8_row_skip_scaling(self) -> None:
         def _fp8_clamp(x: torch.Tensor) -> torch.Tensor:
-            fp8_dtype = torch.float8_e4m3fn
-            fp8_max = torch.finfo(fp8_dtype).max
+            fp8_dtype, _, fp8_max, _ = get_fp8_constants()
             xq = torch.clamp(x, min=-1 * fp8_max, max=fp8_max).to(fp8_dtype)
             return xq
 


### PR DESCRIPTION
Current ROCm CI fails with missing `pynvml` dependency and mismatched fp8 format on ROCm. This PR addresses those issues