### PR TITLE
MXFP4 quantize: native ROCm/gfx950 support (stacked)

### DIFF
--- a/mslk/quantize/triton/fp4_primitives/packing.py
+++ b/mslk/quantize/triton/fp4_primitives/packing.py
@@ -9,60 +9,125 @@
 """
 FP4 packing primitives for converting float values to packed FP4 E2M1 format.
 
-Blackwell PTX hardware-accelerated packing.
+Device-aware packing:
+- NVIDIA (SM100+): Blackwell PTX ``cvt.rn.satfinite.e2m1x2.f32``.
+- AMD gfx950 (CDNA4 / MI350X): native ``v_cvt_scalef32_pk_fp4_f32``.
+- Other ROCm (gfx942, ...): pure-Triton ``_fp32_to_e2m1_nibble`` fallback.
+
+All three backends emit the identical packed layout: for each value pair
+``(t0, t1)`` (from ``x_blocks.reshape(..., 32, 2).split()``), ``t0`` goes in the
+low nibble [3:0] and ``t1`` in the high nibble [7:4] of the output byte.
 """
 
 import triton  # @manual
 from triton import language as tl  # @manual
 
 
+# gfx950 (CDNA4) hardware FP4 conversion: two f32 -> one packed E2M1 byte.
+# ``$1`` -> low nibble [3:0], ``$2`` -> high nibble [7:4]; scale operand 1.0
+# (E8M0=127, no extra scaling — the kernel already group-scaled into [-6, 6]).
+# Rounding: round-to-nearest-even (RNE), per AMD CDNA4 ISA.
+_GFX950_CVT_PK_FP4_F32 = "v_cvt_scalef32_pk_fp4_f32 $0, $1, $2, 1.0"
+
+
 @triton.jit
-def convert_fp32_to_fp4_packed(x_pairs):
-    """Convert FP32 value pairs to packed FP4 E2M1 format using PTX inline assembly.
+def _fp32_to_e2m1_nibble(v):
+    """Encode one float32 element as a 4-bit E2M1 nibble (int32, 0-15).
 
-    Uses the Blackwell ``cvt.rn.satfinite.e2m1x2.f32`` PTX instruction to convert
-    pairs of FP32 values into packed FP4 bytes. Each output byte contains two
-    E2M1 values:
+    Pure-Triton fallback for non-gfx950 ROCm (gfx942, etc.). Representable
+    magnitudes: {0, 0.5, 1, 1.5, 2, 3, 4, 6}; rounding is round-half-up
+    (ties always round toward the larger magnitude). This diverges from gfx950
+    hardware (which uses RNE) at tie values 0.25, 1.25, 2.5, and 5.0. E2M1
+    levels are non-uniformly spaced, so the branchless ``tl.where`` chain
+    (each lowers to v_cmp + v_cndmask on CDNA) is the correct GPU
+    implementation.
+    """
+    sign = tl.where(v < 0.0, 1, 0).to(tl.int32)
+    ax = tl.abs(v)
+    # Clamp to the representable range [0, 6].
+    ax = tl.minimum(ax, 6.0)
+    mag = tl.where(
+        ax < 0.25,
+        0,
+        tl.where(
+            ax < 0.75,
+            1,
+            tl.where(
+                ax < 1.25,
+                2,
+                tl.where(
+                    ax < 1.75,
+                    3,
+                    tl.where(
+                        ax < 2.5, 4, tl.where(ax < 3.5, 5, tl.where(ax < 5.0, 6, 7))
+                    ),
+                ),
+            ),
+        ),
+    )
+    return ((sign << 3) | mag).to(tl.int32)
 
-    - Low nibble (bits 0-3): first value of the pair
-    - High nibble (bits 4-7): second value of the pair
 
-    The PTX instruction handles:
-    - Round-to-nearest-even rounding
-    - Saturation to the FP4 E2M1 range [-6.0, 6.0]
-    - Proper encoding of E2M1 special values
-
-    Implementation detail: The ``pack=4`` parameter means 4 pairs are processed
-    per inline asm invocation, producing 4 bytes that are assembled into a single
-    uint32 via ``mov.b32``.
+@triton.jit
+def convert_fp32_to_fp4_packed(
+    x_pairs,
+    IS_GFX950: tl.constexpr,
+    IS_ROCM: tl.constexpr,
+):
+    """Convert FP32 value pairs to packed FP4 E2M1 format.
 
     Args:
