### PR TITLE
[ROCm] Fix tl.constexpr annotation form in global variables

### DIFF
--- a/mslk/quantize/triton/fp4_primitives/constants.py
+++ b/mslk/quantize/triton/fp4_primitives/constants.py
@@ -22,14 +22,20 @@ from triton import language as tl  # @manual=//triton:triton
 # E8M0 / BF16 Constants
 # =============================================================================
 #
-# These are annotated ``tl.constexpr`` at module scope so they remain valid Triton
-# kernel constants in OSS: OSS Triton rejects a plain (non-constexpr) Python global
-# referenced inside a ``@triton.jit`` kernel (triton-lang/triton#3762). The
-# annotation is a no-op for host/Python use (the value is the bare float/int).
-E8M0_EXPONENT_BIAS: tl.constexpr = 127  # type: ignore[Incompatible variable type]
+# These are instantiated as ``tl.constexpr(...)`` at module scope so they remain
+# valid Triton kernel constants in OSS: OSS Triton rejects a plain (non-constexpr)
+# Python global referenced inside a ``@triton.jit`` kernel, and it *only* accepts
+# the assignment form ``x = tl.constexpr(v)`` — the annotation form
+# ``x: tl.constexpr = v`` is unsupported.
+#
+# Inside a ``@triton.jit`` kernel, reference these directly (bare ``VAR``); Triton
+# treats them as compile-time constants. For host/Python use (torch ops, ``math``,
+# etc.) use ``VAR.value`` to recover the bare float/int — a ``tl.constexpr`` object
+# is not a drop-in for the raw number (e.g. ``torch.clamp(min=VAR)`` raises).
+E8M0_EXPONENT_BIAS = tl.constexpr(127)
 """Exponent bias for the E8M0 scale format (same as IEEE 754 FP32 exponent bias)."""
 
-BF16_MIN_NORMAL: tl.constexpr = 2 ** (-126)  # type: ignore[Incompatible variable type]
+BF16_MIN_NORMAL = tl.constexpr(2 ** (-126))
 """Minimum positive normal BF16 value; zero-guard in MX4 scale computation."""
 
 

--- a/mslk/quantize/triton/fp4_primitives/packing.py
+++ b/mslk/quantize/triton/fp4_primitives/packing.py
@@ -27,7 +27,7 @@ from triton import language as tl  # @manual
 # ``$1`` -> low nibble [3:0], ``$2`` -> high nibble [7:4]; scale operand 1.0
 # (E8M0=127, no extra scaling — the kernel already group-scaled into [-6, 6]).
 # Rounding: round-to-nearest-even (RNE), per AMD CDNA4 ISA.
-_GFX950_CVT_PK_FP4_F32 = "v_cvt_scalef32_pk_fp4_f32 $0, $1, $2, 1.0"
+_GFX950_CVT_PK_FP4_F32 = tl.constexpr("v_cvt_scalef32_pk_fp4_f32 $0, $1, $2, 1.0")
 
 
 @triton.jit


### PR DESCRIPTION
Follow-up for https://github.com/meta-pytorch/MSLK/pull/414, https://github.com/meta-pytorch/MSLK/pull/421 and https://github.com/meta-pytorch/MSLK/pull/425. `tl.constexpr` annotation form global variables usage in triton kernels causes compilation errors:

```bash
NameError("Cannot access global variable BF16_MIN_NORMAL from within @jit'ed function. Triton kernels can only access global variables that are instanstiated as constexpr (`x = triton.language.constexpr(42)`). Note that this is different from annotating a variable as constexpr (`x: triton.language.constexpr = 42`), which is not supported.  Alternatively, set the envvar TRITON_ALLOW_NON_CONSTEXPR_GLOBALS=1, but we do not promise to support this forever.")
```