### PR TITLE
Migrate contained C10_LIKELY/C10_UNLIKELY to [[likely]]/[[unlikely]] (mslk)

### DIFF
--- a/csrc/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd.cu
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd.cu
@@ -22,7 +22,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> dispatch_fmha_bwd(
     int64_t window_size_right,
     bool bottom_right,
     bool deterministic) {
-  if (C10_LIKELY(at::cuda::currentStreamCaptureStatus() == at::cuda::CaptureStatus::None)) {
+  if (at::cuda::currentStreamCaptureStatus() == at::cuda::CaptureStatus::None) [[likely]] {
     // This workaround initializes the CUDA context to prevent the 201 error
     // (invalid context).  When this function is invoked through PyTorch
     // autograd, it runs on a new thread that hasn't been associated with a CUDA

--- a/include/mslk/utils/kernel_launcher.cuh
+++ b/include/mslk/utils/kernel_launcher.cuh
@@ -257,7 +257,7 @@ struct KernelLauncher {
     const auto cuda_kernel_failure =
         c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().has_failed();
 
-    if (C10_LIKELY(cuda_error == cudaSuccess && !cuda_kernel_failure)) {
+    if (cuda_error == cudaSuccess && !cuda_kernel_failure) [[likely]] {
       return;
     }
 


### PR DESCRIPTION
Summary:
Migrates fully-contained uses of the `C10_LIKELY`/`C10_UNLIKELY` macros -- where the macro is the entire controlling condition of an `if`/`else if`/`while`/`for` -- to the standard C++20 `[[likely]]`/`[[unlikely]]` branch-prediction attributes, e.g. `if (C10_LIKELY(x))` becomes `if (x) [[likely]]`.

This diff is one of several split out from D111576576 by GitHub project, and contains only the changes under `fbcode/mslk/`. Conditions where the macro is only one clause of a compound condition (`if (a && C10_LIKELY(b))`), `return C10_LIKELY(x);` forms, macro definitions, and `generated` files are deliberately left untouched.

The migration was performed by the `c10_likely_to_attr` codemod, landed as a companion diff.

This diff was authored with the assistance of an AI coding agent.

Differential Revision: D111945036


