### PR TITLE
Add MSLK_FMHA_LOG_DISPATCH env var to log selected attention kernel at runtime

### DIFF
--- a/mslk/attention/fmha/dispatch.py
+++ b/mslk/attention/fmha/dispatch.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 
 
+import logging
+import os
 import textwrap
 from collections import deque
 from typing import Any, List, Optional, Sequence, Tuple, Type, TypeVar
@@ -16,6 +18,17 @@ from . import attn_bias, ck, cutlass, flash, flash3, flash_mtia, triton_splitk
 from .common import AttentionBwOpBase, AttentionFwOpBase, Inputs
 
 T = TypeVar("T", Type[AttentionFwOpBase], Type[AttentionBwOpBase])
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# When set to "1" / "true" / "yes", logs the operator selected by
+# `_run_priority_list` (e.g. Flash3/Flash/Cutlass/Triton-splitk/CK) so that
+# the chosen FMHA kernel can be inspected at runtime for debugging.
+_LOG_DISPATCH: bool = os.getenv("MSLK_FMHA_LOG_DISPATCH", "0").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 
 
 try:
@@ -87,6 +100,8 @@ def _run_priority_list(
     for op in priority_list:
         not_supported = op.not_supported_reasons(inp)
         if not not_supported:
+            if _LOG_DISPATCH:
+                logger.debug("MSLK dispatch (%s): selected op=%s", name, op.NAME)
             return op
         not_supported_reasons.append(not_supported)
 


### PR DESCRIPTION
## Problem
`memory_efficient_attention()` dispatches to one of several kernel
implementations (Flash3, Flash, Cutlass, Triton-splitk, CK, MTIA) with
no runtime indication of which one was actually chosen, making it
hard to debug performance or correctness issues.

## Root cause
All dispatch converges in `_run_priority_list()` in
`mslk/attention/fmha/dispatch.py`, which returns the selected op
silently.

## Solution
Add an `MSLK_FMHA_LOG_DISPATCH` env var (accepts "1"/"true"/"yes",
case-insensitive - same convention as the existing
`MSLK_ROCM_FORCE_FP8FNUZ_TYPE` flag in `mslk/utils/device.py`). When
set, `_run_priority_list` logs the selected op's name via
`logging.debug`. The check is a single guarded boolean, so there is
no overhead when the variable is unset.

## Testing done
- Verified via `ast.parse`/`py_compile` that the file is syntactically valid.
- Verified the env-var truthiness logic against 10 input cases.
- Verified formatting via `black --check` and `isort --check` (no diff).

Fixes #405