### PR TITLE
Suppress pre-existing amdsmi DeprecationWarning in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,10 @@ excludes = [
 # not do first-party namespace detection), so disable it here to match.
 [tool.usort]
 first_party_detection = false
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    # amdsmi emits DeprecationWarnings on Python 3.14+ that are pre-existing
+    # noise unrelated to mslk; suppress to keep test output clean.
+    "ignore::DeprecationWarning:amdsmi",
+]


### PR DESCRIPTION
Summary:
...entry silences this pre-existing noise to
keep test output clean and prevent the warnings from inadvertently failing
future CI runs.

Add [tool.pytest.ini_options] filterwarnings to mslk/pyproject.toml
to suppress amdsmi DeprecationWarnings on Python 3.14+.

Differential Revision: D110277845