-        x_pairs: List of 8 float32 tensors representing 4 pairs:
-            [pair0_lo, pair1_lo, pair2_lo, pair3_lo,
-             pair0_hi, pair1_hi, pair2_hi, pair3_hi]
+        x_pairs: 2-tuple ``(lo, hi)`` of fp32 tensors (from ``.split()`` on a
+            ``[..., 2]`` trailing dim). ``lo`` -> low nibble, ``hi`` -> high
+            nibble of each output byte.
+        IS_GFX950: compile-time; use the gfx950 native conversion instruction.
+        IS_ROCM: compile-time; use the pure-Triton fallback (non-gfx950 ROCm).
+            Ignored when ``IS_GFX950`` is True.
 
     Returns:
-        Packed uint8 tensor where each byte contains two E2M1 values.
+        Packed uint8 tensor; each byte holds two E2M1 values.
 
-    Note:
-        Requires Blackwell (SM 100+) GPU. Will fail on older architectures.
+    Default (both False) is the NVIDIA Blackwell PTX path (SM100+).
     """
-    x_fp4x2 = tl.inline_asm_elementwise(
-        asm="""
-        {
-        .reg .b8 byte0, byte1, byte2, byte3;
-        cvt.rn.satfinite.e2m1x2.f32 byte0, $5, $1;
-        cvt.rn.satfinite.e2m1x2.f32 byte1, $6, $2;
-        cvt.rn.satfinite.e2m1x2.f32 byte2, $7, $3;
-        cvt.rn.satfinite.e2m1x2.f32 byte3, $8, $4;
-        mov.b32 $0, {byte0, byte1, byte2, byte3};
-        }
-        """,
-        constraints=("=r,r,r,r,r,r,r,r,r"),
-        args=x_pairs,
-        dtype=tl.uint8,
-        is_pure=True,
-        pack=4,
-    )
-
-    return x_fp4x2
+    if IS_GFX950:
+        lo, hi = x_pairs
+        # v_cvt writes the packed byte into bits [7:0] of a 32-bit VGPR, so the
+        # inline-asm output must be int32 (a uint8 output can't be allocated to a
+        # `=v` register); mask the low byte and narrow to uint8.
+        packed = tl.inline_asm_elementwise(
+            asm=_GFX950_CVT_PK_FP4_F32,
+            constraints="=v,v,v",
+            args=[lo, hi],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1,
+        )
+        # pyre-ignore[16,58]: tl.inline_asm_elementwise is typed as a tuple by
+        # pyre; at runtime (dtype=int32) this is a tl.tensor supporting & / .to().
+        return (packed & 0xFF).to(tl.uint8)
+    elif IS_ROCM:
+        lo, hi = x_pairs
+        return (_fp32_to_e2m1_nibble(lo) | (_fp32_to_e2m1_nibble(hi) << 4)).to(tl.uint8)
+    else:
+        # NVIDIA Blackwell (SM100+): pairs -> packed FP4 via PTX. ``pack=4``
+        # processes 4 pairs per invocation ($1-$4 = lo lanes, $5-$8 = hi lanes),
+        # assembling 4 bytes into a uint32 via mov.b32. Round-to-nearest-even,
+        # saturation to [-6, 6].
+        x_fp4x2 = tl.inline_asm_elementwise(
+            asm="""
+            {
+            .reg .b8 byte0, byte1, byte2, byte3;
+            cvt.rn.satfinite.e2m1x2.f32 byte0, $5, $1;
+            cvt.rn.satfinite.e2m1x2.f32 byte1, $6, $2;
+            cvt.rn.satfinite.e2m1x2.f32 byte2, $7, $3;
+            cvt.rn.satfinite.e2m1x2.f32 byte3, $8, $4;
+            mov.b32 $0, {byte0, byte1, byte2, byte3};
+            }
+            """,
+            constraints=("=r,r,r,r,r,r,r,r,r"),
+            args=x_pairs,
+            dtype=tl.uint8,
+            is_pure=True,
+            pack=4,
+        )
+        return x_fp4x2

--- a/mslk/quantize/triton/quantize_kernels/mx4.py
+++ b/mslk/quantize/triton/quantize_kernels/mx4.py
@@ -22,6 +22,7 @@ from mslk.quantize.triton.fp4_primitives import (
     RoundingMode,
 )
 from mslk.quantize.triton.quantize_kernels import _resolve_seed
+from mslk.utils.device import is_gfx950, is_rocm
 from triton import language as tl  # @manual=//triton:triton
 
 
@@ -44,6 +45,8 @@ def quantize_mx4_kernel(
     MBITS: tl.constexpr,  # mantissa bits in target FP4 format (1 for E2M1)
     N_COL_BLOCKS: tl.constexpr,  # ceil(num_scale_cols / 4) — blocked layout offset
     STOCHASTIC: tl.constexpr,  # True → enable software stochastic rounding
+    IS_ROCM: tl.constexpr,  # True → plain [M, K//32] scale layout (AMD GEMM contract)
+    IS_GFX950: tl.constexpr,  # True → gfx950 native FP4 packing instruction
 ):
     """MX4 quantization kernel processing [M_PER_BLOCK, 64] tiles.
 
