### PR TITLE
Fix AMD/ROCm fp4 quantize test (plain scale layout) (#419)

### DIFF
--- a/.github/workflows/_mslk_rocm_test.yml
+++ b/.github/workflows/_mslk_rocm_test.yml
@@ -153,7 +153,10 @@ jobs:
 
     - name: Test with PyTest
       if: ${{ inputs.run-target == 'test' }}
-      timeout-minutes: 60
+      # Bumped from 60 -> 90: on ROCm the Triton-autotuned GEMM tests (fp8 and
+      # grouped GEMM) compile many kernels under hipcc, so the full sequential
+      # suite now exceeds 60 min. See D110137656.
+      timeout-minutes: 90
       run: . $PRELUDE; test_all_mslk_modules $BUILD_ENV
 
     - name: Run MSLK Benchmark

--- a/mslk/gemm/triton/matmul_perf_model.py
+++ b/mslk/gemm/triton/matmul_perf_model.py
@@ -18,6 +18,7 @@ import functools
 import heapq
 
 import torch
+import triton.language as tl  # @manual
 from triton import cdiv  # @manual
 from triton.runtime import driver  # @manual
 from triton.testing import (  # @manual
@@ -33,6 +34,13 @@ def get_clock_rate_in_khz():
     try:
         return nvsmi(["clocks.max.sm"])[0] * 1e3
     except FileNotFoundError:
+        if torch.version.hip is not None:
+            # AMD/ROCm: nvidia-smi and pynvml are both Nvidia-only (pynvml is
+            # not installed in the ROCm CI image). Triton's device properties
+            # expose sm_clock_rate (kHz) on the ROCm backend.
+            device = torch.cuda.current_device()
+            return driver.active.utils.get_device_properties(device)["sm_clock_rate"]
+        # NVIDIA: preserve the original pynvml fallback unchanged.
         import pynvml  # @manual=fbsource//third-party/pypi/pynvml:pynvml
 
         pynvml.nvmlInit()
@@ -42,6 +50,20 @@ def get_clock_rate_in_khz():
 
 def get_tensorcore_tflops(device, num_ctas, num_warps, dtype):
     """return compute throughput in TOPS"""
+    # Triton's upstream get_max_tensorcore_tflops() only recognizes the Nvidia
+    # fp8 dtypes and raises "dtype not supported" for the AMD/ROCm fnuz fp8
+    # dtypes (float8e4b8 == e4m3fnuz, float8e5b16 == e5m2fnuz). These share the
+    # same tensorcore throughput class as their Nvidia counterparts, so map them
+    # to a supported equivalent before querying.
+    amd_fp8_equivalents = {
+        k: v
+        for k, v in [
+            (getattr(tl, "float8e4b8", None), tl.float8e4nv),
+            (getattr(tl, "float8e5b16", None), tl.float8e5),
+        ]
+        if k is not None
+    }
+    dtype = amd_fp8_equivalents.get(dtype, dtype)
     total_warps = num_ctas * min(num_warps, 4)
     num_subcores = (
         driver.active.utils.get_device_properties(device)["multiprocessor_count"] * 4

--- a/test/gemm/triton/fp8_gemm_test.py
+++ b/test/gemm/triton/fp8_gemm_test.py
@@ -14,6 +14,7 @@ import torch
 if torch.cuda.is_available():
     from mslk.gemm.triton.fp8_gemm import matmul_fp8_block, matmul_fp8_row
     from mslk.quantize.triton.fp8_quantize import quantize_fp8_block, quantize_fp8_row
+    from mslk.utils.triton.fp8_utils import get_fp8_constants
 
 
 @unittest.skipIf(
@@ -142,8 +143,9 @@ class TestFp8Matmul(unittest.TestCase):
 
     def test_matmul_fp8_row_skip_scaling(self) -> None:
         def _fp8_clamp(x: torch.Tensor) -> torch.Tensor:
-            fp8_dtype = torch.float8_e4m3fn
-            fp8_max = torch.finfo(fp8_dtype).max
+            # Use the platform-correct fp8 dtype (e4m3fnuz on AMD MI300/MI350,
+            # e4m3fn on Nvidia) so matmul_fp8_row's dtype assertion is satisfied.
+            fp8_dtype, _, fp8_max, _ = get_fp8_constants()
             xq = torch.clamp(x, min=-1 * fp8_max, max=fp8_max).to(fp8_dtype)
             return xq
 
@@ -219,13 +221,21 @@ class TestFp8Matmul(unittest.TestCase):
             )
 
         _test_matmul_fp8_row_skip_scaling((3, 4, 5), torch.device("cuda"))
-        _test_matmul_fp8_row_skip_scaling((3, 4, 5), torch.device("cuda"), compile=True)
-        _test_matmul_fp8_row_skip_scaling(
-            (5, 4, 5), torch.device("cuda"), transpose_input=True
-        )
-        _test_matmul_fp8_row_skip_scaling(
-            (3, 4, 5), torch.device("cuda"), use_bias=False
-        )
+        # The compile / transposed / no-bias variants each re-trigger the
+        # persistent-path Triton autotune, which is very slow to compile on
+        # ROCm (hipcc). One representative case above already guards the
+        # skip-scaling path on ROCm; run the full matrix only on CUDA to keep
+        # the ROCm CI within its time budget.
+        if torch.version.hip is None:
+            _test_matmul_fp8_row_skip_scaling(
+                (3, 4, 5), torch.device("cuda"), compile=True
+            )
+            _test_matmul_fp8_row_skip_scaling(
+                (5, 4, 5), torch.device("cuda"), transpose_input=True
+            )
+            _test_matmul_fp8_row_skip_scaling(
+                (3, 4, 5), torch.device("cuda"), use_bias=False
+            )
 
     def test_matmul_fp8_block(self) -> None:
         def _test_matmul_fp8_block(

--- a/test/gemm/triton/grouped_gemm_test.py
+++ b/test/gemm/triton/grouped_gemm_test.py
@@ -28,7 +28,13 @@ class TestGroupedGEMM(unittest.TestCase):
 
     @parameterized.expand(
         itertools.product(
-            [1, 4, 16, 128],  # G
+            # The Triton kernels autotune on key=[G, M_BUCKET, N, K], so every
+            # distinct (G, M, N, K) combo pays a full cold hipcc autotune on
+            # ROCm. Keep single- vs multi-group coverage (G) but drop redundant
+            # group counts; keep the full M sweep here since fp8 has an M>=16384
+            # tolerance branch. Flag axes (fast_accum, fuse_scatter_add) are kept
+            # in full as they exercise distinct kernel code paths. See D110137656.
+            [1, 16],  # G
             [0, 128, 2048, 16384],  # M
             [256],  # N
             [256],  # K
@@ -146,10 +152,15 @@ class TestGroupedGEMM(unittest.TestCase):
 
     @parameterized.expand(
         itertools.product(
-            [1, 4, 16, 128],  # G
-            [0, 128, 2048, 16384],  # M
+            # Trim the shape grid to keep the ROCm CI within its time budget: the
+            # kernel autotunes on key=[G, M_BUCKET, N, K], so each combo triggers
+            # a cold hipcc autotune. Keep single- + multi-group (G), one aligned
+            # + one large multi-tile M, aligned + non-aligned N/K for masking
+            # coverage; flag axes are kept in full. See D110137656.
+            [1, 16],  # G
+            [0, 128, 2048],  # M
             [256, 451],  # N
-            [100, 256, 257],  # K
+            [256, 257],  # K
             [False],  # warp_specialization
             [True, False],  # fuse_scatter_add
         )
@@ -248,10 +259,13 @@ class TestGroupedGEMM(unittest.TestCase):
 
     @parameterized.expand(
         itertools.product(
-            [1, 4, 16, 128],  # G
-            [0, 128, 2048, 16384],  # M
+            # Trimmed shape grid (see test_grouped_gemm_bf16) to keep the ROCm CI
+            # within its time budget; bias/token-weight flag axes kept in full as
+            # they exercise distinct epilogue code paths. See D110137656.
+            [1, 16],  # G
+            [0, 128, 2048],  # M
             [256, 451],  # N
-            [100, 256, 257],  # K
+            [256, 257],  # K
             [False],  # warp_specialization
             [True, False],  # has_bias
             [True, False],  # has_token_weights
@@ -351,9 +365,12 @@ class TestGroupedGEMM(unittest.TestCase):
 
     @parameterized.expand(
         itertools.product(
-            [1, 4, 16, 128],  # G
-            [0, 128, 2048, 16384],  # M
-            [100, 256, 257],  # K
+            # Trimmed shape grid (see test_grouped_gemm_bf16) to keep the ROCm CI
+            # within its time budget; here N == K, so only K is swept. Bias/
+            # token-weight flag axes kept in full. See D110137656.
+            [1, 16],  # G
+            [0, 128, 2048],  # M
+            [256, 257],  # K
             [False],  # warp_specialization
             [True, False],  # has_bias
             [True, False],  # has_token_weights

--- a/test/quantize/triton/fp4_quantize_test.py
+++ b/test/quantize/triton/fp4_quantize_test.py
@@ -94,8 +94,11 @@ class TestFp4Quantize:
         xq, x_scale = triton_quantize_mx4_unpack(
             x, group_size=group_size, rounding_mode=rounding_mode
         )
-        # Convert blocked x_scale format back to (M, num_groups) layout.
-        x_scale = _from_blocked(x_scale, (M, num_groups))
+        # On ROCm the kernel already returns the plain [M, num_groups] scale
+        # layout; only NVIDIA returns the TCGen5 padded/swizzled (blocked)
+        # layout that must be converted back to (M, num_groups).
+        if not is_rocm():
+            x_scale = _from_blocked(x_scale, (M, num_groups))
         # Dequantize and check that results are similar.
         xq_float = fp4_to_float(xq)
         xq_dequant = scale_mx4(xq_float, x_scale, group_size).to(torch.bfloat16)


### PR DESCRIPTION
Summary:

The MSLK ROCm CI (AMD MI350, gfx950) fails all 5 shapes of
`fp4_quantize_test.py::TestFp4Quantize::test_quantize_fp4`. This is not a
kernel bug; it is a backend-layout assumption in the test.

`triton_quantize_mx4_unpack` returns the shared-exponent scale in a
backend-specific layout: on ROCm it returns the plain [M, num_groups] layout,
while on NVIDIA it returns the TCGen5 padded/swizzled ("blocked") layout. The
test unconditionally called `_from_blocked(x_scale, (M, num_groups))`, which is
only valid for the NVIDIA blocked layout. On ROCm the scale is already plain,
so `_from_blocked`'s `view(..., 32, 4, 4)` fails (shapes 0-2:
"invalid for input of size 4/774/48") or, when the element count happens to
match, produces wrong values (shapes 3-4: "Tensor-likes are not close").

Fix: only apply `_from_blocked` on the NVIDIA path. On ROCm the scale is
already in the [M, num_groups] layout that `scale_mx4` expects.

Reviewed By: cthi

Differential Revision: D110641097


