### PR TITLE
Add MXFP4 (E2M1/E8M0) quantize kernels + tests

### DIFF
--- a/mslk/quantize/triton/fp4_primitives/__init__.py
+++ b/mslk/quantize/triton/fp4_primitives/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+fp4_primitives — Reusable building blocks for FP4 (E2M1) quantization kernels.
+
+Submodules
+----------
+- constants: FP4/FP8 numeric limits, format parameters, RoundingMode enum.
+- scale: Triton JIT helpers for computing MX4 quantization scales.
+- packing: Triton JIT helpers for FP32→FP4 conversion and packing.
+- layout: Blackwell 128×4 scale layout (blocked offset + segment map).
+"""
+
+from mslk.quantize.triton.fp4_primitives.constants import (  # noqa: F401
+    BF16_MIN_NORMAL,
+    E8M0_EXPONENT_BIAS,
+    RoundingMode,
+)
+from mslk.quantize.triton.fp4_primitives.layout import (  # noqa: F401
+    blocked_scale_offset,
+    stacked_segment_map,
+)
+from mslk.quantize.triton.fp4_primitives.packing import (  # noqa: F401
+    convert_fp32_to_fp4_packed,
+)
+from mslk.quantize.triton.fp4_primitives.scale import (  # noqa: F401
+    mx4_scale_normalize_encode,
+)

--- a/mslk/quantize/triton/fp4_primitives/constants.py
+++ b/mslk/quantize/triton/fp4_primitives/constants.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Constants and enums for FP4 (E2M1) quantization.
+
+Defines numeric limits, format parameters, and rounding modes used throughout
+the MX4 quantization pipeline.
+"""
+
+from enum import IntEnum
+
+from triton import language as tl  # @manual=//triton:triton
+
+
+# =============================================================================
+# E8M0 / BF16 Constants
+# =============================================================================
+#
+# These are annotated ``tl.constexpr`` at module scope so they remain valid Triton
+# kernel constants in OSS: OSS Triton rejects a plain (non-constexpr) Python global
+# referenced inside a ``@triton.jit`` kernel (triton-lang/triton#3762). The
+# annotation is a no-op for host/Python use (the value is the bare float/int).
+E8M0_EXPONENT_BIAS: tl.constexpr = 127  # type: ignore[Incompatible variable type]
+"""Exponent bias for the E8M0 scale format (same as IEEE 754 FP32 exponent bias)."""
+
+BF16_MIN_NORMAL: tl.constexpr = 2 ** (-126)  # type: ignore[Incompatible variable type]
+"""Minimum positive normal BF16 value; zero-guard in MX4 scale computation."""
+
+
+class RoundingMode(IntEnum):
+    """Rounding options for quantization.
+
+    Controls how shared exponents are rounded during quantization. Each mode
+    trades off between accuracy and hardware cost:
+
+    - ``nearest``: Round to nearest integer (0.5 rounds up). Simple and fast.
+    - ``floor``: Always round down. Uses fast FP32 bit manipulation.
+    - ``even``: Round to nearest even integer (banker's rounding). Reduces bias.
+    - ``stochastic``: Add random noise before truncation. Unbiased in expectation.
+    - ``ceil``: Always round up. Most conservative (largest exponent).
+    """
+
+    nearest = 0
+    floor = 1
+    even = 2
+    stochastic = 3
+    ceil = 4

--- a/mslk/quantize/triton/fp4_primitives/layout.py
+++ b/mslk/quantize/triton/fp4_primitives/layout.py
@@ -1,0 +1,139 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Storage layout primitives for the Blackwell 128×4 FP4 scale arrangement.
+
+Provides the blocked-layout offset helper and the stacked-MoE segment map used
+by the MX4 quantize kernels.
+"""
+
+import triton  # @manual
+from triton import language as tl  # @manual
+
+
+@triton.jit
+def blocked_scale_offset(logical_row, logical_col, n_col_blocks, num_cols):
+    """Convert logical (row, col) scale indices to Blackwell blocked layout offsets.
+
+    The row stride is padded to a multiple of 4 columns (``n_col_blocks * 4``), matching
+    the canonical NVIDIA/cuBLAS block-scaled layout (and ``_to_blocked`` /
+    ``_from_blocked``). When ``num_cols`` is already a multiple of 4 this is unchanged;
+    otherwise it places each logical row at the padded stride so the dense un-blocking
+    inverse (and the GEMM) read it back from the correct offset.
+
+    Args:
+        logical_row: Row indices into the logical scale matrix (int tensor).
+        logical_col: Column indices into the logical scale matrix (int tensor).
+        n_col_blocks: Number of 4-column blocks (ceil(total_scale_cols / 4)).
+        num_cols: Unpadded scale columns per row; used by callers for the store mask
+            (the padded tail columns are left zero), not for the offset itself.
+
+    Returns:
+        Flat offsets into the blocked layout buffer.
+    """
+    # Pad the row stride to a multiple of 4 columns so the layout matches the canonical
+    # NVIDIA blocked-scale convention even when num_cols is not a multiple of 4.
+    flat_idx = logical_row * (n_col_blocks * 4) + logical_col
+
+    elems_per_row_block = 512 * n_col_blocks
+
+    first_dim = flat_idx // elems_per_row_block
+    second_dim = (flat_idx % elems_per_row_block) // (128 * n_col_blocks)
+    third_dim = (flat_idx % (128 * n_col_blocks)) // (4 * n_col_blocks)
+    fourth_dim = (flat_idx % (4 * n_col_blocks)) // 4
+    fifth_dim = flat_idx % 4
+
+    return (
+        first_dim * elems_per_row_block
+        + fourth_dim * 512
+        + third_dim * 16
+        + second_dim * 4
+        + fifth_dim
+    )
+
+
+@triton.jit
+def stacked_segment_map(
+    m_sizes_ptr,  # [num_segments] int64 — rows per segment
+    pid_m,  # program id along the padded-row (M) grid axis
+    M_PER_BLOCK: tl.constexpr,  # rows per program (power of 2, capped at 128)
+    NUM_SEGMENTS: tl.constexpr,  # number of expert segments
+    PREFIX_NUM: tl.constexpr,  # next_power_of_2(NUM_SEGMENTS) for tl.cumsum
+    BSEARCH_ITERS: tl.constexpr,  # ceil(log2(NUM_SEGMENTS)) binary search iterations
+):
+    """Map a tile of *padded* rows back to their MoE segments (stacked quant).
+
+    Loads ``m_sizes``, computes inclusive/exclusive cumsums of the logical and
+    128-row-padded segment row counts, then binary-searches each padded row in
+    this program's tile to its segment, deriving the logical row index and a
+    per-row validity mask.
+
+    Returns (all shape ``[M_PER_BLOCK]`` unless noted):
+      - ``padded_rows`` (int64): padded-row indices owned by this program.
+      - ``logical_rows``: logical (unpadded) row index, clamped to 0 where invalid.
+      - ``is_valid_row`` (bool): row is a real (non-padding) row within the buffer.
+      - ``padded_total`` (scalar): total padded-row count across all segments.
+      - ``seg_idx``: segment each padded row belongs to (used by NVFP4-stacked for
+        the per-row global-scale gather; MX4-stacked ignores it).
+
+    Only these five are returned. The intermediate cumsums
+    (``cumsum_exc``/``padded_cumsum_exc``/``seg_cumsum``/``seg_padded_cumsum``/``seg_m``)
+    are computed locally to derive ``logical_rows``/``is_valid_row`` and are not
+    returned — no caller needs them.
+
+    NOTE: the fully-slack-tile early-return
+    (``if pid_m * M_PER_BLOCK >= padded_total: return``) cannot live here — a
+    ``@triton.jit`` helper cannot return out of its caller — so each kernel must
+    perform that early-return itself using the returned ``padded_total``.
+    """
+    seg_offs = tl.arange(0, PREFIX_NUM)
+    seg_mask = seg_offs < NUM_SEGMENTS
+    m_vals = tl.load(m_sizes_ptr + seg_offs, mask=seg_mask, other=0)
+    cumsum_inc = tl.cumsum(m_vals, axis=0)
+    padded_vals = ((m_vals + 127) // 128) * 128
+    padded_cumsum_inc = tl.cumsum(padded_vals, axis=0)
+    # Exclusive cumsums: [0, m_0, m_0+m_1, ...]
+    cumsum_exc = cumsum_inc - m_vals
+    padded_cumsum_exc = padded_cumsum_inc - padded_vals
+
+    # Promote to int64: padded_r * num_scale_cols can overflow int32 for
+    # large stacked inputs.
+    padded_total = tl.sum(padded_vals, axis=0)  # actual padded-row count
+    padded_rows = (pid_m * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK)).to(
+        tl.int64
+    )  # [M_PER_BLOCK] — padded-row indices
+
+    # Binary search padded_rows against padded_cumsum_exc → segment.
+    lo = tl.zeros([M_PER_BLOCK], dtype=tl.int32)
+    hi = tl.full([M_PER_BLOCK], NUM_SEGMENTS - 1, dtype=tl.int32)
+    for _ in range(BSEARCH_ITERS):
+        mid = (lo + hi + 1) // 2
+        mid_val = tl.gather(padded_cumsum_exc, mid, 0)
+        lo = tl.where(mid_val <= padded_rows, mid, lo)
+        hi = tl.where(mid_val <= padded_rows, hi, mid - 1)
+    seg_idx = lo  # [M_PER_BLOCK]
+
+    seg_cumsum = tl.gather(cumsum_exc, seg_idx, 0)  # [M_PER_BLOCK]
+    seg_padded_cumsum = tl.gather(padded_cumsum_exc, seg_idx, 0)
+    seg_m = tl.gather(m_vals, seg_idx, 0)
+    padded_r_in_seg = padded_rows - seg_padded_cumsum  # [M_PER_BLOCK]
+    # Valid = within the segment's logical rows AND within actual padded total.
+    is_valid_row = (padded_r_in_seg < seg_m) & (padded_rows < padded_total)
+    # Logical row index (safe-clamped to 0 where invalid, for masked loads).
+    logical_rows = tl.where(
+        is_valid_row, seg_cumsum + padded_r_in_seg, 0
+    )  # [M_PER_BLOCK]
+
+    return (
+        padded_rows,
+        logical_rows,
+        is_valid_row,
+        padded_total,
+        seg_idx,
+    )

--- a/mslk/quantize/triton/fp4_primitives/packing.py
+++ b/mslk/quantize/triton/fp4_primitives/packing.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+FP4 packing primitives for converting float values to packed FP4 E2M1 format.
+
+Blackwell PTX hardware-accelerated packing.
+"""
+
+import triton  # @manual
+from triton import language as tl  # @manual
+
+
+@triton.jit
+def convert_fp32_to_fp4_packed(x_pairs):
+    """Convert FP32 value pairs to packed FP4 E2M1 format using PTX inline assembly.
+
+    Uses the Blackwell ``cvt.rn.satfinite.e2m1x2.f32`` PTX instruction to convert
+    pairs of FP32 values into packed FP4 bytes. Each output byte contains two
+    E2M1 values:
+
+    - Low nibble (bits 0-3): first value of the pair
+    - High nibble (bits 4-7): second value of the pair
+
+    The PTX instruction handles:
+    - Round-to-nearest-even rounding
+    - Saturation to the FP4 E2M1 range [-6.0, 6.0]
+    - Proper encoding of E2M1 special values
+
+    Implementation detail: The ``pack=4`` parameter means 4 pairs are processed
+    per inline asm invocation, producing 4 bytes that are assembled into a single
+    uint32 via ``mov.b32``.
+
+    Args:
+        x_pairs: List of 8 float32 tensors representing 4 pairs:
+            [pair0_lo, pair1_lo, pair2_lo, pair3_lo,
+             pair0_hi, pair1_hi, pair2_hi, pair3_hi]
+
+    Returns:
+        Packed uint8 tensor where each byte contains two E2M1 values.
+
+    Note:
+        Requires Blackwell (SM 100+) GPU. Will fail on older architectures.
+    """
+    x_fp4x2 = tl.inline_asm_elementwise(
+        asm="""
+        {
+        .reg .b8 byte0, byte1, byte2, byte3;
+        cvt.rn.satfinite.e2m1x2.f32 byte0, $5, $1;
+        cvt.rn.satfinite.e2m1x2.f32 byte1, $6, $2;
+        cvt.rn.satfinite.e2m1x2.f32 byte2, $7, $3;
+        cvt.rn.satfinite.e2m1x2.f32 byte3, $8, $4;
+        mov.b32 $0, {byte0, byte1, byte2, byte3};
+        }
+        """,
+        constraints=("=r,r,r,r,r,r,r,r,r"),
+        args=x_pairs,
+        dtype=tl.uint8,
+        is_pure=True,
+        pack=4,
+    )
+
+    return x_fp4x2