@@ -64,7 +67,7 @@ def quantize_mx4_kernel(
     # Tail-scale zeroing: when M_PER_BLOCK != 128, extra blocks zero out padded
     # scales in the 128-row-aligned tail for tensor core compatibility.
     # ========================================================================
-    if M_PER_BLOCK != 128 and pid_m * M_PER_BLOCK >= M:
+    if (not IS_ROCM) and M_PER_BLOCK != 128 and pid_m * M_PER_BLOCK >= M:
         offs_m = tl.arange(0, 128)[:, None]
         logical_col = pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS)[None, :]
         num_scale_cols = N // GROUP_SIZE
@@ -138,23 +141,35 @@ def quantize_mx4_kernel(
         # M * (N // GROUP_SIZE) > 2**31; promote like the data-offset paths above.
         logical_row = logical_row.to(tl.int64)
         logical_col = logical_col.to(tl.int64)
-    scale_offs = blocked_scale_offset(
-        logical_row, logical_col, N_COL_BLOCKS, num_scale_cols
-    )
-    # Mask out scale columns beyond num_scale_cols (= N // GROUP_SIZE).
-    # Without this mask, writes for col >= num_scale_cols collide with
-    # valid scales of subsequent rows in the swizzled layout. Rows are
-    # already on-tile by construction in the non-stacked path.
+    if IS_ROCM:
+        # AMD GEMMs consume the plain [M, num_scale_cols] row-major layout (no
+        # swizzle / 128-row pad). The buffer has exactly M rows, so tail rows
+        # from a partial last tile (logical_row >= M) must be masked out.
+        scale_offs = logical_row * num_scale_cols + logical_col
+        scale_store_mask = (logical_col < num_scale_cols) & (logical_row < M)
+    else:
+        scale_offs = blocked_scale_offset(
+            logical_row, logical_col, N_COL_BLOCKS, num_scale_cols
+        )
+        # Mask out scale columns beyond num_scale_cols (= N // GROUP_SIZE).
+        # Without this mask, writes for col >= num_scale_cols collide with
+        # valid scales of subsequent rows in the swizzled layout. Rows are
+        # already on-tile by construction in the non-stacked path.
+        scale_store_mask = logical_col < num_scale_cols
     tl.store(
         s_ptr + scale_offs,
         encoded_scales,
-        mask=(logical_col < num_scale_cols),
+        mask=scale_store_mask,
     )
 
     # ========================================================================
     # Pack to FP4 and store
     # ========================================================================
-    x_fp4x2 = convert_fp32_to_fp4_packed(x_blocks.reshape(M_PER_BLOCK, 32, 2).split())
+    x_fp4x2 = convert_fp32_to_fp4_packed(
+        x_blocks.reshape(M_PER_BLOCK, 32, 2).split(),
+        IS_GFX950=IS_GFX950,
+        IS_ROCM=IS_ROCM,
+    )
 
     q_offs_m = pid_m * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK)[:, None]
     q_offs_n = pid_n * 32 + tl.arange(0, 32)[None, :]
