### PR TITLE
Add Buck targets for the mslk.flydsl package

### DIFF
--- a/test/flydsl/common_test.py
+++ b/test/flydsl/common_test.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-import importlib
 import unittest
 from unittest import mock
 
@@ -32,16 +31,6 @@ class FlyDSLCommonTest(unittest.TestCase):
     def test_require_passes_when_available(self) -> None:
         with mock.patch.object(common, "is_flydsl_available", return_value=True):
             common.require_flydsl()
-
-    def test_attention_wrapper_is_lazy_when_flydsl_unavailable(self) -> None:
-        with mock.patch.object(common, "is_flydsl_available", return_value=False):
-            attention_flydsl = importlib.import_module("mslk.attention.flydsl")
-
-            with self.assertRaisesRegex(
-                RuntimeError,
-                r"Install it with `pip install flydsl`",
-            ):
-                attention_flydsl.flydsl_flash_attn_func()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
D113438352 (OSS PR meta-pytorch/MSLK#447) consolidated the FlyDSL support
code under the new `mslk/flydsl/` package (`common.py`, `jit.py`, `aot.py`)
and moved its tests to `test/flydsl/`, but it only updated the OSS
`setup.py` packaging. The equivalent internal Buck target definitions were
never added, so the new package and its tests are not built internally.

Before the move, the FlyDSL modules lived under `mslk/utils/` and were
picked up by the `//mslk:python_utils` glob (`mslk/utils/**/*.py`); after
the move nothing globs `mslk/flydsl/`, and `test/flydsl/` has no target.

This restores parity on the non-OSS side:
- Add `//mslk:flydsl` `python_library` globbing `mslk/flydsl/**/*.py`
  (`base_module = ""` to preserve the `mslk.flydsl.*` import path). No deps
  are needed: the modules only use stdlib and lazily import the ROCm-only
  `flydsl` package (not vendored internally).
- Add `fbcode/mslk/test/flydsl/BUCK` with CPU `python_unittest` targets for
  `common_test`, `jit_test`, and `aot_test`, each depending on
  `//mslk:flydsl`. The tests mock `flydsl`, so no GPU/network is required.

## Detailed Changes

`fbcode/mslk/BUCK`
- New `python_library` `//mslk:flydsl`:
  - `srcs = glob(["mslk/flydsl/**/*.py"])` picks up `__init__.py`,
    `common.py`, `jit.py`, and `aot.py`.
  - `base_module = ""` keeps the `mslk.flydsl.*` import path (matching the
    sibling `python_utils` / `gemm_ops` / ... targets in this file).
  - `typing = True`, `visibility = ["PUBLIC"]`, and no `deps`: the modules
    use only stdlib and lazily import the ROCm-only `flydsl` PyPI package,
    which is not vendored internally, so a hard dep would be unresolvable.
  - Carries `autodeps-skip` + `lint-ignore BUCKLINT imported from OSS`,
    matching the other OSS-imported targets here.

`fbcode/mslk/test/flydsl/BUCK` (new)
- Three `python_unittest` targets generated via a comprehension over
  `["common", "jit", "aot"]`: `common_test`, `jit_test`, `aot_test`.
  - Each depends only on `//mslk:flydsl`.
  - `network_access = network_access_utils.none()`: the tests mock the
    `flydsl` module, so they are pure CPU and need no network.
  - `visibility = ["//mslk/..."]`, `oncall("mslk_dev")`.

Reviewed By: cthi

Differential Revision: D113633095


