### PR TITLE
Move existing nvfp4 quant kernel and optimize sf layout

### DIFF
--- a/mslk/quantize/triton/fp4_primitives/__init__.py
+++ b/mslk/quantize/triton/fp4_primitives/__init__.py
@@ -24,6 +24,8 @@ from mslk.quantize.triton.fp4_primitives.constants import (  # noqa: F401
 )
 from mslk.quantize.triton.fp4_primitives.layout import (  # noqa: F401
     blocked_scale_offset,
+    mx4_scale_swizzle,
+    nvfp4_scale_swizzle,
     stacked_segment_map,
 )
 from mslk.quantize.triton.fp4_primitives.packing import (  # noqa: F401

--- a/mslk/quantize/triton/fp4_primitives/layout.py
+++ b/mslk/quantize/triton/fp4_primitives/layout.py
@@ -9,8 +9,8 @@
 """
 Storage layout primitives for the Blackwell 128×4 FP4 scale arrangement.
 
-Provides the blocked-layout offset helper and the stacked-MoE segment map used
-by the MX4 quantize kernels.
+Provides blocked-layout offset helpers and the stacked-MoE segment map used by
+the FP4 quantize kernels.
 """
 
 import triton  # @manual
@@ -37,25 +37,46 @@ def blocked_scale_offset(logical_row, logical_col, n_col_blocks, num_cols):
     Returns:
         Flat offsets into the blocked layout buffer.
     """
-    # Pad the row stride to a multiple of 4 columns so the layout matches the canonical
-    # NVIDIA blocked-scale convention even when num_cols is not a multiple of 4.
-    flat_idx = logical_row * (n_col_blocks * 4) + logical_col
-
-    elems_per_row_block = 512 * n_col_blocks
-
-    first_dim = flat_idx // elems_per_row_block
-    second_dim = (flat_idx % elems_per_row_block) // (128 * n_col_blocks)
-    third_dim = (flat_idx % (128 * n_col_blocks)) // (4 * n_col_blocks)
-    fourth_dim = (flat_idx % (4 * n_col_blocks)) // 4
-    fifth_dim = flat_idx % 4
+    row_block = logical_row // 128
+    row_in_block = logical_row % 128
+    col_block = logical_col // 4
+    col_in_block = logical_col % 4
 
     return (
-        first_dim * elems_per_row_block
-        + fourth_dim * 512
-        + third_dim * 16
-        + second_dim * 4
-        + fifth_dim
+        row_block * (512 * n_col_blocks)
+        + col_block * 512
+        + (row_in_block % 32) * 16
+        + (row_in_block // 32) * 4
+        + col_in_block
     )
+
+
+@triton.jit
+def nvfp4_scale_swizzle(offs_m):
+    """Return offsets within one Blackwell 128x4 NVFP4 scale layout."""
+    sub_layout_off = (offs_m % 32) * 16
+    sub_layout_row = offs_m // 32
+    elems = tl.arange(0, 4)[None, :]
+    return sub_layout_off + sub_layout_row * 4 + elems
+
+
+@triton.jit
+def mx4_scale_swizzle(
+    offs_m,
+    pid_n,
+    NUM_COLS: tl.constexpr,
+):
+    """Return blocked offsets for one MX4 program's contiguous scale columns.
+
+    ``NUM_COLS`` must divide the four columns in a Blackwell scale tile. The
+    caller adds the base offset of the enclosing 128-row block; this helper
+    selects the 128x4 column tile and the program's columns within that tile.
+    """
+    PROGRAMS_PER_COL_BLOCK: tl.constexpr = 4 // NUM_COLS
+    col_block = pid_n // PROGRAMS_PER_COL_BLOCK
+    col_start = (pid_n % PROGRAMS_PER_COL_BLOCK) * NUM_COLS
+    elems = col_start + tl.arange(0, NUM_COLS)[None, :]
+    return col_block * 512 + (offs_m % 32) * 16 + (offs_m // 32) * 4 + elems
 
 
 @triton.jit

--- a/mslk/quantize/triton/fp4_quantize.py
+++ b/mslk/quantize/triton/fp4_quantize.py
@@ -9,6 +9,10 @@
 from __future__ import annotations
 
 import torch
+from mslk.quantize.triton.fp4_primitives import (  # noqa: F401
+    convert_fp32_to_fp4_packed,
+    nvfp4_scale_swizzle,
+)
 from mslk.quantize.triton.fp4_primitives.scale import (  # noqa: F401
     _compute_exp,
     _floor_log2,
@@ -27,13 +31,16 @@ from mslk.quantize.triton.legacy.primitives import (  # noqa: F401
     get_mx4_exp_bias,
     RoundingMode,
 )
-from mslk.quantize.triton.legacy.quantize import triton_quantize_nvfp4  # noqa: F401
 from mslk.quantize.triton.legacy.quantize_stacked import (  # noqa: F401
     _nvfp4_quantize_stacked_kernel,
     nvfp4_quantize_stacked,
     nvfp4_quantize_stacked_with_token_scale,
 )
 from mslk.quantize.triton.quantize_kernels.mx4 import quantize_mx4
+from mslk.quantize.triton.quantize_kernels.nvfp4 import (  # noqa: F401
+    _fp32_to_e8m0,
+    quantize_nvfp4 as triton_quantize_nvfp4,
+)
 
 
 def triton_quantize_mx4_unpack(
@@ -109,13 +116,10 @@ def triton_quantize_mx4(
 
 
 # Private symbol aliases (same-object re-exports for internal consumers)
-_fp32_to_e8m0 = _primitives._fp32_to_e8m0  # noqa: F401
 _from_blocked = _primitives._from_blocked  # noqa: F401
 _to_blocked = _primitives._to_blocked  # noqa: F401
 _e2m1_round_to_even = _primitives._e2m1_round_to_even  # noqa: F401
 unsigned_fp32_to_e8m0 = _primitives.unsigned_fp32_to_e8m0  # noqa: F401
-nvfp4_scale_swizzle = _primitives.nvfp4_scale_swizzle  # noqa: F401
-convert_fp32_to_fp4_packed = _primitives.convert_fp32_to_fp4_packed  # noqa: F401
 
 __all__ = [
     "triton_quantize_nvfp4",

--- a/mslk/quantize/triton/legacy/primitives.py
+++ b/mslk/quantize/triton/legacy/primitives.py
@@ -119,55 +119,6 @@ def _from_blocked(x: torch.Tensor, original_shape: Tuple[int, int]) -> torch.Ten
         return padded.contiguous()
 
 
-@triton.jit
-def _fp32_to_e8m0(
-    unscale,
-    mbits: tl.constexpr,
-    scale_round_mode: tl.constexpr,
-):
-    E8M0_EXPONENT_BIAS: tl.constexpr = 127  # type: ignore[Incompatible variable type]
-    sign = tl.where(unscale < 0, -1.0, 1.0)
-    abs_tensor = tl.abs(unscale)
-
-    # MBITS_F32 = 23
-    if scale_round_mode == "even":
-        val_to_add = (1 << (23 - mbits - 1)) - 1
-    elif scale_round_mode == "ceil":
-        val_to_add = (1 << 23) - 1
-    else:
-        val_to_add = 0
-
-    mask_exponent = ((1 << (8 + 1)) - 1) << 23
-    mask_mantissa = (1 << 23) - 1
-
-    fp32_bits = tl.extra.cuda.libdevice.float_as_int(abs_tensor)
-    fp32_bits_exp = (fp32_bits + val_to_add) & mask_exponent
-    exponent = (fp32_bits_exp >> 23) & 0xFF
-
-    if scale_round_mode == "nv_round":
-        mantissa = fp32_bits & mask_mantissa
-        is_denormal = (exponent == 0) & (mantissa != 0)
-        is_normal = ~is_denormal
-        condition1 = is_normal & (exponent < 254) & (mantissa > 0)
-        condition2 = is_denormal & (mantissa / (2**23) > 0.5)
-
-        exponent = tl.where(condition1 | condition2, exponent + 1, exponent)
-
-    exponent = exponent.to(tl.float32)
-    e8m0_values = sign * tl.exp2(exponent - E8M0_EXPONENT_BIAS)
-
-    unscale = e8m0_values
-    # In case unscale=0 (scale will be inf), or unscale=inf or nan, we set the scale to 1.0
-    unscale_invalid_mask = (
-        (e8m0_values == 0)
-        | (e8m0_values == float("inf"))
-        | (e8m0_values == float("nan"))
-    )
-    unscale = tl.where(unscale_invalid_mask, 1.0, unscale)
-
-    return unscale
-
-
 def unsigned_fp32_to_e8m0(
     tensor: torch.Tensor, mbits: tl.constexpr, scale_round_mode: tl.constexpr
 ) -> torch.Tensor:
@@ -222,73 +173,6 @@ def cal_global_scale_mx4_as_nvfp4(x: torch.Tensor):
     global_scale = 256.0 / global_amax_in_mx4_range
 
     return global_scale
-
-
-@triton.jit
-def nvfp4_scale_swizzle(offs_m):
-    """
-    Produces scale offsets swizzled according to the blackwell 128x4 scale layout.
-    Each 128x4 layout can be viewed as 32 4x4 layouts, each of which we'll refer to below as a sub_layout.
-
-    The returned offsets assume a 128x4 layout starting at 0. offs_m could be a subset of rows within a 128x4 layout.
-    """
-    # Offset of the 4x4 sub_layout within the 128x4 layout
-    sub_layout_idx = offs_m % 32
-    sub_layout_stride = 16
-    sub_layout_off = sub_layout_idx * sub_layout_stride
-    # Which row within the 4x4 sub_layout
-    sub_layout_row = offs_m // 32
-    # Offsets of the elements within 4x4 sub_layout
-    elems = tl.arange(0, 4)[None, :]
-    sub_layout_elem_offs = sub_layout_row * 4 + elems
-
-    scale_offs = sub_layout_off + sub_layout_elem_offs
-
-    return scale_offs
-
-
-@triton.jit
-def convert_fp32_to_fp4_packed(x_pairs):
-    """Convert FP32 pairs to packed FP4 format.
-
-    This function takes tensor where consecutive values along the last dimension
-    are packed together into single bytes.
-
-    Args:
-        x_pairs: [Tensor, Tensor] both w/ shapes [..., 1] where zipped last dimension contains
-                interleaved pairs of FP32 values to be packed together.
-
-    Returns:
-        Packed tensor with shape [...] (last dimension removed) where each
-        element is an int8 containing 2 FP4 values:
-        - First value of pair → low nibble (bits 0-3)
-        - Second value of pair → high nibble (bits 4-7)
-
-    Example:
-        Input:  [128, 32, 2] containing FP32 pairs
-        Output: [128, 32] containing packed FP4 bytes
-
-    """
-
-    x_fp4x2 = tl.inline_asm_elementwise(
-        asm="""
-        {
-        .reg .b8 byte0, byte1, byte2, byte3;
-        cvt.rn.satfinite.e2m1x2.f32 byte0, $5, $1;
-        cvt.rn.satfinite.e2m1x2.f32 byte1, $6, $2;
-        cvt.rn.satfinite.e2m1x2.f32 byte2, $7, $3;
-        cvt.rn.satfinite.e2m1x2.f32 byte3, $8, $4;
-        mov.b32 $0, {byte0, byte1, byte2, byte3};
-        }
-        """,
-        constraints=("=r,r,r,r,r,r,r,r,r"),
-        args=x_pairs,
-        dtype=tl.uint8,
-        is_pure=True,
-        pack=4,
-    )
-
-    return x_fp4x2
 
 
 @triton.jit

--- a/mslk/quantize/triton/legacy/quantize_stacked.py
+++ b/mslk/quantize/triton/legacy/quantize_stacked.py
@@ -12,7 +12,7 @@ from typing import Tuple
 
 import torch
 import triton  # @manual
-from mslk.quantize.triton.legacy.primitives import (
+from mslk.quantize.triton.fp4_primitives import (
     convert_fp32_to_fp4_packed,
     nvfp4_scale_swizzle,
 )
@@ -129,7 +129,11 @@ def _nvfp4_quantize_stacked_kernel(
     scales = tl.where(scale_mask, scales, 0.0)
 
     # ---- Step 5: Write FP4 data (flat, no segment awareness) ----
-    x_fp4x2 = convert_fp32_to_fp4_packed(x_blocks.reshape(M_PER_BLOCK, 32, 2).split())
+    x_fp4x2 = convert_fp32_to_fp4_packed(
+        x_blocks.reshape(M_PER_BLOCK, 32, 2).split(),
+        IS_GFX950=False,
+        IS_ROCM=False,
+    )
     fp4_offs_m = pid_m * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK)[:, None]
     fp4_offs_n = pid_n * 32 + tl.arange(0, 32)[None, :]
     fp4_mask = (fp4_offs_m < M) & (fp4_offs_n < N // 2)
@@ -221,7 +225,11 @@ def _nvfp4_quantize_stacked_token_scale_fused_row_kernel(
         total_scale = tl.div_rn(row_scale, scales_fp8.to(tl.float32)[:, None])
         x_blocks = x_blocks * total_scale
 
-        x_fp4x2 = convert_fp32_to_fp4_packed(x_blocks.reshape(BLOCK_K // 2, 2).split())
+        x_fp4x2 = convert_fp32_to_fp4_packed(
+            x_blocks.reshape(BLOCK_K // 2, 2).split(),
+            IS_GFX950=False,
+            IS_ROCM=False,
+        )
         fp4_offs_n = tl.arange(0, BLOCK_K // 2)
         fp4_mask = (row < M) & (fp4_offs_n < N // 2)
         tl.store(q_ptr + row * (N // 2) + fp4_offs_n, x_fp4x2, mask=fp4_mask)
@@ -269,7 +277,9 @@ def _nvfp4_quantize_stacked_token_scale_fused_row_kernel(
             x_blocks = x_blocks * total_scale
 
             x_fp4x2 = convert_fp32_to_fp4_packed(
-                x_blocks.reshape(CHUNK_SIZE // 2, 2).split()
+                x_blocks.reshape(CHUNK_SIZE // 2, 2).split(),
+                IS_GFX950=False,
+                IS_ROCM=False,
             )
             fp4_offs_n = k_start // 2 + fp4_offs_in_chunk
             fp4_mask = (row < M) & (fp4_offs_n < N // 2)

--- a/mslk/quantize/triton/quantize_kernels/__init__.py
+++ b/mslk/quantize/triton/quantize_kernels/__init__.py
@@ -4,12 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Self-contained, single-operator MX4 FP4 quantization Triton kernels.
+"""Self-contained, single-operator FP4 quantization Triton kernels.
 
 Each module owns exactly one ``@triton.jit`` kernel, specialized for one
-operator (MX4 non-stacked / stacked) with its ``SCALE_FORMAT`` / ``STACKED``
-behavior hardcoded, so each operator can be read, perf-tuned, and
-regression-tested in isolation. Genuinely-shared pieces (segment mapping,
+operator and scale format, so each operator can be read, perf-tuned, and
+regression-tested in isolation. Genuinely shared pieces (segment mapping,
 scale math, pack primitives) live in ``fp4_primitives``.
 """
 

--- a/mslk/quantize/triton/quantize_kernels/mx4.py
+++ b/mslk/quantize/triton/quantize_kernels/mx4.py
@@ -16,9 +16,9 @@ from typing import Optional, Union
 import torch
 import triton  # @manual=//triton:triton
 from mslk.quantize.triton.fp4_primitives import (
-    blocked_scale_offset,
     convert_fp32_to_fp4_packed,
     mx4_scale_normalize_encode,
+    mx4_scale_swizzle,
     RoundingMode,
 )
 from mslk.quantize.triton.quantize_kernels import _resolve_seed
@@ -69,11 +69,10 @@ def quantize_mx4_kernel(
     # ========================================================================
     if (not IS_ROCM) and M_PER_BLOCK != 128 and pid_m * M_PER_BLOCK >= M:
         offs_m = tl.arange(0, 128)[:, None]
-        logical_col = pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS)[None, :]
-        num_scale_cols = N // GROUP_SIZE
-        scale_offs = blocked_scale_offset(
-            offs_m, logical_col, N_COL_BLOCKS, num_scale_cols
-        )
+        scale_pid_n = pid_n
+        if USE_INT64_INDEXING:
+            scale_pid_n = scale_pid_n.to(tl.int64)
+        scale_offs = mx4_scale_swizzle(offs_m, scale_pid_n, NUM_GROUPS)
         oob_mask = (offs_m >= M) & tl.full((NUM_GROUPS,), True, dtype=tl.int1)[None, :]
         zero_scales = tl.full([128, NUM_GROUPS], 0, dtype=tl.int8)
         tl.store(s_ptr + scale_offs, zero_scales, mask=oob_mask)
@@ -148,8 +147,18 @@ def quantize_mx4_kernel(
         scale_offs = logical_row * num_scale_cols + logical_col
         scale_store_mask = (logical_col < num_scale_cols) & (logical_row < M)
     else:
-        scale_offs = blocked_scale_offset(
-            logical_row, logical_col, N_COL_BLOCKS, num_scale_cols
+        ROW_TILES_PER_LAYOUT: tl.constexpr = 128 // M_PER_BLOCK
+        offs_m_in_layout = (
+            (pid_m % ROW_TILES_PER_LAYOUT) * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK)
+        )[:, None]
+        row_block = pid_m // ROW_TILES_PER_LAYOUT
+        scale_pid_n = pid_n
+        if USE_INT64_INDEXING:
+            row_block = row_block.to(tl.int64)
+            scale_pid_n = scale_pid_n.to(tl.int64)
+        layout_off = row_block * N_COL_BLOCKS * 512
+        scale_offs = layout_off + mx4_scale_swizzle(
+            offs_m_in_layout, scale_pid_n, NUM_GROUPS
         )
         # Mask out scale columns beyond num_scale_cols (= N // GROUP_SIZE).
         # Without this mask, writes for col >= num_scale_cols collide with

--- a/mslk/quantize/triton/quantize_kernels/nvfp4.py
+++ b/mslk/quantize/triton/quantize_kernels/nvfp4.py
@@ -6,39 +6,80 @@
 
 # pyre-unsafe
 
-from __future__ import annotations
-
-from typing import Tuple
+"""Dense NVFP4 quantization kernel and host wrapper."""
 
 import torch
-import triton  # @manual
-from mslk.quantize.triton.legacy.primitives import (
-    _fp32_to_e8m0,
+import triton  # @manual=//triton:triton
+from mslk.quantize.triton.fp4_primitives import (
     convert_fp32_to_fp4_packed,
     nvfp4_scale_swizzle,
 )
-from triton import language as tl  # @manual
+from triton import language as tl  # @manual=//triton:triton
 
 
-def triton_quantize_nvfp4(
+@triton.jit
+def _fp32_to_e8m0(
+    unscale,
+    mbits: tl.constexpr,
+    scale_round_mode: tl.constexpr,
+):
+    """Round FP32 scale values to power-of-two E8M0 values."""
+    E8M0_EXPONENT_BIAS: tl.constexpr = 127  # type: ignore[Incompatible variable type]
+    sign = tl.where(unscale < 0, -1.0, 1.0)
+    abs_tensor = tl.abs(unscale)
+
+    if scale_round_mode == "even":
+        val_to_add = (1 << (23 - mbits - 1)) - 1
+    elif scale_round_mode == "ceil":
+        val_to_add = (1 << 23) - 1
+    else:
+        val_to_add = 0
+
+    mask_exponent = ((1 << (8 + 1)) - 1) << 23
+    mask_mantissa = (1 << 23) - 1
+
+    fp32_bits = abs_tensor.to(tl.int32, bitcast=True)
+    fp32_bits_exp = (fp32_bits + val_to_add) & mask_exponent
+    exponent = (fp32_bits_exp >> 23) & 0xFF
+
+    if scale_round_mode == "nv_round":
+        mantissa = fp32_bits & mask_mantissa
+        is_denormal = (exponent == 0) & (mantissa != 0)
+        is_normal = ~is_denormal
+        condition1 = is_normal & (exponent < 254) & (mantissa > 0)
+        condition2 = is_denormal & (mantissa / (2**23) > 0.5)
+        exponent = tl.where(condition1 | condition2, exponent + 1, exponent)
+
+    e8m0_values = sign * tl.exp2(exponent.to(tl.float32) - E8M0_EXPONENT_BIAS)
+    invalid_mask = (
+        (e8m0_values == 0)
+        | (e8m0_values == float("inf"))
+        | (e8m0_values != e8m0_values)
+    )
+    return tl.where(invalid_mask, 1.0, e8m0_values)
+
+
+def quantize_nvfp4(
     x: torch.Tensor,
     global_scale: torch.Tensor | None,
     use_e8m0_scale: bool = False,
     use_precise_math: bool = True,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Quantize a tensor to NVFP4 format.
 
     Args:
         x (torch.Tensor): Input tensor to be quantized.
-        global_scale (torch.Tensor | None): Per-tensor scale for two-level quantization.
+        global_scale (torch.Tensor | None): Per-tensor scale for two-level
+            quantization.
             If None, the global scale is not applied (treated as 1.0).
-        use_e8m0_scale (bool): Whether to use E8M0 for quantization. If True will mimic mx4's e8m0 scaling factor in nvfp4's fp8 local scale.
-        use_precise_math (bool): Whether to use precise math for quantization.
-            If disabled the kernel would multiply by the reciprocal instead of dividing when computing scales.
-            In practice this is **often** bitwise accurate as the scales are converted to FP8 right after.
+        use_e8m0_scale (bool): Whether to mimic MX4's E8M0 scaling factor in
+            NVFP4's FP8 local scale.
+        use_precise_math (bool): Whether to use division when computing scales.
+            If disabled, the kernel multiplies by the reciprocal instead. This
+            is often bitwise accurate because scales are immediately cast to FP8.
 
     Returns:
-        Tuple[torch.Tensor, torch.Tensor]: Quantized tensor and scales tensor in swizzled layout.
+        The quantized tensor and scales tensor in swizzled layout.
     """
     # reshape to 2d
     orig_leading_dims, orig_N = x.shape[:-2], x.shape[-1]
@@ -66,8 +107,7 @@ def triton_quantize_nvfp4(
     USE_MASK = M % M_PER_BLOCK != 0 or N % 64 != 0
 
     grid = (triton.cdiv(N, 64), triton.cdiv(M, M_PER_BLOCK))
-    # If M_PER_BLOCK is not 128 launch an extra set of blocks along M to handle zeroing scales.
-    # This is needed as otherwise the kernel would not visit those scales, and the spec requires padded scales to be zero.
+    # Launch an extra M block to zero scales in the 128-row padded tail.
     if M_PER_BLOCK != 128:
         grid = (grid[0], grid[1] + 1)
 
@@ -79,7 +119,7 @@ def triton_quantize_nvfp4(
     # Use int64 indexing when pointer offsets can exceed INT32_MAX
     use_int64_indexing = M * N > 2**31 - 1
 
-    triton_quantize_nvfp4_kernel[grid](
+    quantize_nvfp4_kernel[grid](
         x,
         global_scale,
         xq,
@@ -110,7 +150,7 @@ def triton_quantize_nvfp4(
 
 
 @triton.jit
-def triton_quantize_nvfp4_kernel(
+def quantize_nvfp4_kernel(
     x_ptr,
     global_scale_ptr,
     q_ptr,
@@ -131,6 +171,7 @@ def triton_quantize_nvfp4_kernel(
     FP4_E2M1_MAX = 6.0
     INV_FP4_E2M1_MAX = 1.0 / 6.0
 
+    NUM_GROUPS: tl.constexpr = 4  # type: ignore[Incompatible variable type]
     NUM_ELEM_PER_LAYOUT = 128 * 4
     NUM_N_BLOCKS = tl.cdiv(N, 64)
 
@@ -138,19 +179,20 @@ def triton_quantize_nvfp4_kernel(
     pid_n = tl.program_id(0)
 
     # Special blocks that zeros out tail M scales if M_PER_BLOCK != 128
-    # Technically this is a data race as we zero out scales another block has also zero'd out.
-    # Since we write the same value, it shouldn't be an issue.
+    # Multiple blocks may race to write the same zero value here.
     if M_PER_BLOCK != 128 and pid_m * M_PER_BLOCK >= M:
         # This is only used (and supported) when M < 128.
         tl.device_assert(pid_m == 1, "pid_m != 1 when M_PER_BLOCK != 128")
 
-        # Offset of the 128x4 layout
-        layout_off = pid_n * NUM_ELEM_PER_LAYOUT
         offs_m = tl.arange(0, 128)[:, None]
+        if USE_INT64_INDEXING:
+            layout_off = pid_n.to(tl.int64) * NUM_ELEM_PER_LAYOUT
+        else:
+            layout_off = pid_n * NUM_ELEM_PER_LAYOUT
         scale_offs = layout_off + nvfp4_scale_swizzle(offs_m)
 
-        oob_mask = (offs_m >= M) & tl.full((4,), True, dtype=tl.int1)[None, :]
-        zero_scales = tl.full([128, 4], 0, dtype=tl.float8e4nv)
+        oob_mask = (offs_m >= M) & tl.full((NUM_GROUPS,), True, dtype=tl.int1)[None, :]
+        zero_scales = tl.full([128, NUM_GROUPS], 0, dtype=tl.float8e4nv)
         tl.store(s_ptr + scale_offs, zero_scales, mask=oob_mask)
         return
 
@@ -174,7 +216,9 @@ def triton_quantize_nvfp4_kernel(
 
     load_offsets = offs_m * stride_xm + offs_n * stride_xn
     x = tl.load(x_ptr + load_offsets, mask=mask, other=other)  # [M_PER_BLOCK, 64]
-    x_blocks = x.to(tl.float32).reshape(M_PER_BLOCK, 4, 16)  # [M_PER_BLOCK, 4, 16]
+    x_blocks = x.to(tl.float32).reshape(
+        M_PER_BLOCK, NUM_GROUPS, 16
+    )  # [M_PER_BLOCK, 4, 16]
 
     # Block-wise max
     block_amax = tl.max(tl.abs(x_blocks), axis=2)  # [M_PER_BLOCK, 4]
@@ -205,7 +249,7 @@ def triton_quantize_nvfp4_kernel(
     x_blocks = x_blocks * total_scale  # [M_PER_BLOCK, 4, 16]
 
     if USE_MASK:
-        scale_offs_n = pid_n * 4 + tl.arange(0, 4)[None, :]
+        scale_offs_n = pid_n * NUM_GROUPS + tl.arange(0, NUM_GROUPS)[None, :]
         scale_mask = (offs_m < M) & (scale_offs_n < (N // 16))
 
         # Mask out scales to 0 if we are not aligned to M_PER_BLOCK x 64
@@ -216,10 +260,14 @@ def triton_quantize_nvfp4_kernel(
         )
 
     offs_m = (pid_m * M_PER_BLOCK % 128) + tl.arange(0, M_PER_BLOCK)[:, None]
-    # Offset of the 128x4 layout
-    layout_off = (
-        (pid_m * M_PER_BLOCK) // 128
-    ) * NUM_N_BLOCKS * NUM_ELEM_PER_LAYOUT + pid_n * NUM_ELEM_PER_LAYOUT
+    row_block = (pid_m * M_PER_BLOCK) // 128
+    if USE_INT64_INDEXING:
+        row_block = row_block.to(tl.int64)
+        layout_off = row_block * NUM_N_BLOCKS * NUM_ELEM_PER_LAYOUT
+        layout_off += pid_n.to(tl.int64) * NUM_ELEM_PER_LAYOUT
+    else:
+        layout_off = row_block * NUM_N_BLOCKS * NUM_ELEM_PER_LAYOUT
+        layout_off += pid_n * NUM_ELEM_PER_LAYOUT
     scale_offs = layout_off + nvfp4_scale_swizzle(offs_m)
     tl.store(
         s_ptr + scale_offs,
@@ -227,7 +275,11 @@ def triton_quantize_nvfp4_kernel(
     )
 
     # Convert to FP4
-    x_fp4x2 = convert_fp32_to_fp4_packed(x_blocks.reshape(M_PER_BLOCK, 32, 2).split())
+    x_fp4x2 = convert_fp32_to_fp4_packed(
+        x_blocks.reshape(M_PER_BLOCK, 32, 2).split(),
+        IS_GFX950=False,
+        IS_ROCM=False,
+    )
     offs_m = pid_m * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK)[:, None]
     offs_n = pid_n * 32 + tl.arange(0, 32)[None, :]
     if USE_MASK:


### PR DESCRIPTION
Summary:
- Move the existing nvfp4 dense quantization kernel out of legacy
- Optimize the SF layout code for existing MX4 kernels
- Remove more code from legacy folder

Differential Revision: D114881947