@@ -197,15 +212,27 @@ def quantize_mx4(
             reproducibility. Ignored for all deterministic rounding modes.
 
     Returns:
-        xq: Packed FP4 data, dtype uint8, shape [..., N//2]. Leading dims preserved.
-        scales: E8M0 biased exponent bytes, dtype int8, **flattened 1D**.
-            Size = rounded_M × rounded_K, both padded to 128/4 multiples.
-            Layout: Blackwell blocked (swizzled).
+        xq: Packed FP4 data, dtype uint8, shape [..., -1, N//2]. Leading dims preserved.
+        scales: E8M0 biased exponent bytes.
+            NVIDIA: dtype int8, **flattened 1D**, size = padded_M × padded_K
+                (both padded to 128/4 multiples). Layout: Blackwell blocked
+                (swizzled).
+            ROCm: dtype uint8, shape [..., -1, scale_K] where
+                scale_K = N // group_size. Plain row-major, no padding.
 
-    eg. [1, 5120] bf16 -> [1, 2560] uint8 + [128×4] int8 (flattened blocked)
+    eg. [1, 5120] bf16 -> [1, 2560] uint8 xq
+        NVIDIA: + [128×160] int8 scales (flattened blocked)
+        ROCm:   + [1, 160] uint8 scales (row-major)
     """
     stochastic = int(rounding_mode) == int(RoundingMode.stochastic)
     seed_int = _resolve_seed(seed, stochastic, x.device)
+
+    rocm = is_rocm()
+    gfx950 = is_gfx950()
+    if stochastic and rocm:
+        raise NotImplementedError(
+            "quantize_mx4: stochastic rounding is not supported on ROCm."
+        )
 
     orig_leading_dims, orig_N = x.shape[:-2], x.shape[-1]
     x_2d = x.reshape(-1, orig_N)
@@ -217,21 +244,29 @@ def quantize_mx4(
         torch.bfloat16,
     ), f"Expected fp16/bf16, got {x.dtype}"
 
+    scale_K = N // group_size
     # Scale padding (128-row × 4-col alignment for tensor cores).
-    n_col_blocks = triton.cdiv(N // group_size, 4)
-    padded_rows = triton.cdiv(M, 128) * 128
-    padded_cols = n_col_blocks * 4
+    n_col_blocks = triton.cdiv(scale_K, 4)
 
     xq = x.new_empty(M, N // 2, dtype=torch.uint8)
-    # Zero-init so OOB positions (where the kernel does not write) are zero.
-    scales = torch.zeros(padded_rows, padded_cols, dtype=torch.int8, device=x.device)
+    if rocm:
+        # AMD kernels consume the plain [M, K//32] E8M0 layout (no swizzle/pad).
+        scales = torch.zeros(M, scale_K, dtype=torch.int8, device=x.device)
+    else:
+        padded_rows = triton.cdiv(M, 128) * 128
+        padded_cols = n_col_blocks * 4
+        # Zero-init so OOB positions (where the kernel does not write) are zero.
+        scales = torch.zeros(
+            padded_rows, padded_cols, dtype=torch.int8, device=x.device
+        )
 
     # M_PER_BLOCK: rows per program. Capped at 128 (scale layout alignment).
     M_PER_BLOCK = min(triton.next_power_of_2(M), 128)
     USE_MASK = M % M_PER_BLOCK != 0 or N % 64 != 0
     grid = (triton.cdiv(N, 64), triton.cdiv(M, M_PER_BLOCK))
-    # Extra row of blocks to zero out tail scales when M_PER_BLOCK < 128.
-    if M_PER_BLOCK != 128:
+    # Extra row of blocks to zero out tail scales when M_PER_BLOCK < 128
+    # (NVIDIA padded layout only; ROCm has no padded tail).
+    if M_PER_BLOCK != 128 and not rocm:
         grid = (grid[0], grid[1] + 1)
     use_int64 = M * N > 2**31 - 1
 
@@ -262,6 +297,10 @@ def quantize_mx4(
         N_COL_BLOCKS=n_col_blocks,
         # pyre-ignore[6]
         STOCHASTIC=stochastic,
+        # pyre-ignore[6]
+        IS_ROCM=rocm,
+        # pyre-ignore[6]
+        IS_GFX950=gfx950,
         # pyre-ignore[28]
         num_stages=3 if M >= 256 else 1,
         # pyre-ignore[28]
@@ -269,4 +308,7 @@ def quantize_mx4(
     )
 
     xq = xq.view(*orig_leading_dims, -1, N // 2)
+    if rocm:
+        # Plain [..., K//32] uint8 E8M0 layout (matches the legacy ROCm return).
+        return xq, scales.view(torch.uint8).reshape(*orig_leading_dims, -1, scale_K)
     return xq, scales.flatten()

--- a/mslk/quantize/triton/quantize_kernels/mx4_stacked.py
+++ b/mslk/quantize/triton/quantize_kernels/mx4_stacked.py
@@ -26,6 +26,7 @@ from mslk.quantize.triton.fp4_primitives import (
     stacked_segment_map,
 )
 from mslk.quantize.triton.quantize_kernels import _resolve_seed
+from mslk.utils.device import is_gfx950, is_rocm
 from triton import language as tl  # @manual=//triton:triton
 
 
@@ -51,6 +52,8 @@ def quantize_mx4_stacked_kernel(
     MBITS: tl.constexpr,  # mantissa bits in target FP4 format (1 for E2M1)
     N_COL_BLOCKS: tl.constexpr,  # ceil(num_scale_cols / 4) — blocked layout offset
     STOCHASTIC: tl.constexpr,  # True → enable software stochastic rounding
+    IS_ROCM: tl.constexpr,  # True → plain [M, K//32] scale layout (AMD GEMM contract)
+    IS_GFX950: tl.constexpr,  # True → gfx950 native FP4 packing instruction
 ):
     """Stacked MX4 quantization kernel processing [M_PER_BLOCK, 64] tiles.
 
@@ -149,30 +152,45 @@ def quantize_mx4_stacked_kernel(
     # ========================================================================
     logical_col = pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS)[None, :]
     num_scale_cols = N // GROUP_SIZE
-    # The grid iterates padded rows directly, so padded_r == padded_rows.
-    padded_r = padded_rows  # [M_PER_BLOCK]
+    if IS_ROCM:
+        # AMD: plain [M, num_scale_cols] row-major, addressed by *logical* row
+        # (padding rows are masked out). No per-segment 128-row pad / swizzle.
+        lrows = logical_rows[:, None]
+        if USE_INT64_INDEXING:
+            lrows = lrows.to(tl.int64)
+        scale_offs = lrows * num_scale_cols + logical_col
+        scale_store_mask = is_valid_row[:, None] & (logical_col < num_scale_cols)
+    else:
+        # The grid iterates padded rows directly, so padded_r == padded_rows.
+        padded_r = padded_rows  # [M_PER_BLOCK]
 
-    seg_block_idx = padded_r // 128  # [M_PER_BLOCK], int64
-    padded_r_local = (padded_r % 128).to(tl.int32)  # [M_PER_BLOCK]
-    local_offs = blocked_scale_offset(
-        padded_r_local[:, None], logical_col, N_COL_BLOCKS, num_scale_cols
-    )
-    scale_offs = seg_block_idx[:, None].to(tl.int64) * (512 * N_COL_BLOCKS) + local_offs
-    # Mask both row and column OOB:
-    # - row: write every padded row in [0, padded_total) (padding rows carry
-    #   zero encoded_scales from scale_mask above).
-    # - column: logical_col >= num_scale_cols would collide with valid scales of
-    #   subsequent rows.
+        seg_block_idx = padded_r // 128  # [M_PER_BLOCK], int64
+        padded_r_local = (padded_r % 128).to(tl.int32)  # [M_PER_BLOCK]
+        local_offs = blocked_scale_offset(
+            padded_r_local[:, None], logical_col, N_COL_BLOCKS, num_scale_cols
+        )
+        scale_offs = (
+            seg_block_idx[:, None].to(tl.int64) * (512 * N_COL_BLOCKS) + local_offs
+        )
+        # Mask both row and column OOB (padding rows carry zero encoded_scales;
+        # logical_col >= num_scale_cols would collide with subsequent rows).
+        scale_store_mask = (padded_rows[:, None] < padded_total) & (
+            logical_col < num_scale_cols
+        )
     tl.store(
         s_ptr + scale_offs,
         encoded_scales,
-        mask=(padded_rows[:, None] < padded_total) & (logical_col < num_scale_cols),
+        mask=scale_store_mask,
     )
 
     # ========================================================================
     # Pack to FP4 and store
     # ========================================================================
-    x_fp4x2 = convert_fp32_to_fp4_packed(x_blocks.reshape(M_PER_BLOCK, 32, 2).split())
+    x_fp4x2 = convert_fp32_to_fp4_packed(
+        x_blocks.reshape(M_PER_BLOCK, 32, 2).split(),
+        IS_GFX950=IS_GFX950,
+        IS_ROCM=IS_ROCM,
+    )
 
     q_offs_m = logical_rows[:, None]
     q_offs_n = pid_n * 32 + tl.arange(0, 32)[None, :]
@@ -215,13 +233,24 @@ def quantize_mx4_stacked(
 
     Returns:
         xq: [M, N//2] packed FP4 data, dtype uint8 (matches ``quantize_mx4``).
-        scales: E8M0 biased exponent bytes, dtype int8, **flattened 1D**.
-            Logical shape is [padded_total_M_ub, padded_cols] in the Blackwell
-            blocked layout, with each segment 128-row aligned. Padding rows
-            between segments are zero.
+        scales: E8M0 biased exponent bytes.
+
+            NVIDIA (Blackwell): dtype int8, **flattened 1D**. Logical shape is
+            [padded_total_M_ub, padded_cols] with each segment 128-row aligned.
+            Padding rows between segments are zero.
+
+            ROCm (gfx950): dtype uint8, 2D shape [M, K//32] addressed by
+            logical row. No per-segment padding or swizzle.
     """
     stochastic = int(rounding_mode) == int(RoundingMode.stochastic)
     seed_int = _resolve_seed(seed, stochastic, x.device)
+
+    rocm = is_rocm()
+    gfx950 = is_gfx950()
+    if stochastic and rocm:
+        raise NotImplementedError(
+            "quantize_mx4_stacked: stochastic rounding is not supported on ROCm."
+        )
 
     x_2d = x.reshape(-1, x.shape[-1])
     M, N = x_2d.shape
@@ -245,17 +274,23 @@ def quantize_mx4_stacked(
 
     n_col_blocks = triton.cdiv(N // group_size, 4)
     padded_cols = n_col_blocks * 4
+    scale_K = N // group_size
 
     xq = torch.empty(M, N // 2, dtype=torch.uint8, device=x.device)
-    # Zero-init the scale buffer. The kernel writes scales only for rows in
-    # ``[0, padded_total)`` where ``padded_total = sum(round_up(m_i, 128))`` is
-    # the exact padded-row count it derives from ``m_sizes``; the CUDA-graph-safe
-    # buffer is over-allocated to the upper bound ``padded_total_M = M +
-    # num_segments * 127`` (to avoid a GPU→CPU sync), so the slack rows
-    # ``[padded_total, padded_total_M)`` are never touched by the kernel and must
-    # be zeroed here (``torch.empty`` leaves them uninitialized → NaN /
-    # non-deterministic).
-    scales = torch.zeros(padded_total_M, padded_cols, dtype=torch.int8, device=x.device)
+    if rocm:
+        # AMD: plain [M, K//32] E8M0 layout, addressed by logical row (padding
+        # rows are masked out by the kernel). No per-segment 128-row pad.
+        scales = torch.zeros(M, scale_K, dtype=torch.int8, device=x.device)
+    else:
+        # Zero-init the scale buffer. The kernel writes scales only for rows in
+        # ``[0, padded_total)`` where ``padded_total = sum(round_up(m_i, 128))``;
+        # the CUDA-graph-safe buffer is over-allocated to the upper bound
+        # ``padded_total_M = M + num_segments * 127`` (to avoid a GPU→CPU sync),
+        # so the slack rows ``[padded_total, padded_total_M)`` are never touched
+        # by the kernel and must be zeroed here.
+        scales = torch.zeros(
+            padded_total_M, padded_cols, dtype=torch.int8, device=x.device
+        )
 
     # M_PER_BLOCK: rows per program. Capped at 128 (scale layout alignment); at
     # M<256, cap at 64 to improve SM occupancy for small-M shapes.
@@ -299,10 +334,17 @@ def quantize_mx4_stacked(
         N_COL_BLOCKS=n_col_blocks,
         # pyre-ignore[6]
         STOCHASTIC=stochastic,
+        # pyre-ignore[6]
+        IS_ROCM=rocm,
+        # pyre-ignore[6]
+        IS_GFX950=gfx950,
         # pyre-ignore[28]
         num_stages=3 if M >= 256 else 1,
         # pyre-ignore[28]
         num_warps=4,
     )
 
+    if rocm:
+        # Plain [M, K//32] uint8 E8M0 layout (matches the non-stacked ROCm return).
+        return xq, scales.view(torch.uint8).reshape(M, scale_K)
     return xq, scales.flatten()

--- a/test/quantize/triton/test_quantize_mx4.py
+++ b/test/quantize/triton/test_quantize_mx4.py
@@ -15,17 +15,16 @@ from mslk.quantize.triton.fp4_primitives import RoundingMode
 from mslk.quantize.triton.quantize_kernels.mx4 import quantize_mx4
 from mslk.test.quantize.triton._mx4_torch_reference import (
     _unblock_mx4_scales,
-    is_blackwell_or_newer,
     swizzle_scales_to_blocked,
     torch_quantize_mx4_ref,
 )
+from mslk.testing.device import skipUnlessCudaCapability, skipUnlessGfxArch
+from mslk.utils.device import is_rocm
 from parameterized import parameterized  # @manual
 
 
-@unittest.skipUnless(
-    is_blackwell_or_newer(),
-    "Requires Blackwell (SM100+) GPU — MX4 PTX paths are SM100-only",
-)
+@skipUnlessGfxArch("gfx950")
+@skipUnlessCudaCapability(10)
 class QuantizeMX4Test(unittest.TestCase):
     """Bitwise-vs-torch-reference + first-principles tests for quantize_mx4."""
 
@@ -68,14 +67,21 @@ class QuantizeMX4Test(unittest.TestCase):
             ),
             f"FP4 data mismatch for shape ({M}, {N}, gs={group_size})",
         )
-        ref_scales_swizzled = swizzle_scales_to_blocked(
-            ref_scales_2d, b_scales.shape, convention="mslk"
-        )
+        if is_rocm():
+            # ROCm returns the plain [M, K//32] layout — compare directly.
+            b_cmp = b_scales.view(torch.uint8).reshape(M, -1).flatten()
+            ref_cmp = ref_scales_2d.view(torch.uint8).reshape(M, -1).flatten()
+        else:
+            b_cmp = b_scales.view(torch.uint8).flatten()
+            ref_cmp = (
+                swizzle_scales_to_blocked(
+                    ref_scales_2d, b_scales.shape, convention="mslk"
+                )
+                .view(torch.uint8)
+                .flatten()
+            )
         self.assertTrue(
-            torch.equal(
-                b_scales.view(torch.uint8).flatten(),
-                ref_scales_swizzled.view(torch.uint8).flatten(),
-            ),
+            torch.equal(b_cmp, ref_cmp),
             f"Scale mismatch for shape ({M}, {N}, gs={group_size})",
         )
 
@@ -94,7 +100,12 @@ class QuantizeMX4Test(unittest.TestCase):
         x = torch.zeros(1, 32, dtype=torch.bfloat16, device="cuda")
         x[0, 0] = group_max
         _, scales = quantize_mx4(x)
-        s = _unblock_mx4_scales(scales, 1, 1)
+        if is_rocm():
+            # ROCm returns the plain [M, K//32] layout (uint8) — no un-blocking.
+            # View as int8 so the byte matches the int8 expected encoding.
+            s = scales.view(torch.int8).reshape(1, -1)
+        else:
+            s = _unblock_mx4_scales(scales.view(torch.int8), 1, 1)
         self.assertEqual(s[0, 0].item(), expected_exp)
 
     @parameterized.expand(

--- a/test/quantize/triton/test_stacked_quantize_mx4.py
+++ b/test/quantize/triton/test_stacked_quantize_mx4.py
@@ -16,10 +16,11 @@ from mslk.quantize.triton.fp4_primitives import RoundingMode
 from mslk.quantize.triton.quantize_kernels.mx4 import quantize_mx4
 from mslk.quantize.triton.quantize_kernels.mx4_stacked import quantize_mx4_stacked
 from mslk.test.quantize.triton._mx4_torch_reference import (
-    is_blackwell_or_newer,
     swizzle_scales_to_blocked,
     torch_quantize_mx4_ref,
 )
+from mslk.testing.device import skipUnlessCudaCapability, skipUnlessGfxArch
+from mslk.utils.device import is_rocm
 from parameterized import parameterized  # @manual
 
 
@@ -49,10 +50,8 @@ def _slice_padded_scales(scales_flat, padded_start, padded_rows, padded_cols):
     return scales_flat[start:end]
 
 
-@unittest.skipUnless(
-    is_blackwell_or_newer(),
-    "Requires Blackwell (SM100+) GPU (matches test_stacked_quantize gating)",
-)
+@skipUnlessGfxArch("gfx950")
+@skipUnlessCudaCapability(10)
 class StackedQuantizeMX4Test(unittest.TestCase):
     """Bitwise-vs-torch-reference tests for stacked (MoE) MX4 quantization."""
 
@@ -105,29 +104,43 @@ class StackedQuantizeMX4Test(unittest.TestCase):
             )
             ref_xq_chunks.append(seg_xq_ref)
 
-            b_seg_slice = _slice_padded_scales(
-                b_scales, padded_start, padded_rows, padded_cols
-            )
+            if is_rocm():
+                # ROCm: plain [M, num_scale_cols] by logical row — compare the
+                # segment's rows directly (no padded slice / swizzle).
+                scales_u8 = b_scales.view(torch.uint8).reshape(-1, num_scale_cols)
+                b_seg_plain = scales_u8[seg_row_start:seg_end]
+                self.assertTrue(
+                    torch.equal(
+                        b_seg_plain.flatten(),
+                        seg_scales_2d.view(torch.uint8).flatten(),
+                    ),
+                    f"Segment {i} (m={m_i}) plain-scale mismatch, "
+                    f"m_sizes={m_sizes_list}",
+                )
+            else:
+                b_seg_slice = _slice_padded_scales(
+                    b_scales, padded_start, padded_rows, padded_cols
+                )
 
-            seg_scales_padded = torch.zeros(
-                (padded_rows, num_scale_cols),
-                dtype=torch.uint8,
-                device=seg.device,
-            )
-            seg_scales_padded[:m_i, :] = seg_scales_2d.view(torch.uint8)
-            seg_swizzled = swizzle_scales_to_blocked(
-                seg_scales_padded,
-                torch.Size([padded_rows * padded_cols]),
-                convention="mslk",
-            )
+                seg_scales_padded = torch.zeros(
+                    (padded_rows, num_scale_cols),
+                    dtype=torch.uint8,
+                    device=seg.device,
+                )
+                seg_scales_padded[:m_i, :] = seg_scales_2d.view(torch.uint8)
+                seg_swizzled = swizzle_scales_to_blocked(
+                    seg_scales_padded,
+                    torch.Size([padded_rows * padded_cols]),
+                    convention="mslk",
+                )
 
-            self.assertTrue(
-                torch.equal(
-                    b_seg_slice.view(torch.uint8).flatten(),
-                    seg_swizzled.view(torch.uint8).flatten(),
-                ),
-                f"Segment {i} (m={m_i}) scale mismatch for m_sizes={m_sizes_list}",
-            )
+                self.assertTrue(
+                    torch.equal(
+                        b_seg_slice.view(torch.uint8).flatten(),
+                        seg_swizzled.view(torch.uint8).flatten(),
+                    ),
+                    f"Segment {i} (m={m_i}) scale mismatch for m_sizes={m_sizes_list}",
+                )
 
         ref_xq = (
             torch.cat(ref_xq_chunks, dim=0)


### PR DESCRIPTION
Summary:
Extend the AMD ROCm support to the stacked (MoE) MXFP4 quantize kernel
(quantize_kernels/mx4_stacked.py), mirroring the non-stacked port:

- Thread IS_GFX950 / IS_ROCM into the shared convert_fp32_to_fp4_packed.
- On ROCm, store scales in a plain [M, K//32] E8M0 layout addressed by *logical*
  row (padding rows masked out) -- no per-segment 128-row pad / swizzle. NVIDIA
  keeps the per-segment padded-blocked layout.
- Host wrapper: device detection, deterministic-only rounding (stochastic on
  ROCm raises), plain [M, K//32] buffer + return on ROCm.

The stacked test reuses the existing per-segment bitwise-vs-torch-reference
parameterization with a device-aware comparison (plain rows on gfx950, padded
swizzled on Blackwell); gated supports_mxfp4() = Blackwell or gfx950.

Reviewed By: cthi

Differential Revision: D110519311


