### PR TITLE
Back triton_quantize_mx4_unpack with the MXFP4 kernels

### DIFF
--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import torch
 from mslk.quantize.triton.legacy import primitives as _primitives
 from mslk.quantize.triton.legacy.fake_quantize import (  # noqa: F401
     triton_fake_quantize_nvfp4_per_tensor,
@@ -28,7 +29,6 @@ from mslk.quantize.triton.legacy.primitives import (  # noqa: F401
 )
 from mslk.quantize.triton.legacy.quantize import (  # noqa: F401
     _kernel_quantize_mx4_unpack,
-    triton_quantize_mx4_unpack,
     triton_quantize_nvfp4,
 )
 from mslk.quantize.triton.legacy.quantize_stacked import (  # noqa: F401
@@ -41,6 +41,80 @@ from mslk.quantize.triton.legacy.unpack import (  # noqa: F401
     mega_fp4_pack,
     mega_fp4_unpack,
 )
+from mslk.quantize.triton.quantize_kernels.mx4 import quantize_mx4
+
+
+def triton_quantize_mx4_unpack(
+    input: torch.Tensor,
+    group_size: int = 32,
+    ebits: int = 2,
+    mbits: int = 1,
+    rounding_mode: RoundingMode | int = RoundingMode.ceil,
+    stochastic_casting: bool = False,
+    *,
+    seed: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """MXFP4 (E2M1 / E8M0, group size 32) quantize.
+
+    Thin adapter over ``quantize_kernels.mx4.quantize_mx4``. Returns packed
+    ``uint8 [..., K//2]`` FP4 data + E8M0 scales, preserving the input's leading
+    dims. Only E2M1 (``ebits=2, mbits=1``) is supported. ``quantize_mx4`` handles
+    the device split internally: CUDA/Blackwell emits the swizzled scale layout;
+    ROCm emits the plain ``[M, K//32]`` layout the ROCm MXFP4 GEMMs consume (and
+    rejects stochastic rounding). Stochastic rounding on CUDA is requested via
+    ``rounding_mode=RoundingMode.stochastic`` or by ``stochastic_casting=True``.
+    The flag is one-way: ``True`` forces stochastic rounding on regardless of
+    ``rounding_mode``, but ``False`` does not turn it off (an explicit
+    ``rounding_mode=RoundingMode.stochastic`` still applies). ``seed`` is
+    forwarded for reproducible output. ``group_size`` is retained for the MX4-16
+    (``group_size=16``) recipe; for the standard group-32 path prefer
+    ``triton_quantize_mx4``.
+    """
+    if ebits != 2 or mbits != 1:
+        raise NotImplementedError(
+            "triton_quantize_mx4_unpack: only E2M1 (ebits=2, mbits=1) is supported, "
+            f"got ebits={ebits}, mbits={mbits}."
+        )
+    effective_rounding_mode: RoundingMode | int = (
+        RoundingMode.stochastic if stochastic_casting else rounding_mode
+    )
+    xq, scale = quantize_mx4(
+        input,
+        group_size=group_size,
+        rounding_mode=effective_rounding_mode,
+        seed=seed,
+    )
+    # Restore the output-shape contract on the packed data: collapse to 1-D for
+    # 1-D input; a no-op for higher-rank input (quantize_mx4 already returns a
+    # shape-equivalent view). ``scale`` is returned exactly as produced.
+    xq = xq.reshape(list(input.shape[:-1]) + [-1])
+    return xq, scale
+
+
+def triton_quantize_mx4(
+    input: torch.Tensor,
+    *,
+    rounding_mode: RoundingMode | int = RoundingMode.ceil,
+    seed: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize to MXFP4 (OCP MX v1.0: E2M1 elements, E8M0 scales, group size 32).
+
+    Preferred public MXFP4 quantize entrypoint. Input is ``[..., N]`` (1-D or
+    higher) bf16/fp16 with ``N % 32 == 0``. Returns packed ``uint8 [..., N//2]``
+    FP4 data + E8M0 scales -- CUDA/Blackwell: flattened swizzled ``int8``;
+    ROCm/gfx950: plain ``[..., N//32]`` ``uint8`` -- delegating to
+    ``quantize_kernels.mx4.quantize_mx4`` (the device split is handled there).
+
+    Stochastic rounding (CUDA only) is requested via
+    ``rounding_mode=RoundingMode.stochastic``; ``seed`` is optional and, when
+    ``None``, is derived from the CUDA default generator so callers respect
+    ``torch.manual_seed``.
+
+    For the legacy signature (``ebits``/``mbits``/``group_size`` incl. MX4-16, or
+    the ``stochastic_casting`` flag), use ``triton_quantize_mx4_unpack``.
+    """
+    return quantize_mx4(input, group_size=32, rounding_mode=rounding_mode, seed=seed)
+
 
 # Private symbol aliases (same-object re-exports for internal consumers)
 _compute_exp = _primitives._compute_exp  # noqa: F401
@@ -56,6 +130,7 @@ convert_fp32_to_fp4_packed = _primitives.convert_fp32_to_fp4_packed  # noqa: F40
 __all__ = [
     "triton_quantize_nvfp4",
     "triton_quantize_mx4_unpack",
+    "triton_quantize_mx4",
     "triton_fake_quantize_nvfp4_per_tensor",
     "calculate_group_max",
     "nvfp4_quantize_stacked",


### PR DESCRIPTION
Summary:
Back the public MXFP4 quantize entrypoint
mslk.quantize.triton.fp4_quantize.triton_quantize_mx4_unpack with the new
self-contained MXFP4 kernel (quantize_kernels.mx4.quantize_mx4).

The adapter is a thin wrapper: it validates E2M1, forwards stochastic_casting,
and calls quantize_mx4, which handles the device split internally --
CUDA/Blackwell emits the swizzled scale layout; ROCm/gfx950 emits the plain
[M, K//32] E8M0 layout the ROCm MXFP4 GEMMs consume (and rejects stochastic
rounding). This supersedes the earlier ROCm re-route to the legacy kernel: the
AMD path now lives in the new kernels (parent diffs), so the adapter no longer
branches on torch.version.hip.

Also introduces a clean public entrypoint triton_quantize_mx4(x, *,
rounding_mode=RoundingMode.ceil, seed=None): E2M1 elements / E8M0 scales at the
canonical group size 32, with no ebits/mbits/group_size/stochastic_casting args
and no "unpack" in the name. It delegates to quantize_mx4(group_size=32).
triton_quantize_mx4_unpack is kept for backwards compatibility -- its group_size
arg still drives the MX4-16 (group_size=16) recipe.

Removes fp4_mx4_parity_test: the adapter is now a thin forward to quantize_mx4,
which is covered directly by test/quantize/triton/test_quantize_mx4.py
(bitwise-vs-torch-reference) and the integrated MXFP4 GEMM tests, so a separate
adapter-vs-legacy parity test is redundant.

Reviewed By: cthi

Differential Revision: D108095766


