### PR TITLE
Fix non nova rocm versions (#462)

### DIFF
--- a/.github/scripts/generate_ci_matrix.py
+++ b/.github/scripts/generate_ci_matrix.py
@@ -281,10 +281,7 @@ class BuildConfigScheme:
         return ["13.0.2"]
 
     def rocm_versions(self) -> List[str]:
-        if GitRepo.ref() == REFS_MAIN and GitRepo.event_name() == EVENT_NAME_PUSH:
-            return ["7.1"]
-        else:
-            return ["7.0", "7.1"]
+        return ["7.1", "7.2"]
 
     def host_machines(self) -> List[Dict[str, str]]:
         # For the list of available instance types:

--- a/ci/scripts/mslk_integration.bash
+++ b/ci/scripts/mslk_integration.bash
@@ -204,8 +204,8 @@ integration_mslk_pip_install_matrix_run () {
     )
   elif [ "$variant_type" == "rocm" ]; then
     local variant_versions=(
-      6.3
-      6.4
+      7.1
+      7.2
     )
   else
     echo "[TEST] Invalid variant type: ${variant_type}"


### PR DESCRIPTION
Summary:

As titled, match the nova and non-nova CI versions. PyTorch supports 7.1 and 7.2.

Differential Revision: D113933538
