### PR TITLE
Fix mx6mx6bf16 CUDA<12.8 fallback signature to match 6-arg header (#422)

### DIFF
--- a/csrc/gemm/cutlass/mx6mx6bf16.cu
+++ b/csrc/gemm/cutlass/mx6mx6bf16.cu
@@ -754,7 +754,8 @@ at::Tensor mx6mx6bf16(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    std::optional<at::Tensor> output) {
+    std::optional<at::Tensor> output,
+    int64_t splits) {
   throw std::runtime_error("CUDA version is older than 12.8");
 }
 


### PR DESCRIPTION
Summary:

D109771475 added an `int64_t splits` parameter to `mslk::gemm::mx6mx6bf16` in the header (`gemm.h`), the CUDA>=12.8 definition, and the `TORCH_LIBRARY` `m.def` schema, but left the CUDA<12.8 `#else` fallback in `mx6mx6bf16.cu` at the old 5-arg signature. On any build using CUDA<12.8, `libmslk_csrc_gemm_gemm_ops.so` then exports only the 5-arg symbol while `gemm_ops.cpp` (through the 6-arg header) references the 6-arg one, so the shared library fails to load: `undefined symbol: _ZN4mslk4gemm10mx6mx6bf16EN2at6TensorES2_S2_S2_St8optionalIS2_El` (`mslk::gemm::mx6mx6bf16(Tensor, Tensor, Tensor, Tensor, optional<Tensor>, long)`).

This broke every consumer that links the lib on a CUDA<12.8 toolchain. Concretely it took down the ToolSim nightly: the `hatch_toolsim.toolsim_nightly` `unit_test_runner.par` crashed on startup with exit 127 (symbol lookup error), so every bucket produced no output and all ~446 tools were reported as `tcid_missing` (0 PASS) in the 2026-07-07 run.

- Add the missing `int64_t splits` param to the CUDA<12.8 fallback so the emitted symbol matches the header on all CUDA versions. The body still just throws (correct for CUDA<12.8); the point is that the symbol resolves at load time.

Reviewed By: cthi, jessexu20

Differential Revision: D110860042


