### PR TITLE
Fix numeric test in D103697749 (mx8-mx6 gemm kernel) + packing guardrails (#427)

### DIFF
--- a/csrc/gemm/cutlass/mx8mx6bf16.cu
+++ b/csrc/gemm/cutlass/mx8mx6bf16.cu
@@ -76,7 +76,7 @@ Kernel_mx8mx6bf16 get_kernel_via_tuning(
 
 at::Tensor mx8mx6bf16(
     at::Tensor XQ, // MX FP8 (e4m3)
-    at::Tensor WQ, // MX FP6 (e2m3)
+    at::Tensor WQ, // MX FP6 (e2m3) — BIT-PACKED, see TORCH_CHECK below
     at::Tensor x_scale,
     at::Tensor w_scale,
     std::optional<at::Tensor> output) {
@@ -91,6 +91,18 @@ at::Tensor mx8mx6bf16(
   TORCH_CHECK(
       K % 32 == 0,
       "K must be a multiple of block size 32 for MX block-scaled GEMM");
+
+  // ElementB = cutlass::mx_float6_t<float_e2m3_t> has sizeof_bits == 6, so
+  // the kernel reads WQ as a bit-contiguous 6-bit stream (4 unpacked 6-bit
+  // values pack into 3 bytes, LSB-first). WQ sized [N, K*6/8] uint8.
+  TORCH_CHECK(
+      WQ.size(1) * 8 == K * 6,
+      "mx8mx6bf16: WQ must be bit-packed 6-bit (4 unpacked uint8s -> 3 ",
+      "packed bytes, LSB-first). Expected WQ.size(1) == K*6/8 == ",
+      K * 6 / 8,
+      ", got ",
+      WQ.size(1),
+      ". See _pack_fp6_e2m3() in gemm_test.py for the canonical packer.");
 
   if (M == 0 || N == 0 || K == 0) {
     return at::zeros({M, N}, XQ.options().dtype(at::kBFloat16));

--- a/include/mslk/gemm/gemm.h
+++ b/include/mslk/gemm/gemm.h
@@ -222,6 +222,18 @@ at::Tensor mx8mx4bf16(
 
 // Mixed MX8 x MX6 GEMM using mxf8f6f4 block-scaled tensor core instruction
 // ElementA = mx_float8_t<float_e4m3_t>, ElementB = mx_float6_t<float_e2m3_t>
+//
+// Tensor shape / format contract:
+//   XQ:       [M, K]     uint8 — MX8 (E4M3) bytes, 1 per element
+//   WQ:       [N, K*6/8] uint8 — MX6 (E2M3) BIT-PACKED, 4 unpacked 6-bit
+//             values per 3 packed bytes (LSB-first). See pack_fp6_e2m3()
+//             in mslk/mslk/quantize/mx_mixed_dtype_utils.py.
+//   x_scale:  E8M0 BS32 scales for XQ, _to_blocked swizzled, dtype uint8.
+//   w_scale:  E8M0 BS32 scales for WQ (per *unpacked* element count K),
+//             _to_blocked swizzled, dtype uint8.
+//   output:   [M, N] bfloat16 (optional; allocated if None).
+//
+// Kernel TORCH_CHECKs WQ.size(1)*8 == K*6.
 at::Tensor mx8mx6bf16(
     at::Tensor XQ,
     at::Tensor WQ,

--- a/mslk/quantize/mx_mixed_dtype_utils.py
+++ b/mslk/quantize/mx_mixed_dtype_utils.py
@@ -1,0 +1,134 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
+"""MX mixed-dtype quantization + packing utilities.
+
+Currently:
+    - pack_fp6_e2m3:            4 unpacked uint8 -> 3 packed bytes (LSB-first)
+    - quantize_bf16_to_mx6_e2m3: BF16 -> unpacked MX6 (E2M3) bytes + E8M0 scales
+
+Used by the mxf8f6f4-family CUTLASS GEMM kernels (mx8mx6bf16 etc), whose
+WQ operand is read as a bit-contiguous 6-bit stream. Callers that produce
+MX6 weights (quantizers, LUT ops) must feed packed bytes into these
+kernels; the mx8mx6bf16 op TORCH_CHECKs on the packed shape.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+__all__ = [
+    "E2M3_DECODE",
+    "E2M3_MAX",
+    "pack_fp6_e2m3",
+    "quantize_bf16_to_mx6_e2m3",
+]
+
+
+# E2M3 magnitude decode table — 32 unsigned values. Copied from
+# fbcode/ai_codesign/numerics/quantization/experimental/lut_upconvert/lut.py
+# (D99909748); also baked into the LUT kernel (nvfp4_to_mx6.cuh) and
+# matches cutlass's float_e2m3_t decode.
+E2M3_DECODE: tuple[float, ...] = (
+    0.0,
+    0.125,
+    0.25,
+    0.375,
+    0.5,
+    0.625,
+    0.75,
+    0.875,
+    1.0,
+    1.125,
+    1.25,
+    1.375,
+    1.5,
+    1.625,
+    1.75,
+    1.875,
+    2.0,
+    2.25,
+    2.5,
+    2.75,
+    3.0,
+    3.25,
+    3.5,
+    3.75,
+    4.0,
+    4.5,
+    5.0,
+    5.5,
+    6.0,
+    6.5,
+    7.0,
+    7.5,
+)
+E2M3_MAX: float = 7.5
+
+
+def pack_fp6_e2m3(unpacked: torch.Tensor) -> torch.Tensor:
+    """Pack 6-bit FP6 (E2M3) values stored as bytes into bit-packed bytes.
+
+    4 unpacked values (24 bits) -> 3 packed bytes, LSB-first.
+    Input shape (..., K), output shape (..., K * 6 // 8).
+    cutlass mx_float6_t<float_e2m3_t> has sizeof_bits == 6 and reads WQ as
+    a bit-contiguous 6-bit stream. Pass the output to
+    torch.ops.mslk.mx8mx6bf16 (or any mxf8f6f4-family kernel with an MX6
+    operand).
+    """
+    assert unpacked.dtype == torch.uint8
+    assert unpacked.shape[-1] % 4 == 0
+    leading = unpacked.shape[:-1]
+    K = unpacked.shape[-1]
+    # uint16 has no CUDA bitwise ops; widen to int32 for the pack arithmetic.
+    x = unpacked.reshape(*leading, K // 4, 4).to(torch.int32)
+    b0 = (x[..., 0] & 0x3F) | ((x[..., 1] & 0x03) << 6)
+    b1 = ((x[..., 1] >> 2) & 0x0F) | ((x[..., 2] & 0x0F) << 4)
+    b2 = ((x[..., 2] >> 4) & 0x03) | ((x[..., 3] & 0x3F) << 2)
+    packed = torch.stack([b0, b1, b2], dim=-1).to(torch.uint8)
+    return packed.reshape(*leading, K * 6 // 8).contiguous()
+
+
+def quantize_bf16_to_mx6_e2m3(
+    x: torch.Tensor, block_size: int = 32
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """BF16 -> MX6 (E2M3 + E8M0 BS32 scale) quantizer.
+
+    Vectorized reimplementation of the BF16->MX6 path from
+    nv4_to_mx6_baseline_dequant() in D99909748's test_real_weights.py:
+        amax/block -> shared_exp = ceil(log2(amax / 7.5)) + 127
+                   -> snap each element to nearest E2M3 code
+
+    Returns:
+        bytes:  [..., K] uint8, byte = [zero:2 | sign:1 | mag_idx:5]
+        scales: [..., K // block_size] uint8 E8M0 (biased exponent)
+    """
+    assert x.shape[-1] % block_size == 0
+    leading = x.shape[:-1]
+    K = x.shape[-1]
+    nb = K // block_size
+
+    codes = torch.tensor(E2M3_DECODE, dtype=torch.float32, device=x.device)
+    blocks = x.float().reshape(*leading, nb, block_size)
+    sign = (blocks < 0).to(torch.uint8)
+    mag = blocks.abs()
+
+    amax = mag.amax(dim=-1, keepdim=True)
+    safe_amax = torch.clamp(amax, min=1e-38)
+    # Clamp k_exp to the E8M0-representable range [-127, 128], then use the
+    # clamped value for BOTH the emitted scale byte AND the normalization
+    # factor. Otherwise blocks with amax outside 2**(-127..128) would emit
+    # a clamped scale byte but normalize against an unclamped 2**k_exp,
+    # producing a quantizer/dequantizer mismatch on extreme inputs.
+    k_exp = (
+        torch.ceil(torch.log2(safe_amax / E2M3_MAX)).clamp(-127, 128).to(torch.int32)
+    )
+    scale_byte = (k_exp + 127).to(torch.uint8)
+    scale = torch.pow(torch.tensor(2.0, device=x.device), k_exp.float())
+
+    normalized = mag / scale
+    # Snap each value to nearest of the 32 E2M3 codes via argmin distance.
+    e2m3_idx = (normalized.unsqueeze(-1) - codes).abs().argmin(dim=-1).to(torch.uint8)
+
+    out = ((sign << 5) | (e2m3_idx & 0x1F)).reshape(*leading, K)
+    return out, scale_byte.squeeze(-1)

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -34,7 +34,11 @@ from mslk.testing.device import (
 from mslk.utils.device import compute_capability_in, supports_float8_fnuz
 
 if torch.cuda.is_available():
-    from mslk.gemm.triton.fp8_gemm import matmul_fp8_block, matmul_fp8_row
+    from mslk.gemm.triton.fp8_gemm import matmul_fp8_block, matmul_fp8_row, to_mxfp8
+    from mslk.quantize.mx_mixed_dtype_utils import (
+        pack_fp6_e2m3,
+        quantize_bf16_to_mx6_e2m3,
+    )
     from mslk.quantize.shuffle import quantize_int4_preshuffle
     from mslk.quantize.triton.fp8_quantize import quantize_fp8_block, quantize_fp8_row
 
@@ -1537,7 +1541,6 @@ class MXFP8Tests(unittest.TestCase):
     ) -> None:
         # Simulate 2d-2d grouped gemm in backward pass `grad_weight = grad_output_t @ input`,
         # where we use "K" as the contracting dim which has "G" groups.
-        from mslk.gemm.triton.fp8_gemm import to_mxfp8
 
         total_K = K  # Alias for clarity, communicating this consists of several groups along this dim
         input_group_end_offsets = generate_jagged_offs(
@@ -1639,8 +1642,6 @@ class MXFP8Tests(unittest.TestCase):
         N: int,
         K: int,
     ) -> None:
-        from mslk.gemm.triton.fp8_gemm import to_mxfp8
-
         # Simulate 2d-3d grouped gemm `out = input @ weight.t()`
         # 2D inputs with groups along M, 3D weights.
         block_size = 32
@@ -1728,7 +1729,6 @@ class MXFP8Tests(unittest.TestCase):
         1. Output with hint matches output without hint (same GEMM, different tile)
         2. Output matches bf16 reference
         """
-        from mslk.gemm.triton.fp8_gemm import to_mxfp8
 
         block_size = 32
         actual_total_M = M_per_group * G
@@ -2901,8 +2901,6 @@ class MX8MX4Tests(unittest.TestCase):
         ]
     )
     def test_gemm(self, M: int, N: int, K: int) -> None:
-        from mslk.gemm.triton.fp8_gemm import to_mxfp8
-
         A = torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
         B = torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
 
@@ -2941,8 +2939,6 @@ class MX8MX4Tests(unittest.TestCase):
         N: int,
         K: int,
     ) -> None:
-        from mslk.gemm.triton.fp8_gemm import to_mxfp8
-
         XS = [
             torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
             for _ in range(G)
@@ -2994,8 +2990,6 @@ class MX8MX4Tests(unittest.TestCase):
         torch.testing.assert_close(out_mx8mx4, out_bf16, atol=6.0e-2, rtol=6.0e-2)
 
     def test_mx8mx4_grouped_gemm_2d_3d_empty_groups(self) -> None:
-        from mslk.gemm.triton.fp8_gemm import to_mxfp8
-
         G = 8
         N = 1024
         K = 2048
@@ -3062,34 +3056,67 @@ class MX8MX6Tests(unittest.TestCase):
         ]
     )
     def test_gemm(self, M: int, N: int, K: int) -> None:
-        from mslk.gemm.triton.fp8_gemm import to_mxfp8
-
+        torch.manual_seed(0)
         A = torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
         B = torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
 
-        # Quantize A to MX8 with blocked scale layout
+        # MX8 activation with blocked scale layout.
         (a_scale_raw, aq) = to_mxfp8(A)
         a_scale = _to_blocked(a_scale_raw.view(torch.int8).reshape(M, -1)).view(
             torch.uint8
         )
 
-        # Quantize B: use MX8 quantization for scale factors (E8M0 BS32),
-        # then create E2M3 weight data from the MX8 data.
-        # E2M3 is stored as 1 byte per element (6-bit value in uint8).
-        # We use the FP8 data masked to 6 bits as a proxy for E2M3.
-        (b_scale_raw, bq_fp8) = to_mxfp8(B)
+        # MX6 weight: BF16 -> unpacked E2M3 bytes -> bit-packed for the
+        # cutlass 6-bit-stream layout. Scale is E8M0 blocked for TMA.
+        wq_unpacked, b_scale_raw = quantize_bf16_to_mx6_e2m3(B, block_size=32)
+        bq = pack_fp6_e2m3(wq_unpacked)
         b_scale = _to_blocked(b_scale_raw.view(torch.int8).reshape(N, -1)).view(
             torch.uint8
         )
-        bq = bq_fp8.view(torch.uint8) & 0x3F  # mask to 6 bits for E2M3 range
 
         out_mx8mx6 = torch.ops.mslk.mx8mx6bf16(aq, bq, a_scale, b_scale)
+        out_bf16 = A @ B.t()
 
-        # Smoke test: no NaN or Inf
         self.assertFalse(out_mx8mx6.isnan().any().item(), "Output contains NaN")
         self.assertFalse(out_mx8mx6.isinf().any().item(), "Output contains Inf")
-        # Output shape check
         self.assertEqual(out_mx8mx6.shape, (M, N))
+        torch.testing.assert_close(out_mx8mx6, out_bf16, atol=1.0e-1, rtol=1.0e-1)
+
+        ref = out_bf16.float()
+        err = out_mx8mx6.float() - ref
+        mask = ref != 0
+        signal_power = (ref[mask] ** 2).sum()
+        noise_power = (err[mask] ** 2).sum().clamp(min=1e-30)
+        sqnr_db = (10.0 * torch.log10(signal_power / noise_power)).item()
+        self.assertGreater(
+            sqnr_db,
+            20.0,
+            f"mx8mx6 SQNR {sqnr_db:.2f} dB below 20 dB floor (M={M}, N={N}, K={K})",
+        )
+
+    def test_unpacked_weight_raises(self) -> None:
+        """Feeding 1-byte-per-element (unpacked) bytes to mx8mx6bf16 must
+        trip the WQ shape TORCH_CHECK in mx8mx6bf16.cu, not silently produce
+        garbage output."""
+        M, N, K = 64, 256, 2048
+        A = torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        B = torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+
+        (a_scale_raw, aq) = to_mxfp8(A)
+        a_scale = _to_blocked(a_scale_raw.view(torch.int8).reshape(M, -1)).view(
+            torch.uint8
+        )
+
+        # Unpacked weight: 1 byte per element instead of K*6/8 packed bytes.
+        # Exactly what the old test (and any naive caller) would produce.
+        wq_unpacked, b_scale_raw = quantize_bf16_to_mx6_e2m3(B, block_size=32)
+        b_scale = _to_blocked(b_scale_raw.view(torch.int8).reshape(N, -1)).view(
+            torch.uint8
+        )
+        self.assertEqual(wq_unpacked.shape, (N, K))  # confirm "wrong" shape
+
+        with self.assertRaisesRegex(RuntimeError, "bit-packed 6-bit"):
+            torch.ops.mslk.mx8mx6bf16(aq, wq_unpacked, a_scale, b_scale)
 
 
 @skipUnlessCuda()


### PR DESCRIPTION
Summary:

## The previous issue: smoke-only test masked a silent packing bug

The MX8MX6Tests added in D103697749 (the mx8mx6bf16 kernel landing) only
smoke-checked the kernel:

    self.assertFalse(out_mx8mx6.isnan().any().item(), 'Output contains NaN')
    self.assertFalse(out_mx8mx6.isinf().any().item(), 'Output contains Inf')
    self.assertEqual(out_mx8mx6.shape, (M, N))

It NEVER measured numerical correctness against a BF16 reference. The
weight tensor was a 'mask-to-6-bits' proxy:

    bq = bq_fp8.view(torch.uint8) & 0x3F  # mask to 6 bits for E2M3 range

…which produces 1-byte-per-element 'unpacked' bytes whose values aren't
even valid E2M3 codes (they're FP8 E4M3 bytes with the sign + top exp bit
masked off). The test passed only because the output happened to be
non-NaN, not because the kernel computed anything correct.

## The packing bug it hid

The cutlass template instantiates ElementB = mx_float6_t<float_e2m3_t>,
where cutlass::sizeof_bits<float_e2m3_t> == 6. The kernel reads WQ as a
bit-contiguous 6-bit stream — 4 unpacked 6-bit values pack into 3 bytes
(LSB-first), so a correctly-shaped WQ has [N, K*6/8] bytes, not [N, K].
Feeding 1-byte-per-element unpacked bytes (as the original test did, and
as any naive caller would) reinterprets the bitstream and produces
scrambled output: ~-2.4 dB SQNR vs BF16 reference. The kernel itself is
correct; the failure was entirely in how WQ was being constructed.

## The fix: kernel-side guard + real test

Kernel side (loud failure on misuse):

  1. mx8mx6bf16.cu: add TORCH_CHECK requiring WQ.size(1)*8 == K*6 with a
     message that names the canonical _pack_fp6_e2m3() helper. Anyone
     passing unpacked bytes now hits a clear runtime error instead of
     debugging numerical issues for days.
  2. gemm.h: document the WQ shape/format contract on the mx8mx6bf16
     declaration so callers see it without reading the kernel source.

Test side (regression guard):

  3. gemm_test.py: add _pack_fp6_e2m3() helper (4 unpacked uint8 -> 3
     packed bytes, LSB-first) for cutlass consumption.
  4. gemm_test.py: add _quantize_bf16_to_mx6_e2m3() — a vectorized
     BF16->MX6 quantizer. Algorithm + E2M3 decode table copied from
     D99909748's nv4_to_mx6_baseline_dequant. Pure PyTorch, no external
     deps.
  5. MX8MX6Tests.test_gemm: replace the FP8-mask proxy with the real
     quantizer + packer + SQNR check (> 20 dB floor vs BF16 reference).
  6. MX8MX6Tests.test_unpacked_weight_raises: regression guard
     verifying the new TORCH_CHECK fires with the documented message
     when callers pass unpacked bytes.

No new BUCK deps.

## SQNR results on B300 (--nvcc_arch=b300f --platform010_cuda_version=13.0)

  +---------------+------+------+------+---------------+
  | Test          |   M  |   N  |   K  | mx8mx6 SQNR   |
  +---------------+------+------+------+---------------+
  | test_gemm_0   |    1 |  256 | 2048 |   27.79 dB    |
  | test_gemm_1   |   64 |  512 | 2048 |   28.25 dB    |
  | test_gemm_2   |  256 | 1024 | 4096 |   28.27 dB    |
  +---------------+------+------+------+---------------+

All 4 tests PASS (3 SQNR + 1 TORCH_CHECK regression guard).  mx8mx6 lands
right at the MX8 ceiling (~28.5 dB).  D103697749's task description
estimated 'MX6 SQNR ~22-24 dB' — actual is 28 dB, comfortably above the
20 dB assert floor.

## Implications for downstream consumers

- D103697749's bench (mx8mx6_bench.py) uses torch.randint for the MX6
  weight — fine for TFLOPS but cannot validate SQNR. With the new helpers
  here, it could now measure MX6 SQNR.
- D100090504 (NV4->MX6 LUT op): writes UNPACKED MX6 bytes. Downstream
  callers that chain this op into mx8mx6bf16 will trip the new
  TORCH_CHECK. Either pack the bytes before calling mx8mx6bf16, or
  update the LUT kernel to write packed bytes natively.
- D109757960 (nv4_pipelines_bench Path 2): packing inserted in that diff.

Reviewed By: cthi

Differential Revision: D110208773


