### PR TITLE
Register MXFP4 quantize bench ops (TritonMXFP4 / TritonMXFP4Stacked)

### DIFF
--- a/bench/quantize/quantize_ops.py
+++ b/bench/quantize/quantize_ops.py
@@ -18,7 +18,11 @@ from mslk.quantize.triton.fp4_quantize import (
     nvfp4_quantize_stacked_with_token_scale,
     triton_quantize_nvfp4,
 )
-from mslk.quantize.triton.fp4_utils import dequantize_nvfp4, global_scale_nvfp4
+from mslk.quantize.triton.fp4_utils import (
+    dequantize_mx4,
+    dequantize_nvfp4,
+    global_scale_nvfp4,
+)
 from mslk.quantize.triton.fp8_quantize import (
     dequantize_fp8_block,
     dequantize_fp8_row,
@@ -27,6 +31,8 @@ from mslk.quantize.triton.fp8_quantize import (
     triton_quantize_fp8_group,
     triton_quantize_fp8_tensor,
 )
+from mslk.quantize.triton.quantize_kernels.mx4 import quantize_mx4
+from mslk.quantize.triton.quantize_kernels.mx4_stacked import quantize_mx4_stacked
 from mslk.utils.device import is_cuda, is_rocm
 
 
@@ -376,6 +382,65 @@ class MegaFP4Quantize(QuantizeOpBase):
 
     def dequantize(self, *args: Any) -> torch.Tensor:
         # Mega kernel output has padded rows; return zeros matching original input shape.
+        return torch.zeros(
+            self.input_shape, dtype=torch.bfloat16, device=args[0].device
+        )
+
+    @property
+    def hip(self) -> bool:
+        return False
+
+    @property
+    def cuda(self) -> bool:
+        return True
+
+
+@register_op
+class TritonMXFP4(QuantizeOpBase):
+    """MXFP4 quantize via quantize_kernels.mx4.quantize_mx4."""
+
+    def quantize(self, input: torch.Tensor, *args: Any) -> Any:
+        xq, scales = quantize_mx4(input)
+        return xq, scales
+
+    def dequantize(self, *args: Any) -> torch.Tensor:
+        xq, scales = args[0], args[1]
+        return dequantize_mx4(xq, scales)
+
+    @property
+    def hip(self) -> bool:
+        return False
+
+    @property
+    def cuda(self) -> bool:
+        return True
+
+
+@register_op
+class TritonMXFP4Stacked(QuantizeOpBase):
+    """Stacked (MoE) MXFP4 quantize via quantize_kernels.mx4_stacked."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_shape: tuple[int, ...] = (0, 0)
+
+    def preprocess(self, input: torch.Tensor, num_groups: int = 1) -> Any:
+        self.input_shape = tuple(input.shape)
+        M = input.shape[0]
+        # Split M evenly across num_groups.
+        base = M // num_groups
+        remainder = M % num_groups
+        sizes = [base + (1 if i < remainder else 0) for i in range(num_groups)]
+        m_sizes = torch.tensor(sizes, dtype=torch.int64, device=input.device)
+        return (m_sizes,)
+
+    def quantize(self, input: torch.Tensor, *args: Any) -> Any:
+        m_sizes: torch.Tensor = args[0]
+        xq, scales = quantize_mx4_stacked(m_sizes, input)
+        return xq, scales
+
+    def dequantize(self, *args: Any) -> torch.Tensor:
+        # Grouped dequant is complex due to per-segment padding; return zeros.
         return torch.zeros(
             self.input_shape, dtype=torch.bfloat16, device=args[0].device
         )

--- a/mslk/quantize/triton/fp4_utils.py
+++ b/mslk/quantize/triton/fp4_utils.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 from mslk.quantize.triton.legacy.fp4_utils import (  # noqa: F401
+    dequantize_mx4,
     dequantize_nvfp4,
     fp4_to_float,
     global_scale_nvfp4,

--- a/mslk/quantize/triton/legacy/fp4_utils.py
+++ b/mslk/quantize/triton/legacy/fp4_utils.py
@@ -118,3 +118,30 @@ def dequantize_nvfp4(
     return scale_nvfp4(input_quantized_float, scale, global_scale, group_size).to(
         torch.bfloat16
     )
+
+
+def dequantize_mx4(
+    input_quantized: torch.Tensor,
+    scale: torch.Tensor,
+    group_size: int = 32,
+) -> torch.Tensor:
+    """Dequantize an MXFP4 (E2M1 element / E8M0 scale) tensor back to bfloat16.
+
+    Args:
+        input_quantized: Quantized tensor in uint8 format (two FP4 values per byte).
+        scale: Per-group E8M0 scales in blocked format.
+        group_size: Number of elements per scale group.
+
+    Returns:
+        Dequantized tensor in bfloat16 format.
+    """
+    packed = input_quantized.view(torch.uint8)
+    M = packed.shape[0]
+    # Two FP4 values are packed into one uint8.
+    N = packed.shape[1] * 2
+    num_groups = math.ceil(N / group_size)
+    # E8M0 scale byte -> power-of-two multiplier 2 ** (byte - 127).
+    e8m0 = _from_blocked(scale.view(torch.uint8), (M, num_groups)).to(torch.int32)
+    scale_per_group = torch.exp2(e8m0.to(torch.float32) - 127.0)
+    scale_per_elem = scale_per_group.repeat_interleave(group_size, dim=1)[:, :N]
+    return (fp4_to_float(packed) * scale_per_elem).to(torch.bfloat16)


### PR DESCRIPTION
Summary:
Register TritonMXFP4 and TritonMXFP4Stacked benchmark ops in the MSLK quantize
bench registry (mslk/bench/quantize/quantize_ops.py), wrapping the MXFP4
quantize kernels (quantize_kernels.mx4.quantize_mx4 /
mx4_stacked.quantize_mx4_stacked). Adds a reference MXFP4 dequant (E2M1 nibble
unpack + E8M0 un-blocking via _from_blocked, reconstructing
value * 2**(e8m0 - 127)) so the non-stacked sim MSE metric is meaningful; the
stacked op returns a zeros placeholder because per-segment padding makes a
faithful round-trip ambiguous. No driver change — the existing quantize_bench
discovers the ops via get_ops() + --kernels.

Perf (B200, HBM roofline 7672 GB/s):
  OpName               Problem Shape   Sim     Us       GB/s     Mem BW Util %
  TritonMXFP4          (1024, 5120)    0.021   6.804    1950.5   25.4
  TritonMXFP4          (2000, 5120)    0.021   9.628    2693.0   35.1
  TritonMXFP4          (1024, 7168)    0.021   7.754    2396.0   31.2
  TritonMXFP4          (4096, 4096)    0.021   13.308   3191.2   41.6
  TritonMXFP4          (4096, 5120)    0.021   16.786   3162.4   41.2
  TritonMXFP4          (16384, 5120)   0.021   60.485   3510.6   45.8
  TritonMXFP4          (1, 5120)       0.020   2.471    13.5     0.2
  TritonMXFP4Stacked   (1024, 5120)    1.000   7.997    1662.1   21.7
  TritonMXFP4Stacked   (2000, 5120)    1.000   12.018   2158.5   28.1
  TritonMXFP4Stacked   (4096, 4096)    1.000   17.229   2465.8   32.1
  TritonMXFP4Stacked   (4096, 5120)    1.000   21.448   2476.0   32.3
  TritonMXFP4Stacked   (16384, 5120)   1.000   73.718   2880.7   37.6

TritonMXFP4 peaks at 3510 GB/s (45.8% of the B200 HBM roofline) at 16384x5120.
The non-stacked sim MSE is ~0.021 (meaningful reconstruction); the stacked op's
sim stays 1.0 (zeros placeholder, per-segment padding) — timing/GB-s are the
real signal there.

Reviewed By: cthi

Differential Revision: D109350371