--- a/mslk/quantize/triton/fp4_primitives/scale.py
+++ b/mslk/quantize/triton/fp4_primitives/scale.py
@@ -1,0 +1,258 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Scale computation primitives for MX4 quantization.
+
+Triton JIT helpers for the shared MX4 exponent, per-group scale + normalize,
+and biased E8M0 encode.
+"""
+
+import triton  # @manual
+from mslk.quantize.triton.fp4_primitives.constants import (
+    BF16_MIN_NORMAL,
+    E8M0_EXPONENT_BIAS,
+)
+from triton import language as tl  # @manual
+
+
+# =============================================================================
+# Shared Exponent Helpers
+# =============================================================================
+
+
+@triton.jit
+def _floor_log2(x):
+    """Efficiently compute floor(log2(x)) using FP32 bit manipulation.
+
+    Instead of computing ``floor(log2(x))`` via expensive math operations, this
+    extracts the exponent field directly from the IEEE 754 FP32 bit representation:
+
+        FP32 layout:  [1 sign][8 exponent][23 mantissa]
+        exponent_bits = (bitcast_to_int(x) & 0x7F800000) >> 23
+        floor_log2    = exponent_bits - 127  (remove FP32 bias)
+
+    This is exact for powers of 2, and equivalent to floor(log2(x)) for all
+    positive normal floats (because the mantissa bits only add a fractional part
+    to the true log2).
+
+    Args:
+        x: FP32 input tensor. Must be positive (undefined for x <= 0).
+
+    Returns:
+        floor(log2(x)) as float32 tensor.
+    """
+    FP32_EXP_MASK: tl.constexpr = 0x7F800000  # type: ignore[Incompatible variable type]
+    FP32_EXP_OFFSET: tl.constexpr = 23  # type: ignore[Incompatible variable type]
+    FP32_EXP_BIAS: tl.constexpr = 127  # type: ignore[Incompatible variable type]
+
+    x = x.to(tl.int32, bitcast=True) & FP32_EXP_MASK
+    x = x >> FP32_EXP_OFFSET
+    return (x - FP32_EXP_BIAS).to(tl.float32)
+
+
+@triton.jit
+def _round_log2_via_bits(x, val_to_add: tl.constexpr):
+    """Compute a rounded ``log2(x)`` via FP32 bit manipulation.
+
+    Generalizes :func:`_floor_log2` by adding ``val_to_add`` to the FP32 bit
+    representation **before** extracting the exponent. Choice of
+    ``val_to_add`` selects the rounding mode:
+
+      - ``val_to_add = 0``               → ``floor(log2(x))`` (== :func:`_floor_log2`).
+      - ``val_to_add = (1 << 23) - 1``   → round-up (ceil): equals
+        ``ceil(log2(x))`` for positive normals. The carry happens iff
+        the mantissa is non-zero, i.e. iff ``x`` is not an exact power
+        of two.
+
+    Note that this helper computes the *mathematically exact*
+    ``ceil(log2(x))`` for positive normal FP32 inputs, which can differ
+    from ``tl.ceil(tl.log2(x))`` at exact powers of two when the
+    underlying device intrinsic ``log2`` returns a value slightly above
+    the true integer (a known ULP-level imprecision in CUDA libm).
+
+    Args:
+        x: Positive FP32 tensor (undefined for ``x <= 0`` and for
+            inf/NaN — same domain as :func:`_floor_log2`).
+        val_to_add: Compile-time integer constant selecting the rounding
+            mode (see above).
+
+    Returns:
+        Rounded ``log2(x)`` as a float32 tensor.
+    """
+    FP32_EXP_MASK: tl.constexpr = 0x7F800000  # type: ignore[Incompatible variable type]
+    FP32_EXP_OFFSET: tl.constexpr = 23  # type: ignore[Incompatible variable type]
+    FP32_EXP_BIAS: tl.constexpr = 127  # type: ignore[Incompatible variable type]
+
+    bits = x.to(tl.int32, bitcast=True) + val_to_add
+    bits = (bits & FP32_EXP_MASK) >> FP32_EXP_OFFSET
+    return (bits - FP32_EXP_BIAS).to(tl.float32)
+
+
+@triton.jit
+def _compute_exp(
+    group_max,
+    rounding_mode,
+    rand_bits,
+    MBITS: tl.constexpr,
+):
+    """Compute the shared MX4 exponent for a group using the specified rounding mode.
+
+    The shared exponent determines the scale for a group of values. Different
+    rounding modes produce different exponents:
+
+    - ``nearest`` (0): Round log2(group_max) to nearest integer.
+    - ``floor`` (1): Use fast bit-manipulation floor(log2).
+    - ``even`` (2): Pre-round mantissa bits, then floor(log2). Reduces bias.
+    - ``stochastic`` (3): Add random noise to mantissa, then floor(log2).
+    - ``ceil`` (4): Always round up log2(group_max).
+
+    Args:
+        group_max: Per-group maximum absolute values (float32 tensor).
+        rounding_mode: Which rounding mode to use (int or RoundingMode value).
+        rand_bits: Random integer values used for stochastic rounding (ignored for
+            other modes).
+        MBITS: Number of mantissa bits in the target MX4 format (compile-time constant).
+
+    Returns:
+        Shared exponent for each group as float32 tensor.
+    """
+    MBITS_FP32: tl.constexpr = 23  # type: ignore[Incompatible variable type]
+    M_ROUND: tl.constexpr = (1 << (MBITS_FP32 - MBITS - 1)) - 1  # type: ignore
+    RAND_MASK: tl.constexpr = (1 << (MBITS_FP32 - MBITS)) - 1  # type: ignore
+    CEIL_ROUND: tl.constexpr = (1 << MBITS_FP32) - 1  # type: ignore
+
+    if rounding_mode == 0:
+        # nearest (round-half-up of log2). The "correct" round-half-up
+        # transition is at x = 2^k * sqrt(2), which does not correspond
+        # to a clean bit-trick threshold, so we keep the legacy
+        # ``floor(log2(x) + 0.5)`` formulation here.
+        return tl.floor(tl.log2(group_max) + 0.5)
+    if rounding_mode == 1:
+        return _floor_log2(group_max)
+    elif rounding_mode == 2:
+        group_max = group_max.to(tl.int32, bitcast=True) + M_ROUND
+        return _floor_log2(group_max)
+    elif rounding_mode == 3:
+        group_max = group_max.to(tl.int32, bitcast=True) + (RAND_MASK & rand_bits)
+        return _floor_log2(group_max)
+    else:
+        # ceil: round-up via bit-extract.
+        return _round_log2_via_bits(group_max, CEIL_ROUND)
+
+
+# =============================================================================
+# MX4 Scale Computation
+# =============================================================================
+
+
+@triton.jit
+def encode_mx4_exponent(group_exp):
+    """Encode an integer-valued group exponent for biased E8M0 storage.
+
+    Adds the E8M0 exponent bias (127) and casts to int8 for storage. This is
+    the inverse of decoding: ``original_exp = stored_value - 127``.
+
+    Args:
+        group_exp: Integer-valued shared exponent (float32 tensor), typically
+            in the range [-127, 125] after clamping.
+
+    Returns:
+        Biased exponent as int8 tensor, with values in [0, 252].
+    """
+    return (group_exp + E8M0_EXPONENT_BIAS).to(tl.int8)
+
+
+@triton.jit
+def mx4_scale_normalize_encode(
+    x_blocks,  # [M_PER_BLOCK, NUM_GROUPS, GROUP_SIZE] fp32 tile (pre-amax reshape)
+    block_amax,  # [M_PER_BLOCK, NUM_GROUPS] per-group abs-max
+    pid_m,  # tl.program_id(1) (runtime)
+    pid_n,  # tl.program_id(0) (runtime)
+    seed,  # int64 seed for tl.randint (only consulted when STOCHASTIC=True)
+    N,  # number of columns (runtime int)
+    M_PER_BLOCK: tl.constexpr,  # rows per program
+    NUM_GROUPS: tl.constexpr,  # scale groups per 64-col tile (TILE_N // GROUP_SIZE)
+    GROUP_SIZE: tl.constexpr,  # elements per scale group (32 for MX4)
+    ROUNDING_MODE: tl.constexpr,  # RoundingMode enum for the shared exponent
+    EBITS: tl.constexpr,  # exponent bits in target FP4 format (2 for E2M1)
+    MBITS: tl.constexpr,  # mantissa bits in target FP4 format (1 for E2M1)
+    STOCHASTIC: tl.constexpr,  # True → software stochastic rounding
+):
+    """Shared MX4 scale + normalize + (optional stochastic) + E8M0 encode.
+
+    Given the fp32 tile ``x_blocks`` and its per-group ``block_amax``, this:
+      1. zero-guards amax with ``BF16_MIN_NORMAL``;
+      2. computes the shared exponent via ``_compute_exp`` (per-group stochastic
+         rand bits when ``STOCHASTIC``), subtracts ``EBITS``, clamps to [-127, 125];
+      3. builds the fp32 scale via an **fp64** ``exp2`` intermediate and divides
+         ``x_blocks`` by it;
+      4. optionally adds per-element mantissa-LSB noise for stochastic rounding of
+         the FP32→FP4 cast (decorrelated stream via ``seed ^ 0x5A5A5A5A``);
+      5. encodes the exponent as biased E8M0 int8.
+
+    The stochastic group/element offsets use the **physical** grid row
+    ``pid_m * M_PER_BLOCK``.
+
+    Returns ``(x_blocks, encoded_scales)`` where ``x_blocks`` is the normalized
+    (and stochastically perturbed) tile and ``encoded_scales`` is int8 E8M0.
+    """
+    safe_amax = tl.where(block_amax == 0, BF16_MIN_NORMAL, block_amax)
+
+    # Stochastic rounding (OCP MX v1.0): per-group rand bits feed the
+    # ``rounding_mode == 3`` branch of ``_compute_exp``. When
+    # ``STOCHASTIC=False``, we pass scalar ``0`` so the non-stochastic
+    # path is byte-identical to the pre-stochastic kernel.
+    if STOCHASTIC:
+        groups_per_row = N // GROUP_SIZE
+        group_offsets = (pid_m * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK))[
+            :, None
+        ] * groups_per_row + (pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS))[None, :]
+        group_rand_bits = tl.randint(seed, group_offsets, n_rounds=7)
+        group_exp = _compute_exp(safe_amax, ROUNDING_MODE, group_rand_bits, MBITS)
+    else:
+        group_exp = _compute_exp(safe_amax, ROUNDING_MODE, 0, MBITS)
+    group_exp = group_exp - EBITS
+    group_exp = tl.clamp(group_exp, -127, 125)
+
+    # Use float64 intermediate for exp2 precision
+    scale_float = tl.exp2(group_exp.to(tl.float64)).to(tl.float32)
+
+    # Normalize input by dividing by scale
+    x_blocks = x_blocks / scale_float[:, :, None]
+
+    # Per-element stochastic rounding on the FP32→FP4 cast. Add uniform noise in
+    # the discarded mantissa bits before the ``cvt.rn.satfinite.e2m1x2.f32`` PTX
+    # cast — the noise crosses the half-ulp boundary with the correct probability,
+    # giving unbiased stochastic rounding. The element stream is decorrelated from
+    # the per-group stream via a constexpr XOR of the seed
+    # (``ELEM_SEED_XOR = 0x5A5A5A5A``). The noise mask ``(1 << (23 - MBITS)) - 1``
+    # covers the bits strictly below the rn-tiebreak position for E2M1 (MBITS=1);
+    # we subtract half the mask so the noise is symmetric about 0 (the FP32 sign
+    # bit is untouched).
+    if STOCHASTIC:
+        ELEM_SEED_XOR: tl.constexpr = 0x5A5A5A5A  # type: ignore
+        elem_offsets = (
+            (pid_m * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK))[:, None, None] * N
+            + (pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS))[None, :, None]
+            * GROUP_SIZE
+            + tl.arange(0, GROUP_SIZE)[None, None, :]
+        )
+        per_elem_rand_bits = tl.randint(seed ^ ELEM_SEED_XOR, elem_offsets, n_rounds=7)
+        PER_ELEM_RAND_MASK: tl.constexpr = (1 << (23 - MBITS)) - 1  # type: ignore
+        x_bits = x_blocks.to(tl.int32, bitcast=True)
+        x_bits = (
+            x_bits
+            + (per_elem_rand_bits & PER_ELEM_RAND_MASK)
+            - (PER_ELEM_RAND_MASK >> 1)
+        )
+        x_blocks = x_bits.to(tl.float32, bitcast=True)
+
+    # Encode as biased E8M0 int8
+    encoded_scales = encode_mx4_exponent(group_exp)
+    return x_blocks, encoded_scales

--- a/mslk/quantize/triton/quantize_kernels/__init__.py
+++ b/mslk/quantize/triton/quantize_kernels/__init__.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Self-contained, single-operator MX4 FP4 quantization Triton kernels.
+
+Each module owns exactly one ``@triton.jit`` kernel, specialized for one
+operator (MX4 non-stacked / stacked) with its ``SCALE_FORMAT`` / ``STACKED``
+behavior hardcoded, so each operator can be read, perf-tuned, and
+regression-tested in isolation. Genuinely-shared pieces (segment mapping,
+scale math, pack primitives) live in ``fp4_primitives``.
+"""
+
+from typing import Optional
+
+import torch
+
+
+def _resolve_seed(seed: Optional[int], stochastic: bool, device: torch.device) -> int:
+    """Resolve the user-supplied ``seed`` to an int the kernel can consume.
+
+    Behavior matrix:
+      - ``stochastic=False``: returns ``0``. The kernel's ``STOCHASTIC=False``
+        constexpr DCE's the entire stochastic branch, so the value is
+        irrelevant.
+      - ``stochastic=True`` and ``seed is not None``: returns
+        ``int(seed) & ((1 << 63) - 1)`` (mask to int63 to stay within
+        ``tl.int64`` range and avoid Python int overflow on the kernel
+        boundary).
+      - ``stochastic=True`` and ``seed is None``: derives a seed from
+        ``torch.cuda.default_generators[device.index].initial_seed()`` so
+        callers respect ``torch.manual_seed``. Falls back to ``0`` when
+        the input is on CPU (no CUDA generator available); the kernel
+        will only be launched on CUDA in practice.
+    """
+    if not stochastic:
+        return 0
+    if seed is not None:
+        return int(seed) & ((1 << 63) - 1)
+    if device.type == "cuda":
+        gen = torch.cuda.default_generators[device.index]
+        return int(gen.initial_seed()) & ((1 << 63) - 1)
+    return 0

