### PR TITLE
Remove some features from bench (#435)

### DIFF
--- a/bench/attn/flash_attn_bench.py
+++ b/bench/attn/flash_attn_bench.py
@@ -161,9 +161,6 @@ def benchmark(
 @click.option(
     "--window-size", default=0, type=int, help="Sliding window size (0 = no window)."
 )
-@click.option(
-    "--num-iters", default=1, type=int, help="Number of benchmark iterations."
-)
 @click.option("--no-cuda-graph", is_flag=True, help="Disable CUDA graphs.")
 @click.option("--export-csv", is_flag=True, help="Export results to CSV.")
 @click.option("--output-dir", default="/tmp", help="Directory for output files.")
@@ -186,19 +183,13 @@ def invoke_main(
     d: int,
     causal: bool,
     window_size: int,
-    num_iters: int,
     no_cuda_graph: bool,
     export_csv: bool,
     output_dir: str,
     shapes: Optional[str],
     rep: int,
 ) -> None:
-    if num_iters < 1:
-        print("Warning: Number of iterations must be at least 1.")
-        num_iters = 1
-
     opts = BenchOptions(
-        num_iters=num_iters,
         cuda_graph=not no_cuda_graph,
         rep_ms=rep,
     )
@@ -220,10 +211,9 @@ def invoke_main(
 
     for B, N, H, H_kv, D in shape_list:
         print(f"Benchmarking B={B}, N={N}, H={H}, H_kv={H_kv}, D={D}")
-        for _ in range(num_iters):
-            m = benchmark(B, N, H, H_kv, D, causal, window_size, opts)
-            results.append(m)
-            csv_rows.append(m.as_dict())
+        m = benchmark(B, N, H, H_kv, D, causal, window_size, opts)
+        results.append(m)
+        csv_rows.append(m.as_dict())
 
     # Print results.
     print("")

--- a/bench/common/utils.py
+++ b/bench/common/utils.py
@@ -29,7 +29,6 @@ class BenchOptions:
     quantize_bench to maintain consistent benchmarking behavior.
 
     Attributes:
-        num_iters: Number of iterations to repeat each benchmark for averaging.
         cuda_graph: Whether to use CUDA graphs for benchmarking. CUDA graphs
             reduce kernel launch overhead and provide more accurate measurements
             for GPU-bound workloads.
@@ -45,7 +44,6 @@ class BenchOptions:
         torch_compile: Whether to use torch.compile for applicable operations.
     """
 
-    num_iters: int = 1
     cuda_graph: bool = True
     rotating_buffer: bool = False
     rep_ms: int = 200
@@ -163,12 +161,6 @@ def common_bench_options(shape_registry):
                 help="Directory to save plots and csvs to",
             ),
             click.option(
-                "--num-iters",
-                default=1,
-                type=int,
-                help="Number of iterations to repeat each benchmark.",
-            ),
-            click.option(
                 "--export-csv",
                 is_flag=True,
                 help="Export results to a CSV file.",
@@ -194,7 +186,10 @@ def common_bench_options(shape_registry):
             click.option(
                 "--shapes",
                 default=None,
-                help=f"Specific model shapes to use, options: {', '.join(shape_registry.keys())}.",
+                help=(
+                    "Specific model shapes to use, options: "
+                    f"{', '.join(shape_registry.keys())}."
+                ),
             ),
             click.option(
                 "--trace",

--- a/bench/conv/conv_bench.py
+++ b/bench/conv/conv_bench.py
@@ -108,7 +108,8 @@ class Metrics:
         )
         return (
             f"{self.op:<20} {problem_shape:<50} "
-            f"{self.sim:<10.3f} {self.ms:<10.3f} {self.tflops:<10.2f} {self.gbps:<10.2f}"
+            f"{self.sim:<10.3f} {self.ms:<10.3f} "
+            f"{self.tflops:<10.2f} {self.gbps:<10.2f}"
         )
 
     def as_dict(self) -> dict[str, float]:
@@ -213,44 +214,38 @@ def benchmark(
         p = 1 + (h + 2 * pad - ((r - 1) * dilation + 1)) // stride
         q = 1 + (w + 2 * pad - ((s - 1) * dilation + 1)) // stride
 
-        for _ in range(opts.num_iters):
-            # Now perform benchmark.
-            if bench_quantize:
-                # Benchmark both quantize and compute.
-                with profiler(enabled=opts.trace, with_stack=True):
-                    ms_runtime = conv_op.benchmark(
-                        *preprocessed_args,
-                        opts=opts,
-                        bench_quantize=True,
-                    )
-            else:
-                with profiler(enabled=opts.trace, with_stack=True):
-                    ms_runtime = conv_op.benchmark(
-                        *quantized_vals,
-                        opts=opts,
-                        bench_quantize=False,
-                    )
+        # Now perform benchmark.
+        if bench_quantize:
+            # Benchmark both quantize and compute.
+            with profiler(enabled=opts.trace, with_stack=True):
+                ms_runtime = conv_op.benchmark(
+                    *preprocessed_args,
+                    opts=opts,
+                    bench_quantize=True,
+                )
+        else:
+            with profiler(enabled=opts.trace, with_stack=True):
+                ms_runtime = conv_op.benchmark(
+                    *quantized_vals,
+                    opts=opts,
+                    bench_quantize=False,
+                )
 
-            # Compute performance metrics
-            # FLOPs for convolution: 2 * N * Z * P * Q * K * T * R * S * C
-            flops = 2 * n * z * p * q * k * t * r * s * c
-            metrics.tflops += flops / (ms_runtime / 1e3) / 1e12
+        # Compute performance metrics
+        # FLOPs for convolution: 2 * N * Z * P * Q * K * T * R * S * C
+        flops = 2 * n * z * p * q * k * t * r * s * c
+        metrics.tflops = flops / (ms_runtime / 1e3) / 1e12
 
-            # Compute memory bandwidth
-            # Input: N * D * H * W * C, Filter: K * T * R * S * C, Output: N * Z * P * Q * K
-            input_size = n * d * h * w * c * quantized_vals[0].element_size()
-            filter_size = k * t * r * s * c * quantized_vals[1].element_size()
-            output_size = n * z * p * q * k * output.element_size()
+        # Compute memory bandwidth
+        # Input: N * D * H * W * C, Filter: K * T * R * S * C, Output: N * Z * P * Q * K
+        input_size = n * d * h * w * c * quantized_vals[0].element_size()
+        filter_size = k * t * r * s * c * quantized_vals[1].element_size()
+        output_size = n * z * p * q * k * output.element_size()
 
-            metrics.gbps += (
-                (input_size + filter_size + output_size) / (ms_runtime / 1e3) / 1e9
-            )
-            metrics.ms += ms_runtime
-
-        # Average metrics over iterations.
-        metrics.ms /= opts.num_iters
-        metrics.tflops /= opts.num_iters
-        metrics.gbps /= opts.num_iters
+        metrics.gbps = (
+            (input_size + filter_size + output_size) / (ms_runtime / 1e3) / 1e9
+        )
+        metrics.ms = ms_runtime
 
         results.append(metrics)
 
@@ -263,7 +258,10 @@ def plot_benchmark(results: list[dict[str, Any]], output_dir: str) -> None:
     data = []
     # Extract measurements for each shape.
     for impl in results:
-        shape_str = f"N{impl['N']}_D{impl['D']}_H{impl['H']}_W{impl['W']}_C{impl['C']}_K{impl['K']}"
+        shape_str = (
+            f"N{impl['N']}_D{impl['D']}_H{impl['H']}_W{impl['W']}"
+            f"_C{impl['C']}_K{impl['K']}"
+        )
         # Iterate over keys to find tflops entries.
         for key in impl:
             if "tflops" in key:
@@ -382,7 +380,6 @@ def print_kernels(kernels: Optional[list[str]]) -> list[ConvOpBase]:
 )
 def invoke_main(
     output_dir: str,
-    num_iters: int,
     export_csv: bool,
     plot: bool,
     bench_quantize: bool,
@@ -415,15 +412,12 @@ def invoke_main(
         print_kernels(all_kernels)
         sys.exit(1)
 
-    if num_iters < 1:
-        print("Warning: Number of iterations must be at least 1.")
-        num_iters = 1
-
     # Enumerate shapes to benchmark.
     if shapes:
         if shapes not in shape_registry:
             print(
-                f"Shape {shapes} not found in shape registry. Valid shapes: {', '.join(shape_registry.keys())}."
+                f"Shape {shapes} not found in shape registry. "
+                f"Valid shapes: {', '.join(shape_registry.keys())}."
             )
             sys.exit(1)
         conv_shapes = shape_registry[shapes]()
@@ -455,7 +449,6 @@ def invoke_main(
     benchmark_results = []
     csv = []
     opts = BenchOptions(
-        num_iters=num_iters,
         cuda_graph=cuda_graph,
         rotating_buffer=rotating_buffer,
         rep_ms=rep_ms,

--- a/bench/gemm/gemm_bench.py
+++ b/bench/gemm/gemm_bench.py
@@ -296,7 +296,6 @@ def benchmark_grouped(
     k: list[int],
     mem_bw_roofline_gbps: float,
     opts: BenchOptions,
-    bench_quantize: bool = False,
     shape_mode: ShapeMode = ShapeMode.GROUPED,
 ) -> list[Metrics]:
     num_groups = len(m)
@@ -375,52 +374,33 @@ def benchmark_grouped(
                 )
         if noise_power > 0:
             metrics.sqnr = float(10 * np.log10(signal_power / noise_power))
-        for _ in range(opts.num_iters):
-            # Now perform benchmark.
-            if bench_quantize:
-                # Benchmark both quantize and compute.
-                with profiler(enabled=opts.trace, with_stack=True):
-                    ms_runtime = gemm_op.benchmark(
-                        *preprocessed_args,
-                        opts=opts,
-                        bench_quantize=True,
-                    )
-            else:
-                with profiler(enabled=opts.trace, with_stack=True):
-                    ms_runtime = gemm_op.benchmark(
-                        *quantized_vals,
-                        opts=opts,
-                        bench_quantize=False,
-                    )
+        # Now perform benchmark.
+        with profiler(enabled=opts.trace, with_stack=True):
+            ms_runtime = gemm_op.benchmark(*quantized_vals, opts=opts)
 
-            for i in range(num_groups):
-                output_multiplier = 2 if "fuse_scatter_add" in gemm_op.name else 1
-                if m[i] > 0:
-                    tflops = 2 * m[i] * n[i] * k[i] / (ms_runtime / 1e3) / 1e12
-                    gbps = (
-                        (
-                            quantized_vals[0][i].numel()
-                            * quantized_vals[0][i].element_size()
-                            + quantized_vals[1][i].numel()
-                            * quantized_vals[1][i].element_size()
-                            + output_multiplier
-                            * output[i].numel()
-                            * output[i].element_size()
-                        )
-                        / (ms_runtime / 1e3)
-                        / 1e9
+        for i in range(num_groups):
+            output_multiplier = 2 if "fuse_scatter_add" in gemm_op.name else 1
+            if m[i] > 0:
+                tflops = 2 * m[i] * n[i] * k[i] / (ms_runtime / 1e3) / 1e12
+                gbps = (
+                    (
+                        quantized_vals[0][i].numel()
+                        * quantized_vals[0][i].element_size()
+                        + quantized_vals[1][i].numel()
+                        * quantized_vals[1][i].element_size()
+                        + output_multiplier
+                        * output[i].numel()
+                        * output[i].element_size()
                     )
-                    metrics.gbps += gbps
-                    metrics.tflops += tflops
-                    metrics.mem_bw_util += (gbps / mem_bw_roofline_gbps) * 100
-                    if compute_roofline_tflops is not None:
-                        metrics.compute_util += (tflops / compute_roofline_tflops) * 100
-            metrics.ms += ms_runtime
-        metrics.ms /= opts.num_iters
-        metrics.tflops /= opts.num_iters
-        metrics.gbps /= opts.num_iters
-        metrics.mem_bw_util /= opts.num_iters
-        metrics.compute_util /= opts.num_iters
+                    / (ms_runtime / 1e3)
+                    / 1e9
+                )
+                metrics.gbps += gbps
+                metrics.tflops += tflops
+                metrics.mem_bw_util += (gbps / mem_bw_roofline_gbps) * 100
+                if compute_roofline_tflops is not None:
+                    metrics.compute_util += (tflops / compute_roofline_tflops) * 100
+        metrics.ms = ms_runtime
 
         results.append(metrics)
 
@@ -434,7 +414,6 @@ def benchmark(
     k: int,
     mem_bw_roofline_gbps: float,
     opts: BenchOptions,
-    bench_quantize: bool = False,
     shape_mode: ShapeMode = ShapeMode.REGULAR,
 ) -> list[Metrics]:
     # Create input tensors.
@@ -477,45 +456,23 @@ def benchmark(
         if noise_power > 0:
             metrics.sqnr = (10 * torch.log10(signal_power / noise_power)).item()
 
-        for _ in range(opts.num_iters):
-            # Now perform benchmark.
-            if bench_quantize:
-                # Benchmark both quantize and compute.
-                with profiler(enabled=opts.trace, with_stack=True):
-                    ms_runtime = gemm_op.benchmark(
-                        *preprocessed_args,
-                        opts=opts,
-                        bench_quantize=True,
-                    )
-            else:
-                with profiler(enabled=opts.trace, with_stack=True):
-                    ms_runtime = gemm_op.benchmark(
-                        *quantized_vals,
-                        opts=opts,
-                        bench_quantize=False,
-                    )
+        # Now perform benchmark.
+        with profiler(enabled=opts.trace, with_stack=True):
+            ms_runtime = gemm_op.benchmark(*quantized_vals, opts=opts)
 
-            tflops = 2 * m * n * k / (ms_runtime / 1e3) / 1e12
-            metrics.tflops += tflops
-            gbps = (
-                (
-                    quantized_vals[0].numel() * quantized_vals[0].element_size()
-                    + quantized_vals[1].numel() * quantized_vals[1].element_size()
-                    + output.numel() * output.element_size()
-                )
-                / (ms_runtime / 1e3)
-                / 1e9
+        metrics.tflops = 2 * m * n * k / (ms_runtime / 1e3) / 1e12
+        metrics.gbps = (
+            (
+                quantized_vals[0].numel() * quantized_vals[0].element_size()
+                + quantized_vals[1].numel() * quantized_vals[1].element_size()
+                + output.numel() * output.element_size()
             )
-            metrics.gbps += gbps
-            metrics.mem_bw_util += (gbps / mem_bw_roofline_gbps) * 100
-            if compute_roofline_tflops is not None:
-                metrics.compute_util += (tflops / compute_roofline_tflops) * 100
-            metrics.ms += ms_runtime
-        metrics.ms /= opts.num_iters
-        metrics.tflops /= opts.num_iters
-        metrics.gbps /= opts.num_iters
-        metrics.mem_bw_util /= opts.num_iters
-        metrics.compute_util /= opts.num_iters
+            / (ms_runtime / 1e3)
+            / 1e9
+        )
+        metrics.mem_bw_util = (metrics.gbps / mem_bw_roofline_gbps) * 100
+        if compute_roofline_tflops is not None:
+            metrics.compute_util = (metrics.tflops / compute_roofline_tflops) * 100
 
         results.append(metrics)
 
@@ -587,11 +544,6 @@ def print_kernels(kernels: Optional[list[str]]) -> list[GemmOpBase]:
     help="Enable a set of environment variables for AMD GPU performance",
 )
 @click.option(
-    "--bench-quantize",
-    is_flag=True,
-    help="If set, include quantization cost in benchmark.",
-)
-@click.option(
     "--M",
     default=None,
     help="Comma separated list of M values to benchmark.",
@@ -609,7 +561,10 @@ def print_kernels(kernels: Optional[list[str]]) -> list[GemmOpBase]:
 @click.option(
     "--pair-NK",
     is_flag=True,
-    help="If set, instead of benchmarking cartesian product of N * K, benchmark consecutive NK pairs together.",
+    help=(
+        "If set, instead of benchmarking cartesian product of N * K, "
+        "benchmark consecutive NK pairs together."
+    ),
 )
 @click.option(
     "--grouped",
@@ -620,7 +575,10 @@ def print_kernels(kernels: Optional[list[str]]) -> list[GemmOpBase]:
 @click.option(
     "--groups",
     default=None,
-    help="If set with grouped mode, repeat MNK shapes this many times. Comma separated list of groups to benchmark",
+    help=(
+        "If set with grouped mode, repeat MNK shapes this many times. "
+        "Comma separated list of groups to benchmark"
+    ),
 )
 @click.option(
     "--total-K",
@@ -648,12 +606,10 @@ def print_kernels(kernels: Optional[list[str]]) -> list[GemmOpBase]:
 )
 def invoke_main(
     output_dir: str,
-    num_iters: int,
     export_csv: bool,
     export_scuba: bool,
     plot: bool,
     enable_amd_env_vars: bool,
-    bench_quantize: bool,
     kernels: Optional[str],
     m: Optional[str],
     n: Optional[str],
@@ -693,10 +649,6 @@ def invoke_main(
         print_kernels(all_kernels)
         sys.exit(1)
 
-    if num_iters < 1:
-        print("Warning: Number of iterations must be at least 1.")
-        num_iters = 1
-
     # Enumerate shapes to benchmark.
     if grouped and not groups:
         # In grouped mode, M, N, and K represent the groups of a single gemm.
@@ -714,7 +666,8 @@ def invoke_main(
         if shapes:
             if shapes not in shape_registry:
                 print(
-                    f"Shape {shapes} not found in shape registry. Valid shapes: {', '.join(shape_registry.keys())}."
+                    f"Shape {shapes} not found in shape registry. "
+                    f"Valid shapes: {', '.join(shape_registry.keys())}."
                 )
                 sys.exit(1)
             MNK = shape_registry[shapes]()
@@ -783,7 +736,6 @@ def invoke_main(
     benchmark_func = benchmark_grouped if grouped else benchmark
 
     opts = BenchOptions(
-        num_iters=num_iters,
         cuda_graph=cuda_graph,
         rotating_buffer=rotating_buffer,
         rep_ms=rep_ms,
@@ -800,7 +752,6 @@ def invoke_main(
             k,  # pyre-ignore[6]: Incompatible parameter type [6]
             mem_bw_gbps,
             opts,
-            bench_quantize,
             shape_mode,
         )
         benchmark_results.extend(shape_measurements)

--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -142,29 +142,20 @@ class GemmOpBase(metaclass=abc.ABCMeta):
         """Function which performs main compute operation."""
         pass
 
-    @abc.abstractmethod
-    def quantize_and_compute(self, *args):
-        """Function which quantizes inputs and performs main compute operation."""
-        pass
-
     def preprocess(self, *args):
-        """Preprocess inputs before benchmarking. These outputs will be passed to quantize."""
+        """Preprocess inputs before benchmarking.
+
+        These outputs will be passed to quantize.
+        """
         return args
 
     def benchmark(
         self,
         *args,
         opts: BenchOptions,
-        bench_quantize: bool,
     ) -> float:
         """Benchmark runtime of this operator."""
-        t = do_bench(
-            lambda *a: self.quantize_and_compute(*a)
-            if bench_quantize
-            else self.compute(*a),
-            args,
-            opts,
-        )
+        t = do_bench(lambda *a: self.compute(*a), args, opts)
         return t
 
     @property
@@ -271,9 +262,6 @@ class TorchFP32(GemmOpBase):
             return output
         return torch.matmul(x, w)
 
-    def quantize_and_compute(self, x, w):
-        return self.compute(*self.quantize(x, w))
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return set(Accelerator)
@@ -315,9 +303,6 @@ class TorchTF32(GemmOpBase):
         torch.set_float32_matmul_precision(original_precision)
         return out
 
-    def quantize_and_compute(self, x, w):
-        return self.compute(*self.quantize(x, w))
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return set(Accelerator)
@@ -355,9 +340,6 @@ class TorchBF16(GemmOpBase):
             return output
         return torch.matmul(x, w)
 
-    def quantize_and_compute(self, x, w):
-        return self.compute(*self.quantize(x, w))
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return set(Accelerator)
@@ -391,10 +373,10 @@ class TorchFP8Tensorwise(GemmOpBase):
         # To make scale dtype to be fp32 for accuracy
         amax = amax.float()
         if float8_dtype == self.fp8_dtype:
-            # pyre-fixme[58]: `/` is not supported for operand types `float` and `Tensor`.
+            # pyre-fixme[58]: unsupported `/` between float and Tensor.
             res = self.E4M3_MAX_POS / torch.clamp(amax, min=self.EPS)
         else:  # e5m2
-            # pyre-fixme[58]: `/` is not supported for operand types `float` and `Tensor`.
+            # pyre-fixme[58]: unsupported `/` between float and Tensor.
             res = self.E5M2_MAX_POS / torch.clamp(amax, min=self.EPS)
 
         # pyre-fixme[7]: Expected `Tensor` but got `Union[float, Tensor]`.
@@ -434,9 +416,6 @@ class TorchFP8Tensorwise(GemmOpBase):
         )
         return output
 
-    def quantize_and_compute(self, x, w):
-        return self.compute(*self.quantize(x, w))
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return set(Accelerator)
@@ -473,9 +452,6 @@ class CublasBF16X9(GemmOpBase):
                 output.append(torch.ops.mslk.bf16x9_gemm(x[i], w[i]))
             return output
         return torch.ops.mslk.bf16x9_gemm(x, w)
-
-    def quantize_and_compute(self, x, w):
-        return self.compute(*self.quantize(x, w))
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -528,9 +504,6 @@ class TorchFP8Rowwise(GemmOpBase):
             use_fast_accum=self.fast_accum,
         )
 
-    def quantize_and_compute(self, x, w):
-        return self.compute(*self.quantize(x, w))
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return set(Accelerator)
@@ -576,9 +549,6 @@ class TorchMXFP8Groupwise(GemmOpBase):
             scale_a=x_scale,
             scale_b=w_scale,
         )
-
-    def quantize_and_compute(self, x, w):
-        return self.compute(*self.quantize(x, w))
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -632,9 +602,6 @@ class TorchNVFP4Groupwise(GemmOpBase):
             scale_a=x_scale,
             scale_b=w_scale,
         )
-
-    def quantize_and_compute(self, x, w):
-        return self.compute(*self.quantize(x, w))
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -714,10 +681,6 @@ class FP8Rowwise(GemmOpBase):
         # Otherwise return normal gemm result.
         return self.gemm_op(xq, wq, x_scale, w_scale, use_fast_accum=self.fast_accum)
 
-    def quantize_and_compute(self, x, wq, w_scale):
-        xq, wq, x_scale, w_scale = self.quantize(x, wq, w_scale)
-        return self.compute(xq, wq, x_scale, w_scale)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {
@@ -786,10 +749,6 @@ class TritonBF16Grouped(GemmOpBase):
     def compute(self, x, w, m_sizes):
         return grouped_gemm(x, w, m_sizes, _use_warp_specialization=True)
 
-    def quantize_and_compute(self, x, w, m_sizes):
-        x, w, m_sizes = self.quantize(x, w, m_sizes)
-        return self.compute(x, w, m_sizes)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return set(Accelerator)
@@ -830,10 +789,6 @@ class TritonBF16GroupedFuseScatterAdd(TritonBF16Grouped):
             _scatter_add_indices=indices,
         )
 
-    def quantize_and_compute(self, x, w, m_sizes, *args):
-        x, w, m_sizes, *ret = self.quantize(x, w, m_sizes, *args)
-        return self.compute(x, w, m_sizes, *ret)
-
 
 @register_gemm_op
 class TritonFP8RowwiseGrouped(GemmOpBase):
@@ -865,10 +820,6 @@ class TritonFP8RowwiseGrouped(GemmOpBase):
         return grouped_gemm_fp8_rowwise(
             xq, wq, m_sizes, x_scale, w_scale, _use_warp_specialization=True
         )
-
-    def quantize_and_compute(self, x, wq, w_scale, m_sizes):
-        xq, wq, x_scale, w_scale, m_sizes = self.quantize(x, wq, w_scale, m_sizes)
-        return self.compute(xq, wq, x_scale, w_scale, m_sizes)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -912,12 +863,6 @@ class TritonFP8RowwiseGroupedFuseScatterAdd(TritonFP8RowwiseGrouped):
             _scatter_add_indices=indices,
         )
 
-    def quantize_and_compute(self, x, wq, w_scale, m_sizes, *args):
-        xq, wq, x_scale, w_scale, m_sizes, *ret = self.quantize(
-            x, wq, w_scale, m_sizes, *args
-        )
-        return self.compute(xq, wq, x_scale, w_scale, m_sizes, *ret)
-
 
 @register_gemm_op
 class DeepGemmFP8GroupwiseGrouped(GemmOpBase):
@@ -957,10 +902,6 @@ class DeepGemmFP8GroupwiseGrouped(GemmOpBase):
             (xq, x_scale), (wq, w_scale), out, m_indices
         )
         return out
-
-    def quantize_and_compute(self, x, wq, w_scale, m_indices):
-        xq, wq, x_scale, w_scale, m_indices = self.quantize(x, wq, w_scale, m_indices)
-        return self.compute(xq, wq, x_scale, w_scale, m_indices)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1032,12 +973,6 @@ class DeepGemmFP8GroupwiseGroupedMasked(DeepGemmFP8GroupwiseGrouped):
         out_list = [out[g, : m_values[g], :] for g in range(num_groups)]
         return out_list
 
-    def quantize_and_compute(self, x, wq, w_scale, masked_m, expected_m, m_values):
-        xq, wq, x_scale, w_scale, masked_m, expected_m = self.quantize(
-            x, wq, w_scale, masked_m, expected_m, m_values
-        )
-        return self.compute(xq, wq, x_scale, w_scale, masked_m, expected_m, m_values)
-
 
 @register_gemm_op
 class DeepGemmFP8Groupwise(GemmOpBase):
@@ -1062,10 +997,6 @@ class DeepGemmFP8Groupwise(GemmOpBase):
     def compute(self, xq, wq, x_scale, w_scale, out):
         gemm_fp8_fp8_bf16_nt((xq, x_scale), (wq, w_scale), out)
         return out
-
-    def quantize_and_compute(self, x, wq, w_scale, out):
-        xq, wq, x_scale, w_scale, out = self.quantize(x, wq, w_scale, out)
-        return self.compute(xq, wq, x_scale, w_scale, out)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1107,10 +1038,6 @@ class DeepGemmFP8Rowwise(GemmOpBase):
     def compute(self, xq, wq, x_scale, w_scale, out):
         gemm_fp8_fp8_bf16_nt((xq, x_scale), (wq, w_scale), out)
         return out
-
-    def quantize_and_compute(self, x, wq, w_scale, out):
-        xq, wq, x_scale, w_scale, out = self.quantize(x, wq, w_scale, out)
-        return self.compute(xq, wq, x_scale, w_scale, out)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1157,10 +1084,6 @@ class FP8RowwiseGrouped(GemmOpBase):
             xq, wq, x_scale, w_scale, m_sizes
         )
 
-    def quantize_and_compute(self, x, wq, w_scale, m_sizes):
-        xq, wq, x_scale, w_scale, m_sizes = self.quantize(x, wq, w_scale, m_sizes)
-        return self.compute(xq, wq, x_scale, w_scale, m_sizes)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {
@@ -1194,10 +1117,6 @@ class FP8RowwiseGrouped2D3D(FP8RowwiseGrouped):
         return torch.ops.mslk.f8f8bf16_rowwise_grouped_mm(
             xq, wq, x_scale, w_scale, offsets, out
         )
-
-    def quantize_and_compute(self, x, wq, w_scale, m_sizes):
-        xq, wq, x_scale, w_scale, offsets, out = self.quantize(x, wq, w_scale, m_sizes)
-        return self.compute(xq, wq, x_scale, w_scale, offsets, out)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1287,10 +1206,6 @@ class FP8GroupwiseGrouped(GemmOpBase):
             xq, wq, x_scale, w_scale, m_sizes
         )
 
-    def quantize_and_compute(self, x, wq, w_scale, m_sizes):
-        xq, wq, x_scale, w_scale, m_sizes = self.quantize(x, wq, w_scale, m_sizes)
-        return self.compute(xq, wq, x_scale, w_scale, m_sizes)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM90, Accelerator.AMD_GFX950, Accelerator.AMD_GFX942}
@@ -1326,10 +1241,6 @@ class FP8RowwiseBatched(GemmOpBase):
 
     def compute(self, xq, wq, x_scale, w_scale):
         return torch.ops.mslk.f8f8bf16_rowwise_batched(xq, wq, x_scale, w_scale)
-
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1377,10 +1288,6 @@ class TritonFP8Rowwise(GemmOpBase):
             use_warp_specialization=True,
         )
 
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return set(Accelerator)
@@ -1408,10 +1315,6 @@ class TritonFP8Blockwise(GemmOpBase):
 
     def compute(self, xq, wq, x_scale, w_scale):
         return matmul_fp8_block(xq, wq, x_scale, w_scale, 128, 128, 128)
-
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1447,10 +1350,6 @@ class FP8Blockwise(GemmOpBase):
         return torch.ops.mslk.f8f8bf16_blockwise(
             xq, wq, x_scale, w_scale, 128, 128, 128
         )
-
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1489,10 +1388,6 @@ class FP8Groupwise(GemmOpBase):
 
     def compute(self, xq, wq, x_scale, w_scale):
         return torch.ops.mslk.f8f8bf16_groupwise(xq, wq, x_scale, w_scale)
-
-    def quantize_and_compute(self, x, wq, w_scale):
-        xq, wq, x_scale, w_scale = self.quantize(x, wq, w_scale)
-        return self.compute(xq, wq, x_scale, w_scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1565,10 +1460,6 @@ class CutlassFP8Int4Rowwise(GemmOpBase):
     def compute(self, xq, wq, x_scale, w_scale, w_zp):
         return torch.ops.mslk.f8i4bf16_rowwise(xq, wq, x_scale, w_scale, w_zp)
 
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale, w_zp = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale, w_zp)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM90}
@@ -1612,12 +1503,6 @@ class CutlassFP8Int4RowwisePreshuffle(GemmOpBase):
         # Otherwise run gemm normally.
         return torch.ops.mslk.f8i4bf16_shuffled(xq, wq, x_scale, row_scale, group_scale)
 
-    def quantize_and_compute(self, x, wq, row_scale, group_scale):
-        xq, wq, x_scale, row_scale, group_scale = self.quantize(
-            x, wq, row_scale, group_scale
-        )
-        return self.compute(xq, wq, x_scale, row_scale, group_scale)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM90}
@@ -1660,10 +1545,6 @@ class CutlassBF16Int4GroupwisePreshuffle(GemmOpBase):
         # Otherwise run Gemm normally.
         return torch.ops.mslk.bf16i4bf16_shuffled(x, wq, group_scale, group_zero)
 
-    def quantize_and_compute(self, x, wq, group_scale, group_zero):
-        x, wq, group_scale, group_zero = self.quantize(x, wq, group_scale, group_zero)
-        return self.compute(x, wq, group_scale, group_zero)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM90}
@@ -1703,10 +1584,6 @@ class CutlassBF16Int4GroupwiseBatchedPreshuffle(GemmOpBase):
         return torch.ops.mslk.bf16i4bf16_shuffled_batched(
             x, wq, group_scale, group_zero
         )
-
-    def quantize_and_compute(self, x, wq, group_scale, group_zero):
-        x, wq, group_scale, group_zero = self.quantize(x, wq, group_scale, group_zero)
-        return self.compute(x, wq, group_scale, group_zero)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1762,12 +1639,6 @@ class CutlassFP8Int4GroupwiseGroupedPreshuffle(GemmOpBase):
         )
         return out
 
-    def quantize_and_compute(self, x, wq, row_scale, group_scale, m_sizes):
-        xq, wq, x_scale, row_scale, group_scale, m_sizes = self.quantize(
-            x, wq, row_scale, group_scale, m_sizes
-        )
-        return self.compute(xq, wq, x_scale, row_scale, group_scale, m_sizes)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM90}
@@ -1822,12 +1693,6 @@ class CutlassBF16Int4GroupwiseGroupedPreshuffle(GemmOpBase):
             x, wq, group_scale, group_zero, m_sizes
         )
 
-    def quantize_and_compute(self, x, wq, group_scale, group_zero, m_sizes):
-        x, wq, group_scale, group_zero, m_sizes = self.quantize(
-            x, wq, group_scale, group_zero, m_sizes
-        )
-        return self.compute(x, wq, group_scale, group_zero, m_sizes)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM90}
@@ -1872,10 +1737,6 @@ class CutlassBF16DGrad(GemmOpBase):
 
     def compute(self, x, w, m_sizes):
         return torch.ops.mslk.bf16bf16bf16_grouped_grad(x, w, m_sizes)
-
-    def quantize_and_compute(self, x, w, m_sizes):
-        x, w, m_sizes = self.quantize(x, w, m_sizes)
-        return self.compute(x, w, m_sizes)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -1923,10 +1784,6 @@ class CutlassBF16WGrad(GemmOpBase):
     def compute(self, x, w, k_sizes):
         return torch.ops.mslk.bf16bf16bf16_grouped_wgrad(x, w, k_sizes)
 
-    def quantize_and_compute(self, x, w, k_sizes):
-        x, w, k_sizes = self.quantize(x, w, k_sizes)
-        return self.compute(x, w, k_sizes)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {
@@ -1972,10 +1829,6 @@ class BF16Grouped(GemmOpBase):
     def compute(self, x, w, m_sizes):
         return torch.ops.mslk.bf16bf16bf16_grouped_stacked(x, w, m_sizes)
 
-    def quantize_and_compute(self, x, w, m_sizes):
-        x, w, m_sizes = self.quantize(x, w, m_sizes)
-        return self.compute(x, w, m_sizes)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {
@@ -2015,10 +1868,6 @@ class CutlassBF16Int4Rowwise(CutlassFP8Int4Rowwise):
     def compute(self, x, wq, w_scale, w_zp):
         return torch.ops.mslk.bf16i4bf16_rowwise(x, wq, w_scale, w_zp)
 
-    def quantize_and_compute(self, x, w):
-        x, wq, w_scale, w_zp = self.quantize(x, w)
-        return self.compute(x, wq, w_scale, w_zp)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM90}
@@ -2049,10 +1898,6 @@ class TritonBF16Int4Rowwise(CutlassBF16Int4Rowwise):
 
         return matmul_bf16i4_rowwise(x, wq, w_scale, w_zp)
 
-    def quantize_and_compute(self, x, w):
-        x, wq, w_scale, w_zp = self.quantize(x, w)
-        return self.compute(x, wq, w_scale, w_zp)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.AMD_GFX942}
@@ -2076,10 +1921,6 @@ class TinyGemmBF16Int4Groupwise(GemmOpBase):
         return torch.ops.tinygemm.tinygemm_y_f16RM_x_f16RM_w_int4TC(
             wq, x, 128, scale, False
         )
-
-    def quantize_and_compute(self, x, w):
-        x, wq, scale = self.quantize(x, w)
-        return self.compute(x, wq, scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -2113,10 +1954,6 @@ class MarlinBF16Int4Groupwise(GemmOpBase):
 
     def compute(self, x, wq, scale):
         return torch.ops.marlin.marlin_gemm(x, wq, scale)
-
-    def quantize_and_compute(self, x, w):
-        x, wq, scale = self.quantize(x, w)
-        return self.compute(x, wq, scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -2156,10 +1993,6 @@ class MacheteBF16Int4Groupwise(GemmOpBase):
 
     def compute(self, x, wq, scale):
         return machete_gemm(x, wq, bits=4, groupsize=128, scales=scale)
-
-    def quantize_and_compute(self, x, w):
-        x, wq, scale = self.quantize(x, w)
-        return self.compute(x, wq, scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -2205,10 +2038,6 @@ class CutlassNVFP4Groupwise(GemmOpBase):
             xq, wq, x_scale, w_scale, global_scale=global_scale
         )
 
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale, global_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale, global_scale=global_scale)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM100, Accelerator.NVIDIA_SM103}
@@ -2235,10 +2064,6 @@ class CutlassMXFP4Groupwise(GemmOpBase):
 
     def compute(self, xq, wq, x_scale, w_scale):
         return torch.ops.mslk.f4f4bf16(xq, wq, x_scale, w_scale)
-
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -2274,10 +2099,6 @@ class MX8MX4Groupwise(GemmOpBase):
 
     def compute(self, xq, wq, x_scale, w_scale):
         return torch.ops.mslk.mx8mx4bf16(xq, wq, x_scale, w_scale)
-
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -2317,10 +2138,6 @@ class CutlassMX8MX6Groupwise(GemmOpBase):
     def compute(self, xq, wq, x_scale, w_scale):
         return torch.ops.mslk.mx8mx6bf16(xq, wq, x_scale, w_scale)
 
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM100, Accelerator.NVIDIA_SM103}
@@ -2353,10 +2170,6 @@ class CutlassMX6MX6Groupwise(GemmOpBase):
 
     def compute(self, xq, wq, x_scale, w_scale):
         return torch.ops.mslk.mx6mx6bf16(xq, wq, x_scale, w_scale)
-
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale, w_scale)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -2426,14 +2239,6 @@ class CutlassMXFP4GroupwiseGrouped(GemmOpBase):
             starting_row_after_padding=starting_row_after_padding,
         )
 
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale, m_sizes, starting_row_after_padding = self.quantize(
-            x, w
-        )
-        return self.compute(
-            xq, wq, x_scale, w_scale, m_sizes, starting_row_after_padding
-        )
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {
@@ -2490,10 +2295,6 @@ class CutlassMXFP4GroupwiseGroupedMm(GemmOpBase):
         return torch.ops.mslk.f4f4bf16_grouped_mm(
             xq, wq.transpose(-2, -1), x_scale, w_scale, offsets
         )
-
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale, offsets = self.quantize(*self.preprocess(x, w))
-        return self.compute(xq, wq, x_scale, w_scale, offsets)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -2563,7 +2364,7 @@ class CutlassNVFP4GroupwiseGrouped(GemmOpBase):
 
         global_scale = 1.0 / (x_global_scale * w_global_scale)
 
-        # we can optionally set optional_tensor_idx to None to run the alternative method
+        # optional_tensor_idx can be None to run the alternative method.
         xq, x_scale, starting_row_after_padding = mega_fp4_quantize_kernel(
             m_sizes, x, x_global_scale, optional_tensor_idx=tensor_idx
         )
@@ -2600,26 +2401,6 @@ class CutlassNVFP4GroupwiseGrouped(GemmOpBase):
             use_mx=False,
         )
         return gemm_result
-
-    def quantize_and_compute(self, x, wq, w_scale, w_global_scale, m_sizes):
-        (
-            xq,
-            wq,
-            x_scale,
-            w_scale,
-            m_sizes,
-            global_scale,
-            starting_row_after_padding,
-        ) = self.quantize(x, wq, w_scale, w_global_scale, m_sizes)
-        return self.compute(
-            xq,
-            wq,
-            x_scale,
-            w_scale,
-            m_sizes,
-            global_scale,
-            starting_row_after_padding,
-        )
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
@@ -2700,24 +2481,6 @@ class CutlassNVFP4TorchGrouped(GemmOpBase):
             w_scale,
             offsets,
             global_scale=global_scale,
-        )
-
-    def quantize_and_compute(self, x, wq, w_scale, w_global_scale, m_sizes, offsets):
-        (
-            xq,
-            wq,
-            x_scale,
-            w_scale,
-            global_scale,
-            offsets,
-        ) = self.quantize(x, wq, w_scale, w_global_scale, m_sizes, offsets)
-        return self.compute(
-            xq,
-            wq,
-            x_scale,
-            w_scale,
-            global_scale,
-            offsets,
         )
 
     @property
@@ -2804,28 +2567,6 @@ class NVFP4UltraGroupwise(GemmOpBase):
             w_global_scale_inv,
         )
 
-    def quantize_and_compute(
-        self, x, wq, w_scale, w_global_scale_inv, m_sizes, offsets
-    ):
-        (
-            xq,
-            wq,
-            x_scale,
-            w_scale,
-            x_global_scale_inv,
-            w_global_scale_inv,
-            offsets,
-        ) = self.quantize(x, wq, w_scale, w_global_scale_inv, m_sizes, offsets)
-        return self.compute(
-            xq,
-            wq,
-            x_scale,
-            w_scale,
-            x_global_scale_inv,
-            w_global_scale_inv,
-            offsets,
-        )
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM100, Accelerator.NVIDIA_SM103}
@@ -2896,7 +2637,7 @@ class CutlassNVFP4GroupwiseStackedGroupedPackUnpack(GemmOpBase):
         )
 
     def quantize(self, x, wq, w_scale, x_global_scale, global_scale, m_sizes):
-        # alternative packing methods that only uses the overall global scale rather than per tensor
+        # Alternative packing methods use the overall global scale, not per tensor.
         """
         packed = mega_fp4_pack(x, x_global_scale[0])
         """
@@ -2967,34 +2708,6 @@ class CutlassNVFP4GroupwiseStackedGroupedPackUnpack(GemmOpBase):
 
         return gemm_result
 
-    def quantize_and_compute(
-        self, x, wq, w_scale, x_global_scale, global_scale, m_sizes
-    ):
-        (
-            xq,
-            wq,
-            x_scale,
-            w_scale,
-            m_sizes,
-            global_scale,
-            starting_row_after_padding,
-            xq_other,
-            x_scale_other,
-            starting_row_after_padding_other,
-        ) = self.quantize(x, wq, w_scale, x_global_scale, global_scale, m_sizes)
-        return self.compute(
-            xq,
-            wq,
-            x_scale,
-            w_scale,
-            m_sizes,
-            global_scale,
-            starting_row_after_padding,
-            xq_other,
-            x_scale_other,
-            starting_row_after_padding_other,
-        )
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {Accelerator.NVIDIA_SM100, Accelerator.NVIDIA_SM103}
@@ -3035,10 +2748,6 @@ class TorchBF16Grouped(GemmOpBase):
             offs=offs,
         )
 
-    def quantize_and_compute(self, x, w, offs):
-        x, w, offs = self.quantize(x, w, offs)
-        return self.compute(x, w, offs)
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return set(Accelerator)
@@ -3074,8 +2783,8 @@ class CutlassMXFP8GroupwiseGrouped2D3D(GemmOpBase):
             group_size, total_M + 1, group_size, dtype=torch.int32, device=x.device
         )
 
-        # For each constituent 2d subtensor in the 3d weights, quantize and convert scale to blocked format separately,
-        # as they each used for independent gemm in the grouped gemm.
+        # Each constituent 2d subtensor in the 3d weights is quantized and
+        # converted separately because grouped gemm uses them independently.
         wq_list = []
         w_scale_list = []
         for i in range(G):
@@ -3086,8 +2795,8 @@ class CutlassMXFP8GroupwiseGrouped2D3D(GemmOpBase):
         wq = torch.stack(wq_list, dim=0).contiguous()
         w_scale = torch.stack(w_scale_list, dim=0).contiguous()
 
-        # For each group along `total_M` in the 2D tensor, quantize and convert scale to blocked format separately,
-        # as they each used for independent gemm in the grouped gemm.
+        # Each group along `total_M` in the 2D tensor is quantized and converted
+        # separately because grouped gemm uses them independently.
         xq_list = []
         x_scale_list = []
         for i in range(G):
@@ -3110,16 +2819,6 @@ class CutlassMXFP8GroupwiseGrouped2D3D(GemmOpBase):
         return torch.ops.mslk.mx8mx8bf16_grouped_mm(
             xq,
             wq.transpose(-2, -1),
-            x_scale,
-            w_scale,
-            input_group_end_offsets,
-        )
-
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale, input_group_end_offsets = self.quantize(x, w)
-        return self.compute(
-            xq,
-            wq,
             x_scale,
             w_scale,
             input_group_end_offsets,
@@ -3199,16 +2898,6 @@ class MX8MX4GroupwiseGrouped2D3D(GemmOpBase):
             input_group_end_offsets,
         )
 
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale, input_group_end_offsets = self.quantize(x, w)
-        return self.compute(
-            xq,
-            wq,
-            x_scale,
-            w_scale,
-            input_group_end_offsets,
-        )
-
     @property
     def supported_accelerators(self) -> set[Accelerator]:
         return {
@@ -3249,8 +2938,9 @@ class CutlassMXFP8GroupwiseGrouped2D2D(GemmOpBase):
         return x, w, G
 
     def quantize(self, x, w, G):
-        # Simulate 2d-2d grouped gemm in backward pass `grad_weight = grad_output_t @ input`,
-        # where we use "K" as the contracting dim which has "G" groups.
+        # Simulate 2d-2d grouped gemm in backward pass
+        # `grad_weight = grad_output_t @ input`, where "K" is the contracting
+        # dim with "G" groups.
         M, total_K = x.shape
         N, _ = w.shape
         group_size = total_K // G
@@ -3319,16 +3009,6 @@ class CutlassMXFP8GroupwiseGrouped2D2D(GemmOpBase):
         return torch.ops.mslk.mx8mx8bf16_grouped_mm(
             xq,
             wq.transpose(-2, -1),
-            x_scale,
-            w_scale,
-            input_group_end_offsets,
-        )
-
-    def quantize_and_compute(self, x, w):
-        xq, wq, x_scale, w_scale, input_group_end_offsets = self.quantize(x, w)
-        return self.compute(
-            xq,
-            wq,
             x_scale,
             w_scale,
             input_group_end_offsets,
@@ -3451,11 +3131,6 @@ class CuteDSLInt4BF16Groupwise(GemmOpBase):
             scale_granularity_k=self._scale_granularity_k,
             acc_dtype=self._acc_dtype,
         )
-
-    def quantize_and_compute(self, x, w):
-        preprocessed = self.preprocess(x, w)
-        quantized = self.quantize(*preprocessed)
-        return self.compute(*quantized)
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:

--- a/bench/quantize/quantize_bench.py
+++ b/bench/quantize/quantize_bench.py
@@ -174,13 +174,20 @@ class Metrics:
 
     @staticmethod
     def header() -> str:
-        header = f"{'OpName':<20} {'Problem Shape':<15} {'Sim':<10} {'Us':<10} {'GB/s':<10} {'Mem BW Util %':<10}"
+        header = (
+            f"{'OpName':<20} {'Problem Shape':<15} {'Sim':<10} {'Us':<10} "
+            f"{'GB/s':<10} {'Mem BW Util %':<10}"
+        )
         divider = "-" * len(header)
         return f"Quantize Bench\n{divider}\n{header}\n{divider}"
 
     def __str__(self) -> str:
         problem_shape = f"({self.M}, {self.K})"
-        return f"{self.op:<20} {problem_shape:<15} {self.sim:<10.3f} {self.us:<10.3f} {self.gbps:<10.2f} {self.memory_bw_util:<10.2f}"
+        return (
+            f"{self.op:<20} {problem_shape:<15} {self.sim:<10.3f} "
+            f"{self.us:<10.3f} {self.gbps:<10.2f} "
+            f"{self.memory_bw_util:<10.2f}"
+        )
 
     def as_dict(self) -> dict[str, float]:
         return {
@@ -205,7 +212,8 @@ def get_problem_shapes(
         for shape in shapes.strip().split(","):
             if shape not in shape_registry:
                 print(
-                    f"Shape {shape} not found in shape registry. Valid shapes: {', '.join(shape_registry.keys())}."
+                    f"Shape {shape} not found in shape registry. "
+                    f"Valid shapes: {', '.join(shape_registry.keys())}."
                 )
                 sys.exit(1)
             all_shapes.update(shape_registry[shape]())
@@ -248,25 +256,19 @@ def benchmark(
         dequantized = quantize_op.dequantize(*quantized)
         metrics.sim = torch.mean(torch.pow(dequantized - input, 2)).item()
 
-        for _ in range(opts.num_iters):
-            with profiler(enabled=opts.trace, with_stack=True):
-                ms_runtime = quantize_op.benchmark(
-                    input,
-                    args,
-                    opts=opts,
-                )
+        with profiler(enabled=opts.trace, with_stack=True):
+            ms_runtime = quantize_op.benchmark(
+                input,
+                args,
+                opts=opts,
+            )
 
-            input_bytes = input.numel() * input.element_size()
-            output_bytes = sum(t.numel() * t.element_size() for t in quantized)
-            total_size_bytes = input_bytes + output_bytes
-            gbps = (total_size_bytes / 1e9) / (ms_runtime / 1e3)
-            metrics.gbps += gbps
-            metrics.us += ms_runtime * 1000
-            metrics.memory_bw_util += (gbps / mem_bw_roofline_gbps) * 100
-
-        metrics.us /= opts.num_iters
-        metrics.gbps /= opts.num_iters
-        metrics.memory_bw_util /= opts.num_iters
+        input_bytes = input.numel() * input.element_size()
+        output_bytes = sum(t.numel() * t.element_size() for t in quantized)
+        total_size_bytes = input_bytes + output_bytes
+        metrics.gbps = (total_size_bytes / 1e9) / (ms_runtime / 1e3)
+        metrics.us = ms_runtime * 1000
+        metrics.memory_bw_util = (metrics.gbps / mem_bw_roofline_gbps) * 100
 
         results.append(metrics)
 
@@ -306,7 +308,10 @@ def print_kernels(kernels: Optional[list[str]]) -> None:
 @click.option(
     "--pair-MK",
     is_flag=True,
-    help="If set, instead of benchmarking cartesian product of M * K, benchmark consecutive MK pairs together.",
+    help=(
+        "If set, instead of benchmarking cartesian product of M * K, "
+        "benchmark consecutive MK pairs together."
+    ),
 )
 @click.option(
     "--num-groups",
@@ -316,7 +321,6 @@ def print_kernels(kernels: Optional[list[str]]) -> None:
 )
 def invoke_main(
     output_dir: str,
-    num_iters: int,
     export_csv: bool,
     kernels: Optional[str],
     m: Optional[str],
@@ -338,15 +342,10 @@ def invoke_main(
         print_kernels(all_kernels)
         sys.exit(1)
 
-    if num_iters < 1:
-        print("Warning: Number of iterations must be at least 1.")
-        num_iters = 1
-
     mem_bw_roofline_gbps = triton.testing.get_dram_gbps()
     MK = get_problem_shapes(shapes, m, k, pair_mk)
 
     opts = BenchOptions(
-        num_iters=num_iters,
         cuda_graph=cuda_graph,
         rotating_buffer=rotating_buffer,
         rep_ms=rep_ms,


### PR DESCRIPTION
Summary:

Removes following:
- num_iters, this was added back before we had proper stable buffer rotation backed benchmarking
- quantize_and_compute, since we have separate `quantize_bench`, this is not needed, and not all kernel is using a real quant kernel anyways.

Differential Revision: D111456033


