### PR TITLE
Add FlyDSL AOT pre-compilation support for ROCm

### DIFF
--- a/.github/workflows/_mslk_rocm_build.yml
+++ b/.github/workflows/_mslk_rocm_build.yml
@@ -122,6 +122,9 @@ jobs:
     - name: Prepare MSLK Build
       run: . $PRELUDE; prepare_mslk_build $BUILD_ENV
 
+    - name: Pre-compile FlyDSL kernels (AOT)
+      run: . $PRELUDE; compile_flydsl_aot $BUILD_ENV
+
     - name: Build MSLK Wheel
       run: |
         . $PRELUDE

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ mslk/version.py
 **/__pycache__
 **/*.so
 *.profraw
-mslk/utils/flydsl_aot_cache/
+mslk/flydsl/aot_artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ mslk/version.py
 **/__pycache__
 **/*.so
 *.profraw
+mslk/utils/flydsl_aot_cache/

--- a/ci/scripts/utils_flydsl.bash
+++ b/ci/scripts/utils_flydsl.bash
@@ -56,3 +56,34 @@ install_flydsl_pip () {
   echo "################################################################################"
   echo ""
 }
+
+compile_flydsl_aot () {
+  local env_name="$1"
+  if [ "$env_name" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_env"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Pre-compile FlyDSL kernels (AOT)"
+    echo "#"
+    echo "# [$(date --utc +%FT%T.%3NZ)] + ${FUNCNAME[0]} ${*}"
+    echo "################################################################################"
+    echo ""
+  fi
+
+  if [ "$BUILD_VARIANT" != "rocm" ]; then
+    echo "[BUILD] Skipping FlyDSL AOT for BUILD_VARIANT '${BUILD_VARIANT}' (rocm only)"
+    return 0
+  fi
+
+  # shellcheck disable=SC2155
+  local env_prefix=$(env_name_or_prefix "${env_name}")
+
+  # Run under MSLK_PYTHON_ONLY=1 so kernel-module imports don't load the
+  # native library, which is not built at this point in the pipeline.
+  echo "[BUILD] Pre-compiling FlyDSL kernels into the bundled cache ..."
+  # shellcheck disable=SC2086
+  (MSLK_PYTHON_ONLY=1 conda run --no-capture-output ${env_prefix} python -m mslk.utils.flydsl_aot) || return 1
+}

--- a/mslk/flydsl/__init__.py
+++ b/mslk/flydsl/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/mslk/utils/flydsl.py
+++ b/mslk/utils/flydsl.py
@@ -17,6 +17,7 @@ and op-specific logic stays in the kernel modules.
 
 import functools
 import importlib.util
+import os
 from typing import Any, Callable
 
 _INSTALL_HINT: str = (
@@ -50,6 +51,27 @@ def require_flydsl() -> None:
         raise RuntimeError(_INSTALL_HINT)
 
 
+# Bundled AOT cache shipped inside the package (populated at build time).
+# Shared across all FlyDSL kernel categories (gemm, moe, ...), so it lives
+# alongside the FlyDSL support module rather than under any kernel domain.
+_BUNDLED_AOT_CACHE: str = os.path.join(os.path.dirname(__file__), "flydsl_aot_cache")
+
+
+def configure_runtime_cache() -> None:
+    """Point FlyDSL at the bundled AOT cache, if present and not overridden.
+
+    Cache hits skip the front-end compile; misses fall back to JIT. Set
+    ``MSLK_FLYDSL_RUN_ONLY=1`` to forbid the JIT fallback (e.g. for CUDA
+    graph capture), which makes FlyDSL raise on a cache miss instead.
+    """
+    if "FLYDSL_RUNTIME_CACHE_DIR" not in os.environ and os.path.isdir(
+        _BUNDLED_AOT_CACHE
+    ):
+        os.environ["FLYDSL_RUNTIME_CACHE_DIR"] = _BUNDLED_AOT_CACHE
+    if os.environ.get("MSLK_FLYDSL_RUN_ONLY", "0") == "1":
+        os.environ["FLYDSL_RUNTIME_RUN_ONLY"] = "1"
+
+
 def run_compiled(launcher: Callable[..., Any], *args: Any) -> None:
     """Dispatch a FlyDSL ``@flyc.jit`` host launcher with ``args``.
 
@@ -63,3 +85,6 @@ def run_compiled(launcher: Callable[..., Any], *args: Any) -> None:
         launcher._mslk_cf = flyc.compile(launcher, *args)  # pyre-ignore[16]
     else:
         cf(*args)
+
+
+configure_runtime_cache()

--- a/mslk/utils/flydsl.py
+++ b/mslk/utils/flydsl.py
@@ -53,8 +53,10 @@ def require_flydsl() -> None:
 
 # Bundled AOT cache shipped inside the package (populated at build time).
 # Shared across all FlyDSL kernel categories (gemm, moe, ...), so it lives
-# alongside the FlyDSL support module rather than under any kernel domain.
-_BUNDLED_AOT_CACHE: str = os.path.join(os.path.dirname(__file__), "flydsl_aot_cache")
+# under a dedicated mslk.flydsl package rather than under any kernel domain.
+_BUNDLED_AOT_CACHE: str = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "flydsl", "aot_artifacts"
+)
 
 
 def configure_runtime_cache() -> None:

--- a/mslk/utils/flydsl.py
+++ b/mslk/utils/flydsl.py
@@ -63,14 +63,14 @@ def configure_runtime_cache() -> None:
     """Point FlyDSL at the bundled AOT cache, if present and not overridden.
 
     Cache hits skip the front-end compile; misses fall back to JIT. Set
-    ``MSLK_FLYDSL_RUN_ONLY=1`` to forbid the JIT fallback (e.g. for CUDA
+    ``MSLK_FLYDSL_DISABLE_JIT=1`` to forbid the JIT fallback (e.g. for CUDA
     graph capture), which makes FlyDSL raise on a cache miss instead.
     """
     if "FLYDSL_RUNTIME_CACHE_DIR" not in os.environ and os.path.isdir(
         _BUNDLED_AOT_CACHE
     ):
         os.environ["FLYDSL_RUNTIME_CACHE_DIR"] = _BUNDLED_AOT_CACHE
-    if os.environ.get("MSLK_FLYDSL_RUN_ONLY", "0") == "1":
+    if os.environ.get("MSLK_FLYDSL_DISABLE_JIT", "0") == "1":
         os.environ["FLYDSL_RUNTIME_RUN_ONLY"] = "1"
 
 

--- a/mslk/utils/flydsl_aot.py
+++ b/mslk/utils/flydsl_aot.py
@@ -1,0 +1,149 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Ahead-of-time (AOT) pre-compilation for FlyDSL kernels.
+
+Builds FlyDSL's on-disk cache for selected kernels in selected
+configurations so the front-end compile is skipped at runtime. Each
+config is compiled under ``COMPILE_ONLY=1`` into
+``FLYDSL_RUNTIME_CACHE_DIR``; at runtime FlyDSL loads from that cache and
+falls back to JIT on a miss. The cache stores lowered IR rather than a
+standalone binary, so FlyDSL remains a runtime dependency.
+
+AOT-eligible kernel modules declare what to pre-compile via three
+attributes:
+  - ``AOT_CONFIGS``: list of config dicts (kernel-specific params).
+  - ``AOT_ARCHS``: list of gfx arch strings to build for.
+  - ``compile_aot_config(config, arch)``: compile one config for one arch
+    (under FakeTensorMode; no GPU tensors needed).
+"""
+
+import importlib
+import os
+from concurrent.futures import as_completed, ProcessPoolExecutor
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Tuple
+
+from mslk.utils.flydsl import _BUNDLED_AOT_CACHE
+
+# Module paths of AOT-eligible FlyDSL kernel modules. Each must expose
+# AOT_CONFIGS, AOT_ARCHS, and compile_aot_config(config, arch).
+_AOT_KERNEL_MODULES: List[str] = []
+
+_DEFAULT_MAX_WORKERS: int = 64
+
+
+@contextmanager
+def _compile_only_env(cache_dir: str) -> Iterator[None]:
+    prev_compile = os.environ.get("COMPILE_ONLY")
+    prev_cache = os.environ.get("FLYDSL_RUNTIME_CACHE_DIR")
+    os.environ["COMPILE_ONLY"] = "1"
+    os.environ["FLYDSL_RUNTIME_CACHE_DIR"] = cache_dir
+    try:
+        yield
+    finally:
+        for name, prev in (
+            ("COMPILE_ONLY", prev_compile),
+            ("FLYDSL_RUNTIME_CACHE_DIR", prev_cache),
+        ):
+            if prev is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = prev
+
+
+def _affinity_aware_cpu_count() -> int:
+    try:
+        return max(len(os.sched_getaffinity(0)), 1)
+    except (AttributeError, OSError):
+        return max(os.cpu_count() or 1, 1)
+
+
+def _resolve_max_workers(num_jobs: int) -> int:
+    env = os.environ.get("MSLK_FLYDSL_AOT_WORKERS")
+    if env is not None:
+        workers = max(int(env), 1)
+    else:
+        workers = min(_affinity_aware_cpu_count(), _DEFAULT_MAX_WORKERS)
+    return max(min(workers, num_jobs), 1)
+
+
+def collect_aot_jobs() -> List[Tuple[str, Dict[str, Any], str]]:
+    """Collect (module_path, config, arch) jobs from registered kernels."""
+    jobs: List[Tuple[str, Dict[str, Any], str]] = []
+    for module_path in _AOT_KERNEL_MODULES:
+        mod = importlib.import_module(module_path)
+        for arch in mod.AOT_ARCHS:
+            for config in mod.AOT_CONFIGS:
+                jobs.append((module_path, config, arch))
+    return jobs
+
+
+def _compile_one(module_path: str, config: Dict[str, Any], arch: str) -> bool:
+    """Worker: compile one config for one arch. Runs in a child process."""
+    mod = importlib.import_module(module_path)
+    mod.compile_aot_config(config, arch)
+    return True
+
+
+def compile_aot(cache_dir: str) -> None:
+    """Pre-compile all registered FlyDSL kernel configs into ``cache_dir``.
+
+    Raises ``RuntimeError`` if any job fails.
+    """
+    os.makedirs(cache_dir, exist_ok=True)
+    jobs = collect_aot_jobs()
+    if not jobs:
+        print("[mslk] FlyDSL AOT: no kernels to compile, skipping")
+        return
+
+    max_workers = _resolve_max_workers(len(jobs))
+    print(
+        f"[mslk] FlyDSL AOT: {len(jobs)} jobs, {max_workers} worker processes "
+        f"(cache: {cache_dir})"
+    )
+
+    errors: List[str] = []
+    with _compile_only_env(cache_dir):
+        with ProcessPoolExecutor(max_workers=max_workers) as pool:
+            futures = {
+                pool.submit(_compile_one, module_path, config, arch): (
+                    module_path,
+                    config,
+                    arch,
+                )
+                for module_path, config, arch in jobs
+            }
+            for done, future in enumerate(as_completed(futures), 1):
+                module_path, config, arch = futures[future]
+                label = f"{module_path} {config} arch={arch}"
+                try:
+                    future.result()
+                    print(f"  [OK] {done}/{len(jobs)} {label}")
+                except Exception as e:
+                    errors.append(f"{label}: {e}")
+                    print(f"  [FAIL] {done}/{len(jobs)} {label}: {e}")
+
+    if errors:
+        raise RuntimeError(
+            f"FlyDSL AOT failed for {len(errors)}/{len(jobs)} jobs: "
+            + "; ".join(errors[:10])
+        )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="AOT pre-compile FlyDSL kernels")
+    parser.add_argument(
+        "--cache-dir",
+        default=_BUNDLED_AOT_CACHE,
+        help="Output cache directory (default: the bundled package cache).",
+    )
+    args = parser.parse_args()
+    compile_aot(args.cache_dir)

--- a/mslk/utils/flydsl_aot.py
+++ b/mslk/utils/flydsl_aot.py
@@ -24,6 +24,7 @@ attributes:
 """
 
 import importlib
+import multiprocessing as mp
 import os
 from concurrent.futures import as_completed, ProcessPoolExecutor
 from contextlib import contextmanager
@@ -109,8 +110,12 @@ def compile_aot(cache_dir: str) -> None:
     )
 
     errors: List[str] = []
+    # Use spawn: workers compile FlyDSL kernels which touch CUDA, and forking
+    # a parent that has already initialized CUDA breaks re-initialization.
     with _compile_only_env(cache_dir):
-        with ProcessPoolExecutor(max_workers=max_workers) as pool:
+        with ProcessPoolExecutor(
+            max_workers=max_workers, mp_context=mp.get_context("spawn")
+        ) as pool:
             futures = {
                 pool.submit(_compile_one, module_path, config, arch): (
                     module_path,

--- a/setup.py
+++ b/setup.py
@@ -735,6 +735,9 @@ def main(argv: List[str]) -> None:
             "ROCm",
         ],
         packages=packages,
+        # Ship the prebuilt FlyDSL AOT cache (populated at build time) so it
+        # is available at runtime; absent when AOT is not run.
+        package_data={"mslk.utils": ["flydsl_aot_cache/*"]},
         install_requires=[
             # Only specify numpy, as specifying torch will auto-install the
             # release version of torch, which is not what we want for the

--- a/setup.py
+++ b/setup.py
@@ -737,7 +737,7 @@ def main(argv: List[str]) -> None:
         packages=packages,
         # Ship the prebuilt FlyDSL AOT cache (populated at build time) so it
         # is available at runtime; absent when AOT is not run.
-        package_data={"mslk.utils": ["flydsl_aot_cache/*"]},
+        package_data={"mslk.flydsl": ["aot_artifacts/*"]},
         install_requires=[
             # Only specify numpy, as specifying torch will auto-install the
             # release version of torch, which is not what we want for the

--- a/test/utils/flydsl_aot_test.py
+++ b/test/utils/flydsl_aot_test.py
@@ -45,9 +45,10 @@ class _InlineExecutor:
 class FlyDSLAOTTest(unittest.TestCase):
     def test_collect_jobs_is_cartesian_product(self) -> None:
         mod = _fake_kernel_module()
-        with mock.patch.object(
-            flydsl_aot, "_AOT_KERNEL_MODULES", ["fake.kernel"]
-        ), mock.patch("importlib.import_module", return_value=mod):
+        with (
+            mock.patch.object(flydsl_aot, "_AOT_KERNEL_MODULES", ["fake.kernel"]),
+            mock.patch("importlib.import_module", return_value=mod),
+        ):
             jobs = flydsl_aot.collect_aot_jobs()
         # 2 archs x 2 configs = 4 jobs.
         self.assertEqual(len(jobs), 4)
@@ -65,10 +66,10 @@ class FlyDSLAOTTest(unittest.TestCase):
         mod.AOT_CONFIGS = [{"n": 128, "k": 256}]
         mod.compile_aot_config = _record
 
-        with mock.patch.object(
-            flydsl_aot, "_AOT_KERNEL_MODULES", ["fake.kernel"]
-        ), mock.patch("importlib.import_module", return_value=mod), mock.patch.object(
-            flydsl_aot, "ProcessPoolExecutor", _InlineExecutor
+        with (
+            mock.patch.object(flydsl_aot, "_AOT_KERNEL_MODULES", ["fake.kernel"]),
+            mock.patch("importlib.import_module", return_value=mod),
+            mock.patch.object(flydsl_aot, "ProcessPoolExecutor", _InlineExecutor),
         ):
             flydsl_aot.compile_aot("/tmp/mslk_aot_unittest")
 

--- a/test/utils/flydsl_aot_test.py
+++ b/test/utils/flydsl_aot_test.py
@@ -1,0 +1,86 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import unittest
+from unittest import mock
+
+from mslk.utils import flydsl_aot
+
+
+def _fake_kernel_module() -> mock.Mock:
+    mod = mock.Mock()
+    mod.AOT_ARCHS = ["gfx942", "gfx950"]
+    mod.AOT_CONFIGS = [{"n": 128, "k": 256}, {"n": 512, "k": 256}]
+    return mod
+
+
+class _InlineExecutor:
+    """Runs submitted work synchronously so mocks/closures apply (the real
+    ProcessPoolExecutor runs in child processes where patches do not)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> None:
+        pass
+
+    def submit(self, fn, *args, **kwargs):
+        future = __import__("concurrent.futures").futures.Future()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except Exception as e:  # noqa: BLE001
+            future.set_exception(e)
+        return future
+
+
+class FlyDSLAOTTest(unittest.TestCase):
+    def test_collect_jobs_is_cartesian_product(self) -> None:
+        mod = _fake_kernel_module()
+        with mock.patch.object(
+            flydsl_aot, "_AOT_KERNEL_MODULES", ["fake.kernel"]
+        ), mock.patch("importlib.import_module", return_value=mod):
+            jobs = flydsl_aot.collect_aot_jobs()
+        # 2 archs x 2 configs = 4 jobs.
+        self.assertEqual(len(jobs), 4)
+        self.assertEqual({arch for _, _, arch in jobs}, {"gfx942", "gfx950"})
+
+    def test_compile_only_env_set_during_compile(self) -> None:
+        seen = {}
+
+        def _record(config, arch):
+            seen["COMPILE_ONLY"] = os.environ.get("COMPILE_ONLY")
+            seen["cache_dir"] = os.environ.get("FLYDSL_RUNTIME_CACHE_DIR")
+
+        mod = _fake_kernel_module()
+        mod.AOT_ARCHS = ["gfx950"]
+        mod.AOT_CONFIGS = [{"n": 128, "k": 256}]
+        mod.compile_aot_config = _record
+
+        with mock.patch.object(
+            flydsl_aot, "_AOT_KERNEL_MODULES", ["fake.kernel"]
+        ), mock.patch("importlib.import_module", return_value=mod), mock.patch.object(
+            flydsl_aot, "ProcessPoolExecutor", _InlineExecutor
+        ):
+            flydsl_aot.compile_aot("/tmp/mslk_aot_unittest")
+
+        self.assertEqual(seen["COMPILE_ONLY"], "1")
+        self.assertEqual(seen["cache_dir"], "/tmp/mslk_aot_unittest")
+
+    def test_compile_only_env_restored_after(self) -> None:
+        before = os.environ.get("COMPILE_ONLY")
+        with mock.patch.object(flydsl_aot, "_AOT_KERNEL_MODULES", []):
+            flydsl_aot.compile_aot("/tmp/mslk_aot_unittest")
+        self.assertEqual(os.environ.get("COMPILE_ONLY"), before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds AOT pre-compilation for FlyDSL kernels, building on the FlyDSL JIT backend (#408). Pre-compiles selected kernels in selected configurations into FlyDSL's on-disk cache so the front-end compile is skipped at runtime; cache misses fall back to JIT.

- `mslk/utils/flydsl_aot.py`: config collection + parallel compile harness, plus a `python -m mslk.utils.flydsl_aot` entrypoint. AOT-eligible kernel modules declare `AOT_CONFIGS`, `AOT_ARCHS`, and `compile_aot_config(config, arch)`.
- `mslk/utils/flydsl.py`: `configure_runtime_cache()` points FlyDSL at the bundled cache on import; `MSLK_FLYDSL_RUN_ONLY=1` forbids the JIT fallback (e.g. for CUDA graph capture).
- ROCm build workflow runs the harness (under `MSLK_PYTHON_ONLY=1`) right before wheel packaging so the cache is bundled via `package_data`. The cache is gitignored and never committed.

The worker pool uses the `spawn` start method: workers compile FlyDSL kernels which initialize CUDA, and forking a parent that has already initialized CUDA fails re-initialization.

**Design notes.** This follows MSLK's existing offline-codegen convention (like the CK `kernel_gen.py` flow): generation is an offline/CI step, and the build just packages the artifact. The FlyDSL cache stores lowered IR, not a standalone binary, so FlyDSL remains a runtime dependency — same as the JIT path.

Infrastructure only: no kernel declares `AOT_CONFIGS` yet, so the harness is a no-op until a kernel opts in.

## Test plan
- [x] `pytest test/utils/flydsl_aot_test.py` — job collection, COMPILE_ONLY/cache-dir env set during compile, env restored after. Passes.
- [x] `MSLK_PYTHON_ONLY=1 python -m mslk.utils.flydsl_aot` runs cleanly (no-op with zero registered kernels).
- [x] Verified end-to-end on gfx950 (ROCm 7.2, torch 2.10) with a sample kernel: AOT compile populates the cache, the op is served from cache, and `MSLK_FLYDSL_RUN_ONLY=1` errors on a non-precompiled shape (proving cache-hit-no-JIT).
- [ ] ROCm CI build step bundles a populated cache into the wheel — pending a live CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