--- a/mslk/quantize/triton/quantize_kernels/mx4.py
+++ b/mslk/quantize/triton/quantize_kernels/mx4.py
@@ -1,0 +1,272 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Self-contained MX4 (E8M0 scale) FP4 quantization kernel — non-stacked.
+
+Also hosts the ``quantize_mx4`` host wrapper that launches this kernel.
+"""
+
+from typing import Optional, Union
+
+import torch
+import triton  # @manual=//triton:triton
+from mslk.quantize.triton.fp4_primitives import (
+    blocked_scale_offset,
+    convert_fp32_to_fp4_packed,
+    mx4_scale_normalize_encode,
+    RoundingMode,
+)
+from mslk.quantize.triton.quantize_kernels import _resolve_seed
+from triton import language as tl  # @manual=//triton:triton
+
+
+@triton.jit
+def quantize_mx4_kernel(
+    x_ptr,  # [M, N] input tensor (bf16/fp16)
+    q_ptr,  # [M, N//2] output — packed FP4 pairs (uint8, 2 values per byte)
+    s_ptr,  # output — per-group E8M0 scales (int8) in blocked layout
+    stride_xm,  # row stride of x_ptr (elements to skip per row)
+    stride_xn,  # col stride of x_ptr (usually 1 for contiguous)
+    M,  # number of rows in the input matrix
+    N,  # number of columns in the input matrix
+    seed,  # int64 seed for tl.randint (Philox-3); only consulted when STOCHASTIC=True
+    M_PER_BLOCK: tl.constexpr,  # rows per program (power of 2, capped at 128)
+    USE_MASK: tl.constexpr,  # True when M or N don't align to tile boundaries
+    USE_INT64_INDEXING: tl.constexpr,  # True when M*N > 2^31-1
+    GROUP_SIZE: tl.constexpr,  # elements per scale group (32 for MX4)
+    ROUNDING_MODE: tl.constexpr,  # RoundingMode enum for shared exponent
+    EBITS: tl.constexpr,  # exponent bits in target FP4 format (2 for E2M1)
+    MBITS: tl.constexpr,  # mantissa bits in target FP4 format (1 for E2M1)
+    N_COL_BLOCKS: tl.constexpr,  # ceil(num_scale_cols / 4) — blocked layout offset
+    STOCHASTIC: tl.constexpr,  # True → enable software stochastic rounding
+):
+    """MX4 quantization kernel processing [M_PER_BLOCK, 64] tiles.
+
+    Each program quantizes a tile of [M_PER_BLOCK, 64] elements into packed FP4
+    bytes and per-group E8M0 (power-of-two biased int8) scales in the Blackwell
+    blocked layout. MX4 has no global scale.
+
+    Grid: (cdiv(N, 64), cdiv(M, M_PER_BLOCK) [+1 for tail zeroing when
+    M_PER_BLOCK != 128]).
+    """
+    TILE_N: tl.constexpr = 64  # type: ignore[Incompatible variable type]
+    NUM_GROUPS: tl.constexpr = TILE_N // GROUP_SIZE
+
+    pid_m = tl.program_id(1)
+    pid_n = tl.program_id(0)
+
+    # ========================================================================
+    # Tail-scale zeroing: when M_PER_BLOCK != 128, extra blocks zero out padded
+    # scales in the 128-row-aligned tail for tensor core compatibility.
+    # ========================================================================
+    if M_PER_BLOCK != 128 and pid_m * M_PER_BLOCK >= M:
+        offs_m = tl.arange(0, 128)[:, None]
+        logical_col = pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS)[None, :]
+        num_scale_cols = N // GROUP_SIZE
+        scale_offs = blocked_scale_offset(
+            offs_m, logical_col, N_COL_BLOCKS, num_scale_cols
+        )
+        oob_mask = (offs_m >= M) & tl.full((NUM_GROUPS,), True, dtype=tl.int1)[None, :]
+        zero_scales = tl.full([128, NUM_GROUPS], 0, dtype=tl.int8)
+        tl.store(s_ptr + scale_offs, zero_scales, mask=oob_mask)
+        return
+
+    # Compute tile offsets and load [M_PER_BLOCK, 64] tile.
+    offs_m = pid_m * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK)[:, None]
+    offs_n = pid_n * TILE_N + tl.arange(0, TILE_N)[None, :]
+    if USE_INT64_INDEXING:
+        offs_m = offs_m.to(tl.int64)
+        offs_n = offs_n.to(tl.int64)
+
+    if USE_MASK:
+        mask = (offs_m < M) & (offs_n < N)
+        other = 0.0
+    else:
+        mask = None
+        other = None
+
+    load_offsets = offs_m * stride_xm + offs_n * stride_xn
+    x = tl.load(x_ptr + load_offsets, mask=mask, other=other)
+
+    x_blocks = x.to(tl.float32).reshape(M_PER_BLOCK, NUM_GROUPS, GROUP_SIZE)
+
+    # Per-group amax
+    block_amax = tl.max(tl.abs(x_blocks), axis=2)  # [M_PER_BLOCK, NUM_GROUPS]
+
+    # ========================================================================
+    # MX4 scale computation (E8M0 biased exponent) + normalize + encode.
+    # Shared with quantize_mx4_stacked_kernel via mx4_scale_normalize_encode.
+    # ========================================================================
+    x_blocks, encoded_scales = mx4_scale_normalize_encode(
+        x_blocks,
+        block_amax,
+        pid_m,
+        pid_n,
+        seed,
+        N,
+        M_PER_BLOCK,
+        NUM_GROUPS,
+        GROUP_SIZE,
+        ROUNDING_MODE,
+        EBITS,
+        MBITS,
+        STOCHASTIC,
+    )
+
+    # ========================================================================
+    # Mask out-of-bounds scales to 0
+    # ========================================================================
+    if USE_MASK:
+        scale_offs_n = pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS)[None, :]
+        num_scale_cols = N // GROUP_SIZE
+        scale_mask = (offs_m < M) & (scale_offs_n < num_scale_cols)
+        encoded_scales = tl.where(scale_mask, encoded_scales, 0)
+
+    # ========================================================================
+    # Store scales — Blackwell blocked layout
+    # ========================================================================
+    logical_col = pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS)[None, :]
+    num_scale_cols = N // GROUP_SIZE
+    logical_row = pid_m * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK)[:, None]
+    if USE_INT64_INDEXING:
+        # flat_idx = logical_row * num_scale_cols overflows int32 once
+        # M * (N // GROUP_SIZE) > 2**31; promote like the data-offset paths above.
+        logical_row = logical_row.to(tl.int64)
+        logical_col = logical_col.to(tl.int64)
+    scale_offs = blocked_scale_offset(
+        logical_row, logical_col, N_COL_BLOCKS, num_scale_cols
+    )
+    # Mask out scale columns beyond num_scale_cols (= N // GROUP_SIZE).
+    # Without this mask, writes for col >= num_scale_cols collide with
+    # valid scales of subsequent rows in the swizzled layout. Rows are
+    # already on-tile by construction in the non-stacked path.
+    tl.store(
+        s_ptr + scale_offs,
+        encoded_scales,
+        mask=(logical_col < num_scale_cols),
+    )
+
+    # ========================================================================
+    # Pack to FP4 and store
+    # ========================================================================
+    x_fp4x2 = convert_fp32_to_fp4_packed(x_blocks.reshape(M_PER_BLOCK, 32, 2).split())
+
+    q_offs_m = pid_m * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK)[:, None]
+    q_offs_n = pid_n * 32 + tl.arange(0, 32)[None, :]
+    if USE_MASK:
+        q_mask = (q_offs_m < M) & (q_offs_n < N // 2)
+    else:
+        q_mask = None
+
+    if USE_INT64_INDEXING:
+        q_offs_m = q_offs_m.to(tl.int64)
+        q_offs_n = q_offs_n.to(tl.int64)
+
+    store_offsets = q_offs_m * (N // 2) + q_offs_n
+    tl.store(q_ptr + store_offsets, x_fp4x2, mask=q_mask)
+
+
+def quantize_mx4(
+    x: torch.Tensor,
+    group_size: int = 32,
+    rounding_mode: Union[RoundingMode, int] = RoundingMode.ceil,
+    *,
+    seed: Optional[int] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize tensor to MX4 format.
+
+    Args:
+        x: Input tensor, shape [..., N] where N % group_size == 0. bf16 or fp16.
+           Supports arbitrary leading dimensions (e.g., [B, S, N] or [M, N]).
+        group_size: Elements per scale group (32 for MX4-32, 16 for MX4-16).
+        rounding_mode: Rounding for shared exponent computation (default: ceil).
+            ceil (4) is the default and guarantees no overflow.
+            The OCP MX v1.0 reference implementation uses even pre-rounding
+            (RoundingMode.even = 2) which is slightly more precise (~0.5 bits).
+            Supported: nearest (0), floor (1), even (2), stochastic (3), ceil (4).
+        seed: Optional seed for stochastic rounding. Only used when
+            ``rounding_mode == RoundingMode.stochastic``. If ``None`` (default),
+            a seed is derived from
+            ``torch.cuda.default_generators[device].initial_seed()`` so callers
+            respect ``torch.manual_seed``. Pass a fixed integer for CUDA-graph
+            reproducibility. Ignored for all deterministic rounding modes.
+
+    Returns:
+        xq: Packed FP4 data, dtype uint8, shape [..., N//2]. Leading dims preserved.
+        scales: E8M0 biased exponent bytes, dtype int8, **flattened 1D**.
+            Size = rounded_M × rounded_K, both padded to 128/4 multiples.
+            Layout: Blackwell blocked (swizzled).
+
+    eg. [1, 5120] bf16 -> [1, 2560] uint8 + [128×4] int8 (flattened blocked)
+    """
+    stochastic = int(rounding_mode) == int(RoundingMode.stochastic)
+    seed_int = _resolve_seed(seed, stochastic, x.device)
+
+    orig_leading_dims, orig_N = x.shape[:-2], x.shape[-1]
+    x_2d = x.reshape(-1, orig_N)
+    M, N = x_2d.shape
+
+    assert N % group_size == 0, f"N must be divisible by {group_size}, got {N}"
+    assert x.dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), f"Expected fp16/bf16, got {x.dtype}"
+
+    # Scale padding (128-row × 4-col alignment for tensor cores).
+    n_col_blocks = triton.cdiv(N // group_size, 4)
+    padded_rows = triton.cdiv(M, 128) * 128
+    padded_cols = n_col_blocks * 4
+
+    xq = x.new_empty(M, N // 2, dtype=torch.uint8)
+    # Zero-init so OOB positions (where the kernel does not write) are zero.
+    scales = torch.zeros(padded_rows, padded_cols, dtype=torch.int8, device=x.device)
+
+    # M_PER_BLOCK: rows per program. Capped at 128 (scale layout alignment).
+    M_PER_BLOCK = min(triton.next_power_of_2(M), 128)
+    USE_MASK = M % M_PER_BLOCK != 0 or N % 64 != 0
+    grid = (triton.cdiv(N, 64), triton.cdiv(M, M_PER_BLOCK))
+    # Extra row of blocks to zero out tail scales when M_PER_BLOCK < 128.
+    if M_PER_BLOCK != 128:
+        grid = (grid[0], grid[1] + 1)
+    use_int64 = M * N > 2**31 - 1
+
+    quantize_mx4_kernel[grid](  # pyre-ignore[28]
+        x_2d,  # [M, N] input (2D-flattened)
+        xq,  # [M, N//2] output packed FP4
+        scales,  # [padded_M, padded_cols] output E8M0 scales
+        x_2d.stride(0),  # stride_xm
+        x_2d.stride(1),  # stride_xn
+        M,  # number of rows
+        N,  # number of columns
+        seed_int,  # int64 seed for tl.randint (unused when STOCHASTIC=False)
+        # pyre-ignore[6]
+        M_PER_BLOCK=M_PER_BLOCK,
+        # pyre-ignore[6]
+        USE_MASK=USE_MASK,
+        # pyre-ignore[6]
+        USE_INT64_INDEXING=use_int64,
+        # pyre-ignore[6]
+        GROUP_SIZE=group_size,  # 32 for MX4-32, 16 for MX4-16
+        # pyre-ignore[6]
+        ROUNDING_MODE=int(rounding_mode),  # ceil, floor, nearest, even, or stochastic
+        # pyre-ignore[6]
+        EBITS=2,  # E2M1 exponent bits (MX4 is always E2M1)
+        # pyre-ignore[6]
+        MBITS=1,  # E2M1 mantissa bits
+        # pyre-ignore[6]
+        N_COL_BLOCKS=n_col_blocks,
+        # pyre-ignore[6]
+        STOCHASTIC=stochastic,
+        # pyre-ignore[28]
+        num_stages=3 if M >= 256 else 1,
+        # pyre-ignore[28]
+        num_warps=4,
+    )
+
+    xq = xq.view(*orig_leading_dims, -1, N // 2)
+    return xq, scales.flatten()

--- a/mslk/quantize/triton/quantize_kernels/mx4_stacked.py
+++ b/mslk/quantize/triton/quantize_kernels/mx4_stacked.py
@@ -1,0 +1,308 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Self-contained MX4 (E8M0 scale) FP4 quantization kernel — stacked (MoE).
+
+The shared per-segment row→segment mapping lives in ``stacked_segment_map``
+(``fp4_primitives.layout``); the fully-slack-tile early-return stays inline
+here (a ``@triton.jit`` helper cannot return out of its caller). Also hosts the
+``quantize_mx4_stacked`` host wrapper that launches this kernel.
+"""
+
+from typing import Optional, Union
+
+import torch
+import triton  # @manual=//triton:triton
+from mslk.quantize.triton.fp4_primitives import (
+    blocked_scale_offset,
+    convert_fp32_to_fp4_packed,
+    mx4_scale_normalize_encode,
+    RoundingMode,
+    stacked_segment_map,
+)
+from mslk.quantize.triton.quantize_kernels import _resolve_seed
+from triton import language as tl  # @manual=//triton:triton
+
+
+@triton.jit
+def quantize_mx4_stacked_kernel(
+    x_ptr,  # [M, N] input tensor (bf16/fp16)
+    q_ptr,  # [M, N//2] output — packed FP4 pairs (uint8, 2 values per byte)
+    s_ptr,  # output — per-group E8M0 scales (int8) in padded blocked layout
+    m_sizes_ptr,  # [num_segments] int64 — rows per segment
+    stride_xm,  # row stride of x_ptr (elements to skip per row)
+    stride_xn,  # col stride of x_ptr (usually 1 for contiguous)
+    N,  # number of columns in the input matrix
+    seed,  # int64 seed for tl.randint (Philox-3); only consulted when STOCHASTIC=True
+    NUM_SEGMENTS: tl.constexpr,  # number of expert segments
+    PREFIX_NUM: tl.constexpr,  # next_power_of_2(NUM_SEGMENTS) for tl.cumsum
+    BSEARCH_ITERS: tl.constexpr,  # ceil(log2(NUM_SEGMENTS)) binary search iterations
+    M_PER_BLOCK: tl.constexpr,  # rows per program (power of 2, capped at 128)
+    USE_MASK: tl.constexpr,  # always True for stacked (segment boundaries unaligned)
+    USE_INT64_INDEXING: tl.constexpr,  # True when M*N > 2^31-1
+    GROUP_SIZE: tl.constexpr,  # elements per scale group (32 for MX4)
+    ROUNDING_MODE: tl.constexpr,  # RoundingMode enum for shared exponent
+    EBITS: tl.constexpr,  # exponent bits in target FP4 format (2 for E2M1)
+    MBITS: tl.constexpr,  # mantissa bits in target FP4 format (1 for E2M1)
+    N_COL_BLOCKS: tl.constexpr,  # ceil(num_scale_cols / 4) — blocked layout offset
+    STOCHASTIC: tl.constexpr,  # True → enable software stochastic rounding
+):
+    """Stacked MX4 quantization kernel processing [M_PER_BLOCK, 64] tiles.
+
+    Per-segment MoE quantization. The grid M-axis spans *padded* rows
+    (``cdiv(padded_total_M, M_PER_BLOCK)``); each padded row is mapped to its
+    segment + logical row via ``stacked_segment_map``, and per-group E8M0 scales
+    are stored at the row's padded offset so each segment is 128-row aligned in
+    the scale buffer. Padding rows within ``[0, padded_total)`` get
+    ``is_valid_row=False`` → zero scales, written in-kernel; the over-allocated
+    slack rows ``[padded_total, padded_total_M)`` are zeroed by the host
+    ``torch.zeros`` allocation.
+
+    Grid: (cdiv(N, 64), cdiv(padded_total_M, M_PER_BLOCK)).
+    """
+    TILE_N: tl.constexpr = 64  # type: ignore[Incompatible variable type]
+    NUM_GROUPS: tl.constexpr = TILE_N // GROUP_SIZE
+
+    pid_m = tl.program_id(1)
+    pid_n = tl.program_id(0)
+
+    # ========================================================================
+    # STACKED setup — cumsum + binary search to map padded rows → segments.
+    # The fully-slack-tile early-return stays inline (the helper cannot exit
+    # its caller).
+    # ========================================================================
+    (
+        padded_rows,
+        logical_rows,
+        is_valid_row,
+        padded_total,
+        _seg_idx,  # unused by MX4-stacked (no global scale); kept for tuple parity
+    ) = stacked_segment_map(
+        m_sizes_ptr, pid_m, M_PER_BLOCK, NUM_SEGMENTS, PREFIX_NUM, BSEARCH_ITERS
+    )
+    # Skip fully-slack tiles (beyond the last segment's padded rows).
+    if pid_m * M_PER_BLOCK >= padded_total:
+        return
+
+    # Compute tile offsets and load [M_PER_BLOCK, 64] tile. Rows are indexed by
+    # *logical* row (padded->logical mapped above); padding rows are masked out.
+    offs_m = logical_rows[:, None]
+    offs_n = pid_n * TILE_N + tl.arange(0, TILE_N)[None, :]
+    if USE_INT64_INDEXING:
+        offs_m = offs_m.to(tl.int64)
+        offs_n = offs_n.to(tl.int64)
+
+    mask = is_valid_row[:, None] & (offs_n < N)
+    other = 0.0
+
+    load_offsets = offs_m * stride_xm + offs_n * stride_xn
+    x = tl.load(x_ptr + load_offsets, mask=mask, other=other)
+
+    x_blocks = x.to(tl.float32).reshape(M_PER_BLOCK, NUM_GROUPS, GROUP_SIZE)
+
+    # Per-group amax
+    block_amax = tl.max(tl.abs(x_blocks), axis=2)  # [M_PER_BLOCK, NUM_GROUPS]
+
+    # ========================================================================
+    # MX4 scale computation (E8M0 biased exponent) + normalize + encode.
+    # Shared with quantize_mx4_kernel via mx4_scale_normalize_encode.
+    # ========================================================================
+    x_blocks, encoded_scales = mx4_scale_normalize_encode(
+        x_blocks,
+        block_amax,
+        pid_m,
+        pid_n,
+        seed,
+        N,
+        M_PER_BLOCK,
+        NUM_GROUPS,
+        GROUP_SIZE,
+        ROUNDING_MODE,
+        EBITS,
+        MBITS,
+        STOCHASTIC,
+    )
+
+    # ========================================================================
+    # Mask out-of-bounds scales to 0 (padding rows + OOB columns)
+    # ========================================================================
+    if USE_MASK:
+        scale_offs_n = pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS)[None, :]
+        num_scale_cols = N // GROUP_SIZE
+        # Padding rows (is_valid_row=False) -> zero scales, written below.
+        scale_mask = is_valid_row[:, None] & (scale_offs_n < num_scale_cols)
+        encoded_scales = tl.where(scale_mask, encoded_scales, 0)
+
+    # ========================================================================
+    # Store scales — per-segment padded blocked layout.
+    #
+    # Each segment owns a contiguous run of 128-row-aligned blocks in the
+    # blocked-layout buffer (per the dequantize_mx4_stacked slicing contract).
+    # Split padded_r into a 128-row-block index and a within-block local row,
+    # compute the local blocked offset using num_scale_cols, then add the
+    # per-block base.
+    # ========================================================================
+    logical_col = pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS)[None, :]
+    num_scale_cols = N // GROUP_SIZE
+    # The grid iterates padded rows directly, so padded_r == padded_rows.
+    padded_r = padded_rows  # [M_PER_BLOCK]
+
+    seg_block_idx = padded_r // 128  # [M_PER_BLOCK], int64
+    padded_r_local = (padded_r % 128).to(tl.int32)  # [M_PER_BLOCK]
+    local_offs = blocked_scale_offset(
+        padded_r_local[:, None], logical_col, N_COL_BLOCKS, num_scale_cols
+    )
+    scale_offs = seg_block_idx[:, None].to(tl.int64) * (512 * N_COL_BLOCKS) + local_offs
+    # Mask both row and column OOB:
+    # - row: write every padded row in [0, padded_total) (padding rows carry
+    #   zero encoded_scales from scale_mask above).
+    # - column: logical_col >= num_scale_cols would collide with valid scales of
+    #   subsequent rows.
+    tl.store(
+        s_ptr + scale_offs,
+        encoded_scales,
+        mask=(padded_rows[:, None] < padded_total) & (logical_col < num_scale_cols),
+    )
+
+    # ========================================================================
+    # Pack to FP4 and store
+    # ========================================================================
+    x_fp4x2 = convert_fp32_to_fp4_packed(x_blocks.reshape(M_PER_BLOCK, 32, 2).split())
+
+    q_offs_m = logical_rows[:, None]
+    q_offs_n = pid_n * 32 + tl.arange(0, 32)[None, :]
+    q_mask = is_valid_row[:, None] & (q_offs_n < N // 2)
+
+    if USE_INT64_INDEXING:
+        q_offs_m = q_offs_m.to(tl.int64)
+        q_offs_n = q_offs_n.to(tl.int64)
+
+    store_offsets = q_offs_m * (N // 2) + q_offs_n
+    tl.store(q_ptr + store_offsets, x_fp4x2, mask=q_mask)
+
+
+def quantize_mx4_stacked(
+    m_sizes: torch.Tensor,
+    x: torch.Tensor,
+    group_size: int = 32,
+    rounding_mode: Union[RoundingMode, int] = RoundingMode.ceil,
+    *,
+    seed: Optional[int] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize stacked MoE activations to MX4 (E8M0 scales).
+
+    MX4 analogue of ``quantize_nvfp4_stacked``: per-segment quantization with
+    padded scale storage so each segment is 128-row aligned in the scale buffer.
+    No global scale (MX4 has no per-tensor or per-segment global scale).
+
+    Args:
+        m_sizes: [num_segments] int64 — rows per expert segment.
+        x: [M, N] concatenated activation tensor (bf16/fp16), M = sum(m_sizes).
+        group_size: Elements per scale group (32 for MX4-32, 16 for MX4-16).
+        rounding_mode: Rounding for shared exponent computation (default ceil).
+            Supported: nearest (0), floor (1), even (2), stochastic (3), ceil (4).
+        seed: Optional seed for stochastic rounding. Only used when
+            ``rounding_mode == RoundingMode.stochastic``. If ``None`` (default),
+            a seed is derived from
+            ``torch.cuda.default_generators[device].initial_seed()`` so callers
+            respect ``torch.manual_seed``. Pass a fixed integer for CUDA-graph
+            reproducibility. Ignored for all deterministic rounding modes.
+
+    Returns:
+        xq: [M, N//2] packed FP4 data, dtype uint8 (matches ``quantize_mx4``).
+        scales: E8M0 biased exponent bytes, dtype int8, **flattened 1D**.
+            Logical shape is [padded_total_M_ub, padded_cols] in the Blackwell
+            blocked layout, with each segment 128-row aligned. Padding rows
+            between segments are zero.
+    """
+    stochastic = int(rounding_mode) == int(RoundingMode.stochastic)
+    seed_int = _resolve_seed(seed, stochastic, x.device)
+
+    x_2d = x.reshape(-1, x.shape[-1])
+    M, N = x_2d.shape
+    num_segments = m_sizes.shape[0]
+
+    assert N % group_size == 0, f"N must be divisible by {group_size}, got {N}"
+    assert x.dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), f"Expected fp16/bf16, got {x.dtype}"
+    assert m_sizes.dtype == torch.int64, f"Expected m_sizes int64, got {m_sizes.dtype}"
+    assert m_sizes.is_cuda and m_sizes.device == x.device, (
+        f"m_sizes must be on the same CUDA device as x "
+        f"(got m_sizes.device={m_sizes.device}, x.device={x.device})"
+    )
+
+    # CUDA-graph-safe upper-bound padded rows (avoids a GPU→CPU sync on
+    # m_sizes). Each segment can add at most 127 padding rows for 128-row
+    # alignment.
+    padded_total_M = M + num_segments * 127
+
+    n_col_blocks = triton.cdiv(N // group_size, 4)
+    padded_cols = n_col_blocks * 4
+
+    xq = torch.empty(M, N // 2, dtype=torch.uint8, device=x.device)
+    # Zero-init the scale buffer. The kernel writes scales only for rows in
+    # ``[0, padded_total)`` where ``padded_total = sum(round_up(m_i, 128))`` is
+    # the exact padded-row count it derives from ``m_sizes``; the CUDA-graph-safe
+    # buffer is over-allocated to the upper bound ``padded_total_M = M +
+    # num_segments * 127`` (to avoid a GPU→CPU sync), so the slack rows
+    # ``[padded_total, padded_total_M)`` are never touched by the kernel and must
+    # be zeroed here (``torch.empty`` leaves them uninitialized → NaN /
+    # non-deterministic).
+    scales = torch.zeros(padded_total_M, padded_cols, dtype=torch.int8, device=x.device)
+
+    # M_PER_BLOCK: rows per program. Capped at 128 (scale layout alignment); at
+    # M<256, cap at 64 to improve SM occupancy for small-M shapes.
+    M_PER_BLOCK = 128 if M >= 256 else min(triton.next_power_of_2(M), 64)
+    USE_MASK = True  # Always True for stacked (segment boundaries are unaligned)
+    grid = (triton.cdiv(N, 64), triton.cdiv(padded_total_M, M_PER_BLOCK))
+    use_int64 = M * N > 2**31 - 1
+    prefix_num = triton.next_power_of_2(num_segments)
+    bsearch_iters = max(1, (num_segments - 1).bit_length()) if num_segments > 1 else 1
+
+    quantize_mx4_stacked_kernel[grid](  # pyre-ignore[28]
+        x_2d,  # [M, N] input (2D-flattened)
+        xq,  # [M, N//2] output packed FP4
+        scales,  # [padded_total_M_ub, padded_cols] output scales (pre-zeroed)
+        m_sizes,  # [num_segments] int64 rows per segment
+        x_2d.stride(0),  # stride_xm
+        x_2d.stride(1),  # stride_xn
+        N,  # number of columns
+        seed_int,  # int64 seed for tl.randint (unused when STOCHASTIC=False)
+        # pyre-ignore[6]
+        NUM_SEGMENTS=num_segments,
+        # pyre-ignore[6]
+        PREFIX_NUM=prefix_num,
+        # pyre-ignore[6]
+        BSEARCH_ITERS=bsearch_iters,
+        # pyre-ignore[6]
+        M_PER_BLOCK=M_PER_BLOCK,
+        # pyre-ignore[6]
+        USE_MASK=USE_MASK,
+        # pyre-ignore[6]
+        USE_INT64_INDEXING=use_int64,
+        # pyre-ignore[6]
+        GROUP_SIZE=group_size,
+        # pyre-ignore[6]
+        ROUNDING_MODE=int(rounding_mode),
+        # pyre-ignore[6]
+        EBITS=2,  # E2M1 exponent bits (MX4 is always E2M1)
+        # pyre-ignore[6]
+        MBITS=1,  # E2M1 mantissa bits
+        # pyre-ignore[6]
+        N_COL_BLOCKS=n_col_blocks,
+        # pyre-ignore[6]
+        STOCHASTIC=stochastic,
+        # pyre-ignore[28]
+        num_stages=3 if M >= 256 else 1,
+        # pyre-ignore[28]
+        num_warps=4,
+    )
+
+    return xq, scales.flatten()

--- a/test/quantize/triton/_mx4_torch_reference.py
+++ b/test/quantize/triton/_mx4_torch_reference.py
@@ -1,0 +1,446 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Torch-based bitwise correctness oracle for the MSLK MX4 quantize copy.
+
+Pure-Torch references that ``test_quantize_mx4.py`` / ``test_stacked_quantize_mx4.py``
+bitwise-compare ``quantize_mx4`` / ``quantize_mx4_stacked`` against:
+
+    xq, scales = quantize_mx4(...)
+    ref_xq, ref_scales_2d = torch_quantize_mx4_ref(..., swizzle=False)
+    assert torch.equal(xq.flatten(), ref_xq.flatten())
+    ref_swz = swizzle_scales_to_blocked(ref_scales_2d, scales.shape, convention="mslk")
+    assert torch.equal(scales.flatten(), ref_swz.flatten())
+
+Self-contained (imports only ``torch``/``math``); MX4-only (no NVFP4 / SiLU / RMS /
+dequant helpers).
+
+Provenance (original upstreams; also vendored into PyTorch
+``caffe2/torch/testing/_internal/common_quantized.py``):
+- ``_to_mxfp`` <- TorchAO ``torchao/prototype/mx_formats/mx_tensor.py`` (RCEIL).
+  (https://github.com/pytorch/ao/blob/v0.12.0/torchao/prototype/mx_formats/mx_tensor.py#L142;
+  common_quantized.py:578-656).
+- ``_f32_to_floatx_unpacked`` <- TorchAO ``torchao/prototype/custom_fp_utils.py``
+  (https://github.com/pytorch/ao/blob/bc4f51da86956275da7db0da6e420c506df97820/torchao/prototype/custom_fp_utils.py#L27-L142;
+  common_quantized.py:247-360).
+- ``_pack_uint4`` <- common_quantized.py:555-561 (TorchAO custom_fp_utils lineage).
+- ``_to_blocked`` <- transformer_nuggets
+  (https://github.com/drisspg/transformer_nuggets/blob/main/transformer_nuggets/mx/to_blocked.py;
+  common_quantized.py:515-546).
+- ``_round_log2_via_bits_ceil`` mirrors fp4_primitives/scale.py:91-115.
+- ``_blocked_scale_offset_swizzle`` mirrors fp4_primitives/layout.py:22-58.
+- ``_unblock_mx4_scales`` (+ ``_five_dim_offset_pt``): inverse scale-byte de-swizzle
+  (matches ``blocked_scale_offset``), used by the scale-inspection tests.
+
+Rounding-mode pinning: MX4 bitwise tests pin ``RoundingMode.ceil`` -- the only mode
+``_to_mxfp`` (RCEIL) implements.
+"""
+
+import math
+
+import torch
+from torch import Tensor
+
+
+# ============================================================
+# Constants
+# ============================================================
+
+# FP4 (E2M1) format parameters.
+FP4_EBITS: int = 2
+FP4_MBITS: int = 1
+
+# FP32 IEEE-754 parameters.
+_EBITS_F32: int = 8
+_MBITS_F32: int = 23
+
+
+def _n_ones(n: int) -> int:
+    return (1 << n) - 1
+
+
+_F32_EXP_BIAS: int = _n_ones(_EBITS_F32 - 1)
+
+# Bit-extract ceil(log2) constants (mirror the _round_log2_via_bits, CEIL_ROUND).
+_FP32_EXP_MASK: int = 0x7F800000
+_FP32_EXP_OFFSET: int = 23
+_F32_CEIL_ROUND: int = (1 << 23) - 1
+
+
+# ============================================================
+# GPU gate
+# ============================================================
+
+
+def is_blackwell_or_newer() -> bool:
+    """Return True if the current CUDA device is Blackwell (SM100) or newer.
+
+    The MX4 quantize kernels exercised here dispatch to inline-PTX paths (e.g.
+    ``cvt.satfinite.e2m1x2.f32``) that are only available on SM100+ devices.
+    """
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major >= 10
+
+
+# ============================================================
+# Ported helpers (TorchAO / transformer_nuggets upstreams; see module docstring).
+# ============================================================
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
+    """Ported from common_quantized.py:247-360.
+
+    Convert FP32 to sub-byte float with ``ebits``/``mbits``; returns uint8 codes.
+    """
+    if x.dtype != torch.float:
+        raise AssertionError(f"Expected x.dtype to be torch.float, got {x.dtype}")
+    if 1 + ebits + mbits > 8:
+        raise AssertionError(
+            f"Expected 1 + ebits + mbits <= 8, got {1 + ebits + mbits}"
+        )
+
+    exp_bias = _n_ones(ebits - 1)
+    max_int = _n_ones(ebits + mbits)
+    sign_mask = 1 << (ebits + mbits)
+    magic_adder = _n_ones(_MBITS_F32 - mbits - 1)
+
+    max_normal = 2 ** (_n_ones(ebits) - exp_bias) * (_n_ones(mbits + 1) / (2**mbits))
+    min_normal = 2 ** (1 - exp_bias)
+
+    denorm_exp = (_F32_EXP_BIAS - exp_bias) + (_MBITS_F32 - mbits) + 1
+    denorm_mask_int = denorm_exp << _MBITS_F32
+
+    denorm_mask_float = torch.tensor(denorm_mask_int, dtype=torch.int32).view(
+        torch.float32
+    )
+
+    x = x.view(torch.int32)
+    sign = x & 0x80000000
+
+    x = x ^ sign
+    x = x.view(torch.float)
+
+    saturate_mask = x >= max_normal
+    denormal_mask = torch.logical_and(torch.logical_not(saturate_mask), x < min_normal)
+    normal_mask = torch.logical_not(torch.logical_or(saturate_mask, denormal_mask))
+
+    denormal_x = x + denorm_mask_float
+    denormal_x = denormal_x.view(torch.int32)
+    denormal_x -= denorm_mask_int
+    denormal_x = denormal_x.to(torch.uint8)
+
+    normal_x = x.view(torch.int32)
+    mant_odd = (normal_x >> (_MBITS_F32 - mbits)) & 1
+    val_to_add = ((exp_bias - _F32_EXP_BIAS) << _MBITS_F32) + magic_adder
+    normal_x += val_to_add
+    normal_x += mant_odd
+    normal_x = normal_x >> (_MBITS_F32 - mbits)
+    normal_x = normal_x.to(torch.uint8)
+
+    x = torch.full_like(x, max_int, dtype=torch.uint8)
+    x = torch.where(denormal_mask, denormal_x, x)
+    x = torch.where(normal_mask, normal_x, x)
+
+    sign_lp = sign >> (_MBITS_F32 + _EBITS_F32 - mbits - ebits)
+    sign_lp = sign_lp.to(torch.uint8)
+    sign_lp = sign_lp & sign_mask
+    x = x | sign_lp
+
+    return x.to(torch.uint8)
+
+
+def _down_size(size):
+    if size[-1] % 2 != 0:
+        raise AssertionError(f"{size} last dim not divisible by two")
+    return (*size[:-1], size[-1] // 2)
+
+
+def _pack_uint4(uint8_data) -> torch.Tensor:
+    """Ported from common_quantized.py:555-561."""
+    shape = uint8_data.shape
+    if shape[-1] % 2 != 0:
+        raise AssertionError(
+            f"Expected shape[-1] to be divisible by 2, got {shape[-1]}"
+        )
+    uint8_data = uint8_data.contiguous().view(-1)
+    return (uint8_data[1::2] << 4 | uint8_data[::2]).view(_down_size(shape))
+
+
+def _round_log2_via_bits_ceil(x: torch.Tensor) -> torch.Tensor:
+    """Exact ``ceil(log2(x))`` for positive normal f32 via FP32 bit manipulation.
+
+    Ports the ``_round_log2_via_bits(x, CEIL_ROUND)`` from
+    ``fp4_primitives/scale.py:91-115`` (avoids the libm ``ceil(log2)`` ULP
+    imprecision on exact powers of two).
+    """
+    if x.dtype != torch.float:
+        raise AssertionError(f"Expected x.dtype to be torch.float, got {x.dtype}")
+    bits = x.view(torch.int32) + _F32_CEIL_ROUND
+    exp_bits = (bits & _FP32_EXP_MASK) >> _FP32_EXP_OFFSET
+    return (exp_bits - _F32_EXP_BIAS).to(torch.float32)
+
+
+def _to_blocked(input_matrix: Tensor) -> torch.Tensor:
+    """Ported from common_quantized.py:515-546.
+
+    Rearrange a 2-D matrix into the 32x16 blocked layout (PyTorch pad-first
+    convention). Used only by the NVFP4/``pytorch`` swizzle branch; kept so
+    ``swizzle_scales_to_blocked`` stays drop-in identical.
+    """
+    rows, cols = input_matrix.shape
+    n_row_blocks = _ceil_div(rows, 128)
+    n_col_blocks = _ceil_div(cols, 4)
+    padded_rows = n_row_blocks * 128
+    padded_cols = n_col_blocks * 4
+
+    padded = input_matrix
+    if (rows, cols) != (padded_rows, padded_cols):
+        padded = torch.zeros(
+            (padded_rows, padded_cols),
+            device=input_matrix.device,
+            dtype=input_matrix.dtype,
+        )
+        padded[:rows, :cols] = input_matrix
+
+    blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
+    rearranged = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16)
+    return rearranged.flatten()
+
+
+def _blocked_scale_offset_swizzle(scales_2d: Tensor) -> torch.Tensor:
+    """FBGEMM blocked-layout swizzle for a 2-D scale matrix (columns padded to a
+    multiple of 4, matching the canonical NVIDIA layout / ``_to_blocked``). Mirrors
+    ``blocked_scale_offset`` in ``fp4_primitives/layout.py``."""
+    if scales_2d.dim() != 2:
+        raise AssertionError(
+            f"Expected 2-D scales_2d, got shape {tuple(scales_2d.shape)}"
+        )
+    M, num_cols = scales_2d.shape
+    n_row_blocks = _ceil_div(M, 128)
+    n_col_blocks = _ceil_div(num_cols, 4)
+    padded_rows = n_row_blocks * 128
+    padded_cols = n_col_blocks * 4
+
+    rows_idx = torch.arange(M, device=scales_2d.device).view(-1, 1).expand(-1, num_cols)
+    cols_idx = torch.arange(num_cols, device=scales_2d.device).view(1, -1).expand(M, -1)
+    flat_idx = rows_idx * (n_col_blocks * 4) + cols_idx
+
+    elems_per_row_block = 512 * n_col_blocks
+
+    first_dim = flat_idx // elems_per_row_block
+    second_dim = (flat_idx % elems_per_row_block) // (128 * n_col_blocks)
+    third_dim = (flat_idx % (128 * n_col_blocks)) // (4 * n_col_blocks)
+    fourth_dim = (flat_idx % (4 * n_col_blocks)) // 4
+    fifth_dim = flat_idx % 4
+
+    out_offsets = (
+        first_dim * elems_per_row_block
+        + fourth_dim * 512
+        + third_dim * 16
+        + second_dim * 4
+        + fifth_dim
+    )
+
+    out = torch.zeros(
+        padded_rows * padded_cols,
+        device=scales_2d.device,
+        dtype=scales_2d.dtype,
+    )
+    out[out_offsets.flatten()] = scales_2d.flatten()
+    return out
+
+
+def _to_mxfp(
+    data_hp: torch.Tensor,
+    block_size: int = 32,
+    format: str = "mxfp8",
+):
+    """Ported from common_quantized.py:578-656.
+
+    RCEIL-only MX quantization. Returns ``(scale_e8m0_biased, data_lp)``.
+
+    For ``format="mxfp4"`` the encoding follows FBGEMM:
+    ``stored_byte = (ceil(log2(max_abs)) - EBITS + 127).to(int8)`` with
+    ``EBITS = FP4_EBITS = 2``.
+    """
+    if data_hp.dtype not in (torch.bfloat16, torch.float):
+        raise AssertionError(f"{data_hp.dtype} is not supported yet")
+    if data_hp.shape[-1] % block_size != 0:
+        raise AssertionError(
+            f"the last dimension of shape {data_hp.shape} must be divisible "
+            f"by block_size {block_size}"
+        )
+    if not data_hp.is_contiguous():
+        raise AssertionError("unsupported: data_hp must be contiguous")
+
+    orig_shape = data_hp.shape
+    data_hp = data_hp.reshape(
+        *orig_shape[:-1], orig_shape[-1] // block_size, block_size
+    )
+
+    max_abs = torch.amax(torch.abs(data_hp), -1).unsqueeze(-1)
+    data_hp = data_hp.to(torch.float32)
+    max_abs = max_abs.to(torch.float32)
+
+    if format == "mxfp8":
+        max_pos = torch.finfo(torch.float8_e4m3fn).max
+        descale = max_abs / max_pos
+        exponent = torch.where(
+            torch.isnan(descale),
+            0xFF,
+            (
+                torch.clamp(
+                    torch.ceil(torch.log2(descale)),
+                    min=-_F32_EXP_BIAS,
+                    max=_F32_EXP_BIAS,
+                )
+                + _F32_EXP_BIAS
+            ).to(torch.uint8),
+        )
+        descale_fp = torch.where(
+            exponent == 0,
+            1.0,
+            torch.exp2(_F32_EXP_BIAS - exponent.to(torch.float32)),
+        )
+        data_lp = torch.clamp(data_hp * descale_fp, min=-1 * max_pos, max=max_pos)
+        scale_e8m0_biased = exponent
+        data_lp = data_lp.to(torch.float8_e4m3fn)
+        data_lp = data_lp.reshape(orig_shape)
+    elif format == "mxfp4":
+        BF16_MIN_NORMAL = 1.1754943508222875e-38
+        safe_max_abs = torch.where(
+            max_abs == 0,
+            torch.tensor(BF16_MIN_NORMAL, dtype=torch.float32, device=max_abs.device),
+            max_abs,
+        )
+        group_exp_unbiased = _round_log2_via_bits_ceil(safe_max_abs)
+        group_exp_unbiased = group_exp_unbiased - float(FP4_EBITS)
+        group_exp_unbiased = torch.clamp(group_exp_unbiased, min=-127.0, max=125.0)
+        scale_float = torch.exp2(group_exp_unbiased.to(torch.float64)).to(torch.float32)
+        data_lp = data_hp / scale_float
+        scale_e8m0_biased = (group_exp_unbiased + _F32_EXP_BIAS).to(torch.uint8)
+        data_lp_unpacked = _f32_to_floatx_unpacked(
+            data_lp.contiguous(), FP4_EBITS, FP4_MBITS
+        )
+        data_lp = _pack_uint4(data_lp_unpacked).view(torch.float4_e2m1fn_x2)
+        final_shape = list(orig_shape)
+        final_shape[-1] //= 2
+        data_lp = data_lp.reshape(final_shape)
+    else:
+        raise AssertionError(f"unsupported format: {format}")
+
+    scale_e8m0_biased = scale_e8m0_biased.view(torch.float8_e8m0fnu)
+    scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
+    return scale_e8m0_biased, data_lp
+
+
+# ============================================================
+# Scale-byte de-swizzle (inverse layout transform — NOT dequantization).
+# Inverse scale-byte de-swizzle (matches blocked_scale_offset).
+# ============================================================
+
+
+def _five_dim_offset_pt(flat_idx, n_col_blocks):
+    """PyTorch vectorized 5-dim blocked layout offset (matches Triton
+    ``blocked_scale_offset``). Reverses the sequential-indexed blocked layout."""
+    epb = 512 * n_col_blocks
+    first = flat_idx // epb
+    second = (flat_idx % epb) // (128 * n_col_blocks)
+    third = (flat_idx % (128 * n_col_blocks)) // (4 * n_col_blocks)
+    fourth = (flat_idx % (4 * n_col_blocks)) // 4
+    fifth = flat_idx % 4
+    return first * epb + fourth * 512 + third * 16 + second * 4 + fifth
+
+
+def _unblock_mx4_scales(
+    scales_flat: torch.Tensor, M: int, num_scale_cols: int
+) -> torch.Tensor:
+    """Reverse the blocked layout used by MX4 kernels (columns padded to a multiple
+    of 4).
+
+    Gathers the valid ``[M, num_scale_cols]`` region back into a 2-D tensor. This
+    is a byte-layout de-swizzle (scale bytes), NOT value dequantization.
+    """
+    n_col_blocks = math.ceil(num_scale_cols / 4)
+    rows = torch.arange(M, device=scales_flat.device).unsqueeze(1)
+    cols = torch.arange(num_scale_cols, device=scales_flat.device).unsqueeze(0)
+    flat_idx = rows * (n_col_blocks * 4) + cols
+    offsets = _five_dim_offset_pt(flat_idx, n_col_blocks)
+    return scales_flat[offsets.long()]
+
+
+# ============================================================
+# Public API
+# ============================================================
+
+
+def torch_quantize_mx4_ref(
+    x: torch.Tensor,
+    *,
+    group_size: int = 32,
+    swizzle: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure-Torch MX4 quantize reference. **RCEIL rounding only.**
+
+    Returns ``(xq_uint8, scales_uint8)``: ``xq_uint8`` shape
+    ``[*x.shape[:-1], x.shape[-1] // 2]``; ``scales_uint8`` 1-D padded if
+    ``swizzle=True`` else 2-D ``[*x.shape[:-1], x.shape[-1] // group_size]``.
+    """
+    if x.dtype not in (torch.bfloat16, torch.float):
+        # fp16 -> f32 is lossless and matches the kernel (tl.load(...).to(f32)).
+        x_for_quant = x.to(torch.float32)
+    else:
+        x_for_quant = x.contiguous()
+
+    scale_e8m0, data_lp = _to_mxfp(x_for_quant, block_size=group_size, format="mxfp4")
+
+    xq_uint8 = data_lp.view(torch.uint8)
+    scales_uint8 = scale_e8m0.view(torch.uint8)
+
+    if swizzle:
+        if scales_uint8.dim() > 2:
+            scales_uint8 = scales_uint8.reshape(-1, scales_uint8.shape[-1])
+        scales_uint8 = _blocked_scale_offset_swizzle(scales_uint8)
+
+    return xq_uint8, scales_uint8
+
+
+def swizzle_scales_to_blocked(
+    scales_unswizzled: torch.Tensor,
+    target_shape: torch.Size,
+    *,
+    convention: str = "auto",
+) -> torch.Tensor:
+    """Apply the appropriate blocked swizzle to match the swizzled scale layout.
+
+    MX4 callers (E8M0 scales) must pass ``convention="mslk"`` when operating on
+    uint8 views (the float8_e8m0fnu dtype hint is lost after a uint8 view-cast).
+    """
+    if convention == "auto":
+        if scales_unswizzled.dtype == torch.float8_e8m0fnu:
+            convention = "mslk"
+        else:
+            convention = "pytorch"
+    if convention not in ("mslk", "pytorch"):
+        raise ValueError(
+            f"convention must be 'auto', 'mslk', or 'pytorch'; got {convention!r}"
+        )
+    if scales_unswizzled.dtype != torch.uint8:
+        scales_unswizzled = scales_unswizzled.view(torch.uint8)
+    if scales_unswizzled.dim() > 2:
+        scales_unswizzled = scales_unswizzled.reshape(-1, scales_unswizzled.shape[-1])
+    if convention == "mslk":
+        return _blocked_scale_offset_swizzle(scales_unswizzled).view(target_shape)
+    return _to_blocked(scales_unswizzled).view(target_shape)

--- a/test/quantize/triton/test_quantize_mx4.py
+++ b/test/quantize/triton/test_quantize_mx4.py
@@ -1,0 +1,120 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""MX4 quantize tests for the MSLK copy: bitwise-vs-torch-reference + E8M0 checks."""
+
+import unittest
+
+import torch
+from mslk.quantize.triton.fp4_primitives import RoundingMode
+from mslk.quantize.triton.quantize_kernels.mx4 import quantize_mx4
+from mslk.test.quantize.triton._mx4_torch_reference import (
+    _unblock_mx4_scales,
+    is_blackwell_or_newer,
+    swizzle_scales_to_blocked,
+    torch_quantize_mx4_ref,
+)
+from parameterized import parameterized  # @manual
+
+
+@unittest.skipUnless(
+    is_blackwell_or_newer(),
+    "Requires Blackwell (SM100+) GPU — MX4 PTX paths are SM100-only",
+)
+class QuantizeMX4Test(unittest.TestCase):
+    """Bitwise-vs-torch-reference + first-principles tests for quantize_mx4."""
+
+    @parameterized.expand(
+        [
+            # (name, M, N, group_size): canonical Blackwell layout + M/N padding +
+            # unaligned-K (num_scale_cols < NUM_GROUPS) + group_size=16.
+            ("canonical_gs32", 128, 256, 32),
+            ("m_pad_gs32", 5, 64, 32),
+            ("n_pad_gs32", 128, 32, 32),
+            ("n_unaligned_gs32", 128, 96, 32),
+            ("single_row_gs32", 1, 64, 32),
+            ("large_gs32", 512, 4096, 32),
+            ("canonical_gs16", 128, 256, 16),
+            ("n_pad_gs16", 128, 16, 16),
+            ("n_unaligned_gs16_80", 128, 80, 16),
+            ("n_unaligned_gs16_144", 128, 144, 16),
+            ("single_row_gs16", 1, 64, 16),
+        ]
+    )
+    def test_bitwise_torch_ref(self, _name, M, N, group_size):
+        """quantize_mx4 must be byte-identical to the pure-Torch reference.
+
+        Pinned to RoundingMode.ceil because the reference (to_mxfp) is RCEIL-only.
+        """
+        torch.manual_seed(42)
+        x = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+
+        b_xq, b_scales = quantize_mx4(
+            x, group_size=group_size, rounding_mode=RoundingMode.ceil
+        )
+        ref_xq, ref_scales_2d = torch_quantize_mx4_ref(
+            x, group_size=group_size, swizzle=False
+        )
+
+        self.assertTrue(
+            torch.equal(
+                b_xq.view(torch.uint8).flatten(),
+                ref_xq.view(torch.uint8).flatten(),
+            ),
+            f"FP4 data mismatch for shape ({M}, {N}, gs={group_size})",
+        )
+        ref_scales_swizzled = swizzle_scales_to_blocked(
+            ref_scales_2d, b_scales.shape, convention="mslk"
+        )
+        self.assertTrue(
+            torch.equal(
+                b_scales.view(torch.uint8).flatten(),
+                ref_scales_swizzled.view(torch.uint8).flatten(),
+            ),
+            f"Scale mismatch for shape ({M}, {N}, gs={group_size})",
+        )
+
+    @parameterized.expand(
+        [
+            # (name, group_max, expected_biased_exponent):
+            # byte = ceil(log2(group_max)) - EBITS(2) + 127, stored as int8.
+            ("pow2_4", 4.0, 127),
+            ("nonpow2_3", 3.0, 127),
+            ("nonpow2_5", 5.0, -128),  # 128 wraps to int8 -128 (unsigned E8M0 byte)
+            ("one", 1.0, 125),
+        ]
+    )
+    def test_shared_exponent_e8m0_encoding(self, _name, group_max, expected_exp):
+        """Shared E8M0 exponent matches the OCP MX v1.0 ceil-rounded formula."""
+        x = torch.zeros(1, 32, dtype=torch.bfloat16, device="cuda")
+        x[0, 0] = group_max
+        _, scales = quantize_mx4(x)
+        s = _unblock_mx4_scales(scales, 1, 1)
+        self.assertEqual(s[0, 0].item(), expected_exp)
+
+    @parameterized.expand(
+        [
+            ("nan", float("nan")),
+            ("pos_inf", float("inf")),
+            ("neg_inf", float("-inf")),
+        ]
+    )
+    def test_quantize_mx4_special_value_saturation(self, _name, bad_value):
+        """A single NaN/±Inf is saturated; scales stay finite."""
+        torch.manual_seed(701)
+        M, N = 64, 128
+        x = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+        x[0, 0] = bad_value
+        xq, scales = quantize_mx4(x)
+        self.assertEqual(xq.shape, (M, N // 2))
+        self.assertFalse(
+            torch.isnan(scales.to(torch.float32)).any(), "scales contain NaN"
+        )
+        self.assertFalse(
+            torch.isinf(scales.to(torch.float32)).any(), "scales contain Inf"
+        )

--- a/test/quantize/triton/test_stacked_quantize_mx4.py
+++ b/test/quantize/triton/test_stacked_quantize_mx4.py
@@ -1,0 +1,209 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Stacked (MoE) MX4 quantize tests for the MSLK copy: bitwise-vs-torch-reference."""
+
+import math
+import unittest
+
+import torch
+from mslk.quantize.triton.fp4_primitives import RoundingMode
+from mslk.quantize.triton.quantize_kernels.mx4 import quantize_mx4
+from mslk.quantize.triton.quantize_kernels.mx4_stacked import quantize_mx4_stacked
+from mslk.test.quantize.triton._mx4_torch_reference import (
+    is_blackwell_or_newer,
+    swizzle_scales_to_blocked,
+    torch_quantize_mx4_ref,
+)
+from parameterized import parameterized  # @manual
+
+
+def _make_stacked_input(m_sizes_list, N, dtype=torch.bfloat16, device="cuda"):
+    """Create a stacked input tensor and m_sizes from a list of segment sizes."""
+    m_sizes = torch.tensor(m_sizes_list, dtype=torch.int64, device=device)
+    M = sum(m_sizes_list)
+    x = torch.randn(M, N, dtype=dtype, device=device)
+    return x, m_sizes
+
+
+def _per_segment_padded_offsets(m_sizes_list):
+    """Yield (seg_idx, m_i, seg_row_start, padded_start, padded_rows) tuples."""
+    seg_row_start = 0
+    padded_start = 0
+    for i, m_i in enumerate(m_sizes_list):
+        padded_rows = math.ceil(m_i / 128) * 128 if m_i > 0 else 0
+        yield i, m_i, seg_row_start, padded_start, padded_rows
+        seg_row_start += m_i
+        padded_start += padded_rows
+
+
+def _slice_padded_scales(scales_flat, padded_start, padded_rows, padded_cols):
+    """Slice the segment's padded sub-buffer out of the stacked flat scales."""
+    start = padded_start * padded_cols
+    end = (padded_start + padded_rows) * padded_cols
+    return scales_flat[start:end]
+
+
+@unittest.skipUnless(
+    is_blackwell_or_newer(),
+    "Requires Blackwell (SM100+) GPU (matches test_stacked_quantize gating)",
+)
+class StackedQuantizeMX4Test(unittest.TestCase):
+    """Bitwise-vs-torch-reference tests for stacked (MoE) MX4 quantization."""
+
+    @parameterized.expand(
+        [
+            ("two_equal", [64, 64], 64, 32),
+            ("three_unequal", [50, 30, 48], 64, 32),
+            ("four_mixed", [16, 64, 128, 256], 128, 32),
+            ("two_large", [256, 512], 512, 32),
+            ("gs16_three_unequal", [50, 30, 48], 64, 16),
+            ("zero_row_segment", [64, 0, 64], 64, 32),
+            # Many small segments (PREFIX_NUM=64, BSEARCH_ITERS=6 path).
+            ("many_segments", [16] * 64, 128, 32),
+            # group_size=16 with N=80 (N%64≠0, (N/16)%4≠0): column-side swizzle-pad.
+            ("gs16_unaligned_n", [128, 128], 80, 16),
+            # Sub-block-height + unaligned segments at gs16 (gs16 avoids the gs32
+            # torch.empty padding-leak in the per-segment scale comparison).
+            ("single_row_segments_gs16", [1, 1, 1, 1], 64, 16),
+            ("unaligned_segment_boundary_gs16", [5, 11, 19], 64, 16),
+        ]
+    )
+    def test_bitwise_torch_ref_match_stacked(self, _name, m_sizes_list, N, group_size):
+        """quantize_mx4_stacked must be byte-identical to per-segment
+        torch_quantize_mx4_ref + concat (xq and per-segment swizzled scales)."""
+        torch.manual_seed(42)
+        x, m_sizes = _make_stacked_input(m_sizes_list, N)
+
+        b_xq, b_scales = quantize_mx4_stacked(
+            m_sizes, x, group_size=group_size, rounding_mode=RoundingMode.ceil
+        )
+
+        num_scale_cols = N // group_size
+        n_col_blocks = math.ceil(num_scale_cols / 4)
+        padded_cols = n_col_blocks * 4
+
+        ref_xq_chunks = []
+        for (
+            i,
+            m_i,
+            seg_row_start,
+            padded_start,
+            padded_rows,
+        ) in _per_segment_padded_offsets(m_sizes_list):
+            if m_i == 0:
+                continue
+            seg_end = seg_row_start + m_i
+            seg = x[seg_row_start:seg_end]
+            seg_xq_ref, seg_scales_2d = torch_quantize_mx4_ref(
+                seg, group_size=group_size, swizzle=False
+            )
+            ref_xq_chunks.append(seg_xq_ref)
+
+            b_seg_slice = _slice_padded_scales(
+                b_scales, padded_start, padded_rows, padded_cols
+            )
+
+            seg_scales_padded = torch.zeros(
+                (padded_rows, num_scale_cols),
+                dtype=torch.uint8,
+                device=seg.device,
+            )
+            seg_scales_padded[:m_i, :] = seg_scales_2d.view(torch.uint8)
+            seg_swizzled = swizzle_scales_to_blocked(
+                seg_scales_padded,
+                torch.Size([padded_rows * padded_cols]),
+                convention="mslk",
+            )
+
+            self.assertTrue(
+                torch.equal(
+                    b_seg_slice.view(torch.uint8).flatten(),
+                    seg_swizzled.view(torch.uint8).flatten(),
+                ),
+                f"Segment {i} (m={m_i}) scale mismatch for m_sizes={m_sizes_list}",
+            )
+
+        ref_xq = (
+            torch.cat(ref_xq_chunks, dim=0)
+            if ref_xq_chunks
+            else b_xq.new_zeros(b_xq.shape)
+        )
+        self.assertTrue(
+            torch.equal(
+                b_xq.view(torch.uint8).flatten(),
+                ref_xq.view(torch.uint8).flatten(),
+            ),
+            f"FP4 data mismatch for m_sizes={m_sizes_list}, N={N}, gs={group_size}",
+        )
+
+    # NaN/Inf saturation: a special value in one segment must not corrupt the
+    # per-segment output (each segment still matches independent quantize_mx4).
+
+    def _check_per_segment_with_modified_x(self, m_sizes_list, N, modify_fn):
+        """Apply modify_fn(x) to inject special values, then run per-segment check."""
+        x, m_sizes = _make_stacked_input(m_sizes_list, N)
+        modify_fn(x)
+
+        xq_stacked, _ = quantize_mx4_stacked(m_sizes, x)
+
+        seg_row_start = 0
+        for i, m_i in enumerate(m_sizes_list):
+            seg_end = seg_row_start + m_i
+            x_i = x[seg_row_start:seg_end]
+            xq_ref_i, _ = quantize_mx4(x_i)
+            xq_stacked_i = xq_stacked[seg_row_start:seg_end]
+            self.assertTrue(
+                torch.equal(xq_stacked_i, xq_ref_i),
+                f"Segment {i} (m={m_i}) xq differs after modify_fn",
+            )
+            seg_row_start += m_i
+
+    @parameterized.expand(
+        [
+            ("inf", (5, 7), float("inf")),
+            ("neg_inf", (10, 3), float("-inf")),
+            ("nan", (20, 5), float("nan")),
+        ]
+    )
+    def test_special_value_per_segment_unaffected(self, _name, pos, value):
+        """A NaN/±Inf in one segment leaves every segment's xq matching quantize_mx4."""
+        torch.manual_seed(10)
+
+        def inject(x):
+            x[pos] = value
+
+        self._check_per_segment_with_modified_x([32, 64], 64, inject)
+
+    def test_no_host_sync_under_cuda_graph(self):
+        """Stacked MX4 quantization captures cleanly under CUDA graph.
+
+        Any GPU→CPU sync inside the wrapper would fail capture; after replay,
+        outputs must match an eager call.
+        """
+        torch.manual_seed(31)
+        x, m_sizes = _make_stacked_input([32, 64, 128], 64)
+
+        xq_ref, scales_ref = quantize_mx4_stacked(m_sizes, x)
+
+        graph = torch.cuda.CUDAGraph()
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(2):
+                _ = quantize_mx4_stacked(m_sizes, x)
+        torch.cuda.current_stream().wait_stream(s)
+
+        with torch.cuda.graph(graph):
+            xq_captured, scales_captured = quantize_mx4_stacked(m_sizes, x)
+
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.equal(xq_captured, xq_ref))
+        self.assertTrue(torch.equal(scales_captured, scales_ref))


### PR DESCRIPTION
Summary:
Add self-contained MXFP4 quantize Triton kernels to mslk/quantize/triton,
following the OCP MX v1.0 spec (E2M1 elements, UE8M0 shared scales, group
size 32):

- quantize_kernels/mx4.py — non-stacked quantize_mx4 kernel + host wrapper:
  [..., N] bf16/fp16 -> packed FP4 (uint8, 2 values/byte) + per-group E8M0
  (int8) scales in the Blackwell blocked (swizzled) layout.
- quantize_kernels/mx4_stacked.py — stacked/MoE quantize_mx4_stacked for
  segmented (per-expert) inputs driven by m_sizes, with per-segment 128-row
  padding; CUDA-graph-safe.
- quantize_kernels/__init__.py — shared _resolve_seed host helper.
- fp4_primitives/{constants,scale,packing,layout}.py — shared building blocks:
  RoundingMode + E8M0 constants; shared-exponent + E8M0 encode math; Blackwell
  PTX FP4 packing (cvt.rn.satfinite.e2m1x2.f32); blocked-scale swizzle +
  stacked segment map.
- test/quantize/triton/_mx4_torch_reference.py — self-contained pure-Torch
  MXFP4 reference (ported from TorchAO mx_formats / PyTorch common_quantized /
  transformer_nuggets to_blocked, with per-helper provenance).
- test/quantize/triton/{test_quantize_mx4,test_stacked_quantize_mx4}.py —
  bitwise (torch.equal) parity vs the reference, plus E8M0-encoding, NaN/+-Inf
  saturation, and CUDA-graph tests; gated to NVIDIA SM100+ (Blackwell).

The kernels are added self-contained; no public entrypoint imports them yet
(they compile via the existing triton/**/*.py glob). Wiring follows separately.

Reviewed By: cthi

Differential Revision: D108095762


