### PR TITLE
Add Buck targets for the mslk.attention.flydsl package

### DIFF
--- a/test/attention/flydsl/flash_attn_lse_test.py
+++ b/test/attention/flydsl/flash_attn_lse_test.py
@@ -15,18 +15,37 @@ import torch
 from mslk.attention.flydsl import flydsl_flash_attn_func
 from mslk.flydsl.common import is_flydsl_available
 
+# The MSLK attention port requires the FlyDSL API introduced in 0.2.3
+# (e.g. flydsl._mlir.dialects.fly_rocdl.TargetAddressSpace). Older wheels
+# are skipped rather than failing with an ImportError at call time.
+_MIN_FLYDSL_VERSION = (0, 2, 3)
+
+
+def _flydsl_version_at_least(minimum: tuple) -> bool:
+    try:
+        import flydsl
+    except Exception:
+        return False
+    parts = []
+    for token in getattr(flydsl, "__version__", "0").split("."):
+        if not token.isdigit():
+            break
+        parts.append(int(token))
+    return tuple(parts) >= minimum
+
 
 def _has_supported_flydsl_environment() -> bool:
     return (
         torch.cuda.is_available()
         and torch.version.hip is not None
         and is_flydsl_available()
+        and _flydsl_version_at_least(_MIN_FLYDSL_VERSION)
     )
 
 
 pytestmark = pytest.mark.skipif(
     not _has_supported_flydsl_environment(),
-    reason="requires a ROCm GPU supported by FlyDSL",
+    reason="requires a ROCm GPU and FlyDSL >= 0.2.3",
 )
 
 DEVICE = torch.device("cuda")

--- a/test/flydsl/common_test.py
+++ b/test/flydsl/common_test.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-import importlib
 import unittest
 from unittest import mock
 
@@ -32,16 +31,6 @@ class FlyDSLCommonTest(unittest.TestCase):
     def test_require_passes_when_available(self) -> None:
         with mock.patch.object(common, "is_flydsl_available", return_value=True):
             common.require_flydsl()
-
-    def test_attention_wrapper_is_lazy_when_flydsl_unavailable(self) -> None:
-        with mock.patch.object(common, "is_flydsl_available", return_value=False):
-            attention_flydsl = importlib.import_module("mslk.attention.flydsl")
-
-            with self.assertRaisesRegex(
-                RuntimeError,
-                r"Install it with `pip install flydsl`",
-            ):
-                attention_flydsl.flydsl_flash_attn_func()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
D113600189 (OSS PR meta-pytorch/MSLK#448) landed the FlyDSL flash-attention
package `mslk/attention/flydsl/` and its test `test/attention/flydsl/`, but
it only updated OSS `setup.py` packaging. The equivalent internal Buck
target definitions were never added, so the new package and test are not
built internally.

Stacked on D113633095 (which adds `//mslk:flydsl` for the `mslk.flydsl`
support package that this package imports). This adds:
- `//mslk:flydsl_flash_attn` `python_library` globbing
  `mslk/attention/flydsl/**/*.py` (`base_module = ""` to preserve the
  `mslk.attention.flydsl.*` import path). `typing = False`: the kernel
  modules import the ROCm-only `flydsl` package at module load and it is
  not vendored internally, so it cannot be Pyre type-checked here (mirrors
  `//mslk:flash_attn`). Deps: `:flydsl` (for `require_flydsl` from
  `mslk.flydsl.common`, imported by the package `__init__`) and
  `//caffe2:torch`.
- `fbcode/mslk/test/attention/flydsl/BUCK` with a `python_pytest` target
  `flash_attn_lse_test`. The test is ROCm/gfx950-gated (module-level
  `pytest.mark.skipif`), so it is marked `ci.skip_target()` and skips when
  no supported ROCm GPU / FlyDSL is present.

Reviewed By: cthi

Differential Revision: D113692220


