### PR TITLE
Back the FP8 rowwise grouped GEMM ops with FlyDSL on ROCm

### DIFF
--- a/.github/workflows/mslk_ci_rocm.yml
+++ b/.github/workflows/mslk_ci_rocm.yml
@@ -41,6 +41,8 @@ on:
       - 'mslk/attention/fmha/flydsl_decoder.py'
       - 'mslk/attention/fmha/flydsl_splitk.py'
       - 'test/attention/fmha/**'
+      # FlyDSL GEMM ops
+      - 'mslk/gemm/flydsl/**'
       # GEMM tests
       - 'test/gemm/gemm_test.py'
       # AMD/ROCm Triton GEMM kernels

--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -24,6 +24,7 @@ from mslk.quantize.shuffle import (
     ck_preshuffle,
     int4_row_quantize_zp,
     pack_int4,
+    preshuffle_b_mfma,
     quantize_int4_preshuffle,
 )
 from mslk.quantize.triton.fp4_quantize import (
@@ -1100,6 +1101,7 @@ class FP8RowwiseGrouped(GemmOpBase):
             Accelerator.NVIDIA_SM100,
             Accelerator.NVIDIA_SM103,
             Accelerator.AMD_GFX942,
+            Accelerator.AMD_GFX950,
         }
 
     @property
@@ -1129,7 +1131,7 @@ class FP8RowwiseGrouped2D3D(FP8RowwiseGrouped):
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.AMD_GFX942}
+        return {Accelerator.AMD_GFX942, Accelerator.AMD_GFX950}
 
     @property
     def supported_gemm_types(self) -> set[GemmType]:
@@ -1183,6 +1185,276 @@ class TorchFP8RowwiseGrouped(FP8RowwiseGrouped2D3D):
     @property
     def compute_dtype(self) -> ComputeDtype:
         return ComputeDtype.FP8
+
+
+# The rowwise grouped variants below are served by FlyDSL on ROCm. Each takes a
+# different group geometry, so each builds its own operands from the per-group
+# tensors the harness supplies, and each states the shapes it needs: the driver
+# reports an op that raises as unsupported for that shape and moves on.
+_ROCM_GROUPED = {Accelerator.AMD_GFX942, Accelerator.AMD_GFX950}
+
+
+class _FlyDSLRowwiseGroupedBase(GemmOpBase):
+    """Shared plumbing for the FlyDSL-backed rowwise grouped variants."""
+
+    op_name: str = ""
+
+    @property
+    def supported_accelerators(self) -> set[Accelerator]:
+        return _ROCM_GROUPED
+
+    @property
+    def supported(self) -> bool:
+        if not super().supported:
+            return False
+        # FlyDSL supplies these on ROCm, and the preshuffled siblings have no
+        # schema in a binary built before they were declared, so check both
+        # rather than assume the op is there and implemented.
+        return is_flydsl_available() and hasattr(torch.ops.mslk, self.op_name)
+
+    @property
+    def supported_gemm_types(self) -> set[GemmType]:
+        return {GemmType.GROUPED}
+
+    @property
+    def compute_dtype(self) -> ComputeDtype:
+        return ComputeDtype.FP8
+
+
+def _uniform(values, what):
+    """Return the single distinct value, or say which variant cannot take it."""
+    distinct = set(values)
+    if len(distinct) != 1:
+        raise ValueError(f"every group must share one {what}, got {sorted(distinct)}")
+    return distinct.pop()
+
+
+@register_gemm_op
+class FP8RowwiseGroupedDynamic(_FlyDSLRowwiseGroupedBase):
+    """Rowwise grouped matmul over fixed per-group slabs.
+
+    Each group owns a slab of the tallest group's height and declares how many
+    of its rows hold real tokens, so ragged groups need no compaction.
+    """
+
+    op_name = "f8f8bf16_rowwise_grouped_dynamic"
+    preshuffled = False
+
+    def preprocess(self, x, w):
+        m_values = [i.shape[0] for i in x]
+        expected_m = max(m_values)
+        xp = x[0].new_zeros((len(x), expected_m, x[0].shape[1]))
+        for g, t in enumerate(x):
+            xp[g, : t.shape[0]] = t
+        wq, w_scale = zip(*[quantize_fp8_row(i) for i in w])
+        wq = torch.stack(wq, dim=0).contiguous()
+        if self.preshuffled:
+            wq = preshuffle_b_mfma(wq)
+        w_scale = torch.stack(w_scale, dim=0).contiguous()
+        zero_start = torch.tensor(m_values, dtype=torch.int64, device=x[0].device)
+        return xp, wq, w_scale, zero_start
+
+    def quantize(self, x, wq, w_scale, zero_start):
+        xq, x_scale = quantize_fp8_row(x)
+        return xq, wq, x_scale, w_scale, zero_start
+
+    def compute(self, xq, wq, x_scale, w_scale, zero_start):
+        return getattr(torch.ops.mslk, self.op_name)(
+            xq, wq, x_scale, w_scale, zero_start, True
+        )
+
+
+@register_gemm_op
+class FP8RowwiseGroupedDynamicPreshuffle(FP8RowwiseGroupedDynamic):
+    """As above, with weights already in the MFMA B layout."""
+
+    op_name = "f8f8bf16_rowwise_grouped_dynamic_preshuffle"
+    preshuffled = True
+
+    @property
+    def supported_accelerators(self) -> set[Accelerator]:
+        return {Accelerator.AMD_GFX950}
+
+
+@register_gemm_op
+class FP8RowwiseGrouped3D3D(_FlyDSLRowwiseGroupedBase):
+    """Rowwise batched matmul: nothing is grouped, one output slab per group."""
+
+    op_name = "f8f8bf16_rowwise_grouped_mm"
+    preshuffled = False
+
+    def preprocess(self, x, w):
+        _uniform([i.shape[0] for i in x], "row count")
+        xs = torch.stack(x, dim=0).contiguous()
+        wq, w_scale = zip(*[quantize_fp8_row(i) for i in w])
+        wq = torch.stack(wq, dim=0).contiguous()
+        if self.preshuffled:
+            wq = preshuffle_b_mfma(wq)
+        return xs, wq, torch.stack(w_scale, dim=0).contiguous()
+
+    def quantize(self, x, wq, w_scale):
+        G, M, _ = x.shape
+        xq, x_scale = quantize_fp8_row(x)
+        out = torch.empty((G, M, wq.shape[1]), dtype=torch.bfloat16, device=x.device)
+        return xq, wq, x_scale.view(G, -1), w_scale.view(G, -1), out
+
+    def compute(self, xq, wq, x_scale, w_scale, out):
+        return getattr(torch.ops.mslk, self.op_name)(
+            xq, wq, x_scale, w_scale, None, out
+        )
+
+
+@register_gemm_op
+class FP8RowwiseGrouped2D3DPreshuffle(FP8RowwiseGrouped2D3D):
+    """The 2D-3D grouped matmul with weights already in the MFMA B layout."""
+
+    def preprocess(self, x, w):
+        x, wq, w_scale, m_sizes = super().preprocess(x, w)
+        return x, preshuffle_b_mfma(wq), w_scale, m_sizes
+
+    def compute(self, xq, wq, x_scale, w_scale, offsets, out):
+        return torch.ops.mslk.f8f8bf16_rowwise_grouped_mm_preshuffle(
+            xq, wq, x_scale, w_scale, offsets, out
+        )
+
+    @property
+    def supported_accelerators(self) -> set[Accelerator]:
+        return {Accelerator.AMD_GFX950}
+
+    @property
+    def supported(self) -> bool:
+        if not super().supported:
+            return False
+        return is_flydsl_available() and hasattr(
+            torch.ops.mslk, "f8f8bf16_rowwise_grouped_mm_preshuffle"
+        )
+
+
+@register_gemm_op
+class FP8RowwiseGroupedPreshuffle(FP8RowwiseGrouped):
+    """The stacked grouped matmul with weights already in the MFMA B layout."""
+
+    def preprocess(self, x, w):
+        x, wq, w_scale, m_sizes = super().preprocess(x, w)
+        return x, preshuffle_b_mfma(wq), w_scale, m_sizes
+
+    def compute(self, xq, wq, x_scale, w_scale, m_sizes):
+        return torch.ops.mslk.f8f8bf16_rowwise_grouped_stacked_preshuffle(
+            xq, wq, x_scale, w_scale, m_sizes
+        )
+
+    @property
+    def supported_accelerators(self) -> set[Accelerator]:
+        return {Accelerator.AMD_GFX950}
+
+    @property
+    def supported(self) -> bool:
+        if not super().supported:
+            return False
+        return is_flydsl_available() and hasattr(
+            torch.ops.mslk, "f8f8bf16_rowwise_grouped_stacked_preshuffle"
+        )
+
+
+@register_gemm_op
+class FP8RowwiseGrouped3D2D(_FlyDSLRowwiseGroupedBase):
+    """Rowwise grouped matmul where the groups divide the output's columns.
+
+    Weights arrive as one [total_N, K] matrix the offsets divide, and the
+    output is [M, total_N] with the groups side by side.
+    """
+
+    op_name = "f8f8bf16_rowwise_grouped_mm"
+
+    def preprocess(self, x, w):
+        _uniform([i.shape[0] for i in x], "row count")
+        n_g = _uniform([i.shape[0] for i in w], "column count")
+        # A group's columns have to reach a store boundary or a store crosses
+        # into the next group. CK asserts this on the device; here the sizes are
+        # on the host, so say so before running.
+        if n_g % 8:
+            raise ValueError(f"every group's N must be a multiple of 8, got {n_g}")
+        xs = torch.stack(x, dim=0).contiguous()
+        wq, w_scale = zip(*[quantize_fp8_row(i) for i in w])
+        return xs, torch.cat(wq, dim=0).contiguous(), torch.cat(w_scale, dim=0)
+
+    def quantize(self, x, wq, w_scale):
+        G, M, _ = x.shape
+        xq, x_scale = quantize_fp8_row(x)
+        total_n = wq.shape[0]
+        n_g = total_n // G
+        offsets = torch.cumsum(torch.full((G,), n_g, dtype=torch.int), dim=0).to(
+            device=x.device, dtype=torch.int32
+        )
+        out = torch.empty((M, total_n), dtype=torch.bfloat16, device=x.device)
+        # The weights go to the op as one [total_N, K] matrix, but the harness
+        # measures bandwidth by indexing the first two operands per group, so
+        # hand it the per-group view; compute flattens it back, which is free.
+        return xq, wq.view(G, n_g, -1), x_scale.view(G, -1), w_scale, offsets, out
+
+    def compute(self, xq, wq, x_scale, w_scale, offsets, out):
+        torch.ops.mslk.f8f8bf16_rowwise_grouped_mm(
+            xq, wq.view(-1, wq.shape[-1]), x_scale, w_scale, offsets, out
+        )
+        # The groups sit side by side in the columns, so hand the harness one
+        # slab each rather than let it split the rows. Both steps are views.
+        groups = x_scale.shape[0]
+        return out.view(out.shape[0], groups, out.shape[1] // groups).permute(1, 0, 2)
+
+
+@register_gemm_op
+class FP8RowwiseGrouped2D2D(_FlyDSLRowwiseGroupedBase):
+    """Rowwise grouped matmul where the groups divide the contraction.
+
+    Every group multiplies the same rows by the same columns over its own slice
+    of K, so each produces a whole output and nothing is packed.
+
+    The operands are concatenated along K, so neither can be indexed per group
+    along its first dimension. The harness measures bandwidth that way, so the
+    reported GB/s undercounts the operands here; the runtime and TFLOPS are
+    unaffected.
+    """
+
+    op_name = "f8f8bf16_rowwise_grouped_mm"
+
+    def preprocess(self, x, w):
+        _uniform([i.shape[0] for i in x], "row count")
+        _uniform([i.shape[0] for i in w], "column count")
+        # A group's K is the vectorised load width or the reduction reads past
+        # its slice. The op cannot check this, since the offsets reach it on the
+        # device, but the sizes are here on the host. Neither this kernel nor CK
+        # is accurate below it, so run only where the answer means something.
+        ragged = [i.shape[1] for i in x if i.shape[1] % 16]
+        if ragged:
+            raise ValueError(f"every group's K must be a multiple of 16, got {ragged}")
+        return x, w
+
+    def quantize(self, x, w):
+        # Each group quantises its own K slice, so the row and column scales
+        # are per group and the operands are concatenated along K.
+        xq, x_scale = zip(*[quantize_fp8_row(i) for i in x])
+        wq, w_scale = zip(*[quantize_fp8_row(i) for i in w])
+        offsets = torch.cumsum(
+            torch.tensor([i.shape[1] for i in x], dtype=torch.int), dim=0
+        ).to(device=x[0].device, dtype=torch.int32)
+        out = torch.empty(
+            (len(x), x[0].shape[0], w[0].shape[0]),
+            dtype=torch.bfloat16,
+            device=x[0].device,
+        )
+        return (
+            torch.cat(xq, dim=1).contiguous(),
+            torch.cat(wq, dim=1).contiguous(),
+            torch.cat([s.flatten() for s in x_scale]),
+            torch.cat([s.flatten() for s in w_scale]),
+            offsets,
+            out,
+        )
+
+    def compute(self, xq, wq, x_scale, w_scale, offsets, out):
+        return torch.ops.mslk.f8f8bf16_rowwise_grouped_mm(
+            xq, wq, x_scale, w_scale, offsets, out
+        )
 
 
 @register_gemm_op

--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -1271,10 +1271,6 @@ class FP8RowwiseGroupedDynamicPreshuffle(FP8RowwiseGroupedDynamic):
     op_name = "f8f8bf16_rowwise_grouped_dynamic_preshuffle"
     preshuffled = True
 
-    @property
-    def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.AMD_GFX950}
-
 
 @register_gemm_op
 class FP8RowwiseGrouped3D3D(_FlyDSLRowwiseGroupedBase):
@@ -1318,10 +1314,6 @@ class FP8RowwiseGrouped2D3DPreshuffle(FP8RowwiseGrouped2D3D):
         )
 
     @property
-    def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.AMD_GFX950}
-
-    @property
     def supported(self) -> bool:
         if not super().supported:
             return False
@@ -1345,7 +1337,8 @@ class FP8RowwiseGroupedPreshuffle(FP8RowwiseGrouped):
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.AMD_GFX950}
+        # The preshuffled sibling has no schema off ROCm, unlike its parent.
+        return _ROCM_GROUPED
 
     @property
     def supported(self) -> bool:

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -112,6 +112,12 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   // Generic PyTorch grouped GEMM API is only available on AMD for now.
   m.def(
       "f8f8bf16_rowwise_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? offsets, Tensor(a!) output) -> Tensor");
+  // Sibling of f8f8bf16_rowwise_grouped_mm taking weights already swizzled into
+  // the MFMA B layout. It serves the 2D-3D and 3D-3D operand ranks, the ones
+  // that leave each group a whole [N, K]; grouping along N or K cuts across the
+  // axes the swizzle interleaves, so those ranks raise.
+  m.def(
+      "f8f8bf16_rowwise_grouped_mm_preshuffle(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? offsets, Tensor(a!) output) -> Tensor");
   // INT8 GEMM via Triton — static and dynamic scale variants.
   m.def("i8i8bf16(Tensor XQ, Tensor WQ, float scale, int split_k=1) -> Tensor");
   m.def(

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -92,15 +92,13 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   // FlyDSL.
   m.def(
       "f8f8bf16_blockwise_preshuffle(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, int block_m=128, int block_n=128, int block_k=128) -> Tensor");
-  // Sibling of f8f8bf16_rowwise_grouped_stacked taking weights already swizzled
-  // into the MFMA B layout; schema only on ROCm, implemented by
+  // Preshuffle siblings of the rowwise grouped ops: each takes the schema of
+  // the op it is named after, with weights already swizzled into the MFMA B
+  // layout. ROCm only, and implemented by
   // mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py via torch.library.impl at
   // Python import time.
   m.def(
-      "f8f8bf16_rowwise_grouped_preshuffle(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes) -> Tensor");
-  // Sibling of f8f8bf16_rowwise_grouped_dynamic taking weights already swizzled
-  // into the MFMA B layout; same schema otherwise, and implemented by the same
-  // FlyDSL module.
+      "f8f8bf16_rowwise_grouped_stacked_preshuffle(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes) -> Tensor");
   m.def(
       "f8f8bf16_rowwise_grouped_dynamic_preshuffle(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor zero_start_index_M, bool zeroing_output_tensor=True) -> Tensor");
   m.def(
@@ -158,12 +156,6 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("f8f8bf16_rowwise_batched", f8f8bf16_rowwise_batched);
   m.impl("f8f8bf16_rowwise_grouped", f8f8bf16_rowwise_grouped);
   m.impl("f8f8bf16_rowwise_grouped_cat", f8f8bf16_rowwise_grouped_cat);
-  // ROCm binds these from Python (fp8_rowwise_grouped_gemm.py), which needs the
-  // slots free; the same registrations serve CUTLASS on CUDA.
-#ifndef USE_ROCM
-  m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
-  m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
-#endif
   m.impl("bf16bf16bf16_grouped", bf16bf16bf16_grouped);
   m.impl("bf16bf16bf16_grouped_cat", bf16bf16bf16_grouped_cat);
   m.impl("bf16bf16bf16_grouped_dynamic", bf16bf16bf16_grouped_dynamic);
@@ -173,18 +165,23 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("f8f8f16_rowwise", f8f8f16_rowwise);
   m.impl("f8f8bf16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
   m.impl("f8f8f16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
-  // f8f8bf16_rowwise_grouped_mm: bound from Python by
-  // fp8_rowwise_grouped_gemm.py, which serves every rank combination the
-  // schema accepts, so the slot is left free here.
-  // i8i8bf16 / i8i8bf16_dynamic: dispatched to Python Triton kernels via
-  // torch.library.impl registered in mslk/gemm/triton/int8_gemm.py.
-  // IMPORTANT: int8_gemm.py must be imported before these ops are called;
-  // the Python-side @torch.library.impl("mslk::i8i8bf16_dynamic", "CUDA")
-  // registration only takes effect after that import.
-  // bf16bf16bf16_grouped_grad / bf16bf16bf16_grouped_wgrad: same pattern —
-  // Python-side @torch.library.impl is registered in
-  // mslk/gemm/triton/grouped_gemm.py, imported by mslk/gemm/__init__.py.
+  // Deliberately unregistered: a Python torch.library.impl owns the CUDA key
+  // for each of these on ROCm, and a C++ registration here would leave that
+  // binding overriding this one rather than being the only implementation.
+  // The module that binds each has to be imported before the op is called;
+  // mslk/gemm/__init__.py does that.
+  //   f8f8bf16_rowwise_grouped_stacked / _dynamic / _mm and their preshuffle
+  //     siblings -> mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+  //   f8f8bf16_groupwise_grouped and its preshuffle sibling
+  //     -> mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py
+  //   f8f8bf16_groupwise -> mslk/gemm/triton/fp8_groupwise_gemm.py
+  //   i8i8bf16 / i8i8bf16_dynamic -> mslk/gemm/triton/int8_gemm.py
+  //   bf16bf16bf16_grouped_grad / _wgrad -> mslk/gemm/triton/grouped_gemm.py
 #else
+  // The rowwise grouped ops share a schema with ROCm, where FlyDSL implements
+  // them from Python; these registrations serve CUTLASS on CUDA only.
+  m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
+  m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
   m.impl("f8f8bf16_groupwise", f8f8bf16_groupwise);
   m.impl("f8f8bf16_groupwise_grouped", f8f8bf16_groupwise_grouped);
   m.impl("i8i8bf16", i8i8bf16);
@@ -236,10 +233,12 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("f8f8f16_rowwise", f8f8f16_rowwise);
   m.impl("f8f8bf16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
   m.impl("f8f8f16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
-  // i8i8bf16 / i8i8bf16_dynamic and the rowwise grouped ops FlyDSL serves
-  // (_stacked, _dynamic, _mm and their preshuffle siblings): Python dispatch;
-  // no CPU fallback needed.
+  // The ops left out here are the ones a Python torch.library.impl owns on
+  // ROCm, listed against the CUDA registration above. They are bound on the
+  // CUDA key alone, so calling one on a CPU tensor raises rather than falling
+  // back, which is what the note at the top of this block is about.
 #else
+  // Shared with ROCm, where FlyDSL implements them from Python.
   m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
   m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
   m.impl("f8f8bf16_groupwise", f8f8bf16_groupwise);

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -92,6 +92,12 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   // FlyDSL.
   m.def(
       "f8f8bf16_blockwise_preshuffle(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, int block_m=128, int block_n=128, int block_k=128) -> Tensor");
+  // Sibling of f8f8bf16_rowwise_grouped_stacked taking weights already swizzled
+  // into the MFMA B layout; schema only on ROCm, implemented by
+  // mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py via torch.library.impl at
+  // Python import time.
+  m.def(
+      "f8f8bf16_rowwise_grouped_preshuffle(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes) -> Tensor");
   m.def(
       "f8f8f16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? bias=None, bool use_fast_accum=True) -> Tensor");
   m.def(
@@ -141,7 +147,11 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("f8f8bf16_rowwise_batched", f8f8bf16_rowwise_batched);
   m.impl("f8f8bf16_rowwise_grouped", f8f8bf16_rowwise_grouped);
   m.impl("f8f8bf16_rowwise_grouped_cat", f8f8bf16_rowwise_grouped_cat);
+  // ROCm binds this from Python (fp8_rowwise_grouped_gemm.py), which needs the
+  // slot free; the same registration serves CUTLASS on CUDA.
+#ifndef USE_ROCM
   m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
+#endif
   m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
   m.impl("bf16bf16bf16_grouped", bf16bf16bf16_grouped);
   m.impl("bf16bf16bf16_grouped_cat", bf16bf16bf16_grouped_cat);
@@ -204,7 +214,6 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("f8f8bf16_rowwise_batched", f8f8bf16_rowwise_batched);
   m.impl("f8f8bf16_rowwise_grouped", f8f8bf16_rowwise_grouped);
   m.impl("f8f8bf16_rowwise_grouped_cat", f8f8bf16_rowwise_grouped_cat);
-  m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
   m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
   m.impl("bf16bf16bf16_grouped", bf16bf16bf16_grouped);
   m.impl("bf16bf16bf16_grouped_cat", bf16bf16bf16_grouped_cat);
@@ -216,9 +225,10 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("f8f8bf16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
   m.impl("f8f8f16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
   m.impl("f8f8bf16_rowwise_grouped_mm", f8f8bf16_rowwise_grouped_mm);
-  // i8i8bf16 / i8i8bf16_dynamic: Python Triton dispatch; no CPU fallback
-  // needed.
+  // i8i8bf16 / i8i8bf16_dynamic and f8f8bf16_rowwise_grouped_stacked: Python
+  // dispatch; no CPU fallback needed.
 #else
+  m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
   m.impl("f8f8bf16_groupwise", f8f8bf16_groupwise);
   m.impl("f8f8bf16_groupwise_grouped", f8f8bf16_groupwise_grouped);
   m.impl("i8i8bf16", i8i8bf16);

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -98,6 +98,11 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   // Python import time.
   m.def(
       "f8f8bf16_rowwise_grouped_preshuffle(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes) -> Tensor");
+  // Sibling of f8f8bf16_rowwise_grouped_dynamic taking weights already swizzled
+  // into the MFMA B layout; same schema otherwise, and implemented by the same
+  // FlyDSL module.
+  m.def(
+      "f8f8bf16_rowwise_grouped_dynamic_preshuffle(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor zero_start_index_M, bool zeroing_output_tensor=True) -> Tensor");
   m.def(
       "f8f8f16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? bias=None, bool use_fast_accum=True) -> Tensor");
   m.def(
@@ -147,12 +152,12 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("f8f8bf16_rowwise_batched", f8f8bf16_rowwise_batched);
   m.impl("f8f8bf16_rowwise_grouped", f8f8bf16_rowwise_grouped);
   m.impl("f8f8bf16_rowwise_grouped_cat", f8f8bf16_rowwise_grouped_cat);
-  // ROCm binds this from Python (fp8_rowwise_grouped_gemm.py), which needs the
-  // slot free; the same registration serves CUTLASS on CUDA.
+  // ROCm binds these from Python (fp8_rowwise_grouped_gemm.py), which needs the
+  // slots free; the same registrations serve CUTLASS on CUDA.
 #ifndef USE_ROCM
   m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
-#endif
   m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
+#endif
   m.impl("bf16bf16bf16_grouped", bf16bf16bf16_grouped);
   m.impl("bf16bf16bf16_grouped_cat", bf16bf16bf16_grouped_cat);
   m.impl("bf16bf16bf16_grouped_dynamic", bf16bf16bf16_grouped_dynamic);
@@ -162,7 +167,9 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("f8f8f16_rowwise", f8f8f16_rowwise);
   m.impl("f8f8bf16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
   m.impl("f8f8f16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
-  m.impl("f8f8bf16_rowwise_grouped_mm", f8f8bf16_rowwise_grouped_mm);
+  // f8f8bf16_rowwise_grouped_mm: bound from Python by
+  // fp8_rowwise_grouped_gemm.py, which serves every rank combination the
+  // schema accepts, so the slot is left free here.
   // i8i8bf16 / i8i8bf16_dynamic: dispatched to Python Triton kernels via
   // torch.library.impl registered in mslk/gemm/triton/int8_gemm.py.
   // IMPORTANT: int8_gemm.py must be imported before these ops are called;
@@ -214,7 +221,6 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("f8f8bf16_rowwise_batched", f8f8bf16_rowwise_batched);
   m.impl("f8f8bf16_rowwise_grouped", f8f8bf16_rowwise_grouped);
   m.impl("f8f8bf16_rowwise_grouped_cat", f8f8bf16_rowwise_grouped_cat);
-  m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
   m.impl("bf16bf16bf16_grouped", bf16bf16bf16_grouped);
   m.impl("bf16bf16bf16_grouped_cat", bf16bf16bf16_grouped_cat);
   m.impl("bf16bf16bf16_grouped_dynamic", bf16bf16bf16_grouped_dynamic);
@@ -224,11 +230,12 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("f8f8f16_rowwise", f8f8f16_rowwise);
   m.impl("f8f8bf16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
   m.impl("f8f8f16_rowwise_preshuffle", f8f8bf16_rowwise_preshuffle);
-  m.impl("f8f8bf16_rowwise_grouped_mm", f8f8bf16_rowwise_grouped_mm);
-  // i8i8bf16 / i8i8bf16_dynamic and f8f8bf16_rowwise_grouped_stacked: Python
-  // dispatch; no CPU fallback needed.
+  // i8i8bf16 / i8i8bf16_dynamic and the rowwise grouped ops FlyDSL serves
+  // (_stacked, _dynamic, _mm and their preshuffle siblings): Python dispatch;
+  // no CPU fallback needed.
 #else
   m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
+  m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
   m.impl("f8f8bf16_groupwise", f8f8bf16_groupwise);
   m.impl("f8f8bf16_groupwise_grouped", f8f8bf16_groupwise_grouped);
   m.impl("i8i8bf16", i8i8bf16);

--- a/mslk/flydsl/autotune.py
+++ b/mslk/flydsl/autotune.py
@@ -139,7 +139,6 @@ def tunable(
                     "from the tuned path; pass returns= naming its output buffer"
                 ) from None
 
-        call.launch_untuned = launch_fn
         return call
 
     return decorate

--- a/mslk/flydsl/autotune.py
+++ b/mslk/flydsl/autotune.py
@@ -1,0 +1,145 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Opt-in tile autotuning for FlyDSL kernels.
+
+Wraps FlyDSL's autotuner in the policy MSLK uses for every backend: tuning runs
+only when ``MSLK_AUTOTUNE_ENABLE`` is set, and otherwise a fixed default config
+is used with no benchmarking. This mirrors the CUTLASS and CK paths in
+``csrc/gemm`` (see ``get_kernel_via_tuning`` vs ``get_kernel_via_heuristics``),
+and it matters for two reasons: benchmarking on a cache miss would make CI pay
+for a sweep, and it cannot happen inside a CUDA graph capture. With the env set,
+a tuned config is benchmarked once per key and persisted to disk by FlyDSL, so
+callers should warm the shapes they intend to capture before capturing them.
+
+Kernel modules supply their own launch function, candidate configs, and cache
+key; nothing here is specific to a kernel or an op.
+
+    TILES = ({"tile_m": 64, "tile_n": 128}, {"tile_m": 128, "tile_n": 128})
+
+    @tunable(
+        configs=TILES,
+        default={"tile_m": 128, "tile_n": 128},
+        key=["m_bucket", "n"],
+        prune=prune_by_divisibility({"tile_n": "n"}),
+    )
+    def launch(A, B, out, m_bucket, n, *, tile_m, tile_n):
+        ...
+        return out
+"""
+
+import functools
+import inspect
+import os
+from typing import Any, Callable, Mapping, Sequence
+
+AUTOTUNE_ENV = "MSLK_AUTOTUNE_ENABLE"
+
+
+def autotune_enabled() -> bool:
+    """True when tuning is opted into for this process."""
+    return bool(os.environ.get(AUTOTUNE_ENV))
+
+
+def next_pow2(x: int) -> int:
+    """Smallest power of two >= x (x >= 1).
+
+    Useful for bucketing a varying dimension into an autotune key so that nearby
+    sizes share one tuned config, which bounds both the number of tuned entries
+    and the set of shapes a caller must warm before graph capture.
+    """
+    if x <= 1:
+        return 1
+    return 1 << (int(x) - 1).bit_length()
+
+
+def prune_by_divisibility(
+    constraints: Mapping[str, str],
+) -> Callable[..., list]:
+    """Build a prune hook dropping configs that do not divide the problem.
+
+    ``constraints`` maps a config key to the launch argument it must divide, e.g.
+    ``{"tile_n": "n"}`` keeps only configs whose ``tile_n`` divides ``n``. If
+    every config is pruned the full list is returned instead, leaving the failure
+    to the kernel's own validation rather than producing an empty sweep.
+    """
+
+    def prune(configs, named_args, **_kwargs):
+        kept = []
+        for c in configs:
+            ok = True
+            for cfg_key, arg_name in constraints.items():
+                extent = named_args.get(arg_name)
+                value = c.kwargs.get(cfg_key)
+                if extent is None or value is None:
+                    continue
+                if int(extent) % int(value) != 0:
+                    ok = False
+                    break
+            if ok:
+                kept.append(c)
+        return kept or list(configs)
+
+    return prune
+
+
+def tunable(
+    *,
+    configs: Sequence[Mapping[str, Any]],
+    default: Mapping[str, Any],
+    key: Sequence[str],
+    prune: Callable[..., list] | None = None,
+    returns: str = "out",
+):
+    """Choose a launch function's tuning kwargs by autotuning, or by a default.
+
+    The wrapped function takes the tuning parameters as keyword-only arguments
+    and everything the cache key needs as ordinary arguments.
+
+    ``returns`` names the output argument. FlyDSL's autotuner discards the tuned
+    function's return value, so on the tuned path the wrapper hands back that
+    argument instead, which requires the kernel to write into a caller-provided
+    buffer.
+    """
+
+    def decorate(launch_fn):
+        signature = inspect.signature(launch_fn)
+        state: dict = {}
+
+        def _tuner():
+            tuner = state.get("tuner")
+            if tuner is None:
+                from flydsl.autotune import autotune, Config
+
+                tuner = autotune(
+                    configs=[Config(**dict(c)) for c in configs],
+                    key=list(key),
+                    prune_configs_by=prune,
+                )(launch_fn)
+                state["tuner"] = tuner
+            return tuner
+
+        @functools.wraps(launch_fn)
+        def call(*args, **kwargs):
+            if not autotune_enabled():
+                return launch_fn(*args, **kwargs, **dict(default))
+            _tuner()(*args, **kwargs)
+            bound = signature.bind_partial(*args, **kwargs)
+            bound.apply_defaults()
+            try:
+                return bound.arguments[returns]
+            except KeyError:
+                raise TypeError(
+                    f"{launch_fn.__name__} has no argument {returns!r} to return "
+                    "from the tuned path; pass returns= naming its output buffer"
+                ) from None
+
+        call.launch_untuned = launch_fn
+        return call
+
+    return decorate

--- a/mslk/flydsl/common.py
+++ b/mslk/flydsl/common.py
@@ -101,3 +101,22 @@ def is_flydsl_version_at_least(minimum: str = MIN_FLYDSL_VERSION) -> bool:
     if current is None:
         return False
     return _version_tuple(current) >= _version_tuple(minimum)
+
+
+# Conservative default for architectures missing from FlyDSL's capacity table.
+_LDS_CAPACITY_FALLBACK_BYTES = 64 * 1024
+
+
+def lds_capacity_bytes(arch=None):
+    """LDS bytes available to one workgroup on ``arch``.
+
+    This is arch-dependent and the difference is large: CDNA3 (gfx942/MI300) has
+    64 KiB while CDNA4 (gfx950/MI350) has 160 KiB. Sourced from FlyDSL's
+    SMEM_CAPACITY_MAP so the limit stays in sync with the compiler that enforces
+    it; unknown architectures fall back to the conservative 64 KiB.
+    """
+    try:
+        from flydsl.utils.smem_allocator import SMEM_CAPACITY_MAP
+    except Exception:
+        return _LDS_CAPACITY_FALLBACK_BYTES
+    return SMEM_CAPACITY_MAP.get(str(arch), _LDS_CAPACITY_FALLBACK_BYTES)

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -27,7 +27,8 @@ Tensors:
     where the groups divide N or K
   - m_sizes: [num_groups] - the group geometry, whose encoding the `layout`
     argument selects: INT64 row counts, INT32 cumulative offsets, or unused
-  - D: [M_total, N] BF16 - output
+  - D: [M_total, N] BF16 - output, which is the flattened [G * M, N] where the
+    groups divide K and each produces a whole output of its own
 
 Rowwise scaling carries one FP32 scale per row of A and per column of B, both
 constant along K, and applies them in the epilogue.

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -94,6 +94,9 @@ from mslk.flydsl.kernels.mma.mfma_epilogues import mfma_epilog
 # Supported encodings of the group geometry; see the ``layout`` argument below.
 LAYOUTS = ("sizes", "offsets", "padded", "batched", "n_offsets", "k_offsets")
 
+# Lanes the CShuffle epilogue lays across N, matching mfma_epilog's default.
+CSHUFFLE_NLANE = 32
+
 
 @functools.lru_cache(maxsize=128)
 def compile_fp8_grouped_gemm(
@@ -127,6 +130,15 @@ def compile_fp8_grouped_gemm(
         scale_block_k: K-dimension scale block size (default 128)
         scale_block_n: N-dimension scale block size (default 128)
         out_dtype: Output data type ("bf16" or "f16")
+        waves_per_eu: Minimum waves per EU to ask the register allocator for,
+            or None to leave the choice to the compiler. Raising it caps the
+            register budget, which trades spills against occupancy.
+        k_padding: Emit the per-load K-range predicate so K need only reach a
+            16-element load boundary rather than a whole tile. Forced on where
+            the groups divide K, whose per-group end is a runtime value.
+        n_padding: Emit the per-store column predicate so N need only reach an
+            8-column store boundary rather than a whole tile. Forced on where
+            the groups divide N, for the same reason.
         b_preshuffled: When True (default) B is expected pre-swizzled into the
             MFMA layout and loaded HBM->registers (no B LDS). When False, B is
             plain row-major [num_groups, N, K] and is staged HBM->LDS->registers
@@ -200,20 +212,19 @@ def compile_fp8_grouped_gemm(
                 "a scale block cannot straddle a group's K slice, and the "
                 "preshuffled layout swizzles K across the whole matrix"
             )
-        # A group's K length is only known on the device, so the trip count
-        # cannot be a compile-time constant and the loop cannot be unrolled.
+        # A group's K length is only known on the device. The trip count is
+        # therefore not a compile-time constant, so the loop cannot be
+        # unrolled, and every tile is bounded by that runtime end rather than
+        # by a compile-time last tile.
         roll_k = True
-    if n_grouped and (blockscale or b_preshuffled):
-        raise ValueError(
-            "layout 'n_offsets' supports only rowwise scaling with plain B: "
-            "ragged N would need per-group scale blocks, and the preshuffled "
-            "layout swizzles N across the whole matrix"
-        )
-    if k_grouped:
-        # Every tile is bounded by the group's K end, which is a runtime value,
-        # so the predicate cannot be confined to a compile-time last tile.
         k_padding = True
     if n_grouped:
+        if blockscale or b_preshuffled:
+            raise ValueError(
+                "layout 'n_offsets' supports only rowwise scaling with plain B: "
+                "ragged N would need per-group scale blocks, and the preshuffled "
+                "layout swizzles N across the whole matrix"
+            )
         # A group's column end is a runtime value, so unlike a compile-time N
         # remainder the tail mask cannot be elided; N only has to reach a store
         # boundary, which validate_params checks below.
@@ -305,7 +316,7 @@ def compile_fp8_grouped_gemm(
         )
 
     # Module name for caching
-    _variant = "contiguous_pingpong" if b_preshuffled else "plain"
+    _variant = "pingpong" if b_preshuffled else "plain"
     _scaling = "blockscale" if blockscale else "rowwise"
     _kpad = "_kpad" if k_padding else ""
     _roll = "_rollk" if roll_k else ""
@@ -468,25 +479,10 @@ def compile_fp8_grouped_gemm(
         def _i32k(v):  # raw i32 constant
             return arith.constant(int(v), type=T.i32)
 
-        _grp = resolve_group_rows(
-            arg_m_sizes=arg_m_sizes,
-            num_groups_in=num_groups_in,
-            m_in=m_in,
-            m_tile_idx=bx,
-            slab_idx=bz,
-            tile_m=tile_m,
-            num_groups=num_groups,
-            layout=layout,
-            group_id=_col_group_id,
-        )
-        group_id_i32 = _grp.group_id
-        row_start_i32 = _grp.row_start
-        row_limit_i32 = _grp.row_limit
-        group_m_start_i32 = _grp.group_m_start
-        group_m_size_i32 = _grp.group_m_size
-        # Rows are always whole slabs when the groups divide N, so validity is
-        # entirely a question of whether this N-block belongs to a group.
         if const_expr(k_grouped):
+            # Every group spans the whole output, so there is no row geometry
+            # to resolve: the group rides the z axis and the M-tile indexes the
+            # output directly.
             group_id_i32 = arith.index_cast(T.i32, bz)
             group_m_start_i32 = _i32k(0)
             group_m_size_i32 = arith.index_cast(T.i32, m_in)
@@ -496,6 +492,24 @@ def compile_fp8_grouped_gemm(
             # output slab is left to the caller, as CK leaves it.
             is_valid = arith.cmpi(arith.CmpIPredicate.slt, k_start_i32, k_end_i32)
         else:
+            _grp = resolve_group_rows(
+                arg_m_sizes=arg_m_sizes,
+                num_groups_in=num_groups_in,
+                m_in=m_in,
+                m_tile_idx=bx,
+                slab_idx=bz,
+                tile_m=tile_m,
+                num_groups=num_groups,
+                layout=layout,
+                group_id=_col_group_id,
+            )
+            group_id_i32 = _grp.group_id
+            row_start_i32 = _grp.row_start
+            row_limit_i32 = _grp.row_limit
+            group_m_start_i32 = _grp.group_m_start
+            group_m_size_i32 = _grp.group_m_size
+            # Rows are always whole slabs when the groups divide N, so validity
+            # is entirely a question of whether this N-block belongs to a group.
             is_valid = _col.is_valid if const_expr(n_grouped) else _grp.is_valid
         if const_expr(n_grouped):
             # Blocks are enumerated across the packed groups, so this block's
@@ -920,7 +934,10 @@ def compile_fp8_grouped_gemm(
 
             # ===== Epilogue: CShuffle vectorized stores =====
             c_n = n_in
-            e_vec = 4 if (tile_n % (32 * 4)) == 0 else 2
+            # The CShuffle epilogue lays CSHUFFLE_NLANE lanes across N, each
+            # storing e_vec elements, and requires tile_n to divide by their
+            # product. Take the wider store where it does.
+            e_vec = 4 if (tile_n % (CSHUFFLE_NLANE * 4)) == 0 else 2
 
             write_row_to_lds, store_pair = make_epilogue_writers(
                 accs=accs,

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -7,35 +7,38 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-"""Contiguous Grouped FP8 GEMM kernel with block scaling.
+"""Grouped FP8 GEMM kernel.
 
-Groups are concatenated along M with arbitrary (not tile-aligned) per-group row
-counts, and the output is compact [M_total, N]. Each output M-tile belongs to
-exactly one group, so a tile never spans a group boundary. The kernel resolves
-the owning group for its M-tile from m_sizes, and rows at or beyond that group's
-end are the partial-tile tail and are masked out of the store.
-
-The `layout` argument selects how the group geometry is encoded; groups may also
-occupy fixed per-group slabs rather than being packed. Only the resolution step
-differs, so the loaders, the K loop and the epilogue are shared by all of them.
+The `layout` argument selects both which axis the groups divide and how their
+geometry is encoded. Where the groups divide M they are concatenated with
+arbitrary, not tile-aligned, row counts and the output is compact
+[M_total, N]; each output M-tile then belongs to exactly one group, resolved
+from m_sizes, and rows at or beyond that group's end are the partial-tile tail
+and are masked out of the store. Groups may instead occupy fixed per-group
+slabs, or divide N or K. Only the resolution step differs between them, so the
+loaders, the K loop and the epilogue are shared.
 
 Scales are FP32 (software scaling) on all architectures.
 
 Tensors:
-  - A: [M_total, K] FP8 - concatenated rows from all groups
-  - scale_a: FP32 per-token, per-128K scales, laid out as per-group blocks (as
-    written by quantize_fp8_group with m_sizes): group g's block begins at
-    m_start * scale_k, and within it element (local_m, k_block) sits at
-    local_m + k_block * M_g. This is not a global [scale_k, M_total] transpose.
-  - B: [num_groups, N, K] FP8 - one weight matrix per group, preshuffled
-  - scale_b: [num_groups, scale_k, scale_n] FP32 - per-block scales
+  - A: [M_total, K] FP8 - the rows of every group, packed or in per-group slabs
+  - B: [num_groups, N, K] FP8 - one weight matrix per group, in the MFMA B
+    layout when b_preshuffled; a single [total_N, K] or [N, total_K] matrix
+    where the groups divide N or K
   - m_sizes: [num_groups] - the group geometry, whose encoding the `layout`
     argument selects: INT64 row counts, INT32 cumulative offsets, or unused
   - D: [M_total, N] BF16 - output
 
-Block scaling granularity:
-  - A: (1, 128) - per-token, per-128-K-elements
-  - B: (128, 128) - per-128-N, per-128-K block
+Rowwise scaling carries one FP32 scale per row of A and per column of B, both
+constant along K, and applies them in the epilogue.
+
+Block scaling carries FP32 scales at (1, 128) for A -- per-token, per-128-K --
+and (128, 128) for B, as:
+  - scale_a: laid out as per-group blocks (as written by quantize_fp8_group
+    with m_sizes): group g's block begins at m_start * scale_k, and within it
+    element (local_m, k_block) sits at local_m + k_block * M_g. This is not a
+    global [scale_k, M_total] transpose.
+  - scale_b: [num_groups, scale_k, scale_n]
 """
 
 import functools
@@ -57,7 +60,7 @@ from flydsl.expr import (
 from flydsl.expr.typing import T, Vector
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
-from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
+from mslk.flydsl.kernels.gemm.fp8_grouped_gemm_common import (
     compute_compile_constants,
     compute_mfma_tiling,
     init_accumulators,
@@ -93,7 +96,7 @@ LAYOUTS = ("sizes", "offsets", "padded", "batched", "n_offsets", "k_offsets")
 
 
 @functools.lru_cache(maxsize=128)
-def compile_grouped_gemm_blockscale_contiguous(
+def compile_fp8_grouped_gemm(
     *,
     n: int,
     k: int,
@@ -315,7 +318,7 @@ def compile_grouped_gemm_blockscale_contiguous(
     ).replace("-", "_")
 
     @flyc.kernel(name=module_name)
-    def grouped_gemm_blockscale_contiguous_kernel(
+    def fp8_grouped_gemm_kernel(
         arg_d: fx.Tensor,
         arg_a: fx.Tensor,
         arg_b: fx.Tensor,
@@ -967,7 +970,7 @@ def compile_grouped_gemm_blockscale_contiguous(
 
     # ===== JIT Launcher =====
     @flyc.jit
-    def launch_grouped_gemm_blockscale_contiguous(
+    def launch_fp8_grouped_gemm(
         arg_d: fx.Tensor,
         arg_a: fx.Tensor,
         arg_b: fx.Tensor,
@@ -1008,7 +1011,7 @@ def compile_grouped_gemm_blockscale_contiguous(
             else fx.Index(1)
         )
 
-        launcher = grouped_gemm_blockscale_contiguous_kernel(
+        launcher = fp8_grouped_gemm_kernel(
             arg_d,
             arg_a,
             arg_b,
@@ -1030,4 +1033,4 @@ def compile_grouped_gemm_blockscale_contiguous(
                         )
         launcher.launch(grid=(gx, gy, gz), block=(total_threads, 1, 1), stream=stream)
 
-    return launch_grouped_gemm_blockscale_contiguous
+    return launch_fp8_grouped_gemm

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -39,9 +39,11 @@ from mslk.flydsl.kernels.mma.mfma_preshuffle_pipeline import (
 # kernel can end on.
 K_LOAD_ELEMS = 16
 
-# Widest vectorised epilogue store, in output columns. With n_padding the tail N
-# block is suppressed a whole store at a time, so this is the finest N
-# granularity the kernel can end on.
+# Finest N granularity the kernel can end on. With n_padding the tail N block is
+# suppressed a whole store at a time, and the widest store covers four output
+# columns (eight bytes), so four would do. Eight is kept because it is also the
+# bound CK enforces, and holding the two to one rule keeps a shape that runs on
+# one running on the other.
 N_STORE_ELEMS = 8
 
 
@@ -1671,10 +1673,17 @@ def make_epilogue_writers(
         col_mask = None
         if n_padding:
             # Columns past the bound belong to the next output row, or to the
-            # next group where the groups share one; drop the whole store.
+            # next group where the groups share one. A store covers e_vec of
+            # them at once, so it is the last column it would write that has to
+            # stay inside the bound: predicating on the first would let a store
+            # that begins inside the group finish outside it, over the columns
+            # the next group owns and also writes.
             col_mask = arith.cmpi(
-                arith.CmpIPredicate.ult,
-                arith.index_cast(T.i32, col_g0),
+                arith.CmpIPredicate.ule,
+                arith.addi(
+                    arith.index_cast(T.i32, col_g0),
+                    arith.constant(int(e_vec), type=T.i32),
+                ),
                 arith.index_cast(T.i32, c_n if n_bound is None else n_bound),
             )
         if e_vec == 4:

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -9,9 +9,8 @@
 
 """Shared building blocks for the grouped FP8 GEMM kernel.
 
-Used by grouped_gemm_blockscale_contiguous.py: parameter validation,
-compile-time scalar constants, and the helper closures the kernel body is
-built from.
+Used by fp8_grouped_gemm.py: parameter validation, compile-time scalar
+constants, and the helper closures the kernel body is built from.
 
 Block scaling indexes scale_b as [num_groups, scale_k, scale_n] (per-group,
 per-K-block, per-N-block) and scale_a as [scale_k, M] (transposed, per-token

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -415,6 +415,10 @@ def resolve_group_rows(
     when the grid cannot place a tile outside its group, so the caller's guard
     disappears at trace time rather than becoming a branch on a constant.
     """
+    # Where the groups divide K there is no row geometry to resolve, and the
+    # metadata is int32 K offsets rather than the int64 row counts decoded
+    # below, so the caller resolves that layout itself.
+    assert layout != "k_offsets", "k_offsets resolves its own geometry"
     reads_group_meta = layout not in ("batched", "n_offsets")
     slab_layout = layout in ("padded", "batched", "n_offsets")
 

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -1604,6 +1604,26 @@ def make_pingpong_stages(
     return prologue, pair
 
 
+def make_pingpong_kloop(*, num_k_tiles, **stage_kwargs):
+    """Build a ping-pong K-loop driver that walks every K tile.
+
+    Returns ``run_kloop(accs)``, which advances ``accs`` through all K tiles
+    using the prologue and per-pair body of :func:`make_pingpong_stages`,
+    unrolled at compile time. For callers that want the loop rolled instead,
+    drive those stages directly: the rolled construct is AST-rewritten and so
+    can only be written in the kernel function's own source.
+    """
+    prologue, pair = make_pingpong_stages(num_k_tiles=num_k_tiles, **stage_kwargs)
+
+    def run_kloop(accs):
+        state = prologue()
+        for k_pair in range_constexpr(0, num_k_tiles, 2):
+            accs, state = pair(accs, k_pair, state)
+        return accs
+
+    return run_kloop
+
+
 def make_epilogue_writers(
     *,
     accs,

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -25,6 +25,7 @@ from flydsl._mlir.dialects import math as math_dialect
 from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
 from flydsl.expr.arith import ArithValue
 from flydsl.expr.typing import T, Vector
+from mslk.flydsl.common import lds_capacity_bytes
 from mslk.flydsl.kernels.mma.mfma_preshuffle_pipeline import (
     crd2idx,
     lds_store_16b_xor16,
@@ -187,25 +188,6 @@ def validate_params(
             )
     if out_dtype not in ("bf16", "f16"):
         raise ValueError(f"out_dtype must be 'bf16' or 'f16', got {out_dtype!r}")
-
-
-# Conservative default for architectures missing from FlyDSL's capacity table.
-_LDS_CAPACITY_FALLBACK_BYTES = 64 * 1024
-
-
-def lds_capacity_bytes(arch=None):
-    """LDS bytes available to one workgroup on ``arch``.
-
-    This is arch-dependent and the difference is large: CDNA3 (gfx942/MI300) has
-    64 KiB while CDNA4 (gfx950/MI350) has 160 KiB. Sourced from FlyDSL's
-    SMEM_CAPACITY_MAP so the limit stays in sync with the compiler that enforces
-    it; unknown architectures fall back to the conservative 64 KiB.
-    """
-    try:
-        from flydsl.utils.smem_allocator import SMEM_CAPACITY_MAP
-    except Exception:
-        return _LDS_CAPACITY_FALLBACK_BYTES
-    return SMEM_CAPACITY_MAP.get(str(arch), _LDS_CAPACITY_FALLBACK_BYTES)
 
 
 def _check_lds_budget(*, variant, total, detail, tile_m, tile_n, tile_k, arch):

--- a/mslk/flydsl/kernels/gemm/gemm_blockscale.py
+++ b/mslk/flydsl/kernels/gemm/gemm_blockscale.py
@@ -24,12 +24,12 @@ block-scale contract:
   Y[m, n] = sum_k (A[m, k] * x_scale[m // 128, k // 128])
                 * (B[n, k] * w_scale[n // 128, k // 128])
 
-Unlike the per-token groupwise kernel (``grouped_gemm_blockscale_contiguous``),
+Unlike the per-token groupwise kernel (``fp8_grouped_gemm``),
 the A scale here has ScaleBlockM=128, so one scalar covers a whole 16-row MFMA
 fragment (all lanes/rows in the block share it): the kernel issues one scalar A
 scale load per (M-block, K-block) instead of the groupwise path's per-token vec4
 loads. All the tile loading / MFMA / epilogue machinery is shared with the
-groupwise kernel via ``grouped_gemm_blockscale_common``; only the scale indexing
+groupwise kernel via ``fp8_grouped_gemm_common``; only the scale indexing
 and the (single-group) tile map differ, so this file adds a ``compute_tile`` and
 the launcher and reuses everything else.
 
@@ -59,7 +59,7 @@ from flydsl.expr.arith import ArithValue
 from flydsl.expr.typing import T, Vector
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
-from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
+from mslk.flydsl.kernels.gemm.fp8_grouped_gemm_common import (
     compute_compile_constants,
     compute_mfma_tiling,
     init_accumulators,
@@ -109,7 +109,7 @@ def make_compute_tile_blockwise(
     Defined at module scope (NOT inside the ``@flyc.kernel`` body) so its plain
     Python ``if``/``else`` control flow runs during tracing instead of being
     AST-rewritten into scf branches -- the same structure the shared
-    ``grouped_gemm_blockscale_common`` helpers use.
+    ``fp8_grouped_gemm_common`` helpers use.
 
     Returns ``compute_tile(accs_in, k_tile_idx_py, lds_base, b_tile_in,
     scales_pf, *, a0_prefetch=None)``. Scales are loaded here (software FP32

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -67,7 +67,10 @@ def make_k_tail_mask(
     A plain out-of-range offset would not do, since reading past K within a row
     lands on the next row's data rather than outside the buffer.
     """
-    tail = k_padding and (k % tile_k != 0)
+    # A supplied bound is a per-group K end, so whether the whole K is tile
+    # aligned says nothing about whether a group's slice is: the tail can land
+    # anywhere inside it, and the predicate is always needed.
+    tail = k_padding and (k_bound is not None or k % tile_k != 0)
     _bound = k_in if k_bound is None else k_bound
 
     def mask(k_tile_idx_py, base_k_div4, col_local_i32):

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -44,12 +44,18 @@ K_LOAD_ELEMS = 16
 N_STORE_ELEMS = 8
 
 
-def make_k_tail_mask(*, k_padding, num_k_tiles, k, tile_k, k_in, always=False):
+def make_k_tail_mask(
+    *, k_padding, num_k_tiles, k, tile_k, k_in, always=False, k_bound=None
+):
     """Build the per-load K-range predicate used by the A and B tile loaders.
 
     Returns ``mask(k_tile_idx_py, base_k_div4, col_local_i32)`` yielding None
     wherever no masking is needed, so every tile but the last emits exactly the
     code it did before.
+
+    ``k_bound`` replaces K as the bound the predicate compares against, which is
+    what the layouts that let the groups divide K need: a load belongs to the
+    group only while it stays inside that group's slice.
 
     ``always`` drops that last-tile test and emits the predicate on every tile.
     A rolled K loop traces its body once, so which iteration is the last is no
@@ -62,6 +68,7 @@ def make_k_tail_mask(*, k_padding, num_k_tiles, k, tile_k, k_in, always=False):
     lands on the next row's data rather than outside the buffer.
     """
     tail = k_padding and (k % tile_k != 0)
+    _bound = k_in if k_bound is None else k_bound
 
     def mask(k_tile_idx_py, base_k_div4, col_local_i32):
         if not tail or not (always or k_tile_idx_py == num_k_tiles - 1):
@@ -72,7 +79,7 @@ def make_k_tail_mask(*, k_padding, num_k_tiles, k, tile_k, k_in, always=False):
         return arith.cmpi(
             arith.CmpIPredicate.ult,
             arith.index_cast(T.i32, chunk_start_div4),
-            arith.index_cast(T.i32, k_in // fx.Index(4)),
+            arith.index_cast(T.i32, _bound // fx.Index(4)),
         )
 
     return mask
@@ -497,6 +504,34 @@ def resolve_group_rows(
     )
 
 
+GroupKSlice = namedtuple("GroupKSlice", ["k_start", "k_end"])
+
+
+def resolve_group_k(*, arg_offsets, num_groups_in, slab_idx):
+    """Read the K slice this group contracts over.
+
+    Where the groups divide K every group produces a full output, so the group
+    is a grid axis and nothing has to be resolved from the tile index -- only
+    the ends of its slice, which are two adjacent cumulative offsets. Group 0
+    starts at zero, so its lower end is not read.
+    """
+    off_rsrc = buffer_ops.create_buffer_resource(
+        arg_offsets, max_size=False, num_records_bytes=num_groups_in * fx.Index(4)
+    )
+    g_i32 = arith.index_cast(T.i32, slab_idx)
+    zero = arith.constant(0, type=T.i32)
+    is_first = arith.cmpi(arith.CmpIPredicate.eq, g_i32, zero)
+    prev = buffer_ops.buffer_load(
+        off_rsrc,
+        arith.subi(g_i32, arith.constant(1, type=T.i32)),
+        vec_width=1,
+        dtype=T.i32,
+    )
+    k_start = arith.select(is_first, zero, prev)
+    k_end = buffer_ops.buffer_load(off_rsrc, g_i32, vec_width=1, dtype=T.i32)
+    return GroupKSlice(k_start=k_start, k_end=k_end)
+
+
 GroupColResolution = namedtuple(
     "GroupColResolution", ["group_id", "col_base", "col_limit", "is_valid"]
 )
@@ -575,6 +610,7 @@ def make_a_tile_loaders(
     m_in=None,
     group_idx=None,
     k_tail_mask=None,
+    k_base_div4=None,
 ):
     """Build the prefetch + LDS-store closures for the A tile.
 
@@ -584,7 +620,10 @@ def make_a_tile_loaders(
     (masked path), `group_idx * m_in * (k_in/4)` is added as the leading
     term inside `prefetch_a_tile`, exactly matching the original masked
     code so the resulting MLIR (and ISA) is byte-identical. `k_blocks16`
-    is returned for reuse by the downstream LDS-load helper.
+    is returned for reuse by the downstream LDS-load helper. `k_base_div4`
+    shifts every load to the start of this group's K slice, for the layouts
+    where the groups divide K rather than an output axis; the row stride stays
+    the full K, since the slice is a column block of a wider matrix.
     """
     _k_tail_mask = k_tail_mask or (lambda *_: None)
     layout_a_tile_div4 = fx.make_layout(
@@ -617,6 +656,8 @@ def make_a_tile_loaders(
     def prefetch_a_tile(k_tile_idx_py):
         """Load A tile from global memory into VGPRs."""
         base_k_div4 = fx.Index(k_tile_idx_py * tile_k_dwords)
+        if k_base_div4 is not None:
+            base_k_div4 = k_base_div4 + base_k_div4
         parts = []
         for i in range_constexpr(num_a_loads):
             row_global = bx_m + a_row_local[i]
@@ -688,6 +729,7 @@ def make_b_tile_loaders(
     n_padding=False,
     b_group_off=None,
     n_bound=None,
+    k_base_div4=None,
 ):
     """Build the prefetch + LDS-store closures for a PLAIN (non-preshuffled)
     B tile [tile_n, tile_k].
@@ -736,6 +778,8 @@ def make_b_tile_loaders(
     def prefetch_b_tile(k_tile_idx_py):
         """Load plain B tile from global memory into VGPRs (coalesced dwordx4)."""
         base_k_div4 = fx.Index(k_tile_idx_py * tile_k_dwords)
+        if k_base_div4 is not None:
+            base_k_div4 = k_base_div4 + base_k_div4
         parts = []
         for i in range_constexpr(num_b_loads):
             row_global = by_n + b_row_local[i]  # global N row

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -365,6 +365,7 @@ def resolve_group_rows(
     tile_m,
     num_groups,
     layout,
+    group_id=None,
 ):
     """Work out which group owns this M-tile and where its rows begin and end.
 
@@ -373,12 +374,15 @@ def resolve_group_rows(
     ``layout`` argument of the kernel factory for what each encoding means.
 
     ``m_tile_idx`` is the M-tile block id, and ``slab_idx`` the group block id
-    that only the slab layouts use. ``is_valid`` comes back as a Python ``True``
+    that only the slab layouts use. ``group_id`` supplies the group when it has
+    already been resolved elsewhere, as the N-grouped layout does: its rows form
+    a full per-group slab exactly as the batched layout's do, but the group
+    follows from the column partition rather than from a grid axis. ``is_valid`` comes back as a Python ``True``
     when the grid cannot place a tile outside its group, so the caller's guard
     disappears at trace time rather than becoming a branch on a constant.
     """
-    reads_group_meta = layout != "batched"
-    slab_layout = layout in ("padded", "batched")
+    reads_group_meta = layout not in ("batched", "n_offsets")
+    slab_layout = layout in ("padded", "batched", "n_offsets")
 
     # Group metadata is INT32 when it holds cumulative offsets and INT64 when it
     # holds row counts. "batched" carries none, so no resource is built for it
@@ -401,7 +405,9 @@ def resolve_group_rows(
     if slab_layout:
         # Every group owns a fixed slab of expected_m rows, so the group is a
         # grid axis and needs no resolution.
-        group_id_i32 = arith.index_cast(T.i32, slab_idx)
+        group_id_i32 = (
+            group_id if group_id is not None else arith.index_cast(T.i32, slab_idx)
+        )
         expected_m_i32 = arith.divui(arith.index_cast(T.i32, m_in), _i32(num_groups))
         group_m_start_i32 = arith.muli(group_id_i32, expected_m_i32)
         group_m_size_i32 = expected_m_i32
@@ -483,6 +489,65 @@ def resolve_group_rows(
         group_m_start=group_m_start_i32,
         group_m_size=group_m_size_i32,
         is_valid=is_valid,
+    )
+
+
+GroupColResolution = namedtuple(
+    "GroupColResolution", ["group_id", "col_base", "col_limit", "is_valid"]
+)
+
+
+def resolve_group_cols(*, arg_offsets, num_groups_in, n_block_idx, tile_n, num_groups):
+    """Work out which group owns this N-block and where its columns end.
+
+    The mirror of ``resolve_group_rows`` for weights concatenated along N, where
+    the groups partition the output's columns instead of its rows, so the group
+    follows from the N-block index. ``arg_offsets`` is [num_groups] INT32
+    cumulative column ends -- the same encoding the "offsets" layout reads on
+    the M axis.
+
+    Returns the owning group, the global first column of this block, and the
+    group's exclusive column end, which is the bound the N tail masks against.
+    Blocks past the last group match none and come back invalid, the same way
+    surplus M-tiles do in the packed layouts.
+    """
+    off_rsrc = buffer_ops.create_buffer_resource(
+        arg_offsets, max_size=False, num_records_bytes=num_groups_in * fx.Index(4)
+    )
+
+    def _i32(v):  # raw i32 constant (arith.* requires unwrapped MLIR values)
+        return arith.constant(int(v), type=T.i32)
+
+    by_i32 = arith.index_cast(T.i32, n_block_idx)
+    tile_n_c = _i32(tile_n)
+    tile_n_bump = _i32(tile_n - 1)
+
+    acc_n = _i32(0)  # cumulative columns before group g
+    acc_b = _i32(0)  # cumulative N-blocks before group g
+    group_id_i32 = _i32(-1)
+    col_base_i32 = _i32(0)
+    col_limit_i32 = _i32(0)
+    for _g in range_constexpr(num_groups):
+        end_g = buffer_ops.buffer_load(off_rsrc, _g, vec_width=1, dtype=T.i32)
+        n_g = arith.subi(end_g, acc_n)
+        blocks_g = arith.divui(arith.addi(n_g, tile_n_bump), tile_n_c)
+        acc_b_next = arith.addi(acc_b, blocks_g)
+        in_grp = arith.andi(
+            arith.cmpi(arith.CmpIPredicate.sge, by_i32, acc_b),
+            arith.cmpi(arith.CmpIPredicate.slt, by_i32, acc_b_next),
+        )
+        cb = arith.addi(acc_n, arith.muli(arith.subi(by_i32, acc_b), tile_n_c))
+        group_id_i32 = arith.select(in_grp, _i32(_g), group_id_i32)
+        col_base_i32 = arith.select(in_grp, cb, col_base_i32)
+        col_limit_i32 = arith.select(in_grp, end_g, col_limit_i32)
+        acc_n = end_g
+        acc_b = acc_b_next
+
+    return GroupColResolution(
+        group_id=group_id_i32,
+        col_base=col_base_i32,
+        col_limit=col_limit_i32,
+        is_valid=arith.cmpi(arith.CmpIPredicate.sge, group_id_i32, _i32(0)),
     )
 
 
@@ -616,6 +681,8 @@ def make_b_tile_loaders(
     k_in,
     k_tail_mask=None,
     n_padding=False,
+    b_group_off=None,
+    n_bound=None,
 ):
     """Build the prefetch + LDS-store closures for a PLAIN (non-preshuffled)
     B tile [tile_n, tile_k].
@@ -623,7 +690,11 @@ def make_b_tile_loaders(
     Mirror of `make_a_tile_loaders` with N in place of M. B is `[G, N, K]`
     row-major, so the per-tile global base adds the group offset
     `group_idx * n_in * (k_in/4)` (always present — B is always grouped) plus
-    the N-tile base `by_n` (the block's N-block start). Coalesced 16-byte
+    the N-tile base `by_n` (the block's N-block start). `b_group_off` replaces
+    that leading offset where B is one flat [total_N, K] matrix and the group is
+    already folded into `by_n`, and `n_bound` replaces the row bound the tail
+    masks against, which is then the group's column end rather than N.
+    Coalesced 16-byte
     (dwordx4) loads via `tile_chunk_coord_i32`; LDS store uses the same XOR16
     swizzle as A. Returns `(prefetch_b_tile, store_b_tile_to_lds, b_row_local,
     b_col_local_i32, k_blocks16_b)`.
@@ -636,7 +707,10 @@ def make_b_tile_loaders(
     tx_i32_base = tx * c_chunk_b
     _k_div4_factor = k_in // fx.Index(4)
     # B is [G, N, K]: leading offset selects this tile's group and N-block base.
-    b_tile_offset_div4 = group_idx * n_in * _k_div4_factor
+    b_tile_offset_div4 = (
+        b_group_off if b_group_off is not None else group_idx * n_in * _k_div4_factor
+    )
+    _n_bound = n_in if n_bound is None else n_bound
     k_blocks16_b = arith.index(tile_k_bytes // 16)
     c4_bytes = fx.Index(4)
 
@@ -672,7 +746,7 @@ def make_b_tile_loaders(
                 nmask = arith.cmpi(
                     arith.CmpIPredicate.ult,
                     arith.index_cast(T.i32, row_global),
-                    arith.index_cast(T.i32, n_in),
+                    arith.index_cast(T.i32, _n_bound),
                 )
                 kmask = nmask if kmask is None else arith.andi(kmask, nmask)
             b_vec = buffer_ops.buffer_load(
@@ -1250,6 +1324,7 @@ def make_rowwise_scaler(
     lane_div_16,
     m_repeat,
     num_acc_n,
+    group_n_off=None,
 ):
     """Build the closure that applies rowwise scales to the finished accumulators.
 
@@ -1284,11 +1359,13 @@ def make_rowwise_scaler(
                 )
             s_a_vecs.append(Vector.from_elements(s_a_row, fx.Float32))
 
-        # scale_b is [num_groups, n]: element (g, col) at g*n + col.
-        group_n_off = group_idx * n_in
+        # scale_b is [num_groups, n]: element (g, col) at g*n + col. Where it is
+        # instead one flat [total_N] vector the group is already folded into
+        # by_n, and the caller passes a zero base.
+        _group_n_off = group_idx * n_in if group_n_off is None else group_n_off
         s_b_bcs = []
         for ni in range_constexpr(num_acc_n):
-            col_global = group_n_off + by_n + n_tile_base + (ni * 16) + lane_mod_16
+            col_global = _group_n_off + by_n + n_tile_base + (ni * 16) + lane_mod_16
             s_b_val = buffer_ops.buffer_load(
                 sb_rsrc, col_global, vec_width=1, dtype=T.f32
             )
@@ -1468,6 +1545,7 @@ def make_epilogue_writers(
     c_n,
     d_group_off=None,
     n_padding=False,
+    n_bound=None,
 ):
     """Build the CShuffle-epilogue writer closures.
 
@@ -1476,6 +1554,11 @@ def make_epilogue_writers(
     addition emitted) and `group_idx * m_in * n_in` for the masked
     path. Using a Python `is None` guard keeps the contig MLIR
     identical to the pre-extraction code.
+
+    `c_n` is the output's leading dimension, and normally also bounds the column
+    mask, since a group's columns run to the end of its row. Where groups sit
+    side by side along N the row spans all of them, so `n_bound` gives the
+    owning group's column end instead.
     """
 
     def write_row_to_lds(
@@ -1507,11 +1590,12 @@ def make_epilogue_writers(
         byte_off = idx_out * 2
         col_mask = None
         if n_padding:
-            # Columns past N belong to the next output row; drop the whole store.
+            # Columns past the bound belong to the next output row, or to the
+            # next group where the groups share one; drop the whole store.
             col_mask = arith.cmpi(
                 arith.CmpIPredicate.ult,
                 arith.index_cast(T.i32, col_g0),
-                arith.index_cast(T.i32, c_n),
+                arith.index_cast(T.i32, c_n if n_bound is None else n_bound),
             )
         if e_vec == 4:
             frag_i32x2 = Vector(frag).bitcast(fx.Int32)

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -1439,7 +1439,7 @@ def make_kloop_plain(
     return run_kloop
 
 
-def make_pingpong_kloop(
+def make_pingpong_stages(
     *,
     num_k_tiles,
     tile_k,
@@ -1455,90 +1455,101 @@ def make_pingpong_kloop(
     row_a_lds_base,
     col_offset_base_bytes,
 ):
-    """Build the ping-pong K-loop driver.
+    """Build the prologue and the per-pair body of the ping-pong K loop.
 
-    Returns `run_kloop(accs)` which advances `accs` through all
-    K-tiles using the prologue + alternating ping/pong stages.
-    Loop body is byte-identical between contig and masked, so this
-    factory has no offset parameters.
+    Returns ``(prologue, pair)``. ``prologue()`` fills the pong buffer and
+    returns the state the first pair consumes; ``pair(accs, k_pair, state)``
+    advances two K tiles and returns the state the next pair consumes.
+
+    Splitting the body out lets the loop itself be written either way. The
+    unrolled form walks it with a compile-time index; the rolled form can only
+    be written in the kernel's own source, since the loop construct is
+    AST-rewritten, and calls the same body from there. ``steady`` says the pair
+    is known to have both of its tiles and a successor to prefetch, which is
+    what a rolled body needs: with a runtime index the tail tests are not
+    Python-level facts.
     """
 
-    def run_kloop(accs):
-        # Prologue: prefetch first A tile into VGPRs, store to LDS, load B + scales
+    def prologue():
+        # Prefetch first A tile into VGPRs, store to LDS, load B + scales
         a_regs0 = prefetch_a_tile(0)
         store_a_tile_to_lds(a_regs0, lds_base_pong)
         b_tile_pong = load_b_tile(fx.Index(0))
         scales_pong_pf = prefetch_scales(0)
         gpu.barrier()
-
         # Prefetch first A pack from pong (hides LDS latency behind upcoming VMEM)
         a0_prefetch_pong = lds_load_packs_k64(
             row_a_lds_base, col_offset_base_bytes, lds_base_pong
         )
+        return (b_tile_pong, scales_pong_pf, a0_prefetch_pong)
 
-        for k_pair in range_constexpr(0, num_k_tiles, 2):
-            # Prefetch the next scales before the B-tile VMEM so the scale-load
-            # latency hides behind it; then the A+B registers.
-            if k_pair + 1 < num_k_tiles:
-                scales_ping_pf = prefetch_scales(k_pair + 1)
-                a_regs_ping = prefetch_a_tile(k_pair + 1)
-                b_tile_ping = load_b_tile(fx.Index((k_pair + 1) * tile_k))
+    def pair(accs, k_pair, state, *, steady=False):
+        b_tile_pong, scales_pong_pf, a0_prefetch_pong = state
+        has_odd = True if steady else (k_pair + 1 < num_k_tiles)
+        has_next = True if steady else (k_pair + 2 < num_k_tiles)
 
-            # Compute current tile from pong LDS
+        # Prefetch the next scales before the B-tile VMEM so the scale-load
+        # latency hides behind it; then the A+B registers.
+        if has_odd:
+            scales_ping_pf = prefetch_scales(k_pair + 1)
+            a_regs_ping = prefetch_a_tile(k_pair + 1)
+            b_tile_ping = load_b_tile(fx.Index((k_pair + 1) * tile_k))
+
+        # Compute current tile from pong LDS
+        accs = compute_tile(
+            accs,
+            k_pair,
+            lds_base_pong,
+            b_tile_pong,
+            scales_pong_pf,
+            a0_prefetch=a0_prefetch_pong,
+        )
+        a0_prefetch_pong = None
+
+        # Store next A to LDS (ds_write after compute, overlaps with trailing MFMAs)
+        if has_odd:
+            store_a_tile_to_lds(a_regs_ping, lds_base_ping)
+            hot_loop_scheduler()
+        gpu.barrier()
+
+        if has_odd:
+            # Prefetch first A pack from ping
+            a0_prefetch_ping = lds_load_packs_k64(
+                row_a_lds_base, col_offset_base_bytes, lds_base_ping
+            )
+
+            # Prefetch next scales + A+B
+            if has_next:
+                scales_pong_pf = prefetch_scales(k_pair + 2)
+                a_regs_pong = prefetch_a_tile(k_pair + 2)
+                b_tile_pong = load_b_tile(fx.Index((k_pair + 2) * tile_k))
+
+            # Compute current tile from ping LDS
             accs = compute_tile(
                 accs,
-                k_pair,
-                lds_base_pong,
-                b_tile_pong,
-                scales_pong_pf,
-                a0_prefetch=a0_prefetch_pong,
+                k_pair + 1,
+                lds_base_ping,
+                b_tile_ping,
+                scales_ping_pf,
+                a0_prefetch=a0_prefetch_ping,
             )
-            a0_prefetch_pong = None
+            a0_prefetch_ping = None
 
-            # Store next A to LDS (ds_write after compute, overlaps with trailing MFMAs)
-            if k_pair + 1 < num_k_tiles:
-                store_a_tile_to_lds(a_regs_ping, lds_base_ping)
+            # Store next A to LDS
+            if has_next:
+                store_a_tile_to_lds(a_regs_pong, lds_base_pong)
                 hot_loop_scheduler()
             gpu.barrier()
 
-            if k_pair + 1 < num_k_tiles:
-                # Prefetch first A pack from ping
-                a0_prefetch_ping = lds_load_packs_k64(
-                    row_a_lds_base, col_offset_base_bytes, lds_base_ping
+            # Prefetch first A pack from pong for next iteration
+            if has_next:
+                a0_prefetch_pong = lds_load_packs_k64(
+                    row_a_lds_base, col_offset_base_bytes, lds_base_pong
                 )
 
-                # Prefetch next scales + A+B
-                if k_pair + 2 < num_k_tiles:
-                    scales_pong_pf = prefetch_scales(k_pair + 2)
-                    a_regs_pong = prefetch_a_tile(k_pair + 2)
-                    b_tile_pong = load_b_tile(fx.Index((k_pair + 2) * tile_k))
+        return accs, (b_tile_pong, scales_pong_pf, a0_prefetch_pong)
 
-                # Compute current tile from ping LDS
-                accs = compute_tile(
-                    accs,
-                    k_pair + 1,
-                    lds_base_ping,
-                    b_tile_ping,
-                    scales_ping_pf,
-                    a0_prefetch=a0_prefetch_ping,
-                )
-                a0_prefetch_ping = None
-
-                # Store next A to LDS
-                if k_pair + 2 < num_k_tiles:
-                    store_a_tile_to_lds(a_regs_pong, lds_base_pong)
-                    hot_loop_scheduler()
-                gpu.barrier()
-
-                # Prefetch first A pack from pong for next iteration
-                if k_pair + 2 < num_k_tiles:
-                    a0_prefetch_pong = lds_load_packs_k64(
-                        row_a_lds_base, col_offset_base_bytes, lds_base_pong
-                    )
-
-        return accs
-
-    return run_kloop
+    return prologue, pair
 
 
 def make_epilogue_writers(

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -38,6 +38,11 @@ from mslk.flydsl.kernels.mma.mfma_preshuffle_pipeline import (
 # kernel can end on.
 K_LOAD_ELEMS = 16
 
+# Widest vectorised epilogue store, in output columns. With n_padding the tail N
+# block is suppressed a whole store at a time, so this is the finest N
+# granularity the kernel can end on.
+N_STORE_ELEMS = 8
+
 
 def make_k_tail_mask(*, k_padding, num_k_tiles, k, tile_k, k_in):
     """Build the per-load K-range predicate used by the A and B tile loaders.
@@ -103,6 +108,7 @@ def validate_params(
     out_dtype,
     blockscale=False,
     k_padding=False,
+    n_padding=False,
 ):
     """Validate the divisibility constraints and out_dtype choice shared by
     the grouped GEMM kernels.
@@ -127,7 +133,15 @@ def validate_params(
             )
     elif k % tile_k != 0:
         raise ValueError(f"k ({k}) must be divisible by tile_k ({tile_k})")
-    if n % tile_n != 0:
+    if n_padding:
+        # The tail N block is masked per store, whose widest form covers
+        # N_STORE_ELEMS columns, so N only has to land on that boundary.
+        if n % N_STORE_ELEMS != 0:
+            raise ValueError(
+                f"n ({n}) must be divisible by {N_STORE_ELEMS} (the widest "
+                "vectorised store) even with n_padding"
+            )
+    elif n % tile_n != 0:
         raise ValueError(f"n ({n}) must be divisible by tile_n ({tile_n})")
     if tile_k % scale_block_k != 0:
         raise ValueError(
@@ -464,6 +478,7 @@ def make_b_tile_loaders(
     n_in,
     k_in,
     k_tail_mask=None,
+    n_padding=False,
 ):
     """Build the prefetch + LDS-store closures for a PLAIN (non-preshuffled)
     B tile [tile_n, tile_k].
@@ -514,12 +529,21 @@ def make_b_tile_loaders(
                 + base_k_div4
                 + b_col_local_i32[i]
             )
+            kmask = _k_tail_mask(k_tile_idx_py, base_k_div4, b_col_local_i32[i])
+            if n_padding:
+                # Rows past N hold the next group's weights, so read zero instead.
+                nmask = arith.cmpi(
+                    arith.CmpIPredicate.ult,
+                    arith.index_cast(T.i32, row_global),
+                    arith.index_cast(T.i32, n_in),
+                )
+                kmask = nmask if kmask is None else arith.andi(kmask, nmask)
             b_vec = buffer_ops.buffer_load(
                 b_rsrc,
                 idx_i32,
                 vec_width=4,
                 dtype=T.i32,
-                mask=_k_tail_mask(k_tile_idx_py, base_k_div4, b_col_local_i32[i]),
+                mask=kmask,
             )
             parts.append(Vector(b_vec).bitcast(fx.Int32))
         return parts
@@ -1306,6 +1330,7 @@ def make_epilogue_writers(
     e_vec,
     c_n,
     d_group_off=None,
+    n_padding=False,
 ):
     """Build the CShuffle-epilogue writer closures.
 
@@ -1343,13 +1368,25 @@ def make_epilogue_writers(
         else:
             idx_out = d_group_off + row * c_n + col_g0
         byte_off = idx_out * 2
+        col_mask = None
+        if n_padding:
+            # Columns past N belong to the next output row; drop the whole store.
+            col_mask = arith.cmpi(
+                arith.CmpIPredicate.ult,
+                arith.index_cast(T.i32, col_g0),
+                arith.index_cast(T.i32, c_n),
+            )
         if e_vec == 4:
             frag_i32x2 = Vector(frag).bitcast(fx.Int32)
-            buffer_ops.buffer_store(frag_i32x2, d_rsrc, byte_off, offset_is_bytes=True)
+            buffer_ops.buffer_store(
+                frag_i32x2, d_rsrc, byte_off, mask=col_mask, offset_is_bytes=True
+            )
         else:
             frag_i32x1 = Vector(frag).bitcast(fx.Int32)
             frag_i32 = frag_i32x1[0]
-            buffer_ops.buffer_store(frag_i32, d_rsrc, byte_off, offset_is_bytes=True)
+            buffer_ops.buffer_store(
+                frag_i32, d_rsrc, byte_off, mask=col_mask, offset_is_bytes=True
+            )
 
     return write_row_to_lds, store_pair
 

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -349,6 +349,143 @@ def setup_lds_allocation_plain(
     return lds_alloc_offset, lds_tile_elems, lds_b_offset_elems
 
 
+GroupResolution = namedtuple(
+    "GroupResolution",
+    ["group_id", "row_start", "row_limit", "group_m_start", "group_m_size", "is_valid"],
+)
+
+
+def resolve_group_rows(
+    *,
+    arg_m_sizes,
+    num_groups_in,
+    m_in,
+    m_tile_idx,
+    slab_idx,
+    tile_m,
+    num_groups,
+    layout,
+):
+    """Work out which group owns this M-tile and where its rows begin and end.
+
+    This is the only part of the kernel that the group layout changes;
+    everything downstream consumes the returned coordinates unchanged. See the
+    ``layout`` argument of the kernel factory for what each encoding means.
+
+    ``m_tile_idx`` is the M-tile block id, and ``slab_idx`` the group block id
+    that only the slab layouts use. ``is_valid`` comes back as a Python ``True``
+    when the grid cannot place a tile outside its group, so the caller's guard
+    disappears at trace time rather than becoming a branch on a constant.
+    """
+    reads_group_meta = layout != "batched"
+    slab_layout = layout in ("padded", "batched")
+
+    # Group metadata is INT32 when it holds cumulative offsets and INT64 when it
+    # holds row counts. "batched" carries none, so no resource is built for it
+    # and arg_m_sizes goes unread.
+    if reads_group_meta:
+        meta_bytes = 4 if layout == "offsets" else 8
+        ms_rsrc = buffer_ops.create_buffer_resource(
+            arg_m_sizes,
+            max_size=False,
+            num_records_bytes=num_groups_in * fx.Index(meta_bytes),
+        )
+
+    def _i32(v):  # raw i32 constant (arith.* requires unwrapped MLIR values)
+        return arith.constant(int(v), type=T.i32)
+
+    bx_i32 = arith.index_cast(T.i32, m_tile_idx)
+    tile_m_c = _i32(tile_m)
+    tile_m_bump = _i32(tile_m - 1)
+
+    if slab_layout:
+        # Every group owns a fixed slab of expected_m rows, so the group is a
+        # grid axis and needs no resolution.
+        group_id_i32 = arith.index_cast(T.i32, slab_idx)
+        expected_m_i32 = arith.divui(arith.index_cast(T.i32, m_in), _i32(num_groups))
+        group_m_start_i32 = arith.muli(group_id_i32, expected_m_i32)
+        group_m_size_i32 = expected_m_i32
+        row_start_i32 = arith.addi(group_m_start_i32, arith.muli(bx_i32, tile_m_c))
+        if reads_group_meta:
+            # m_sizes holds the count of rows in each slab that carry real
+            # data; the rest is padding the epilogue must not write.
+            valid_m = buffer_ops.buffer_load(
+                ms_rsrc, slab_idx * 2, vec_width=1, dtype=T.i32
+            )
+            # A group can hold fewer valid rows than the grid has tiles for
+            # it, so skip whole tiles that start past them.
+            is_valid = arith.cmpi(
+                arith.CmpIPredicate.slt, arith.muli(bx_i32, tile_m_c), valid_m
+            )
+        else:
+            # The slab is full, so every row of it carries data and the grid
+            # is exactly ceil(slab / tile_m) tiles: no tile starts past the
+            # slab, and the guard is dropped rather than emitted always-true.
+            # The rows of the tile past the slab still carry nothing, though:
+            # tile_m need not divide it, and the overrun lands on the next
+            # group, so the epilogue still masks by row.
+            valid_m = expected_m_i32
+            is_valid = True
+        row_limit_i32 = arith.addi(group_m_start_i32, valid_m)
+    else:
+        # Packed layout: groups are concatenated along M, so resolve which one
+        # owns this flat M-tile id from m_sizes. Doing it here rather than
+        # from a host-built dispatch map keeps the launch free of helper
+        # kernels, which matters under CUDA-graph capture where each one is
+        # replayed per call. num_groups is a compile-time constant, so the loop
+        # unrolls to a few scalar ops. acc_m/acc_t are the running m_start and
+        # tile_start prefixes; tiles beyond the real tile count (the grid extent
+        # is an upper bound) match no group and stay marked -1.
+        acc_m = _i32(0)  # cumulative rows before group g (m_starts[g])
+        acc_t = _i32(0)  # cumulative tiles before group g (tile_starts[g])
+        group_id_i32 = _i32(-1)
+        row_start_i32 = _i32(0)
+        row_limit_i32 = _i32(0)
+        group_m_start_i32 = _i32(0)  # first global row of the owning group
+        group_m_size_i32 = _i32(0)  # row count of the owning group
+        for _g in range_constexpr(num_groups):
+            if layout == "offsets":
+                # Cumulative int32 row ends. acc_m is already the running
+                # prefix, so a group's own row count is the step between them;
+                # decoding here costs a subtract and saves the caller a whole
+                # kernel launch to difference the offsets host-side.
+                m_g = arith.subi(
+                    buffer_ops.buffer_load(ms_rsrc, _g, vec_width=1, dtype=T.i32),
+                    acc_m,
+                )
+            else:
+                # m_sizes is int64; read the low dword of element _g (index
+                # _g*2 in dwords). Row counts fit in int32, so the high dword
+                # is always zero and no host-side narrowing kernel is needed.
+                m_g = buffer_ops.buffer_load(ms_rsrc, _g * 2, vec_width=1, dtype=T.i32)
+            tiles_g = arith.divui(arith.addi(m_g, tile_m_bump), tile_m_c)
+            acc_t_next = arith.addi(acc_t, tiles_g)
+            in_grp = arith.andi(
+                arith.cmpi(arith.CmpIPredicate.sge, bx_i32, acc_t),
+                arith.cmpi(arith.CmpIPredicate.slt, bx_i32, acc_t_next),
+            )
+            rs = arith.addi(acc_m, arith.muli(arith.subi(bx_i32, acc_t), tile_m_c))
+            rl = arith.addi(acc_m, m_g)
+            group_id_i32 = arith.select(in_grp, _i32(_g), group_id_i32)
+            row_start_i32 = arith.select(in_grp, rs, row_start_i32)
+            row_limit_i32 = arith.select(in_grp, rl, row_limit_i32)
+            group_m_start_i32 = arith.select(in_grp, acc_m, group_m_start_i32)
+            group_m_size_i32 = arith.select(in_grp, m_g, group_m_size_i32)
+            acc_m = arith.addi(acc_m, m_g)
+            acc_t = acc_t_next
+
+        is_valid = arith.cmpi(arith.CmpIPredicate.sge, group_id_i32, _i32(0))
+
+    return GroupResolution(
+        group_id=group_id_i32,
+        row_start=row_start_i32,
+        row_limit=row_limit_i32,
+        group_m_start=group_m_start_i32,
+        group_m_size=group_m_size_i32,
+        is_valid=is_valid,
+    )
+
+
 def make_a_tile_loaders(
     *,
     a_rsrc,

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -57,9 +57,22 @@ CompileConstants = namedtuple(
 )
 
 
-def validate_params(*, n, k, tile_n, tile_k, scale_block_k, scale_block_n, out_dtype):
+def validate_params(
+    *, n, k, tile_n, tile_k, scale_block_k, scale_block_n, out_dtype, blockscale=False
+):
     """Validate the divisibility constraints and out_dtype choice shared by
-    both grouped GEMM blockscale kernels."""
+    the grouped GEMM kernels.
+
+    scale_block_k splits a K tile into the sub-blocks the MFMA schedule steps
+    through, so tile_k must cover a whole number of them under either scaling
+    scheme -- a tile_k below scale_block_k yields zero sub-blocks and a compute
+    loop that never runs.
+
+    scale_block_n only matters to block scaling, where a tile must not straddle
+    a scale block. Rowwise scaling carries one scale per row of A and per column
+    of B and applies it in the epilogue, so tile_n is free of that alignment and
+    may be smaller than scale_block_n.
+    """
     if k % tile_k != 0:
         raise ValueError(f"k ({k}) must be divisible by tile_k ({tile_k})")
     if n % tile_n != 0:
@@ -68,7 +81,7 @@ def validate_params(*, n, k, tile_n, tile_k, scale_block_k, scale_block_n, out_d
         raise ValueError(
             f"tile_k ({tile_k}) must be divisible by scale_block_k ({scale_block_k})"
         )
-    if tile_n % scale_block_n != 0:
+    if blockscale and tile_n % scale_block_n != 0:
         raise ValueError(
             f"tile_n ({tile_n}) must be divisible by scale_block_n ({scale_block_n})"
         )
@@ -744,6 +757,7 @@ def make_compute_tile(
     sa_group_off=None,
     group_m_start=None,
     group_m_size=None,
+    blockscale=False,
 ):
     """Build the per-K-tile compute closure.
 
@@ -756,6 +770,14 @@ def make_compute_tile(
     `sa_group_off` is None for the contig path (no addition emitted)
     and `group_idx * c_scale_k * m_in` for the masked path; only the
     gfx942 SW path uses it.
+
+    Where the scales are applied follows from how they vary. Block scaling has a
+    distinct scale per (scale_block_k x scale_block_n) block, so each block's
+    partial sum needs its own factor and the scaling happens here, per block,
+    inside the K loop. Rowwise scaling has one scale per row of A and one per
+    column of B, both constant along K, so they factor out of the reduction and
+    the K loop accumulates unscaled, leaving a single scaling in the epilogue
+    (see `make_rowwise_scaler`).
     """
 
     def compute_tile(
@@ -768,7 +790,7 @@ def make_compute_tile(
 
             s_a_vecs = []
             s_b_vals = []
-            if not _use_hw_scale:
+            if blockscale and not _use_hw_scale:
                 if group_m_start is not None:
                     # quantize_fp8_group(m_sizes=...) stores scale_a as per-group
                     # blocks: group g starts at M_start*scale_k and holds element
@@ -854,24 +876,29 @@ def make_compute_tile(
                         )
             elif _is_gfx950:
                 # gfx950: use the wide 16x16x128 MFMA with a neutral E8M0 scale
-                # (0x7F7F7F7F = no-op hardware scaling), accumulate a whole
-                # scale-block into block_accs, then apply the FP32 scales in
-                # software once per scale-block. This avoids both the 4x-narrower
-                # 16x16x32 MFMA and the per-K-step VALU scale cost of the path
-                # below.
-                combined_scales = []
-                for mi in range_constexpr(m_repeat):
-                    mi_combined = []
-                    for ni in range_constexpr(num_acc_n):
-                        s_b_bc = Vector.filled(
-                            (4,), fx.Float32(s_b_vals[ni]), fx.Float32
-                        )
-                        mi_combined.append(
-                            ArithValue(s_a_vecs[mi]) * ArithValue(s_b_bc)
-                        )
-                    combined_scales.append(mi_combined)
-
-                block_accs = [acc_init] * (num_acc_n * m_repeat)
+                # (0x7F7F7F7F = no-op hardware scaling), which avoids the
+                # 4x-narrower 16x16x32 MFMA of the path below.
+                #
+                # Block scaling accumulates a whole scale block into block_accs
+                # and folds it into current_accs with the FP32 scales once per
+                # block, keeping the VALU scale cost off the per-K-step path.
+                # Rowwise scaling has nothing to fold in per block, so the MFMAs
+                # accumulate straight into current_accs.
+                if blockscale:
+                    combined_scales = []
+                    for mi in range_constexpr(m_repeat):
+                        mi_combined = []
+                        for ni in range_constexpr(num_acc_n):
+                            s_b_bc = Vector.filled(
+                                (4,), fx.Float32(s_b_vals[ni]), fx.Float32
+                            )
+                            mi_combined.append(
+                                ArithValue(s_a_vecs[mi]) * ArithValue(s_b_bc)
+                            )
+                        combined_scales.append(mi_combined)
+                    mfma_accs = [acc_init] * (num_acc_n * m_repeat)
+                else:
+                    mfma_accs = current_accs
                 ku0 = sb * ku_per_sb
                 ku1 = ku0 + 1
                 b0_packs0, b0_packs1 = b_tile_in[ku0]
@@ -893,12 +920,12 @@ def make_compute_tile(
                             b0_packs0[ni], b0_packs1[ni], b1_packs0[ni], b1_packs1[ni]
                         )
                         acc_idx = mi * num_acc_n + ni
-                        block_accs[acc_idx] = rocdl.mfma_scale_f32_16x16x128_f8f6f4(
+                        mfma_accs[acc_idx] = rocdl.mfma_scale_f32_16x16x128_f8f6f4(
                             mfma_res_ty,
                             [
                                 a128,
                                 b128,
-                                block_accs[acc_idx],
+                                mfma_accs[acc_idx],
                                 0,
                                 0,
                                 0,
@@ -908,14 +935,15 @@ def make_compute_tile(
                             ],
                         )
 
-                for mi in range_constexpr(m_repeat):
-                    for ni in range_constexpr(num_acc_n):
-                        acc_idx = mi * num_acc_n + ni
-                        current_accs[acc_idx] = math_dialect.fma(
-                            block_accs[acc_idx],
-                            combined_scales[mi][ni],
-                            current_accs[acc_idx],
-                        )
+                if blockscale:
+                    for mi in range_constexpr(m_repeat):
+                        for ni in range_constexpr(num_acc_n):
+                            acc_idx = mi * num_acc_n + ni
+                            current_accs[acc_idx] = math_dialect.fma(
+                                mfma_accs[acc_idx],
+                                combined_scales[mi][ni],
+                                current_accs[acc_idx],
+                            )
             else:
                 for ku_local in range_constexpr(ku_per_sb):
                     ku = sb * ku_per_sb + ku_local
@@ -941,27 +969,108 @@ def make_compute_tile(
 
                         for ni in range_constexpr(num_acc_n):
                             acc_idx = mi * num_acc_n + ni
-
                             mfma_fn = rocdl.mfma_f32_16x16x32_fp8_fp8
-                            mfma_mid = mfma_fn(
-                                T.f32x4, [a0, b_packs0[ni], acc_init, 0, 0, 0]
-                            )
-                            mfma_result = mfma_fn(
-                                T.f32x4, [a1, b_packs1[ni], mfma_mid, 0, 0, 0]
-                            )
 
-                            s_a_v4 = s_a_vecs[mi]
-                            s_b_bc = Vector.filled(
-                                (4,), fx.Float32(s_b_vals[ni]), fx.Float32
-                            )
-                            scaled = ArithValue(mfma_result) * ArithValue(s_a_v4)
-                            current_accs[acc_idx] = math_dialect.fma(
-                                scaled, s_b_bc, current_accs[acc_idx]
-                            )
+                            if blockscale:
+                                # This block's partial sum starts from zero so it
+                                # can be scaled on its own before joining the
+                                # running accumulator.
+                                mfma_mid = mfma_fn(
+                                    T.f32x4, [a0, b_packs0[ni], acc_init, 0, 0, 0]
+                                )
+                                mfma_result = mfma_fn(
+                                    T.f32x4, [a1, b_packs1[ni], mfma_mid, 0, 0, 0]
+                                )
+
+                                s_a_v4 = s_a_vecs[mi]
+                                s_b_bc = Vector.filled(
+                                    (4,), fx.Float32(s_b_vals[ni]), fx.Float32
+                                )
+                                scaled = ArithValue(mfma_result) * ArithValue(s_a_v4)
+                                current_accs[acc_idx] = math_dialect.fma(
+                                    scaled, s_b_bc, current_accs[acc_idx]
+                                )
+                            else:
+                                # Nothing to scale per block, so chain the MFMAs
+                                # straight onto the running accumulator.
+                                mfma_mid = mfma_fn(
+                                    T.f32x4,
+                                    [a0, b_packs0[ni], current_accs[acc_idx], 0, 0, 0],
+                                )
+                                current_accs[acc_idx] = mfma_fn(
+                                    T.f32x4, [a1, b_packs1[ni], mfma_mid, 0, 0, 0]
+                                )
 
         return current_accs
 
     return compute_tile
+
+
+def make_rowwise_scaler(
+    *,
+    sa_rsrc,
+    sb_rsrc,
+    group_idx,
+    n_in,
+    by_n,
+    n_tile_base,
+    bx_m,
+    lane_mod_16,
+    lane_div_16,
+    m_repeat,
+    num_acc_n,
+):
+    """Build the closure that applies rowwise scales to the finished accumulators.
+
+    Rowwise scaling multiplies each output element by ``scale_a[row]`` and
+    ``scale_b[group, col]``, both constant along K, so this runs once after the
+    K loop rather than inside it.
+
+    The MFMA 16x16 C fragment holds four f32 per lane that share a column and
+    differ by row, which is exactly how the two scales vary: scale_b contributes
+    one value broadcast across the fragment, and scale_a contributes a vector of
+    the fragment's four rows. Unlike the block-scale lookup, the column here
+    includes ``lane_mod_16``, so scale_b is not wave-uniform and must not be
+    routed through readfirstlane.
+
+    Returns ``apply_rowwise_scales(accs)``.
+    """
+
+    def apply_rowwise_scales(accs):
+        scaled = list(accs)
+
+        # scale_a is [total_M]: one value per global row.
+        row_off_base = lane_div_16 * fx.Index(4)
+        s_a_vecs = []
+        for mi in range_constexpr(m_repeat):
+            s_a_row = []
+            for ii in range_constexpr(4):
+                row_global = bx_m + (mi * 16) + row_off_base + fx.Index(ii)
+                s_a_row.append(
+                    buffer_ops.buffer_load(
+                        sa_rsrc, row_global, vec_width=1, dtype=T.f32
+                    )
+                )
+            s_a_vecs.append(Vector.from_elements(s_a_row, fx.Float32))
+
+        # scale_b is [num_groups, n]: element (g, col) at g*n + col.
+        group_n_off = group_idx * n_in
+        s_b_bcs = []
+        for ni in range_constexpr(num_acc_n):
+            col_global = group_n_off + by_n + n_tile_base + (ni * 16) + lane_mod_16
+            s_b_val = buffer_ops.buffer_load(
+                sb_rsrc, col_global, vec_width=1, dtype=T.f32
+            )
+            s_b_bcs.append(Vector.filled((4,), fx.Float32(s_b_val), fx.Float32))
+
+        for mi in range_constexpr(m_repeat):
+            for ni in range_constexpr(num_acc_n):
+                acc_idx = mi * num_acc_n + ni
+                v = ArithValue(scaled[acc_idx]) * ArithValue(s_a_vecs[mi])
+                scaled[acc_idx] = v * ArithValue(s_b_bcs[ni])
+        return scaled
+
+    return apply_rowwise_scales
 
 
 def make_kloop_plain(

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -33,6 +33,41 @@ from mslk.flydsl.kernels.mma.mfma_preshuffle_pipeline import (
     tile_chunk_coord_i32,
 )
 
+# FP8 elements covered by one 16-byte vectorised load. With k_padding the tail K
+# tile is masked a whole load at a time, so this is the finest K granularity the
+# kernel can end on.
+K_LOAD_ELEMS = 16
+
+
+def make_k_tail_mask(*, k_padding, num_k_tiles, k, tile_k, k_in):
+    """Build the per-load K-range predicate used by the A and B tile loaders.
+
+    Returns ``mask(k_tile_idx_py, base_k_div4, col_local_i32)`` yielding None
+    wherever no masking is needed, so every tile but the last emits exactly the
+    code it did before.
+
+    A masked ``buffer_load`` reads out of the buffer's range and so returns zero,
+    which is what a K tail needs: the excess lanes contribute nothing to the sum.
+    A plain out-of-range offset would not do, since reading past K within a row
+    lands on the next row's data rather than outside the buffer.
+    """
+    tail = k_padding and (k % tile_k != 0)
+
+    def mask(k_tile_idx_py, base_k_div4, col_local_i32):
+        if not tail or k_tile_idx_py != num_k_tiles - 1:
+            return None
+        # Loads are 16-byte aligned and K is a multiple of that width, so a chunk
+        # is either wholly inside K or wholly outside it.
+        chunk_start_div4 = base_k_div4 + col_local_i32
+        return arith.cmpi(
+            arith.CmpIPredicate.ult,
+            arith.index_cast(T.i32, chunk_start_div4),
+            arith.index_cast(T.i32, k_in // fx.Index(4)),
+        )
+
+    return mask
+
+
 CompileConstants = namedtuple(
     "CompileConstants",
     [
@@ -58,7 +93,16 @@ CompileConstants = namedtuple(
 
 
 def validate_params(
-    *, n, k, tile_n, tile_k, scale_block_k, scale_block_n, out_dtype, blockscale=False
+    *,
+    n,
+    k,
+    tile_n,
+    tile_k,
+    scale_block_k,
+    scale_block_n,
+    out_dtype,
+    blockscale=False,
+    k_padding=False,
 ):
     """Validate the divisibility constraints and out_dtype choice shared by
     the grouped GEMM kernels.
@@ -73,7 +117,15 @@ def validate_params(
     of B and applies it in the epilogue, so tile_n is free of that alignment and
     may be smaller than scale_block_n.
     """
-    if k % tile_k != 0:
+    if k_padding:
+        # The tail K tile is masked off per 16-byte load, so K only has to land on
+        # a load boundary rather than a whole tile.
+        if k % K_LOAD_ELEMS != 0:
+            raise ValueError(
+                f"k ({k}) must be divisible by {K_LOAD_ELEMS} (the vectorised "
+                "load width) even with k_padding"
+            )
+    elif k % tile_k != 0:
         raise ValueError(f"k ({k}) must be divisible by tile_k ({tile_k})")
     if n % tile_n != 0:
         raise ValueError(f"n ({n}) must be divisible by tile_n ({tile_n})")
@@ -181,7 +233,7 @@ def out_mlir_for(out_dtype):
 
 
 def compute_compile_constants(
-    *, n, k, tile_m, tile_n, tile_k, scale_block_k, scale_block_n
+    *, n, k, tile_m, tile_n, tile_k, scale_block_k, scale_block_n, k_padding=False
 ):
     """Compute the compile-time scalar constants shared by both kernels.
 
@@ -189,7 +241,9 @@ def compute_compile_constants(
     """
     total_threads = 256
     elem_bytes = 1  # FP8
-    num_k_tiles = k // tile_k
+    # With k_padding the last tile is only partly covered by K; it still runs, with
+    # its out-of-range loads masked to zero, which contribute nothing to the sum.
+    num_k_tiles = -(-k // tile_k) if k_padding else k // tile_k
     scale_k = k // scale_block_k
     scale_n = n // scale_block_n
     sb_per_tile = tile_k // scale_block_k  # scale blocks per K-tile
@@ -299,6 +353,7 @@ def make_a_tile_loaders(
     k_in,
     m_in=None,
     group_idx=None,
+    k_tail_mask=None,
 ):
     """Build the prefetch + LDS-store closures for the A tile.
 
@@ -310,6 +365,7 @@ def make_a_tile_loaders(
     code so the resulting MLIR (and ISA) is byte-identical. `k_blocks16`
     is returned for reuse by the downstream LDS-load helper.
     """
+    _k_tail_mask = k_tail_mask or (lambda *_: None)
     layout_a_tile_div4 = fx.make_layout(
         (tile_m, tile_k_dwords), stride=(tile_k_dwords, 1)
     )
@@ -352,7 +408,13 @@ def make_a_tile_loaders(
                     + base_k_div4
                     + a_col_local_i32[i]
                 )
-            a_vec = buffer_ops.buffer_load(a_rsrc, idx_i32, vec_width=4, dtype=T.i32)
+            a_vec = buffer_ops.buffer_load(
+                a_rsrc,
+                idx_i32,
+                vec_width=4,
+                dtype=T.i32,
+                mask=_k_tail_mask(k_tile_idx_py, base_k_div4, a_col_local_i32[i]),
+            )
             parts.append(Vector(a_vec).bitcast(fx.Int32))
         return parts
 
@@ -401,6 +463,7 @@ def make_b_tile_loaders(
     elem_bytes,
     n_in,
     k_in,
+    k_tail_mask=None,
 ):
     """Build the prefetch + LDS-store closures for a PLAIN (non-preshuffled)
     B tile [tile_n, tile_k].
@@ -413,6 +476,7 @@ def make_b_tile_loaders(
     swizzle as A. Returns `(prefetch_b_tile, store_b_tile_to_lds, b_row_local,
     b_col_local_i32, k_blocks16_b)`.
     """
+    _k_tail_mask = k_tail_mask or (lambda *_: None)
     layout_b_tile_div4 = fx.make_layout(
         (tile_n, tile_k_dwords), stride=(tile_k_dwords, 1)
     )
@@ -450,7 +514,13 @@ def make_b_tile_loaders(
                 + base_k_div4
                 + b_col_local_i32[i]
             )
-            b_vec = buffer_ops.buffer_load(b_rsrc, idx_i32, vec_width=4, dtype=T.i32)
+            b_vec = buffer_ops.buffer_load(
+                b_rsrc,
+                idx_i32,
+                vec_width=4,
+                dtype=T.i32,
+                mask=_k_tail_mask(k_tile_idx_py, base_k_div4, b_col_local_i32[i]),
+            )
             parts.append(Vector(b_vec).bitcast(fx.Int32))
         return parts
 

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -7,14 +7,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-"""Shared building blocks for the grouped FP8 blockscale GEMM kernels.
+"""Shared building blocks for the grouped FP8 GEMM kernel.
 
-Used by the grouped_gemm_blockscale contiguous and masked kernels. Holds the
-parts of the two kernels that are byte-identical (parameter validation,
-compile-time scalar constants, helper closures) so they live in one place.
+Used by grouped_gemm_blockscale_contiguous.py: parameter validation,
+compile-time scalar constants, and the helper closures the kernel body is
+built from.
 
-scale_b is indexed as [num_groups, scale_k, scale_n] (per-group, per-K-block,
-per-N-block); scale_a is [scale_k, M] (transposed, per-token per-K-block).
+Block scaling indexes scale_b as [num_groups, scale_k, scale_n] (per-group,
+per-K-block, per-N-block) and scale_a as [scale_k, M] (transposed, per-token
+per-K-block). Rowwise scaling carries one scale per row of A and per column of
+B and applies them in the epilogue.
 """
 
 from collections import namedtuple
@@ -167,11 +169,11 @@ def validate_params(
             f"tile_n ({tile_n}) must be divisible by scale_block_n ({scale_block_n})"
         )
     if blockscale:
-        # Block scaling counts whole scale blocks along K and N, so a partial
-        # one at either end would be left out of that count and the scales
-        # misindexed from there on. Padding relaxes the tile bound, which used
-        # to imply this one, so state it in its own right. Rowwise scaling
-        # carries a scale per row and per column and is unaffected.
+        # A scale block is the unit one scale covers, so K and N have to span
+        # whole ones: a partial block at either end falls outside the count and
+        # misindexes the scales from there on. The tile bounds above do not
+        # imply this, since padding relaxes them. Rowwise scaling carries a
+        # scale per row and per column and is unaffected.
         if k % scale_block_k != 0:
             raise ValueError(
                 f"k ({k}) must be divisible by scale_block_k ({scale_block_k}) "

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -44,12 +44,17 @@ K_LOAD_ELEMS = 16
 N_STORE_ELEMS = 8
 
 
-def make_k_tail_mask(*, k_padding, num_k_tiles, k, tile_k, k_in):
+def make_k_tail_mask(*, k_padding, num_k_tiles, k, tile_k, k_in, always=False):
     """Build the per-load K-range predicate used by the A and B tile loaders.
 
     Returns ``mask(k_tile_idx_py, base_k_div4, col_local_i32)`` yielding None
     wherever no masking is needed, so every tile but the last emits exactly the
     code it did before.
+
+    ``always`` drops that last-tile test and emits the predicate on every tile.
+    A rolled K loop traces its body once, so which iteration is the last is no
+    longer a Python-level fact; the predicate is correct on every tile either
+    way, since it compares against K rather than against the tile index.
 
     A masked ``buffer_load`` reads out of the buffer's range and so returns zero,
     which is what a K tail needs: the excess lanes contribute nothing to the sum.
@@ -59,7 +64,7 @@ def make_k_tail_mask(*, k_padding, num_k_tiles, k, tile_k, k_in):
     tail = k_padding and (k % tile_k != 0)
 
     def mask(k_tile_idx_py, base_k_div4, col_local_i32):
-        if not tail or k_tile_idx_py != num_k_tiles - 1:
+        if not tail or not (always or k_tile_idx_py == num_k_tiles - 1):
             return None
         # Loads are 16-byte aligned and K is a multiple of that width, so a chunk
         # is either wholly inside K or wholly outside it.

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_common.py
@@ -166,6 +166,22 @@ def validate_params(
         raise ValueError(
             f"tile_n ({tile_n}) must be divisible by scale_block_n ({scale_block_n})"
         )
+    if blockscale:
+        # Block scaling counts whole scale blocks along K and N, so a partial
+        # one at either end would be left out of that count and the scales
+        # misindexed from there on. Padding relaxes the tile bound, which used
+        # to imply this one, so state it in its own right. Rowwise scaling
+        # carries a scale per row and per column and is unaffected.
+        if k % scale_block_k != 0:
+            raise ValueError(
+                f"k ({k}) must be divisible by scale_block_k ({scale_block_k}) "
+                "under block scaling, which k_padding does not relax"
+            )
+        if n % scale_block_n != 0:
+            raise ValueError(
+                f"n ({n}) must be divisible by scale_block_n ({scale_block_n}) "
+                "under block scaling, which n_padding does not relax"
+            )
     if out_dtype not in ("bf16", "f16"):
         raise ValueError(f"out_dtype must be 'bf16' or 'f16', got {out_dtype!r}")
 

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -54,7 +54,7 @@ from flydsl.expr import (
     rocdl,
     vector,
 )
-from flydsl.expr.typing import T
+from flydsl.expr.typing import T, Vector
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
@@ -109,6 +109,7 @@ def compile_grouped_gemm_blockscale_contiguous(
     layout: str = "sizes",
     k_padding: bool = False,
     n_padding: bool = False,
+    roll_k: bool = False,
 ):
     """Compile grouped FP8 GEMM kernel and return the JIT launcher.
 
@@ -157,9 +158,22 @@ def compile_grouped_gemm_blockscale_contiguous(
             [M, total_N] with the groups side by side, and m_sizes is
             [num_groups] INT32 cumulative column ends. Rowwise plain-B only.
 
+        roll_k: Emit the K loop once as a real loop instead of unrolling it over
+            every K tile. The unrolled form folds the tile index into every
+            address and keeps the pipeline free of loop overhead, but the traced
+            IR, the compile time and the final code all then grow linearly with
+            K. Rolling holds them constant, at the cost of carrying the
+            accumulators and the prefetched tiles as loop state. Only the plain-B
+            K loop can be rolled today.
+
     Returns:
         JIT launcher function.
     """
+    if roll_k and b_preshuffled:
+        raise ValueError(
+            "roll_k applies to the plain-B K loop; the preshuffled path uses the "
+            "two-deep ping-pong loop, which is still unrolled"
+        )
     if layout not in LAYOUTS:
         raise ValueError(f"layout must be one of {LAYOUTS}, got {layout!r}")
     # Each group owns a fixed slab of rows and rides the grid's z axis, so it
@@ -269,11 +283,12 @@ def compile_grouped_gemm_blockscale_contiguous(
     _variant = "contiguous_pingpong" if b_preshuffled else "plain"
     _scaling = "blockscale" if blockscale else "rowwise"
     _kpad = "_kpad" if k_padding else ""
+    _roll = "_rollk" if roll_k else ""
     _npad = "_npad" if n_padding else ""
     module_name = (
         f"grouped_gemm_{_scaling}_{layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
-        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}"
+        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}"
     ).replace("-", "_")
 
     @flyc.kernel(name=module_name)
@@ -485,6 +500,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                 k=k,
                 tile_k=tile_k,
                 k_in=k_in,
+                always=roll_k,
             )
 
             (
@@ -668,7 +684,55 @@ def compile_grouped_gemm_blockscale_contiguous(
                     lds_base_pong=lds_base_pong,
                     lds_base_b=lds_base_b,
                 )
-            accs = run_kloop(accs)
+
+            if const_expr(roll_k):
+                # Rolled K loop. The body is traced once, so it has to live here
+                # rather than behind a helper: only the kernel function's own
+                # source is AST-rewritten, and fx.range/yield is a rewritten
+                # construct. The pipeline is the same as the unrolled form --
+                # the next tile's global loads are issued before the current
+                # tile computes -- which is why the prefetched registers ride
+                # the loop next to the accumulators. The final tile is peeled,
+                # having no successor to prefetch.
+                _a_regs = prefetch_a_tile(0)
+                _b_regs = prefetch_b_tile(0)
+                _n_acc = len(accs)
+                _n_a = len(_a_regs)
+                if const_expr(num_k_tiles > 1):
+                    for _kt, _st in fx.range(
+                        0,
+                        num_k_tiles - 1,
+                        1,
+                        init=list(accs) + list(_a_regs) + list(_b_regs),
+                    ):
+                        _accs = [Vector(v) for v in _st[:_n_acc]]
+                        _a_cur = [Vector(v) for v in _st[_n_acc : _n_acc + _n_a]]
+                        _b_cur = [Vector(v) for v in _st[_n_acc + _n_a :]]
+                        store_a_tile_to_lds(_a_cur, lds_base_pong)
+                        store_b_tile_to_lds(_b_cur, lds_base_b)
+                        _scales = prefetch_scales(_kt)
+                        gpu.barrier()
+                        _a_nxt = prefetch_a_tile(_kt + 1)
+                        _b_nxt = prefetch_b_tile(_kt + 1)
+                        _b_tile = load_b_tile_from_lds(lds_base_b)
+                        _accs = compute_tile(
+                            _accs, _kt, lds_base_pong, _b_tile, _scales
+                        )
+                        gpu.barrier()
+                        _res = yield list(_accs) + list(_a_nxt) + list(_b_nxt)
+                    accs = [Vector(v) for v in _res[:_n_acc]]
+                    _a_regs = [Vector(v) for v in _res[_n_acc : _n_acc + _n_a]]
+                    _b_regs = [Vector(v) for v in _res[_n_acc + _n_a :]]
+                _last = num_k_tiles - 1
+                store_a_tile_to_lds(_a_regs, lds_base_pong)
+                store_b_tile_to_lds(_b_regs, lds_base_b)
+                _scales = prefetch_scales(_last)
+                gpu.barrier()
+                _b_tile = load_b_tile_from_lds(lds_base_b)
+                accs = compute_tile(accs, _last, lds_base_pong, _b_tile, _scales)
+                gpu.barrier()
+            else:
+                accs = run_kloop(accs)
 
             if const_expr(not blockscale):
                 # Rowwise scales are constant along K, so the whole reduction is

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -164,7 +164,9 @@ def compile_grouped_gemm_blockscale_contiguous(
             IR, the compile time and the final code all then grow linearly with
             K. Rolling holds them constant, at the cost of carrying the
             accumulators and the prefetched tiles as loop state. Only the plain-B
-            K loop can be rolled today.
+            K loop can be rolled today. This is the kernel's mechanism and
+            defaults off; the host dispatch sets the policy and turns it on
+            wherever it applies.
 
     Returns:
         JIT launcher function.

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -15,6 +15,10 @@ exactly one group, so a tile never spans a group boundary. The kernel resolves
 the owning group for its M-tile from m_sizes, and rows at or beyond that group's
 end are the partial-tile tail and are masked out of the store.
 
+The `layout` argument selects how the group geometry is encoded; groups may also
+occupy fixed per-group slabs rather than being packed. Only the resolution step
+differs, so the loaders, the K loop and the epilogue are shared by all of them.
+
 Scales are FP32 (software scaling) on all architectures.
 
 Tensors:
@@ -80,6 +84,9 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
 )
 from mslk.flydsl.kernels.mma.mfma_epilogues import mfma_epilog
 
+# Supported encodings of the group geometry; see the ``layout`` argument below.
+LAYOUTS = ("sizes", "padded")
+
 
 @functools.lru_cache(maxsize=128)
 def compile_grouped_gemm_blockscale_contiguous(
@@ -96,7 +103,7 @@ def compile_grouped_gemm_blockscale_contiguous(
     waves_per_eu: int | None = None,
     b_preshuffled: bool = True,
     blockscale: bool = False,
-    masked: bool = False,
+    layout: str = "sizes",
     k_padding: bool = False,
     n_padding: bool = False,
 ):
@@ -127,10 +134,24 @@ def compile_grouped_gemm_blockscale_contiguous(
             True is block scaling: scale_a is per-group [M_g, scale_k] blocks and
             scale_b is [num_groups, scale_k, scale_n], applied per scale block
             inside the K loop, which requires the tile to align to the blocks.
+        layout: How the kernel learns which rows belong to which group. The
+            encodings differ only in that resolution step; the loaders, the K
+            loop and the epilogue are shared.
+            "sizes" (default): rows of every group are packed into one [M_total,
+            K] buffer and m_sizes is [num_groups] INT64 per-group row counts.
+            "padded": each group owns a fixed slab of M_total/num_groups rows and
+            m_sizes is [num_groups] INT64 counts of the rows per slab that hold
+            real data; the rest is padding the epilogue must not write.
 
     Returns:
         JIT launcher function.
     """
+    if layout not in LAYOUTS:
+        raise ValueError(f"layout must be one of {LAYOUTS}, got {layout!r}")
+    # Each group owns a fixed slab of rows, so the group is a grid axis and does
+    # not have to be resolved from the row counts.
+    slab_layout = layout == "padded"
+
     gpu_arch = get_hip_arch()
     # This FP8 kernel always uses the FP32 software-scaling path; the shared
     # helpers' hardware E8M0 microscaling path is not used here.
@@ -219,11 +240,10 @@ def compile_grouped_gemm_blockscale_contiguous(
     # Module name for caching
     _variant = "contiguous_pingpong" if b_preshuffled else "plain"
     _scaling = "blockscale" if blockscale else "rowwise"
-    _layout = "masked" if masked else "contig"
     _kpad = "_kpad" if k_padding else ""
     _npad = "_npad" if n_padding else ""
     module_name = (
-        f"grouped_gemm_{_scaling}_{_layout}_{_variant}_{out_dtype}"
+        f"grouped_gemm_{_scaling}_{layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
         f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}"
     ).replace("-", "_")
@@ -343,7 +363,7 @@ def compile_grouped_gemm_blockscale_contiguous(
         tile_m_c = _i32(tile_m)
         tile_m_bump = _i32(tile_m - 1)
 
-        if const_expr(masked):
+        if const_expr(slab_layout):
             # Padded layout: every group owns a fixed slab of expected_m rows, so
             # the group is a grid axis and needs no resolution. m_sizes holds the
             # count of rows in each slab that carry real data; the rest is padding
@@ -724,7 +744,7 @@ def compile_grouped_gemm_blockscale_contiguous(
             else n_in // fx.Index(tile_n)
         )  # N-blocks
         gy = fx.Index(i32_num_m_tiles)  # M-tiles
-        gz = fx.Index(i32_num_groups) if const_expr(masked) else fx.Index(1)
+        gz = fx.Index(i32_num_groups) if const_expr(slab_layout) else fx.Index(1)
 
         launcher = grouped_gemm_blockscale_contiguous_kernel(
             arg_d,

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -72,7 +72,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
     make_lds_b_loader,
     make_lds_loader,
     make_n_block_coords,
-    make_pingpong_kloop,
+    make_pingpong_stages,
     make_plain_b_tile,
     make_prefetch_scales,
     make_rowwise_scaler,
@@ -163,19 +163,15 @@ def compile_grouped_gemm_blockscale_contiguous(
             address and keeps the pipeline free of loop overhead, but the traced
             IR, the compile time and the final code all then grow linearly with
             K. Rolling holds them constant, at the cost of carrying the
-            accumulators and the prefetched tiles as loop state. Only the plain-B
-            K loop can be rolled today. This is the kernel's mechanism and
-            defaults off; the host dispatch sets the policy and turns it on
-            wherever it applies.
+            accumulators and the prefetched tiles as loop state. Both K loops
+            can be rolled: the plain one a tile at a time, the ping-pong one a
+            pair at a time so its buffer alternation stays compile-time inside
+            the body. This is the kernel's mechanism and defaults off; the host
+            dispatch sets the policy.
 
     Returns:
         JIT launcher function.
     """
-    if roll_k and b_preshuffled:
-        raise ValueError(
-            "roll_k applies to the plain-B K loop; the preshuffled path uses the "
-            "two-deep ping-pong loop, which is still unrolled"
-        )
     if layout not in LAYOUTS:
         raise ValueError(f"layout must be one of {LAYOUTS}, got {layout!r}")
     # Each group owns a fixed slab of rows and rides the grid's z axis, so it
@@ -657,7 +653,7 @@ def compile_grouped_gemm_blockscale_contiguous(
             )
 
             if const_expr(b_preshuffled):
-                run_kloop = make_pingpong_kloop(
+                pingpong_prologue, pingpong_pair = make_pingpong_stages(
                     num_k_tiles=num_k_tiles,
                     tile_k=tile_k,
                     prefetch_a_tile=prefetch_a_tile,
@@ -687,7 +683,61 @@ def compile_grouped_gemm_blockscale_contiguous(
                     lds_base_b=lds_base_b,
                 )
 
-            if const_expr(roll_k):
+            # The ping-pong state is nested (a B tile is k_unroll pairs of
+            # num_acc_n packs); a loop carries a flat list, so convert both ways.
+            # The prefetched scales are always None on this software-scaling
+            # path, so they are rebuilt rather than carried.
+            def _flatten_pp(st):
+                b_tile, _sc, a0 = st
+                flat = []
+                for _p0, _p1 in b_tile:
+                    flat.extend(_p0)
+                    flat.extend(_p1)
+                flat.extend(a0)
+                return flat
+
+            def _unflatten_pp(vals):
+                vals = [fx.Int64(v) for v in vals]
+                b_tile = []
+                _i = 0
+                for _ in range_constexpr(k_unroll):
+                    _p0 = vals[_i : _i + num_acc_n]
+                    _i += num_acc_n
+                    _p1 = vals[_i : _i + num_acc_n]
+                    _i += num_acc_n
+                    b_tile.append((_p0, _p1))
+                return (b_tile, None, tuple(vals[_i : _i + 2]))
+
+            if const_expr(b_preshuffled and roll_k):
+                # Rolled ping-pong loop. Two K tiles per iteration, which keeps
+                # the ping/pong alternation compile-time inside the body while
+                # the loop itself rolls; the pairs that have no successor to
+                # prefetch are peeled off the end and walked unrolled, so the
+                # rolled body needs no tail tests. The B tile and the first A
+                # pack ride the loop, being produced one pair ahead of use.
+                _st0 = pingpong_prologue()
+                _pairs = max((num_k_tiles - 1) // 2, 0)
+                _n_acc = len(accs)
+                if const_expr(_pairs > 0):
+                    for _it, _sv in fx.range(
+                        0,
+                        _pairs,
+                        1,
+                        init=list(accs) + _flatten_pp(_st0),
+                    ):
+                        _accs = [Vector(v) for v in _sv[:_n_acc]]
+                        _cur = _unflatten_pp(_sv[_n_acc:])
+                        _accs, _cur = pingpong_pair(_accs, _it * 2, _cur, steady=True)
+                        _res = yield list(_accs) + _flatten_pp(_cur)
+                    accs = [Vector(v) for v in _res[:_n_acc]]
+                    _st0 = _unflatten_pp(_res[_n_acc:])
+                for _kp in range_constexpr(2 * _pairs, num_k_tiles, 2):
+                    accs, _st0 = pingpong_pair(accs, _kp, _st0)
+            elif const_expr(b_preshuffled):
+                _st0 = pingpong_prologue()
+                for _kp in range_constexpr(0, num_k_tiles, 2):
+                    accs, _st0 = pingpong_pair(accs, _kp, _st0)
+            elif const_expr(roll_k):
                 # Rolled K loop. The body is traced once, so it has to live here
                 # rather than behind a helper: only the kernel function's own
                 # source is AST-rewritten, and fx.range/yield is a rewritten

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -29,8 +29,8 @@ Tensors:
     local_m + k_block * M_g. This is not a global [scale_k, M_total] transpose.
   - B: [num_groups, N, K] FP8 - one weight matrix per group, preshuffled
   - scale_b: [num_groups, scale_k, scale_n] FP32 - per-block scales
-  - m_sizes: [num_groups] INT64 - rows per group (sum to M_total), or unused
-    when the layout carries no per-group metadata
+  - m_sizes: [num_groups] - the group geometry, whose encoding the `layout`
+    argument selects: INT64 row counts, INT32 cumulative offsets, or unused
   - D: [M_total, N] BF16 - output
 
 Block scaling granularity:
@@ -86,7 +86,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
 from mslk.flydsl.kernels.mma.mfma_epilogues import mfma_epilog
 
 # Supported encodings of the group geometry; see the ``layout`` argument below.
-LAYOUTS = ("sizes", "padded", "batched")
+LAYOUTS = ("sizes", "offsets", "padded", "batched")
 
 
 @functools.lru_cache(maxsize=128)
@@ -140,6 +140,8 @@ def compile_grouped_gemm_blockscale_contiguous(
             loop and the epilogue are shared.
             "sizes" (default): rows of every group are packed into one [M_total,
             K] buffer and m_sizes is [num_groups] INT64 per-group row counts.
+            "offsets": same packed buffer, but m_sizes is [num_groups] INT32
+            cumulative row ends, i.e. the inclusive prefix sum of the sizes.
             "padded": each group owns a fixed slab of M_total/num_groups rows and
             m_sizes is [num_groups] INT64 counts of the rows per slab that hold
             real data; the rest is padding the epilogue must not write.
@@ -360,13 +362,15 @@ def compile_grouped_gemm_blockscale_contiguous(
             arg_scale_b, max_size=False, num_records_bytes=sb_nbytes
         )
 
-        # "batched" carries no group metadata, so no resource is built for it
-        # and arg_m_sizes goes unread.
+        # Group metadata is INT32 when it holds cumulative offsets and INT64
+        # when it holds row counts. "batched" carries none, so no resource is
+        # built for it and arg_m_sizes goes unread.
         if const_expr(reads_group_meta):
+            meta_bytes = 4 if layout == "offsets" else 8
             ms_rsrc = buffer_ops.create_buffer_resource(
                 arg_m_sizes,
                 max_size=False,
-                num_records_bytes=num_groups_in * fx.Index(8),
+                num_records_bytes=num_groups_in * fx.Index(meta_bytes),
             )
 
         def _i32(v):  # raw i32 constant (arith.* requires unwrapped MLIR values)
@@ -422,10 +426,22 @@ def compile_grouped_gemm_blockscale_contiguous(
             group_m_start_i32 = _i32(0)  # first global row of the owning group
             group_m_size_i32 = _i32(0)  # row count of the owning group
             for _g in range_constexpr(num_groups):
-                # m_sizes is int64; read the low dword of element _g (index _g*2 in
-                # dwords). Row counts fit in int32, so the high dword is always zero
-                # and no host-side narrowing kernel is needed.
-                m_g = buffer_ops.buffer_load(ms_rsrc, _g * 2, vec_width=1, dtype=T.i32)
+                if const_expr(layout == "offsets"):
+                    # Cumulative int32 row ends. acc_m is already the running
+                    # prefix, so a group's own row count is the step between them;
+                    # decoding here costs a subtract and saves the caller a whole
+                    # kernel launch to difference the offsets host-side.
+                    m_g = arith.subi(
+                        buffer_ops.buffer_load(ms_rsrc, _g, vec_width=1, dtype=T.i32),
+                        acc_m,
+                    )
+                else:
+                    # m_sizes is int64; read the low dword of element _g (index
+                    # _g*2 in dwords). Row counts fit in int32, so the high dword
+                    # is always zero and no host-side narrowing kernel is needed.
+                    m_g = buffer_ops.buffer_load(
+                        ms_rsrc, _g * 2, vec_width=1, dtype=T.i32
+                    )
                 tiles_g = arith.divui(arith.addi(m_g, tile_m_bump), tile_m_c)
                 acc_t_next = arith.addi(acc_t, tiles_g)
                 in_grp = arith.andi(

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -78,6 +78,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
     make_rowwise_scaler,
     out_mlir_for,
     resolve_group_cols,
+    resolve_group_k,
     resolve_group_rows,
     setup_lds_allocation,
     setup_lds_allocation_plain,
@@ -88,7 +89,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
 from mslk.flydsl.kernels.mma.mfma_epilogues import mfma_epilog
 
 # Supported encodings of the group geometry; see the ``layout`` argument below.
-LAYOUTS = ("sizes", "offsets", "padded", "batched", "n_offsets")
+LAYOUTS = ("sizes", "offsets", "padded", "batched", "n_offsets", "k_offsets")
 
 
 @functools.lru_cache(maxsize=128)
@@ -157,6 +158,12 @@ def compile_grouped_gemm_blockscale_contiguous(
             [total_N, K] matrix whose rows the groups divide, the output is
             [M, total_N] with the groups side by side, and m_sizes is
             [num_groups] INT32 cumulative column ends. Rowwise plain-B only.
+            "k_offsets": the groups divide the CONTRACTION. A is [M, total_K]
+            and B is [N, total_K], each group taking a column slice, and every
+            group produces a full [M, N] so the output is [G, M, N] with nothing
+            packed. m_sizes is [num_groups] INT32 cumulative K ends. The slice
+            length is a runtime value, so this layout always rolls the K loop.
+            Rowwise plain-B only.
 
         roll_k: Emit the K loop once as a real loop instead of unrolling it over
             every K tile. The unrolled form folds the tile index into every
@@ -180,12 +187,29 @@ def compile_grouped_gemm_blockscale_contiguous(
     # Groups divide the output's columns, so the group follows from the N-block
     # index and B is one matrix rather than a stack of per-group ones.
     n_grouped = layout == "n_offsets"
+    # Groups divide the contraction: every group owns a K slice of both operands
+    # and produces a whole output of its own.
+    k_grouped = layout == "k_offsets"
+    if k_grouped:
+        if blockscale or b_preshuffled:
+            raise ValueError(
+                "layout 'k_offsets' supports only rowwise scaling with plain B: "
+                "a scale block cannot straddle a group's K slice, and the "
+                "preshuffled layout swizzles K across the whole matrix"
+            )
+        # A group's K length is only known on the device, so the trip count
+        # cannot be a compile-time constant and the loop cannot be unrolled.
+        roll_k = True
     if n_grouped and (blockscale or b_preshuffled):
         raise ValueError(
             "layout 'n_offsets' supports only rowwise scaling with plain B: "
             "ragged N would need per-group scale blocks, and the preshuffled "
             "layout swizzles N across the whole matrix"
         )
+    if k_grouped:
+        # Every tile is bounded by the group's K end, which is a runtime value,
+        # so the predicate cannot be confined to a compile-time last tile.
+        k_padding = True
     if n_grouped:
         # A group's column end is a runtime value, so unlike a compile-time N
         # remainder the tail mask cannot be elided; N only has to reach a store
@@ -357,6 +381,8 @@ def compile_grouped_gemm_blockscale_contiguous(
         ).get()
 
         # Buffer resources
+        # Where the groups divide K, A is [M, total_K] -- one set of rows shared
+        # by every group -- while the output and scale_a hold a slab per group.
         a_nbytes = m_in * k_in
         a_rsrc = buffer_ops.create_buffer_resource(
             arg_a, max_size=False, num_records_bytes=a_nbytes
@@ -364,14 +390,24 @@ def compile_grouped_gemm_blockscale_contiguous(
 
         # B is one [total_N, K] matrix when the groups divide N, and a stack of
         # num_groups [N, K] ones otherwise.
-        b_nbytes = (n_in if const_expr(n_grouped) else num_groups_in * n_in) * k_in
+        if const_expr(n_grouped or k_grouped):
+            # One matrix the groups divide, by row under n_offsets and by column
+            # under k_offsets.
+            b_nbytes = n_in * k_in
+        else:
+            b_nbytes = num_groups_in * n_in * k_in
         b_rsrc = buffer_ops.create_buffer_resource(
             arg_b, max_size=False, num_records_bytes=b_nbytes
         )
 
         # The output is [M, total_N] when the groups divide N: m_in counts the
         # rows of every group's slab, but they share the output's rows.
-        d_rows = m_in // num_groups_in if const_expr(n_grouped) else m_in
+        if const_expr(n_grouped):
+            d_rows = m_in // num_groups_in
+        elif const_expr(k_grouped):
+            d_rows = num_groups_in * m_in
+        else:
+            d_rows = m_in
         d_nbytes = d_rows * n_in * fx.Index(2)  # bf16/f16 = 2 bytes
         d_rsrc = buffer_ops.create_buffer_resource(
             arg_d, max_size=False, num_records_bytes=d_nbytes
@@ -387,8 +423,10 @@ def compile_grouped_gemm_blockscale_contiguous(
             # scale_b: [num_groups, scale_k, scale_n]
             sb_nbytes = num_groups_in * fx.Index(scale_n * scale_k * scale_byte_size)
         else:
-            # scale_a: [M_total], one value per row.
-            sa_nbytes = m_in * fx.Index(scale_byte_size)
+            # scale_a: [M_total], one value per row, or one per row per group
+            # where the groups divide K and each quantised its own slice.
+            sa_rows = num_groups_in * m_in if const_expr(k_grouped) else m_in
+            sa_nbytes = sa_rows * fx.Index(scale_byte_size)
             # scale_b: [num_groups, N], one value per column of each group, or
             # a flat [total_N] when the groups divide N.
             sb_cols = n_in if const_expr(n_grouped) else num_groups_in * n_in
@@ -400,6 +438,16 @@ def compile_grouped_gemm_blockscale_contiguous(
             arg_scale_b, max_size=False, num_records_bytes=sb_nbytes
         )
 
+        if const_expr(k_grouped):
+            # The group is the grid axis, so only the ends of its K slice have
+            # to be read. Group 0 starts at zero and is not read.
+            _ks = resolve_group_k(
+                arg_offsets=arg_m_sizes,
+                num_groups_in=num_groups_in,
+                slab_idx=bz,
+            )
+            k_start_i32 = _ks.k_start
+            k_end_i32 = _ks.k_end
         if const_expr(n_grouped):
             _col = resolve_group_cols(
                 arg_offsets=arg_m_sizes,
@@ -412,6 +460,9 @@ def compile_grouped_gemm_blockscale_contiguous(
         else:
             _col = None
             _col_group_id = None
+
+        def _i32k(v):  # raw i32 constant
+            return arith.constant(int(v), type=T.i32)
 
         _grp = resolve_group_rows(
             arg_m_sizes=arg_m_sizes,
@@ -431,7 +482,17 @@ def compile_grouped_gemm_blockscale_contiguous(
         group_m_size_i32 = _grp.group_m_size
         # Rows are always whole slabs when the groups divide N, so validity is
         # entirely a question of whether this N-block belongs to a group.
-        is_valid = _col.is_valid if const_expr(n_grouped) else _grp.is_valid
+        if const_expr(k_grouped):
+            group_id_i32 = arith.index_cast(T.i32, bz)
+            group_m_start_i32 = _i32k(0)
+            group_m_size_i32 = arith.index_cast(T.i32, m_in)
+            row_start_i32 = arith.muli(arith.index_cast(T.i32, bx), _i32k(tile_m))
+            row_limit_i32 = arith.index_cast(T.i32, m_in)
+            # A group that contracts over nothing contributes nothing, and its
+            # output slab is left to the caller, as CK leaves it.
+            is_valid = arith.cmpi(arith.CmpIPredicate.slt, k_start_i32, k_end_i32)
+        else:
+            is_valid = _col.is_valid if const_expr(n_grouped) else _grp.is_valid
         if const_expr(n_grouped):
             # Blocks are enumerated across the packed groups, so this block's
             # first column comes from the partition rather than from its index.
@@ -440,9 +501,19 @@ def compile_grouped_gemm_blockscale_contiguous(
             # row tail and the epilogue's column mask.
             n_bound = fx.Index(_col.col_limit)
             b_group_off = fx.Index(0)
+            # scale_b is one flat [total_N] here, so the group is already in by_n.
+            sb_group_off = fx.Index(0)
+        elif const_expr(k_grouped):
+            # B is a single [N, total_K] the groups slice by column, so it has no
+            # per-group row base -- the slice is expressed as a K offset instead.
+            # scale_b is still [G, N], one set of column scales per group.
+            n_bound = None
+            b_group_off = fx.Index(0)
+            sb_group_off = None
         else:
             n_bound = None
             b_group_off = None
+            sb_group_off = None
 
         # Early exit for surplus/no-op tiles.
         if is_valid:
@@ -460,6 +531,20 @@ def compile_grouped_gemm_blockscale_contiguous(
             else:
                 bx_m_out = bx_m
                 row_limit_out_i32 = row_limit_i32
+            # Where the groups divide K, A's [M, total_K] rows are shared by
+            # every group while scale_a is [G, M], each group having quantised
+            # its own slice. So A keeps the plain row and scale_a takes the
+            # group's slab; the output does too, via d_group_off below.
+            if const_expr(k_grouped):
+                bx_m_scale = bx_m + fx.Index(group_id_i32) * m_in
+                d_group_off = fx.Index(group_id_i32) * m_in * n_in
+                k_base_div4 = fx.Index(k_start_i32) // fx.Index(4)
+                k_bound = fx.Index(k_end_i32)
+            else:
+                bx_m_scale = bx_m
+                d_group_off = None
+                k_base_div4 = None
+                k_bound = None
 
             _t = compute_mfma_tiling(tile_m=tile_m, tile_n=tile_n)
             m_repeat = _t.m_repeat
@@ -499,6 +584,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                 tile_k=tile_k,
                 k_in=k_in,
                 always=roll_k,
+                k_bound=k_bound,
             )
 
             (
@@ -523,6 +609,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                 elem_bytes=elem_bytes,
                 k_in=k_in,
                 k_tail_mask=k_tail_mask,
+                k_base_div4=k_base_div4,
             )
 
             lds_load_packs_k64 = make_lds_loader(
@@ -577,6 +664,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                     n_padding=n_padding,
                     b_group_off=b_group_off,
                     n_bound=n_bound,
+                    k_base_div4=k_base_div4,
                 )
                 lds_load_b_packs_k64 = make_lds_b_loader(
                     lds_b=lds_b,
@@ -750,10 +838,22 @@ def compile_grouped_gemm_blockscale_contiguous(
                 _b_regs = prefetch_b_tile(0)
                 _n_acc = len(accs)
                 _n_a = len(_a_regs)
-                if const_expr(num_k_tiles > 1):
+                if const_expr(k_grouped):
+                    # ceil(K_g / tile_k), a runtime value. A bound of zero or
+                    # less simply runs no iterations.
+                    _kt_n = (
+                        fx.Index(arith.subi(k_end_i32, k_start_i32))
+                        + fx.Index(tile_k - 1)
+                    ) // fx.Index(tile_k)
+                    _main = _kt_n - fx.Index(1)
+                    _run_main = True
+                else:
+                    _main = num_k_tiles - 1
+                    _run_main = num_k_tiles > 1
+                if _run_main:
                     for _kt, _st in fx.range(
                         0,
-                        num_k_tiles - 1,
+                        _main,
                         1,
                         init=list(accs) + list(_a_regs) + list(_b_regs),
                     ):
@@ -775,7 +875,17 @@ def compile_grouped_gemm_blockscale_contiguous(
                     accs = [Vector(v) for v in _res[:_n_acc]]
                     _a_regs = [Vector(v) for v in _res[_n_acc : _n_acc + _n_a]]
                     _b_regs = [Vector(v) for v in _res[_n_acc + _n_a :]]
-                _last = num_k_tiles - 1
+                # The peeled tile. Clamped so an empty group still names a
+                # real tile; every one of its loads is masked off regardless.
+                if const_expr(k_grouped):
+                    _last = fx.Index(
+                        arith.maxsi(
+                            arith.index_cast(T.i32, _kt_n - fx.Index(1)),
+                            _i32k(0),
+                        )
+                    )
+                else:
+                    _last = num_k_tiles - 1
                 store_a_tile_to_lds(_a_regs, lds_base_pong)
                 store_b_tile_to_lds(_b_regs, lds_base_b)
                 _scales = prefetch_scales(_last)
@@ -796,12 +906,12 @@ def compile_grouped_gemm_blockscale_contiguous(
                     n_in=n_in,
                     by_n=by_n,
                     n_tile_base=n_tile_base,
-                    bx_m=bx_m,
+                    bx_m=bx_m_scale,
                     lane_mod_16=lane_mod_16,
                     lane_div_16=lane_div_16,
                     m_repeat=m_repeat,
                     num_acc_n=num_acc_n,
-                    group_n_off=b_group_off,
+                    group_n_off=sb_group_off,
                 )(accs)
 
             # ===== Epilogue: CShuffle vectorized stores =====
@@ -816,6 +926,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                 c_n=c_n,
                 n_padding=n_padding,
                 n_bound=n_bound,
+                d_group_off=d_group_off,
             )
 
             # Mask the partial-tile tail: skip stores for global rows at or beyond
@@ -890,7 +1001,11 @@ def compile_grouped_gemm_blockscale_contiguous(
         else:
             gx = n_in // fx.Index(tile_n)
         gy = fx.Index(i32_num_m_tiles)  # M-tiles
-        gz = fx.Index(i32_num_groups) if const_expr(slab_layout) else fx.Index(1)
+        gz = (
+            fx.Index(i32_num_groups)
+            if const_expr(slab_layout or k_grouped)
+            else fx.Index(1)
+        )
 
         launcher = grouped_gemm_blockscale_contiguous_kernel(
             arg_d,

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -29,7 +29,8 @@ Tensors:
     local_m + k_block * M_g. This is not a global [scale_k, M_total] transpose.
   - B: [num_groups, N, K] FP8 - one weight matrix per group, preshuffled
   - scale_b: [num_groups, scale_k, scale_n] FP32 - per-block scales
-  - m_sizes: [num_groups] INT64 - rows per group (sum to M_total)
+  - m_sizes: [num_groups] INT64 - rows per group (sum to M_total), or unused
+    when the layout carries no per-group metadata
   - D: [M_total, N] BF16 - output
 
 Block scaling granularity:
@@ -85,7 +86,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
 from mslk.flydsl.kernels.mma.mfma_epilogues import mfma_epilog
 
 # Supported encodings of the group geometry; see the ``layout`` argument below.
-LAYOUTS = ("sizes", "padded")
+LAYOUTS = ("sizes", "padded", "batched")
 
 
 @functools.lru_cache(maxsize=128)
@@ -142,6 +143,10 @@ def compile_grouped_gemm_blockscale_contiguous(
             "padded": each group owns a fixed slab of M_total/num_groups rows and
             m_sizes is [num_groups] INT64 counts of the rows per slab that hold
             real data; the rest is padding the epilogue must not write.
+            "batched": fixed slabs as in "padded" but every row holds real
+            data, so the row count is implied and m_sizes is never read. Rows
+            still need masking, since a tile that overruns the slab would spill
+            into the next group.
 
     Returns:
         JIT launcher function.
@@ -150,7 +155,10 @@ def compile_grouped_gemm_blockscale_contiguous(
         raise ValueError(f"layout must be one of {LAYOUTS}, got {layout!r}")
     # Each group owns a fixed slab of rows, so the group is a grid axis and does
     # not have to be resolved from the row counts.
-    slab_layout = layout == "padded"
+    slab_layout = layout in ("padded", "batched")
+    # Only the batched layout implies its row counts; the rest read them from
+    # the group metadata.
+    reads_group_meta = layout != "batched"
 
     gpu_arch = get_hip_arch()
     # This FP8 kernel always uses the FP32 software-scaling path; the shared
@@ -352,9 +360,14 @@ def compile_grouped_gemm_blockscale_contiguous(
             arg_scale_b, max_size=False, num_records_bytes=sb_nbytes
         )
 
-        ms_rsrc = buffer_ops.create_buffer_resource(
-            arg_m_sizes, max_size=False, num_records_bytes=num_groups_in * fx.Index(8)
-        )
+        # "batched" carries no group metadata, so no resource is built for it
+        # and arg_m_sizes goes unread.
+        if const_expr(reads_group_meta):
+            ms_rsrc = buffer_ops.create_buffer_resource(
+                arg_m_sizes,
+                max_size=False,
+                num_records_bytes=num_groups_in * fx.Index(8),
+            )
 
         def _i32(v):  # raw i32 constant (arith.* requires unwrapped MLIR values)
             return arith.constant(int(v), type=T.i32)
@@ -364,10 +377,8 @@ def compile_grouped_gemm_blockscale_contiguous(
         tile_m_bump = _i32(tile_m - 1)
 
         if const_expr(slab_layout):
-            # Padded layout: every group owns a fixed slab of expected_m rows, so
-            # the group is a grid axis and needs no resolution. m_sizes holds the
-            # count of rows in each slab that carry real data; the rest is padding
-            # the epilogue must not write.
+            # Every group owns a fixed slab of expected_m rows, so the group is a
+            # grid axis and needs no resolution.
             group_id_i32 = arith.index_cast(T.i32, bz)
             expected_m_i32 = arith.divui(
                 arith.index_cast(T.i32, m_in), _i32(num_groups)
@@ -375,9 +386,22 @@ def compile_grouped_gemm_blockscale_contiguous(
             group_m_start_i32 = arith.muli(group_id_i32, expected_m_i32)
             group_m_size_i32 = expected_m_i32
             row_start_i32 = arith.addi(group_m_start_i32, arith.muli(bx_i32, tile_m_c))
-            valid_m = buffer_ops.buffer_load(ms_rsrc, bz * 2, vec_width=1, dtype=T.i32)
+            if const_expr(reads_group_meta):
+                # m_sizes holds the count of rows in each slab that carry real
+                # data; the rest is padding the epilogue must not write.
+                valid_m = buffer_ops.buffer_load(
+                    ms_rsrc, bz * 2, vec_width=1, dtype=T.i32
+                )
+            else:
+                # The slab is full, so every row of it carries data. The rows of
+                # the tile past it still do not: tile_m need not divide the slab,
+                # and the overrun lands on the next group.
+                valid_m = expected_m_i32
             row_limit_i32 = arith.addi(group_m_start_i32, valid_m)
-            # Skip whole tiles that start past this group's valid rows.
+            # Skip whole tiles that start past this group's valid rows. A full
+            # slab leaves no such tile, but the guard still has to be emitted as
+            # a branch: hoisting the body out of it to run unconditionally races
+            # against the K loop's LDS staging and corrupts the result.
             is_valid = arith.cmpi(
                 arith.CmpIPredicate.slt, arith.muli(bx_i32, tile_m_c), valid_m
             )

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -62,6 +62,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
     make_compute_tile,
     make_epilogue_writers,
     make_hot_loop_scheduler,
+    make_k_tail_mask,
     make_kloop_plain,
     make_lds_b_loader,
     make_lds_loader,
@@ -96,6 +97,7 @@ def compile_grouped_gemm_blockscale_contiguous(
     b_preshuffled: bool = True,
     blockscale: bool = False,
     masked: bool = False,
+    k_padding: bool = False,
 ):
     """Compile grouped FP8 GEMM kernel and return the JIT launcher.
 
@@ -146,6 +148,7 @@ def compile_grouped_gemm_blockscale_contiguous(
         tile_n=tile_n,
         tile_k=tile_k,
         blockscale=blockscale,
+        k_padding=k_padding,
         scale_block_k=scale_block_k,
         scale_block_n=scale_block_n,
         out_dtype=out_dtype,
@@ -173,6 +176,7 @@ def compile_grouped_gemm_blockscale_contiguous(
         tile_k=tile_k,
         scale_block_k=scale_block_k,
         scale_block_n=scale_block_n,
+        k_padding=k_padding,
     )
     total_threads = _c.total_threads
     elem_bytes = _c.elem_bytes
@@ -214,10 +218,11 @@ def compile_grouped_gemm_blockscale_contiguous(
     _variant = "contiguous_pingpong" if b_preshuffled else "plain"
     _scaling = "blockscale" if blockscale else "rowwise"
     _layout = "masked" if masked else "contig"
+    _kpad = "_kpad" if k_padding else ""
     module_name = (
         f"grouped_gemm_{_scaling}_{_layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
-        f"_t{tile_m}x{tile_n}x{tile_k}"
+        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}"
     ).replace("-", "_")
 
     @flyc.kernel(name=module_name)
@@ -429,6 +434,16 @@ def compile_grouped_gemm_blockscale_contiguous(
             n_intra_list = _nb.n_intra_list
             c_scale_k = _nb.c_scale_k
 
+            # Predicate for the partial final K tile; a no-op unless k_padding is
+            # on and K stops mid-tile.
+            k_tail_mask = make_k_tail_mask(
+                k_padding=k_padding,
+                num_k_tiles=num_k_tiles,
+                k=k,
+                tile_k=tile_k,
+                k_in=k_in,
+            )
+
             (
                 prefetch_a_tile,
                 store_a_tile_to_lds,
@@ -450,6 +465,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                 total_threads=total_threads,
                 elem_bytes=elem_bytes,
                 k_in=k_in,
+                k_tail_mask=k_tail_mask,
             )
 
             lds_load_packs_k64 = make_lds_loader(
@@ -500,6 +516,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                     elem_bytes=elem_bytes,
                     n_in=n_in,
                     k_in=k_in,
+                    k_tail_mask=k_tail_mask,
                 )
                 lds_load_b_packs_k64 = make_lds_b_loader(
                     lds_b=lds_b,

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -77,6 +77,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
     make_prefetch_scales,
     make_rowwise_scaler,
     out_mlir_for,
+    resolve_group_cols,
     resolve_group_rows,
     setup_lds_allocation,
     setup_lds_allocation_plain,
@@ -87,7 +88,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
 from mslk.flydsl.kernels.mma.mfma_epilogues import mfma_epilog
 
 # Supported encodings of the group geometry; see the ``layout`` argument below.
-LAYOUTS = ("sizes", "offsets", "padded", "batched")
+LAYOUTS = ("sizes", "offsets", "padded", "batched", "n_offsets")
 
 
 @functools.lru_cache(maxsize=128)
@@ -150,15 +151,34 @@ def compile_grouped_gemm_blockscale_contiguous(
             data, so the row count is implied and m_sizes is never read. Rows
             still need masking, since a tile that overruns the slab would spill
             into the next group.
+            "n_offsets": the groups partition the output's COLUMNS rather than
+            its rows. A is per-group [G, M, K] slabs as in "batched", B is one
+            [total_N, K] matrix whose rows the groups divide, the output is
+            [M, total_N] with the groups side by side, and m_sizes is
+            [num_groups] INT32 cumulative column ends. Rowwise plain-B only.
 
     Returns:
         JIT launcher function.
     """
     if layout not in LAYOUTS:
         raise ValueError(f"layout must be one of {LAYOUTS}, got {layout!r}")
-    # Each group owns a fixed slab of rows, so the group is a grid axis and does
-    # not have to be resolved from the row counts.
+    # Each group owns a fixed slab of rows and rides the grid's z axis, so it
+    # does not have to be resolved from the row counts.
     slab_layout = layout in ("padded", "batched")
+    # Groups divide the output's columns, so the group follows from the N-block
+    # index and B is one matrix rather than a stack of per-group ones.
+    n_grouped = layout == "n_offsets"
+    if n_grouped and (blockscale or b_preshuffled):
+        raise ValueError(
+            "layout 'n_offsets' supports only rowwise scaling with plain B: "
+            "ragged N would need per-group scale blocks, and the preshuffled "
+            "layout swizzles N across the whole matrix"
+        )
+    if n_grouped:
+        # A group's column end is a runtime value, so unlike a compile-time N
+        # remainder the tail mask cannot be elided; N only has to reach a store
+        # boundary, which validate_params checks below.
+        n_padding = True
 
     gpu_arch = get_hip_arch()
     # This FP8 kernel always uses the FP32 software-scaling path; the shared
@@ -329,12 +349,17 @@ def compile_grouped_gemm_blockscale_contiguous(
             arg_a, max_size=False, num_records_bytes=a_nbytes
         )
 
-        b_nbytes = num_groups_in * n_in * k_in
+        # B is one [total_N, K] matrix when the groups divide N, and a stack of
+        # num_groups [N, K] ones otherwise.
+        b_nbytes = (n_in if const_expr(n_grouped) else num_groups_in * n_in) * k_in
         b_rsrc = buffer_ops.create_buffer_resource(
             arg_b, max_size=False, num_records_bytes=b_nbytes
         )
 
-        d_nbytes = m_in * n_in * fx.Index(2)  # bf16/f16 = 2 bytes
+        # The output is [M, total_N] when the groups divide N: m_in counts the
+        # rows of every group's slab, but they share the output's rows.
+        d_rows = m_in // num_groups_in if const_expr(n_grouped) else m_in
+        d_nbytes = d_rows * n_in * fx.Index(2)  # bf16/f16 = 2 bytes
         d_rsrc = buffer_ops.create_buffer_resource(
             arg_d, max_size=False, num_records_bytes=d_nbytes
         )
@@ -351,14 +376,29 @@ def compile_grouped_gemm_blockscale_contiguous(
         else:
             # scale_a: [M_total], one value per row.
             sa_nbytes = m_in * fx.Index(scale_byte_size)
-            # scale_b: [num_groups, N], one value per column of each group.
-            sb_nbytes = num_groups_in * n_in * fx.Index(scale_byte_size)
+            # scale_b: [num_groups, N], one value per column of each group, or
+            # a flat [total_N] when the groups divide N.
+            sb_cols = n_in if const_expr(n_grouped) else num_groups_in * n_in
+            sb_nbytes = sb_cols * fx.Index(scale_byte_size)
         sa_rsrc = buffer_ops.create_buffer_resource(
             arg_scale_a, max_size=False, num_records_bytes=sa_nbytes
         )
         sb_rsrc = buffer_ops.create_buffer_resource(
             arg_scale_b, max_size=False, num_records_bytes=sb_nbytes
         )
+
+        if const_expr(n_grouped):
+            _col = resolve_group_cols(
+                arg_offsets=arg_m_sizes,
+                num_groups_in=num_groups_in,
+                n_block_idx=by,
+                tile_n=tile_n,
+                num_groups=num_groups,
+            )
+            _col_group_id = _col.group_id
+        else:
+            _col = None
+            _col_group_id = None
 
         _grp = resolve_group_rows(
             arg_m_sizes=arg_m_sizes,
@@ -369,13 +409,27 @@ def compile_grouped_gemm_blockscale_contiguous(
             tile_m=tile_m,
             num_groups=num_groups,
             layout=layout,
+            group_id=_col_group_id,
         )
         group_id_i32 = _grp.group_id
         row_start_i32 = _grp.row_start
         row_limit_i32 = _grp.row_limit
         group_m_start_i32 = _grp.group_m_start
         group_m_size_i32 = _grp.group_m_size
-        is_valid = _grp.is_valid
+        # Rows are always whole slabs when the groups divide N, so validity is
+        # entirely a question of whether this N-block belongs to a group.
+        is_valid = _col.is_valid if const_expr(n_grouped) else _grp.is_valid
+        if const_expr(n_grouped):
+            # Blocks are enumerated across the packed groups, so this block's
+            # first column comes from the partition rather than from its index.
+            by_n = fx.Index(_col.col_base)
+            # Where the owning group's columns stop; the bound for both the B
+            # row tail and the epilogue's column mask.
+            n_bound = fx.Index(_col.col_limit)
+            b_group_off = fx.Index(0)
+        else:
+            n_bound = None
+            b_group_off = None
 
         # Early exit for surplus/no-op tiles.
         if is_valid:
@@ -384,6 +438,15 @@ def compile_grouped_gemm_blockscale_contiguous(
             # Global row base of this tile and the exclusive row end of its group
             # (the group end masks the partial-tile tail in the epilogue store).
             bx_m = fx.Index(row_start_i32)
+            # The output of an N-grouped GEMM is [M, total_N]: every group shares
+            # its rows, so the epilogue indexes rows within the slab while A and
+            # scale_a keep addressing the flattened [G * M, ...] operands.
+            if const_expr(n_grouped):
+                bx_m_out = bx * fx.Index(tile_m)
+                row_limit_out_i32 = group_m_size_i32
+            else:
+                bx_m_out = bx_m
+                row_limit_out_i32 = row_limit_i32
 
             _t = compute_mfma_tiling(tile_m=tile_m, tile_n=tile_n)
             m_repeat = _t.m_repeat
@@ -498,6 +561,8 @@ def compile_grouped_gemm_blockscale_contiguous(
                     k_in=k_in,
                     k_tail_mask=k_tail_mask,
                     n_padding=n_padding,
+                    b_group_off=b_group_off,
+                    n_bound=n_bound,
                 )
                 lds_load_b_packs_k64 = make_lds_b_loader(
                     lds_b=lds_b,
@@ -620,6 +685,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                     lane_div_16=lane_div_16,
                     m_repeat=m_repeat,
                     num_acc_n=num_acc_n,
+                    group_n_off=b_group_off,
                 )(accs)
 
             # ===== Epilogue: CShuffle vectorized stores =====
@@ -633,6 +699,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                 e_vec=e_vec,
                 c_n=c_n,
                 n_padding=n_padding,
+                n_bound=n_bound,
             )
 
             # Mask the partial-tile tail: skip stores for global rows at or beyond
@@ -640,7 +707,9 @@ def compile_grouped_gemm_blockscale_contiguous(
             # the whole N-store loop for out-of-group rows.
             def precompute_row(*, row_local, row):
                 row_i32 = arith.index_cast(T.i32, row)
-                row_valid = arith.cmpi(arith.CmpIPredicate.ult, row_i32, row_limit_i32)
+                row_valid = arith.cmpi(
+                    arith.CmpIPredicate.ult, row_i32, row_limit_out_i32
+                )
                 return (None, row_valid)
 
             mfma_epilog(
@@ -658,7 +727,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                 tx=tx,
                 lane_div_16=lane_div_16,
                 lane_mod_16=lane_mod_16,
-                bx_m=bx_m,
+                bx_m=bx_m_out,
                 by_n=by_n,
                 n_tile_base=n_tile_base,
                 lds_out=lds_out,
@@ -695,11 +764,15 @@ def compile_grouped_gemm_blockscale_contiguous(
         # The padded layout instead gives each group its own z slice, so the M axis
         # only has to cover one group's slab and tiles past its valid rows exit.
         n_in = fx.Index(i32_n)
-        gx = (
-            (n_in + fx.Index(tile_n - 1)) // fx.Index(tile_n)
-            if const_expr(n_padding)
-            else n_in // fx.Index(tile_n)
-        )  # N-blocks
+        if const_expr(n_grouped):
+            # One N-block enumeration across every group, with the same
+            # host-known upper bound the packed M axis uses: each group wastes
+            # at most one partial block, and surplus blocks match no group.
+            gx = n_in // fx.Index(tile_n) + fx.Index(i32_num_groups)
+        elif const_expr(n_padding):
+            gx = (n_in + fx.Index(tile_n - 1)) // fx.Index(tile_n)
+        else:
+            gx = n_in // fx.Index(tile_n)
         gy = fx.Index(i32_num_m_tiles)  # M-tiles
         gz = fx.Index(i32_num_groups) if const_expr(slab_layout) else fx.Index(1)
 

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -69,6 +69,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
     make_pingpong_kloop,
     make_plain_b_tile,
     make_prefetch_scales,
+    make_rowwise_scaler,
     out_mlir_for,
     setup_lds_allocation,
     setup_lds_allocation_plain,
@@ -93,6 +94,7 @@ def compile_grouped_gemm_blockscale_contiguous(
     out_dtype: str = "bf16",
     waves_per_eu: int | None = None,
     b_preshuffled: bool = True,
+    blockscale: bool = False,
 ):
     """Compile grouped FP8 GEMM kernel and return the JIT launcher.
 
@@ -110,8 +112,17 @@ def compile_grouped_gemm_blockscale_contiguous(
             MFMA layout and loaded HBM->registers (no B LDS). When False, B is
             plain row-major [num_groups, N, K] and is staged HBM->LDS->registers
             like A. The two paths share the entire kernel body (tile-map group
-            dispatch, FP32 block scaling, wide-MFMA, CShuffle epilogue); only the
-            B load stage and its LDS allocation differ.
+            dispatch, scaling, wide-MFMA, CShuffle epilogue); only the B load
+            stage and its LDS allocation differ.
+        blockscale: Selects the scaling scheme, which sets the expected layout of
+            scale_a / scale_b and where the scales are applied.
+            False (default) is rowwise: scale_a is [M_total] and scale_b is
+            [num_groups, N], one factor per row of A and per column of B, applied
+            once in the epilogue. Tiles are then free of scale-block alignment,
+            so tile_n may be smaller than scale_block_n.
+            True is block scaling: scale_a is per-group [M_g, scale_k] blocks and
+            scale_b is [num_groups, scale_k, scale_n], applied per scale block
+            inside the K loop, which requires the tile to align to the blocks.
 
     Returns:
         JIT launcher function.
@@ -133,6 +144,7 @@ def compile_grouped_gemm_blockscale_contiguous(
         k=k,
         tile_n=tile_n,
         tile_k=tile_k,
+        blockscale=blockscale,
         scale_block_k=scale_block_k,
         scale_block_n=scale_block_n,
         out_dtype=out_dtype,
@@ -199,8 +211,9 @@ def compile_grouped_gemm_blockscale_contiguous(
 
     # Module name for caching
     _variant = "contiguous_pingpong" if b_preshuffled else "plain"
+    _scaling = "blockscale" if blockscale else "rowwise"
     module_name = (
-        f"grouped_gemm_blockscale_{_variant}_{out_dtype}"
+        f"grouped_gemm_{_scaling}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
         f"_t{tile_m}x{tile_n}x{tile_k}"
     ).replace("-", "_")
@@ -291,14 +304,19 @@ def compile_grouped_gemm_blockscale_contiguous(
         # pre-packed on host); gfx942 SW path consumes f32.
         scale_byte_size = 1 if _use_hw_scale else 4
 
-        # scale_a: [scale_k, M] - transposed layout
-        sa_nbytes = fx.Index(scale_k) * m_in * fx.Index(scale_byte_size)
+        if const_expr(blockscale):
+            # scale_a: per-group [M_g, scale_k] blocks, scale_k values per row.
+            sa_nbytes = fx.Index(scale_k) * m_in * fx.Index(scale_byte_size)
+            # scale_b: [num_groups, scale_k, scale_n]
+            sb_nbytes = num_groups_in * fx.Index(scale_n * scale_k * scale_byte_size)
+        else:
+            # scale_a: [M_total], one value per row.
+            sa_nbytes = m_in * fx.Index(scale_byte_size)
+            # scale_b: [num_groups, N], one value per column of each group.
+            sb_nbytes = num_groups_in * n_in * fx.Index(scale_byte_size)
         sa_rsrc = buffer_ops.create_buffer_resource(
             arg_scale_a, max_size=False, num_records_bytes=sa_nbytes
         )
-
-        # scale_b: [num_groups, scale_n, scale_k]
-        sb_nbytes = num_groups_in * fx.Index(scale_n * scale_k * scale_byte_size)
         sb_rsrc = buffer_ops.create_buffer_resource(
             arg_scale_b, max_size=False, num_records_bytes=sb_nbytes
         )
@@ -530,6 +548,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                 acc_init=acc_init,
                 group_m_start=fx.Index(group_m_start_i32),
                 group_m_size=fx.Index(group_m_size_i32),
+                blockscale=blockscale,
             )
 
             if const_expr(b_preshuffled):
@@ -563,6 +582,23 @@ def compile_grouped_gemm_blockscale_contiguous(
                     lds_base_b=lds_base_b,
                 )
             accs = run_kloop(accs)
+
+            if const_expr(not blockscale):
+                # Rowwise scales are constant along K, so the whole reduction is
+                # scaled here in one pass rather than per K tile.
+                accs = make_rowwise_scaler(
+                    sa_rsrc=sa_rsrc,
+                    sb_rsrc=sb_rsrc,
+                    group_idx=group_idx,
+                    n_in=n_in,
+                    by_n=by_n,
+                    n_tile_base=n_tile_base,
+                    bx_m=bx_m,
+                    lane_mod_16=lane_mod_16,
+                    lane_div_16=lane_div_16,
+                    m_repeat=m_repeat,
+                    num_acc_n=num_acc_n,
+                )(accs)
 
             # ===== Epilogue: CShuffle vectorized stores =====
             c_n = n_in

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -396,19 +396,21 @@ def compile_grouped_gemm_blockscale_contiguous(
                 valid_m = buffer_ops.buffer_load(
                     ms_rsrc, bz * 2, vec_width=1, dtype=T.i32
                 )
+                # A group can hold fewer valid rows than the grid has tiles for
+                # it, so skip whole tiles that start past them.
+                is_valid = arith.cmpi(
+                    arith.CmpIPredicate.slt, arith.muli(bx_i32, tile_m_c), valid_m
+                )
             else:
-                # The slab is full, so every row of it carries data. The rows of
-                # the tile past it still do not: tile_m need not divide the slab,
-                # and the overrun lands on the next group.
+                # The slab is full, so every row of it carries data and the grid
+                # is exactly ceil(slab / tile_m) tiles: no tile starts past the
+                # slab, and the guard is dropped rather than emitted always-true.
+                # The rows of the tile past the slab still carry nothing, though:
+                # tile_m need not divide it, and the overrun lands on the next
+                # group, so the epilogue still masks by row.
                 valid_m = expected_m_i32
+                is_valid = True
             row_limit_i32 = arith.addi(group_m_start_i32, valid_m)
-            # Skip whole tiles that start past this group's valid rows. A full
-            # slab leaves no such tile, but the guard still has to be emitted as
-            # a branch: hoisting the body out of it to run unconditionally races
-            # against the K loop's LDS staging and corrupts the result.
-            is_valid = arith.cmpi(
-                arith.CmpIPredicate.slt, arith.muli(bx_i32, tile_m_c), valid_m
-            )
         else:
             # Packed layout: groups are concatenated along M, so resolve which one
             # owns this flat M-tile id (bx) from m_sizes. Doing it here rather than

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -95,6 +95,7 @@ def compile_grouped_gemm_blockscale_contiguous(
     waves_per_eu: int | None = None,
     b_preshuffled: bool = True,
     blockscale: bool = False,
+    masked: bool = False,
 ):
     """Compile grouped FP8 GEMM kernel and return the JIT launcher.
 
@@ -212,8 +213,9 @@ def compile_grouped_gemm_blockscale_contiguous(
     # Module name for caching
     _variant = "contiguous_pingpong" if b_preshuffled else "plain"
     _scaling = "blockscale" if blockscale else "rowwise"
+    _layout = "masked" if masked else "contig"
     module_name = (
-        f"grouped_gemm_{_scaling}_{_variant}_{out_dtype}"
+        f"grouped_gemm_{_scaling}_{_layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
         f"_t{tile_m}x{tile_n}x{tile_k}"
     ).replace("-", "_")
@@ -241,6 +243,7 @@ def compile_grouped_gemm_blockscale_contiguous(
         tx = gpu.thread_id("x")
         by = gpu.block_id("x")  # N-block index
         bx = gpu.block_id("y")  # M-tile index (into the per-tile dispatch map)
+        bz = gpu.block_id("z")  # group index; carries the group in the padded layout
 
         # N-block position; bx_m (global row base) is loaded from the tile map below.
         by_n = by * fx.Index(tile_n)
@@ -321,13 +324,6 @@ def compile_grouped_gemm_blockscale_contiguous(
             arg_scale_b, max_size=False, num_records_bytes=sb_nbytes
         )
 
-        # Resolve which group owns this flat M-tile id (bx) from m_sizes. Doing it
-        # here rather than from a host-built dispatch map keeps the launch free of
-        # helper kernels, which matters under CUDA-graph capture where each one is
-        # replayed per call. num_groups is a compile-time constant, so the loop
-        # unrolls to a few scalar ops. acc_m/acc_t are the running m_start and
-        # tile_start prefixes; tiles beyond the real tile count (the grid extent is
-        # an upper bound) match no group and stay marked -1.
         ms_rsrc = buffer_ops.create_buffer_resource(
             arg_m_sizes, max_size=False, num_records_bytes=num_groups_in * fx.Index(8)
         )
@@ -338,35 +334,63 @@ def compile_grouped_gemm_blockscale_contiguous(
         bx_i32 = arith.index_cast(T.i32, bx)
         tile_m_c = _i32(tile_m)
         tile_m_bump = _i32(tile_m - 1)
-        acc_m = _i32(0)  # cumulative rows before group g (m_starts[g])
-        acc_t = _i32(0)  # cumulative tiles before group g (tile_starts[g])
-        group_id_i32 = _i32(-1)
-        row_start_i32 = _i32(0)
-        row_limit_i32 = _i32(0)
-        group_m_start_i32 = _i32(0)  # first global row of the owning group
-        group_m_size_i32 = _i32(0)  # row count of the owning group
-        for _g in range_constexpr(num_groups):
-            # m_sizes is int64; read the low dword of element _g (index _g*2 in
-            # dwords). Row counts fit in int32, so the high dword is always zero
-            # and no host-side narrowing kernel is needed.
-            m_g = buffer_ops.buffer_load(ms_rsrc, _g * 2, vec_width=1, dtype=T.i32)
-            tiles_g = arith.divui(arith.addi(m_g, tile_m_bump), tile_m_c)
-            acc_t_next = arith.addi(acc_t, tiles_g)
-            in_grp = arith.andi(
-                arith.cmpi(arith.CmpIPredicate.sge, bx_i32, acc_t),
-                arith.cmpi(arith.CmpIPredicate.slt, bx_i32, acc_t_next),
-            )
-            rs = arith.addi(acc_m, arith.muli(arith.subi(bx_i32, acc_t), tile_m_c))
-            rl = arith.addi(acc_m, m_g)
-            group_id_i32 = arith.select(in_grp, _i32(_g), group_id_i32)
-            row_start_i32 = arith.select(in_grp, rs, row_start_i32)
-            row_limit_i32 = arith.select(in_grp, rl, row_limit_i32)
-            group_m_start_i32 = arith.select(in_grp, acc_m, group_m_start_i32)
-            group_m_size_i32 = arith.select(in_grp, m_g, group_m_size_i32)
-            acc_m = arith.addi(acc_m, m_g)
-            acc_t = acc_t_next
 
-        is_valid = arith.cmpi(arith.CmpIPredicate.sge, group_id_i32, _i32(0))
+        if const_expr(masked):
+            # Padded layout: every group owns a fixed slab of expected_m rows, so
+            # the group is a grid axis and needs no resolution. m_sizes holds the
+            # count of rows in each slab that carry real data; the rest is padding
+            # the epilogue must not write.
+            group_id_i32 = arith.index_cast(T.i32, bz)
+            expected_m_i32 = arith.divui(
+                arith.index_cast(T.i32, m_in), _i32(num_groups)
+            )
+            group_m_start_i32 = arith.muli(group_id_i32, expected_m_i32)
+            group_m_size_i32 = expected_m_i32
+            row_start_i32 = arith.addi(group_m_start_i32, arith.muli(bx_i32, tile_m_c))
+            valid_m = buffer_ops.buffer_load(ms_rsrc, bz * 2, vec_width=1, dtype=T.i32)
+            row_limit_i32 = arith.addi(group_m_start_i32, valid_m)
+            # Skip whole tiles that start past this group's valid rows.
+            is_valid = arith.cmpi(
+                arith.CmpIPredicate.slt, arith.muli(bx_i32, tile_m_c), valid_m
+            )
+        else:
+            # Packed layout: groups are concatenated along M, so resolve which one
+            # owns this flat M-tile id (bx) from m_sizes. Doing it here rather than
+            # from a host-built dispatch map keeps the launch free of helper
+            # kernels, which matters under CUDA-graph capture where each one is
+            # replayed per call. num_groups is a compile-time constant, so the loop
+            # unrolls to a few scalar ops. acc_m/acc_t are the running m_start and
+            # tile_start prefixes; tiles beyond the real tile count (the grid extent
+            # is an upper bound) match no group and stay marked -1.
+            acc_m = _i32(0)  # cumulative rows before group g (m_starts[g])
+            acc_t = _i32(0)  # cumulative tiles before group g (tile_starts[g])
+            group_id_i32 = _i32(-1)
+            row_start_i32 = _i32(0)
+            row_limit_i32 = _i32(0)
+            group_m_start_i32 = _i32(0)  # first global row of the owning group
+            group_m_size_i32 = _i32(0)  # row count of the owning group
+            for _g in range_constexpr(num_groups):
+                # m_sizes is int64; read the low dword of element _g (index _g*2 in
+                # dwords). Row counts fit in int32, so the high dword is always zero
+                # and no host-side narrowing kernel is needed.
+                m_g = buffer_ops.buffer_load(ms_rsrc, _g * 2, vec_width=1, dtype=T.i32)
+                tiles_g = arith.divui(arith.addi(m_g, tile_m_bump), tile_m_c)
+                acc_t_next = arith.addi(acc_t, tiles_g)
+                in_grp = arith.andi(
+                    arith.cmpi(arith.CmpIPredicate.sge, bx_i32, acc_t),
+                    arith.cmpi(arith.CmpIPredicate.slt, bx_i32, acc_t_next),
+                )
+                rs = arith.addi(acc_m, arith.muli(arith.subi(bx_i32, acc_t), tile_m_c))
+                rl = arith.addi(acc_m, m_g)
+                group_id_i32 = arith.select(in_grp, _i32(_g), group_id_i32)
+                row_start_i32 = arith.select(in_grp, rs, row_start_i32)
+                row_limit_i32 = arith.select(in_grp, rl, row_limit_i32)
+                group_m_start_i32 = arith.select(in_grp, acc_m, group_m_start_i32)
+                group_m_size_i32 = arith.select(in_grp, m_g, group_m_size_i32)
+                acc_m = arith.addi(acc_m, m_g)
+                acc_t = acc_t_next
+
+            is_valid = arith.cmpi(arith.CmpIPredicate.sge, group_id_i32, _i32(0))
 
         # Early exit for surplus/no-op tiles.
         if is_valid:
@@ -666,12 +690,15 @@ def compile_grouped_gemm_blockscale_contiguous(
         with ir.InsertionPoint(ctx.gpu_module_body):
             allocator.finalize()
 
-        # Grid dimensions. The M axis enumerates output M-tiles; its extent is a
-        # host-known upper bound on the tile count, and tiles past the real count
-        # match no group and exit early.
+        # Grid dimensions. In the packed layout the M axis enumerates output
+        # M-tiles across all groups; its extent is a host-known upper bound on the
+        # tile count, and tiles past the real count match no group and exit early.
+        # The padded layout instead gives each group its own z slice, so the M axis
+        # only has to cover one group's slab and tiles past its valid rows exit.
         n_in = fx.Index(i32_n)
         gx = n_in // fx.Index(tile_n)  # N-blocks
         gy = fx.Index(i32_num_m_tiles)  # M-tiles
+        gz = fx.Index(i32_num_groups) if const_expr(masked) else fx.Index(1)
 
         launcher = grouped_gemm_blockscale_contiguous_kernel(
             arg_d,
@@ -693,6 +720,6 @@ def compile_grouped_gemm_blockscale_contiguous(
                         op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
                             T.i32, _wpe
                         )
-        launcher.launch(grid=(gx, gy, 1), block=(total_threads, 1, 1), stream=stream)
+        launcher.launch(grid=(gx, gy, gz), block=(total_threads, 1, 1), stream=stream)
 
     return launch_grouped_gemm_blockscale_contiguous

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -77,6 +77,7 @@ from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_common import (
     make_prefetch_scales,
     make_rowwise_scaler,
     out_mlir_for,
+    resolve_group_rows,
     setup_lds_allocation,
     setup_lds_allocation_plain,
     validate_lds_budget_plain,
@@ -158,9 +159,6 @@ def compile_grouped_gemm_blockscale_contiguous(
     # Each group owns a fixed slab of rows, so the group is a grid axis and does
     # not have to be resolved from the row counts.
     slab_layout = layout in ("padded", "batched")
-    # Only the batched layout implies its row counts; the rest read them from
-    # the group metadata.
-    reads_group_meta = layout != "batched"
 
     gpu_arch = get_hip_arch()
     # This FP8 kernel always uses the FP32 software-scaling path; the shared
@@ -362,105 +360,22 @@ def compile_grouped_gemm_blockscale_contiguous(
             arg_scale_b, max_size=False, num_records_bytes=sb_nbytes
         )
 
-        # Group metadata is INT32 when it holds cumulative offsets and INT64
-        # when it holds row counts. "batched" carries none, so no resource is
-        # built for it and arg_m_sizes goes unread.
-        if const_expr(reads_group_meta):
-            meta_bytes = 4 if layout == "offsets" else 8
-            ms_rsrc = buffer_ops.create_buffer_resource(
-                arg_m_sizes,
-                max_size=False,
-                num_records_bytes=num_groups_in * fx.Index(meta_bytes),
-            )
-
-        def _i32(v):  # raw i32 constant (arith.* requires unwrapped MLIR values)
-            return arith.constant(int(v), type=T.i32)
-
-        bx_i32 = arith.index_cast(T.i32, bx)
-        tile_m_c = _i32(tile_m)
-        tile_m_bump = _i32(tile_m - 1)
-
-        if const_expr(slab_layout):
-            # Every group owns a fixed slab of expected_m rows, so the group is a
-            # grid axis and needs no resolution.
-            group_id_i32 = arith.index_cast(T.i32, bz)
-            expected_m_i32 = arith.divui(
-                arith.index_cast(T.i32, m_in), _i32(num_groups)
-            )
-            group_m_start_i32 = arith.muli(group_id_i32, expected_m_i32)
-            group_m_size_i32 = expected_m_i32
-            row_start_i32 = arith.addi(group_m_start_i32, arith.muli(bx_i32, tile_m_c))
-            if const_expr(reads_group_meta):
-                # m_sizes holds the count of rows in each slab that carry real
-                # data; the rest is padding the epilogue must not write.
-                valid_m = buffer_ops.buffer_load(
-                    ms_rsrc, bz * 2, vec_width=1, dtype=T.i32
-                )
-                # A group can hold fewer valid rows than the grid has tiles for
-                # it, so skip whole tiles that start past them.
-                is_valid = arith.cmpi(
-                    arith.CmpIPredicate.slt, arith.muli(bx_i32, tile_m_c), valid_m
-                )
-            else:
-                # The slab is full, so every row of it carries data and the grid
-                # is exactly ceil(slab / tile_m) tiles: no tile starts past the
-                # slab, and the guard is dropped rather than emitted always-true.
-                # The rows of the tile past the slab still carry nothing, though:
-                # tile_m need not divide it, and the overrun lands on the next
-                # group, so the epilogue still masks by row.
-                valid_m = expected_m_i32
-                is_valid = True
-            row_limit_i32 = arith.addi(group_m_start_i32, valid_m)
-        else:
-            # Packed layout: groups are concatenated along M, so resolve which one
-            # owns this flat M-tile id (bx) from m_sizes. Doing it here rather than
-            # from a host-built dispatch map keeps the launch free of helper
-            # kernels, which matters under CUDA-graph capture where each one is
-            # replayed per call. num_groups is a compile-time constant, so the loop
-            # unrolls to a few scalar ops. acc_m/acc_t are the running m_start and
-            # tile_start prefixes; tiles beyond the real tile count (the grid extent
-            # is an upper bound) match no group and stay marked -1.
-            acc_m = _i32(0)  # cumulative rows before group g (m_starts[g])
-            acc_t = _i32(0)  # cumulative tiles before group g (tile_starts[g])
-            group_id_i32 = _i32(-1)
-            row_start_i32 = _i32(0)
-            row_limit_i32 = _i32(0)
-            group_m_start_i32 = _i32(0)  # first global row of the owning group
-            group_m_size_i32 = _i32(0)  # row count of the owning group
-            for _g in range_constexpr(num_groups):
-                if const_expr(layout == "offsets"):
-                    # Cumulative int32 row ends. acc_m is already the running
-                    # prefix, so a group's own row count is the step between them;
-                    # decoding here costs a subtract and saves the caller a whole
-                    # kernel launch to difference the offsets host-side.
-                    m_g = arith.subi(
-                        buffer_ops.buffer_load(ms_rsrc, _g, vec_width=1, dtype=T.i32),
-                        acc_m,
-                    )
-                else:
-                    # m_sizes is int64; read the low dword of element _g (index
-                    # _g*2 in dwords). Row counts fit in int32, so the high dword
-                    # is always zero and no host-side narrowing kernel is needed.
-                    m_g = buffer_ops.buffer_load(
-                        ms_rsrc, _g * 2, vec_width=1, dtype=T.i32
-                    )
-                tiles_g = arith.divui(arith.addi(m_g, tile_m_bump), tile_m_c)
-                acc_t_next = arith.addi(acc_t, tiles_g)
-                in_grp = arith.andi(
-                    arith.cmpi(arith.CmpIPredicate.sge, bx_i32, acc_t),
-                    arith.cmpi(arith.CmpIPredicate.slt, bx_i32, acc_t_next),
-                )
-                rs = arith.addi(acc_m, arith.muli(arith.subi(bx_i32, acc_t), tile_m_c))
-                rl = arith.addi(acc_m, m_g)
-                group_id_i32 = arith.select(in_grp, _i32(_g), group_id_i32)
-                row_start_i32 = arith.select(in_grp, rs, row_start_i32)
-                row_limit_i32 = arith.select(in_grp, rl, row_limit_i32)
-                group_m_start_i32 = arith.select(in_grp, acc_m, group_m_start_i32)
-                group_m_size_i32 = arith.select(in_grp, m_g, group_m_size_i32)
-                acc_m = arith.addi(acc_m, m_g)
-                acc_t = acc_t_next
-
-            is_valid = arith.cmpi(arith.CmpIPredicate.sge, group_id_i32, _i32(0))
+        _grp = resolve_group_rows(
+            arg_m_sizes=arg_m_sizes,
+            num_groups_in=num_groups_in,
+            m_in=m_in,
+            m_tile_idx=bx,
+            slab_idx=bz,
+            tile_m=tile_m,
+            num_groups=num_groups,
+            layout=layout,
+        )
+        group_id_i32 = _grp.group_id
+        row_start_i32 = _grp.row_start
+        row_limit_i32 = _grp.row_limit
+        group_m_start_i32 = _grp.group_m_start
+        group_m_size_i32 = _grp.group_m_size
+        is_valid = _grp.is_valid
 
         # Early exit for surplus/no-op tiles.
         if is_valid:

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -98,6 +98,7 @@ def compile_grouped_gemm_blockscale_contiguous(
     blockscale: bool = False,
     masked: bool = False,
     k_padding: bool = False,
+    n_padding: bool = False,
 ):
     """Compile grouped FP8 GEMM kernel and return the JIT launcher.
 
@@ -149,6 +150,7 @@ def compile_grouped_gemm_blockscale_contiguous(
         tile_k=tile_k,
         blockscale=blockscale,
         k_padding=k_padding,
+        n_padding=n_padding,
         scale_block_k=scale_block_k,
         scale_block_n=scale_block_n,
         out_dtype=out_dtype,
@@ -219,10 +221,11 @@ def compile_grouped_gemm_blockscale_contiguous(
     _scaling = "blockscale" if blockscale else "rowwise"
     _layout = "masked" if masked else "contig"
     _kpad = "_kpad" if k_padding else ""
+    _npad = "_npad" if n_padding else ""
     module_name = (
         f"grouped_gemm_{_scaling}_{_layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
-        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}"
+        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}"
     ).replace("-", "_")
 
     @flyc.kernel(name=module_name)
@@ -517,6 +520,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                     n_in=n_in,
                     k_in=k_in,
                     k_tail_mask=k_tail_mask,
+                    n_padding=n_padding,
                 )
                 lds_load_b_packs_k64 = make_lds_b_loader(
                     lds_b=lds_b,
@@ -651,6 +655,7 @@ def compile_grouped_gemm_blockscale_contiguous(
                 out_mlir=out_mlir,
                 e_vec=e_vec,
                 c_n=c_n,
+                n_padding=n_padding,
             )
 
             # Mask the partial-tile tail: skip stores for global rows at or beyond
@@ -713,7 +718,11 @@ def compile_grouped_gemm_blockscale_contiguous(
         # The padded layout instead gives each group its own z slice, so the M axis
         # only has to cover one group's slab and tiles past its valid rows exit.
         n_in = fx.Index(i32_n)
-        gx = n_in // fx.Index(tile_n)  # N-blocks
+        gx = (
+            (n_in + fx.Index(tile_n - 1)) // fx.Index(tile_n)
+            if const_expr(n_padding)
+            else n_in // fx.Index(tile_n)
+        )  # N-blocks
         gy = fx.Index(i32_num_m_tiles)  # M-tiles
         gz = fx.Index(i32_num_groups) if const_expr(masked) else fx.Index(1)
 

--- a/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
+++ b/mslk/flydsl/kernels/gemm/grouped_gemm_blockscale_contiguous.py
@@ -306,11 +306,12 @@ def compile_grouped_gemm_blockscale_contiguous(
     _scaling = "blockscale" if blockscale else "rowwise"
     _kpad = "_kpad" if k_padding else ""
     _roll = "_rollk" if roll_k else ""
+    _wpe = f"_wpe{int(waves_per_eu)}" if waves_per_eu else ""
     _npad = "_npad" if n_padding else ""
     module_name = (
         f"grouped_gemm_{_scaling}_{layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
-        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}"
+        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}{_wpe}"
     ).replace("-", "_")
 
     @flyc.kernel(name=module_name)

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -196,3 +196,65 @@ if torch.version.hip is not None:
 
             except RuntimeError:
                 pass  # already registered (e.g. module imported more than once)
+
+    @functools.lru_cache(maxsize=1)
+    def _flydsl_rowwise_grouped_module() -> ModuleType | None:
+        """The FlyDSL rowwise grouped module, or None when not opted into.
+
+        Resolved the same way as the groupwise one above, and for the same
+        reason: this package must not depend on
+        ``//mslk/mslk/gemm:flydsl_ops``.
+        """
+        try:
+            from mslk.flydsl.common import is_flydsl_available
+
+            if not is_flydsl_available():
+                return None
+            return importlib.import_module("mslk.gemm.flydsl.fp8_rowwise_grouped_gemm")
+        except ImportError:
+            return None
+
+    def _rowwise_grouped_impl(op: str, fn: str) -> Callable[..., torch.Tensor]:
+        """Bind one rowwise grouped op to its FlyDSL entry point, lazily.
+
+        gemm_ops.cpp leaves these slots free on ROCm, so FlyDSL is the only
+        implementation and there is nothing to arbitrate. Resolution is still
+        deferred to the first call so that registering does not import FlyDSL;
+        calling without having opted into flydsl_ops raises rather than
+        silently doing something else.
+        """
+
+        def _impl(*args: object) -> torch.Tensor:
+            mod = _flydsl_rowwise_grouped_module()
+            if mod is None:
+                raise RuntimeError(
+                    f"mslk::{op} requires the FlyDSL backend. Add "
+                    "//mslk/mslk/gemm:flydsl_ops to your target's deps."
+                )
+            return getattr(mod, fn)(*args)
+
+        return _impl
+
+    for _op, _fn in (
+        ("f8f8bf16_rowwise_grouped_stacked", "matmul_f8f8bf16_rowwise_grouped_stacked"),
+        (
+            "f8f8bf16_rowwise_grouped_stacked_preshuffle",
+            "matmul_f8f8bf16_rowwise_grouped_stacked_preshuffle",
+        ),
+        ("f8f8bf16_rowwise_grouped_dynamic", "matmul_f8f8bf16_rowwise_grouped_dynamic"),
+        (
+            "f8f8bf16_rowwise_grouped_dynamic_preshuffle",
+            "matmul_f8f8bf16_rowwise_grouped_dynamic_preshuffle",
+        ),
+        ("f8f8bf16_rowwise_grouped_mm", "matmul_f8f8bf16_rowwise_grouped_mm"),
+        (
+            "f8f8bf16_rowwise_grouped_mm_preshuffle",
+            "matmul_f8f8bf16_rowwise_grouped_mm_preshuffle",
+        ),
+    ):
+        if not hasattr(torch.ops.mslk, _op):
+            continue  # schema absent, as in a python-only build
+        try:
+            torch.library.impl(f"mslk::{_op}", "CUDA")(_rowwise_grouped_impl(_op, _fn))
+        except RuntimeError:
+            pass  # already registered (e.g. module imported more than once)

--- a/mslk/gemm/_meta.py
+++ b/mslk/gemm/_meta.py
@@ -757,3 +757,55 @@ if hasattr(torch.ops.mslk, "f8f8bf16_groupwise_grouped_preshuffle"):
         TotalM = XQ.shape[0]
         N = WQ.shape[1]
         return XQ.new_empty((TotalM, N), dtype=torch.bfloat16)
+
+
+# The rowwise grouped ops FlyDSL serves on ROCm. Their shape functions live here
+# for the same reason as the groupwise one above: inference must not require
+# depending on //mslk/mslk/gemm:flydsl_ops.
+if hasattr(torch.ops.mslk, "f8f8bf16_rowwise_grouped_stacked_preshuffle"):
+
+    @torch.library.register_fake("mslk::f8f8bf16_rowwise_grouped_stacked_preshuffle")
+    def _f8f8bf16_rowwise_grouped_stacked_preshuffle_meta(
+        XQ: torch.Tensor,
+        WQ: torch.Tensor,
+        x_scale: torch.Tensor,
+        w_scale: torch.Tensor,
+        M_sizes: torch.Tensor,
+    ) -> torch.Tensor:
+        return XQ.new_empty((XQ.shape[0], WQ.shape[1]), dtype=torch.bfloat16)
+
+
+def _rowwise_grouped_dynamic_meta(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    zero_start_index_M: torch.Tensor,
+    zeroing_output_tensor: bool = True,
+) -> torch.Tensor:
+    # One slab per group, of the height every group was given.
+    G, expected_m, _ = XQ.shape
+    return XQ.new_empty((G, expected_m, WQ.shape[1]), dtype=torch.bfloat16)
+
+
+def _rowwise_grouped_mm_meta(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    offsets: torch.Tensor | None,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    # Written in place and returned, so the shape is fixed by the argument
+    # whichever rank combination the operands select.
+    return out
+
+
+for _op, _fake in (
+    ("f8f8bf16_rowwise_grouped_dynamic", _rowwise_grouped_dynamic_meta),
+    ("f8f8bf16_rowwise_grouped_dynamic_preshuffle", _rowwise_grouped_dynamic_meta),
+    ("f8f8bf16_rowwise_grouped_mm", _rowwise_grouped_mm_meta),
+    ("f8f8bf16_rowwise_grouped_mm_preshuffle", _rowwise_grouped_mm_meta),
+):
+    if hasattr(torch.ops.mslk, _op):
+        torch.library.register_fake(f"mslk::{_op}")(_fake)

--- a/mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py
@@ -96,6 +96,7 @@ def _launch_kernel(
         scale_block_n=_SCALE_BLOCK,
         out_dtype="bf16",
         b_preshuffled=b_preshuffled,
+        blockscale=True,
     )
     # Operands keep their natural shape: argument marshalling packs each memref
     # extent as int32, which a flattened view overflows at 2**31 elements. The

--- a/mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py
@@ -29,95 +29,12 @@ Tensor contract:
   Output  : [TotalM, N]             BF16
 """
 
-import os
-
 import torch
 from mslk.flydsl.common import require_flydsl
-from mslk.flydsl.jit import run_compiled
+from mslk.gemm.flydsl import grouped_dispatch
 from mslk.utils.device import supports_float8_fnuz
 
 _OP_NAME = "mslk::f8f8bf16_groupwise_grouped_preshuffle"
-
-# Only the scale-block granularity is fixed; tile_m/tile_n/tile_k are chosen per
-# call -- either by FlyDSL autotune (MSLK_AUTOTUNE_ENABLE set) or a fixed default.
-_SCALE_BLOCK = 128
-
-# Default tile when autotuning is disabled. Valid for any supported shape
-# (tile_n=tile_k=128 divide every supported N/K, incl. small N=128). This is the
-# CI / no-benchmark path -- matches the CUTLASS heuristic fallback tile.
-_DEFAULT_TILE = (128, 128, 128)
-
-# Candidate tile space swept by autotune. tile_n must be a multiple of
-# scale_block_n=128 so a tile never straddles a weight scale block, and tile_k is
-# pinned to the same granularity. Configs that do not divide a given shape are
-# pruned before benchmarking, and ones that overflow LDS are rejected at compile.
-_AUTOTUNE_TILES = (
-    (64, 128, 128),
-    (128, 128, 128),
-    (256, 128, 128),
-    (64, 256, 128),
-    (128, 256, 128),
-    (256, 256, 128),
-)
-
-
-def _next_pow2(x: int) -> int:
-    """Smallest power of two >= x (x>=1). Buckets TotalM for the autotune key so
-    nearby token counts share one tuned config -- matching the CUDA-graph capture
-    buckets a server pre-captures, and bounding the pre-warm set."""
-    if x <= 1:
-        return 1
-    return 1 << (int(x) - 1).bit_length()
-
-
-def _launch_kernel(
-    XQ, WQ, x_scale, w_scale, m_sizes, output, *, tile_m, tile_n, tile_k, b_preshuffled
-):
-    """Compile (cached) and launch the grouped GEMM for one tile config. Shared
-    by the autotune target and the fixed-config path. Writes into `output`."""
-    from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_contiguous import (
-        compile_grouped_gemm_blockscale_contiguous,
-    )
-
-    TotalM, K = XQ.shape
-    G, N, _ = WQ.shape
-    # Grid M-extent: host-known upper bound (each group wastes at most one partial
-    # tile). The kernel resolves group ownership from M_sizes and self-skips
-    # surplus tiles.
-    num_m_tiles = TotalM // tile_m + G
-    launcher = compile_grouped_gemm_blockscale_contiguous(
-        n=N,
-        k=K,
-        num_groups=G,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        scale_block_k=_SCALE_BLOCK,
-        scale_block_n=_SCALE_BLOCK,
-        out_dtype="bf16",
-        b_preshuffled=b_preshuffled,
-        blockscale=True,
-    )
-    # Operands keep their natural shape: argument marshalling packs each memref
-    # extent as int32, which a flattened view overflows at 2**31 elements. The
-    # kernel addresses them as flat byte buffers regardless. FP8 is viewed as
-    # int8 for the handoff.
-    run_compiled(
-        launcher,
-        output,
-        XQ.contiguous().view(torch.int8),
-        WQ.contiguous().view(torch.int8),
-        x_scale.contiguous(),
-        w_scale.contiguous(),
-        m_sizes,
-        TotalM,
-        N,
-        K,
-        G,
-        num_m_tiles,
-        torch.cuda.current_stream(),
-    )
-    return output
 
 
 def _f8f8bf16_groupwise_grouped_preshuffle_meta(
@@ -132,85 +49,6 @@ def _f8f8bf16_groupwise_grouped_preshuffle_meta(
     return XQ.new_empty((TotalM, N), dtype=torch.bfloat16)
 
 
-def _autotune_target(
-    XQ,
-    WQ,
-    x_scale,
-    w_scale,
-    m_sizes,
-    output,
-    m_bucket,
-    n,
-    k,
-    b_preshuffled,
-    *,
-    tile_m,
-    tile_n,
-    tile_k,
-):
-    """FlyDSL @autotune benchmarks this per candidate tile. Keyed on
-    (m_bucket, n, k, b_preshuffled): m_bucket=nextPow2(TotalM) buckets token
-    counts; n/k separate the problem shapes (gate/up vs down-proj want different
-    tiles); b_preshuffled distinguishes the two kernels (different B-load path,
-    can't share a tuned config). Key args are otherwise passed straight through.
-    tile_* arrive as Config kwargs."""
-    return _launch_kernel(
-        XQ,
-        WQ,
-        x_scale,
-        w_scale,
-        m_sizes,
-        output,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
-        b_preshuffled=b_preshuffled,
-    )
-
-
-def _prune_tiles(configs, named_args, **kwargs):
-    """Drop tile configs invalid for this shape (tile_n must divide N, tile_k
-    must divide K) before benchmarking.
-
-    FlyDSL's Autotuner calls this as ``(configs, sig_args)``; ``**kwargs`` keeps
-    it compatible with the Triton-style ``(configs, named_args, **meta)`` form.
-    """
-    WQ = named_args.get("WQ")
-    XQ = named_args.get("XQ")
-    if WQ is None or XQ is None:
-        return configs
-    N = WQ.shape[1]
-    K = XQ.shape[1]
-    kept = [
-        c
-        for c in configs
-        if N % c.kwargs["tile_n"] == 0 and K % c.kwargs["tile_k"] == 0
-    ]
-    return kept or configs
-
-
-# Single autotuner for both B-layout variants, built lazily (flydsl.autotune only
-# imports when FlyDSL is present). b_preshuffled is a KEY arg (not a Config kwarg)
-# so the two kernels get separate tuned entries in one shared disk cache.
-_AUTOTUNER = None
-
-
-def _get_autotuner():
-    global _AUTOTUNER
-    if _AUTOTUNER is None:
-        from flydsl.autotune import autotune, Config
-
-        configs = [
-            Config(tile_m=tm, tile_n=tn, tile_k=tk) for (tm, tn, tk) in _AUTOTUNE_TILES
-        ]
-        _AUTOTUNER = autotune(
-            configs=configs,
-            key=["m_bucket", "n", "k", "b_preshuffled"],
-            prune_configs_by=_prune_tiles,
-        )(_autotune_target)
-    return _AUTOTUNER
-
-
 def _dispatch_grouped_gemm(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
@@ -223,14 +61,9 @@ def _dispatch_grouped_gemm(
     """Shared dispatch for both grouped ops. WQ is already in the layout the
     variant expects (MFMA-preshuffled if b_preshuffled else plain [G,N,K]).
 
-    Tile selection follows the CUTLASS precedent: when MSLK_AUTOTUNE_ENABLE is
-    set, FlyDSL autotune benchmarks the candidate tiles on a cache-miss and
-    persists the winner (keyed on nextPow2(TotalM) and b_preshuffled); otherwise
-    a fixed default tile is used with no benchmarking (the CI / graph-capture-safe
-    path).
+    Tile selection lives in grouped_dispatch. Registration does not probe for
+    FlyDSL, so this is the first point at which it is required.
 
-    The registrations below deliberately do not probe for FlyDSL, so this is
-    the first point at which it is required.
     """
     require_flydsl()
     assert XQ.ndim == 2, f"XQ must be [TotalM, K], got {XQ.shape}"
@@ -250,41 +83,14 @@ def _dispatch_grouped_gemm(
     assert WQ.dtype == expected_fp8, f"WQ must be {expected_fp8}, got {WQ.dtype}"
     assert M_sizes.dtype == torch.int64, f"M_sizes must be int64, got {M_sizes.dtype}"
 
-    output = torch.empty((TotalM, N), dtype=torch.bfloat16, device=XQ.device)
-    if TotalM == 0 or N == 0 or K == 0 or G == 0:
-        return output
-
-    if os.environ.get("MSLK_AUTOTUNE_ENABLE"):
-        # FlyDSL's Autotuner discards the tuned function's return value, so read
-        # the result from the output buffer the kernel wrote into.
-        _get_autotuner()(
-            XQ,
-            WQ,
-            x_scale,
-            w_scale,
-            M_sizes,
-            output,
-            _next_pow2(TotalM),
-            N,
-            K,
-            b_preshuffled,
-        )
-        return output
-
-    tile_m, tile_n, tile_k = _DEFAULT_TILE
-    assert N % tile_n == 0, f"N={N} must be a multiple of tile_n={tile_n}"
-    assert K % tile_k == 0, f"K={K} must be a multiple of tile_k={tile_k}"
-    return _launch_kernel(
+    return grouped_dispatch.dispatch(
         XQ,
         WQ,
         x_scale,
         w_scale,
         M_sizes,
-        output,
-        tile_m=tile_m,
-        tile_n=tile_n,
-        tile_k=tile_k,
         b_preshuffled=b_preshuffled,
+        blockscale=True,
     )
 
 

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -23,8 +23,8 @@ takes as a compile-time ``layout``:
   MFMA B-preshuffle layout (see ``mslk.quantize.shuffle.preshuffle_b_mfma``).
   Callers shuffle once at load time; the op does no shuffling.
 
-Only ``_stacked`` and its preshuffle sibling are registered; the others are
-reachable as plain functions.
+All of these are registered on ROCm. The padded layout's preshuffle sibling has
+no schema declared for it, so it stays a plain function until one is added.
 
 Rowwise scaling carries one scale per row of A and per column of B, both
 constant along K, so they factor out of the reduction and the kernel applies
@@ -467,11 +467,17 @@ if (
     and torch.version.hip is not None
     and hasattr(torch.ops, "mslk")
 ):
-    # FlyDSL supplies the ROCm implementation of both ops; their schemas are
+    # FlyDSL supplies the ROCm implementation of these ops; their schemas are
     # declared in csrc/gemm/gemm_ops.cpp, which also leaves the _stacked slot
     # free on ROCm so this binding can take it. Skip an op whose schema is
     # missing, as in a python-only build, and tolerate a repeat import
     # rebinding it.
+    #
+    # _dynamic and _mm still carry a CK implementation on the CUDA key, so
+    # binding here overrides it and torch warns. Guarding those to non-ROCm in
+    # gemm_ops.cpp the way _stacked is would silence that, but it needs a
+    # rebuild to take effect; the override is what decides the dispatch either
+    # way.
     def _register(op_name, cuda_fn, meta_fn=None) -> None:
         if not hasattr(torch.ops.mslk, op_name.split("::")[1]):
             return
@@ -489,3 +495,15 @@ if (
         matmul_f8f8bf16_rowwise_grouped_preshuffle,
         _f8f8bf16_rowwise_grouped_preshuffle_meta,
     )
+    _register(
+        "mslk::f8f8bf16_rowwise_grouped_dynamic",
+        matmul_f8f8bf16_rowwise_grouped_dynamic,
+    )
+    # Every rank combination is served, which this op needs: it is one entry
+    # point covering all four, so taking the slot for some of them would break
+    # the rest.
+    _register("mslk::f8f8bf16_rowwise_grouped_mm", matmul_f8f8bf16_rowwise_grouped_mm)
+
+    # matmul_f8f8bf16_rowwise_grouped_dynamic_preshuffle has no schema to bind
+    # to; adding one is a C++ change and so a rebuild. It stays reachable as a
+    # plain function until then.

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -113,6 +113,119 @@ def matmul_f8f8bf16_rowwise_grouped(
     )
 
 
+def _dispatch_rowwise_grouped_dynamic(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    zero_start_index_M: torch.Tensor,
+    zeroing_output_tensor: bool,
+    *,
+    b_preshuffled: bool,
+) -> torch.Tensor:
+    """Shared dispatch for the padded-layout ops.
+
+    Each group owns a fixed slab of ``expected_m`` rows and only the first
+    ``zero_start_index_M[g]`` of them hold real tokens, so the caller never has to
+    compact tokens into one buffer. The slabs are contiguous, so the kernel sees
+    the flattened ``[G * expected_m, ...]`` views and treats the group as a grid
+    axis rather than resolving it from row counts.
+    """
+    assert XQ.ndim == 3, f"XQ must be [G, M, K], got {XQ.shape}"
+    assert WQ.ndim == 3, f"WQ must be [G, N, K], got {WQ.shape}"
+    assert zero_start_index_M.ndim == 1, (
+        f"zero_start_index_M must be [G], got {zero_start_index_M.shape}"
+    )
+    G, expected_m, K = XQ.shape
+    Gw, N, Kw = WQ.shape
+    assert Kw == K, f"K mismatch: XQ K={K}, WQ K={Kw}"
+    assert Gw == G, f"group mismatch: XQ G={G}, WQ G={Gw}"
+    assert zero_start_index_M.shape[0] == G, (
+        f"zero_start_index_M length {zero_start_index_M.shape[0]} must equal G={G}"
+    )
+    # The MFMA instructions read the operands in the arch's native FP8 format, and
+    # the kernel passes them through as raw bytes, so an fnuz/OCP mismatch would
+    # be applied with the wrong exponent bias rather than rejected.
+    expected_fp8 = (
+        torch.float8_e4m3fnuz if supports_float8_fnuz() else torch.float8_e4m3fn
+    )
+    assert XQ.dtype == expected_fp8, f"XQ must be {expected_fp8}, got {XQ.dtype}"
+    assert WQ.dtype == expected_fp8, f"WQ must be {expected_fp8}, got {WQ.dtype}"
+    assert zero_start_index_M.dtype == torch.int64, (
+        f"zero_start_index_M must be int64, got {zero_start_index_M.dtype}"
+    )
+    assert x_scale.numel() == G * expected_m, (
+        f"x_scale must hold one scale per row ({G * expected_m}), got {x_scale.numel()}"
+    )
+    assert w_scale.numel() == G * N, (
+        f"w_scale must hold one scale per group column ({G * N}), got {w_scale.numel()}"
+    )
+
+    # Rows past a group's valid count are never written, so they carry whatever the
+    # buffer already held. Zero them up front when the caller asks for it, matching
+    # the CK implementation's separate zeroing pass.
+    alloc = torch.zeros if zeroing_output_tensor else torch.empty
+    out = alloc((G, expected_m, N), dtype=torch.bfloat16, device=XQ.device)
+
+    grouped_dispatch.dispatch(
+        XQ.contiguous().view(G * expected_m, K),
+        WQ,
+        x_scale,
+        w_scale,
+        zero_start_index_M,
+        b_preshuffled=b_preshuffled,
+        blockscale=False,
+        masked=True,
+        out=out.view(G * expected_m, N),
+    )
+    return out
+
+
+def matmul_f8f8bf16_rowwise_grouped_dynamic(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    zero_start_index_M: torch.Tensor,
+    zeroing_output_tensor: bool = True,
+) -> torch.Tensor:
+    """Padded-layout rowwise grouped GEMM with plain row-major weights."""
+    return _dispatch_rowwise_grouped_dynamic(
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        zero_start_index_M,
+        zeroing_output_tensor,
+        b_preshuffled=False,
+    )
+
+
+def matmul_f8f8bf16_rowwise_grouped_dynamic_preshuffle(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    zero_start_index_M: torch.Tensor,
+    zeroing_output_tensor: bool = True,
+) -> torch.Tensor:
+    """Preshuffled-B padded-layout rowwise grouped GEMM (WQ already
+    MFMA-preshuffled).
+
+    Loads B straight to registers rather than staging it through LDS, in
+    exchange for the caller shuffling the weights once at load time.
+    """
+    return _dispatch_rowwise_grouped_dynamic(
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        zero_start_index_M,
+        zeroing_output_tensor,
+        b_preshuffled=True,
+    )
+
+
 def matmul_f8f8bf16_rowwise_grouped_preshuffle(
     XQ: torch.Tensor,
     WQ: torch.Tensor,

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -175,7 +175,7 @@ def _dispatch_rowwise_grouped_dynamic(
         zero_start_index_M,
         b_preshuffled=b_preshuffled,
         blockscale=False,
-        masked=True,
+        layout="padded",
         out=out.view(G * expected_m, N),
     )
     return out

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -23,8 +23,8 @@ takes as a compile-time ``layout``:
   MFMA B-preshuffle layout (see ``mslk.quantize.shuffle.preshuffle_b_mfma``).
   Callers shuffle once at load time; the op does no shuffling.
 
-All of these are registered on ROCm. The padded layout's preshuffle sibling has
-no schema declared for it, so it stays a plain function until one is added.
+All of these are registered on ROCm, and gemm_ops.cpp leaves their slots free
+there, so nothing else implements them on this platform.
 
 Rowwise scaling carries one scale per row of A and per column of B, both
 constant along K, so they factor out of the reduction and the kernel applies
@@ -468,16 +468,10 @@ if (
     and hasattr(torch.ops, "mslk")
 ):
     # FlyDSL supplies the ROCm implementation of these ops; their schemas are
-    # declared in csrc/gemm/gemm_ops.cpp, which also leaves the _stacked slot
-    # free on ROCm so this binding can take it. Skip an op whose schema is
-    # missing, as in a python-only build, and tolerate a repeat import
-    # rebinding it.
-    #
-    # _dynamic and _mm still carry a CK implementation on the CUDA key, so
-    # binding here overrides it and torch warns. Guarding those to non-ROCm in
-    # gemm_ops.cpp the way _stacked is would silence that, but it needs a
-    # rebuild to take effect; the override is what decides the dispatch either
-    # way.
+    # declared in csrc/gemm/gemm_ops.cpp, which leaves every one of these slots
+    # free on ROCm so these bindings can take them. Skip an op whose schema is
+    # missing, as in a python-only build or against a binary built before the
+    # schema was added, and tolerate a repeat import rebinding it.
     def _register(op_name, cuda_fn, meta_fn=None) -> None:
         if not hasattr(torch.ops.mslk, op_name.split("::")[1]):
             return
@@ -503,7 +497,7 @@ if (
     # point covering all four, so taking the slot for some of them would break
     # the rest.
     _register("mslk::f8f8bf16_rowwise_grouped_mm", matmul_f8f8bf16_rowwise_grouped_mm)
-
-    # matmul_f8f8bf16_rowwise_grouped_dynamic_preshuffle has no schema to bind
-    # to; adding one is a C++ change and so a rebuild. It stays reachable as a
-    # plain function until then.
+    _register(
+        "mslk::f8f8bf16_rowwise_grouped_dynamic_preshuffle",
+        matmul_f8f8bf16_rowwise_grouped_dynamic_preshuffle,
+    )

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -91,6 +91,32 @@ def _f8f8bf16_rowwise_grouped_stacked_preshuffle_meta(
     return XQ.new_empty((total_M, N), dtype=torch.bfloat16)
 
 
+def _f8f8bf16_rowwise_grouped_dynamic_meta(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    zero_start_index_M: torch.Tensor,
+    zeroing_output_tensor: bool = True,
+) -> torch.Tensor:
+    G, expected_m, _ = XQ.shape
+    N = WQ.shape[1]
+    return XQ.new_empty((G, expected_m, N), dtype=torch.bfloat16)
+
+
+def _f8f8bf16_rowwise_grouped_mm_meta(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    offsets: torch.Tensor | None,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    # The op writes the caller's buffer in place and returns it, so the result
+    # is that buffer whichever rank combination the operands select.
+    return out
+
+
 def _dispatch_rowwise_grouped(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
@@ -186,7 +212,8 @@ def _dispatch_rowwise_grouped_dynamic(
 
     # Rows past a group's valid count are never written, so they carry whatever the
     # buffer already held. Zero them up front when the caller asks for it, matching
-    # the CK implementation's separate zeroing pass.
+    # the CK implementation's separate zeroing pass. A shape that reduces over
+    # nothing is zeroed either way, since zero is then the whole answer.
     alloc = torch.zeros if zeroing_output_tensor else torch.empty
     out = alloc((G, expected_m, N), dtype=torch.bfloat16, device=XQ.device)
 
@@ -414,6 +441,8 @@ def _rowwise_grouped_mm_2d2d(XQ, WQ, x_scale, w_scale, offsets, out):
 
     A group whose K slice is empty contributes nothing, and its slab of ``out``
     is left as the caller passed it -- the same as CK, which skips such groups.
+    Where every group is empty the whole contraction has length zero, which sums
+    to zero, and ``out`` is zeroed rather than left alone.
     """
     assert offsets is not None, "2D-2D grouped mm requires offsets for K"
     assert offsets.dtype == torch.int32, f"offsets must be int32, got {offsets.dtype}"
@@ -549,16 +578,23 @@ if (
     _register(
         "mslk::f8f8bf16_rowwise_grouped_dynamic",
         matmul_f8f8bf16_rowwise_grouped_dynamic,
+        _f8f8bf16_rowwise_grouped_dynamic_meta,
     )
     # Every rank combination is served, which this op needs: it is one entry
     # point covering all four, so taking the slot for some of them would break
     # the rest.
-    _register("mslk::f8f8bf16_rowwise_grouped_mm", matmul_f8f8bf16_rowwise_grouped_mm)
+    _register(
+        "mslk::f8f8bf16_rowwise_grouped_mm",
+        matmul_f8f8bf16_rowwise_grouped_mm,
+        _f8f8bf16_rowwise_grouped_mm_meta,
+    )
     _register(
         "mslk::f8f8bf16_rowwise_grouped_dynamic_preshuffle",
         matmul_f8f8bf16_rowwise_grouped_dynamic_preshuffle,
+        _f8f8bf16_rowwise_grouped_dynamic_meta,
     )
     _register(
         "mslk::f8f8bf16_rowwise_grouped_mm_preshuffle",
         matmul_f8f8bf16_rowwise_grouped_mm_preshuffle,
+        _f8f8bf16_rowwise_grouped_mm_meta,
     )

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -384,6 +384,55 @@ def _rowwise_grouped_mm_3d2d(XQ, WQ, x_scale, w_scale, offsets, out):
     return out
 
 
+def _rowwise_grouped_mm_2d2d(XQ, WQ, x_scale, w_scale, offsets, out):
+    """Groups divide the contraction rather than either output axis.
+
+    Every group multiplies the same M rows by the same N columns but over its
+    own slice of K, so each produces a whole [M, N] of its own and the output is
+    [G, M, N] with nothing packed. The operands are one matrix each, the groups
+    taking column slices of them.
+
+    Every group's K length must be a multiple of 16, the vectorised load width.
+    The offsets live on the device, so like CK this cannot be checked on the
+    host; CK does not check it anywhere, and is silently wrong below it.
+
+    A group whose K slice is empty contributes nothing, and its slab of ``out``
+    is left as the caller passed it -- the same as CK, which skips such groups.
+    """
+    assert offsets is not None, "2D-2D grouped mm requires offsets for K"
+    assert offsets.dtype == torch.int32, f"offsets must be int32, got {offsets.dtype}"
+    M, total_K = XQ.shape
+    N, Kw = WQ.shape
+    assert Kw == total_K, f"K mismatch: XQ K={total_K}, WQ K={Kw}"
+    G = offsets.shape[0]
+    assert x_scale.numel() == G * M, (
+        f"x_scale must hold one scale per row per group ({G * M}), "
+        f"got {x_scale.numel()}"
+    )
+    assert w_scale.numel() == G * N, (
+        f"w_scale must hold one scale per column per group ({G * N}), "
+        f"got {w_scale.numel()}"
+    )
+    assert tuple(out.shape) == (G, M, N), (
+        f"out must be [G, M, N] = {(G, M, N)}, got {tuple(out.shape)}"
+    )
+    assert out.is_contiguous(), "out must be contiguous"
+    _assert_fp8_operands(XQ, WQ)
+
+    grouped_dispatch.dispatch(
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        offsets,
+        b_preshuffled=False,
+        blockscale=False,
+        layout="k_offsets",
+        out=out.view(G * M, N),
+    )
+    return out
+
+
 def matmul_f8f8bf16_rowwise_grouped_mm(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
@@ -407,10 +456,7 @@ def matmul_f8f8bf16_rowwise_grouped_mm(
     if ranks == (3, 2):
         return _rowwise_grouped_mm_3d2d(XQ, WQ, x_scale, w_scale, offsets, out)
     if ranks == (2, 2):
-        raise NotImplementedError(
-            "grouped mm with 2D XQ and 2D WQ groups along K, which this kernel "
-            "does not yet support"
-        )
+        return _rowwise_grouped_mm_2d2d(XQ, WQ, x_scale, w_scale, offsets, out)
     raise ValueError(
         f"XQ must be 2D or 3D and WQ 2D or 3D, got {XQ.ndim}D and {WQ.ndim}D"
     )

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -8,15 +8,23 @@
 
 """FP8 rowwise-scaled grouped GEMM via FlyDSL.
 
-Registers two ops, both backed by the same kernel as the groupwise sibling in
-fp8_groupwise_grouped_gemm.py, compiled for rowwise scaling instead:
+Every entry point here is backed by the same kernel as the groupwise sibling in
+fp8_groupwise_grouped_gemm.py, compiled for rowwise scaling instead. The
+variants differ only in how the caller lays out the groups, which the kernel
+takes as a compile-time ``layout``:
 
-* ``mslk::f8f8bf16_rowwise_grouped_stacked`` -- the ROCm implementation, taking
-  row-major ``[G, N, K]`` weights.
-* ``mslk::f8f8bf16_rowwise_grouped_preshuffle`` -- a sibling that consumes
-  weights already in the MFMA B-preshuffle layout (see
-  ``mslk.quantize.shuffle.preshuffle_b_mfma``). Callers shuffle once at load
-  time; the op does no shuffling.
+* ``mslk::f8f8bf16_rowwise_grouped_stacked`` -- groups packed along M with a
+  ``[G]`` int64 row count per group, and row-major ``[G, N, K]`` weights.
+* ``mslk::f8f8bf16_rowwise_grouped_dynamic`` -- one fixed ``[G, M, K]`` slab per
+  group, of which the first ``zero_start_index_M[g]`` rows hold real tokens.
+* ``mslk::f8f8bf16_rowwise_grouped_mm`` -- the torch-native API, where the
+  operand ranks pick the grouped axis.
+* ``..._preshuffle`` siblings of the first two consume weights already in the
+  MFMA B-preshuffle layout (see ``mslk.quantize.shuffle.preshuffle_b_mfma``).
+  Callers shuffle once at load time; the op does no shuffling.
+
+Only ``_stacked`` and its preshuffle sibling are registered; the others are
+reachable as plain functions.
 
 Rowwise scaling carries one scale per row of A and per column of B, both
 constant along K, so they factor out of the reduction and the kernel applies
@@ -34,12 +42,38 @@ Tensor contract:
   out[m, n] = (sum_k XQ[m, k] * WQ[g, n, k]) * x_scale[m] * w_scale[g, n]
 """
 
+import functools
+
 import torch
 from mslk.flydsl.common import is_flydsl_available
 from mslk.gemm.flydsl import grouped_dispatch
 from mslk.utils.device import supports_float8_fnuz
 
 _PRESHUFFLE_OP_NAME = "mslk::f8f8bf16_rowwise_grouped_preshuffle"
+
+
+def _assert_fp8_operands(XQ: torch.Tensor, WQ: torch.Tensor) -> None:
+    """Reject a mismatched FP8 flavour.
+
+    The MFMA instructions read the operands in the arch's native FP8 format, and
+    the kernel passes them through as raw bytes, so an fnuz/OCP mismatch would be
+    applied with the wrong exponent bias rather than rejected.
+    """
+    expected = torch.float8_e4m3fnuz if supports_float8_fnuz() else torch.float8_e4m3fn
+    assert XQ.dtype == expected, f"XQ must be {expected}, got {XQ.dtype}"
+    assert WQ.dtype == expected, f"WQ must be {expected}, got {WQ.dtype}"
+
+
+@functools.lru_cache(maxsize=8)
+def _unused_group_meta(device: torch.device) -> torch.Tensor:
+    """Stand-in for the group-metadata operand under the batched layout.
+
+    That layout carries no per-group metadata and the kernel never reads the
+    argument, but the launcher's argument list is fixed at compile time. Caching
+    keeps a call free of an allocation and holds the address stable, which
+    CUDA-graph capture requires.
+    """
+    return torch.zeros((1,), dtype=torch.int32, device=device)
 
 
 def _f8f8bf16_rowwise_grouped_preshuffle_meta(
@@ -73,14 +107,7 @@ def _dispatch_rowwise_grouped(
     G, N, Kw = WQ.shape
     assert Kw == K, f"K mismatch: XQ K={K}, WQ K={Kw}"
     assert M_sizes.shape[0] == G, f"M_sizes length {M_sizes.shape[0]} must equal G={G}"
-    # The MFMA instructions read the operands in the arch's native FP8 format, and
-    # the kernel passes them through as raw bytes, so an fnuz/OCP mismatch would
-    # be applied with the wrong exponent bias rather than rejected.
-    expected_fp8 = (
-        torch.float8_e4m3fnuz if supports_float8_fnuz() else torch.float8_e4m3fn
-    )
-    assert XQ.dtype == expected_fp8, f"XQ must be {expected_fp8}, got {XQ.dtype}"
-    assert WQ.dtype == expected_fp8, f"WQ must be {expected_fp8}, got {WQ.dtype}"
+    _assert_fp8_operands(XQ, WQ)
     assert M_sizes.dtype == torch.int64, f"M_sizes must be int64, got {M_sizes.dtype}"
     assert x_scale.numel() == total_M, (
         f"x_scale must hold one scale per row ({total_M}), got {x_scale.numel()}"
@@ -143,14 +170,7 @@ def _dispatch_rowwise_grouped_dynamic(
     assert zero_start_index_M.shape[0] == G, (
         f"zero_start_index_M length {zero_start_index_M.shape[0]} must equal G={G}"
     )
-    # The MFMA instructions read the operands in the arch's native FP8 format, and
-    # the kernel passes them through as raw bytes, so an fnuz/OCP mismatch would
-    # be applied with the wrong exponent bias rather than rejected.
-    expected_fp8 = (
-        torch.float8_e4m3fnuz if supports_float8_fnuz() else torch.float8_e4m3fn
-    )
-    assert XQ.dtype == expected_fp8, f"XQ must be {expected_fp8}, got {XQ.dtype}"
-    assert WQ.dtype == expected_fp8, f"WQ must be {expected_fp8}, got {WQ.dtype}"
+    _assert_fp8_operands(XQ, WQ)
     assert zero_start_index_M.dtype == torch.int64, (
         f"zero_start_index_M must be int64, got {zero_start_index_M.dtype}"
     )
@@ -240,6 +260,113 @@ def matmul_f8f8bf16_rowwise_grouped_preshuffle(
     """
     return _dispatch_rowwise_grouped(
         XQ, WQ, x_scale, w_scale, M_sizes, b_preshuffled=True
+    )
+
+
+def _rowwise_grouped_mm_2d3d(XQ, WQ, x_scale, w_scale, offsets, out):
+    """Groups packed along M, addressed by cumulative offsets rather than sizes.
+
+    Same operand layout as the stacked variant; only the group metadata differs,
+    so the kernel decodes the offsets in its resolution loop.
+    """
+    assert offsets is not None, "2D-3D grouped mm requires offsets for XQ"
+    assert offsets.dtype == torch.int32, f"offsets must be int32, got {offsets.dtype}"
+    total_M, K = XQ.shape
+    G, N, Kw = WQ.shape
+    assert Kw == K, f"K mismatch: XQ K={K}, WQ K={Kw}"
+    assert offsets.shape[0] == G, f"offsets length {offsets.shape[0]} must equal G={G}"
+    assert x_scale.numel() == total_M, (
+        f"x_scale must hold one scale per row ({total_M}), got {x_scale.numel()}"
+    )
+    assert w_scale.numel() == G * N, (
+        f"w_scale must hold one scale per group column ({G * N}), got {w_scale.numel()}"
+    )
+    assert tuple(out.shape) == (total_M, N), (
+        f"out must be [total_M, N] = {(total_M, N)}, got {tuple(out.shape)}"
+    )
+    _assert_fp8_operands(XQ, WQ)
+
+    grouped_dispatch.dispatch(
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        offsets,
+        b_preshuffled=False,
+        blockscale=False,
+        layout="offsets",
+        out=out,
+    )
+    return out
+
+
+def _rowwise_grouped_mm_3d3d(XQ, WQ, x_scale, w_scale, offsets, out):
+    """Plain batched GEMM: fixed per-group slabs with every row carrying data.
+
+    This is the padded layout with nothing to mask, so the kernel skips both the
+    metadata load and the epilogue's row predicate.
+    """
+    assert offsets is None, "3D-3D is a batched GEMM and takes no offsets"
+    G, M, K = XQ.shape
+    Gw, N, Kw = WQ.shape
+    assert Kw == K, f"K mismatch: XQ K={K}, WQ K={Kw}"
+    assert Gw == G, f"group mismatch: XQ G={G}, WQ G={Gw}"
+    assert x_scale.numel() == G * M, (
+        f"x_scale must hold one scale per row ({G * M}), got {x_scale.numel()}"
+    )
+    assert w_scale.numel() == G * N, (
+        f"w_scale must hold one scale per group column ({G * N}), got {w_scale.numel()}"
+    )
+    assert tuple(out.shape) == (G, M, N), (
+        f"out must be [G, M, N] = {(G, M, N)}, got {tuple(out.shape)}"
+    )
+    # The kernel writes out in place, so it has to be the caller's buffer; a
+    # contiguity fixup would silently write to a copy instead.
+    assert out.is_contiguous(), "out must be contiguous"
+    _assert_fp8_operands(XQ, WQ)
+
+    grouped_dispatch.dispatch(
+        XQ.contiguous().view(G * M, K),
+        WQ,
+        x_scale,
+        w_scale,
+        _unused_group_meta(XQ.device),
+        b_preshuffled=False,
+        blockscale=False,
+        layout="batched",
+        out=out.view(G * M, N),
+    )
+    return out
+
+
+def matmul_f8f8bf16_rowwise_grouped_mm(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    offsets: torch.Tensor | None,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Torch-native grouped GEMM, where the operand ranks pick the grouped axis.
+
+    2D-3D groups along M, 3D-2D along N, 2D-2D along K, and 3D-3D is an ordinary
+    batched GEMM. ``offsets`` gives the cumulative int32 end of each group along
+    whichever axis is grouped, and is None for 3D-3D. ``out`` is written in place
+    and returned.
+    """
+    ranks = (XQ.ndim, WQ.ndim)
+    if ranks == (2, 3):
+        return _rowwise_grouped_mm_2d3d(XQ, WQ, x_scale, w_scale, offsets, out)
+    if ranks == (3, 3):
+        return _rowwise_grouped_mm_3d3d(XQ, WQ, x_scale, w_scale, offsets, out)
+    if ranks in ((3, 2), (2, 2)):
+        raise NotImplementedError(
+            f"grouped mm with XQ {XQ.ndim}D and WQ {WQ.ndim}D groups along "
+            f"{'N' if ranks == (3, 2) else 'K'}, which this kernel does not yet "
+            "support"
+        )
+    raise ValueError(
+        f"XQ must be 2D or 3D and WQ 2D or 3D, got {XQ.ndim}D and {WQ.ndim}D"
     )
 
 

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -19,9 +19,12 @@ takes as a compile-time ``layout``:
   group, of which the first ``zero_start_index_M[g]`` rows hold real tokens.
 * ``mslk::f8f8bf16_rowwise_grouped_mm`` -- the torch-native API, where the
   operand ranks pick the grouped axis.
-* ``..._preshuffle`` siblings of the first two consume weights already in the
-  MFMA B-preshuffle layout (see ``mslk.quantize.shuffle.preshuffle_b_mfma``).
-  Callers shuffle once at load time; the op does no shuffling.
+* ``..._preshuffle`` siblings of all three consume weights already in the MFMA
+  B-preshuffle layout (see ``mslk.quantize.shuffle.preshuffle_b_mfma``).
+  Callers shuffle once at load time; the op does no shuffling. The swizzle
+  interleaves N and K across the whole matrix, so it only applies where a group
+  owns an entire ``[N, K]``: the mm sibling therefore serves the 2D-3D and
+  3D-3D ranks and rejects the two that group along N or K.
 
 All of these are registered on ROCm, and gemm_ops.cpp leaves their slots free
 there, so nothing else implements them on this platform.
@@ -263,11 +266,16 @@ def matmul_f8f8bf16_rowwise_grouped_preshuffle(
     )
 
 
-def _rowwise_grouped_mm_2d3d(XQ, WQ, x_scale, w_scale, offsets, out):
+def _rowwise_grouped_mm_2d3d(
+    XQ, WQ, x_scale, w_scale, offsets, out, b_preshuffled=False
+):
     """Groups packed along M, addressed by cumulative offsets rather than sizes.
 
     Same operand layout as the stacked variant; only the group metadata differs,
     so the kernel decodes the offsets in its resolution loop.
+
+    The groups divide M, leaving each one a whole [N, K] of B to itself, so the
+    MFMA swizzle applies here exactly as it does to the stacked variant.
     """
     assert offsets is not None, "2D-3D grouped mm requires offsets for XQ"
     assert offsets.dtype == torch.int32, f"offsets must be int32, got {offsets.dtype}"
@@ -292,7 +300,7 @@ def _rowwise_grouped_mm_2d3d(XQ, WQ, x_scale, w_scale, offsets, out):
         x_scale,
         w_scale,
         offsets,
-        b_preshuffled=False,
+        b_preshuffled=b_preshuffled,
         blockscale=False,
         layout="offsets",
         out=out,
@@ -300,11 +308,16 @@ def _rowwise_grouped_mm_2d3d(XQ, WQ, x_scale, w_scale, offsets, out):
     return out
 
 
-def _rowwise_grouped_mm_3d3d(XQ, WQ, x_scale, w_scale, offsets, out):
+def _rowwise_grouped_mm_3d3d(
+    XQ, WQ, x_scale, w_scale, offsets, out, b_preshuffled=False
+):
     """Plain batched GEMM: fixed per-group slabs with every row carrying data.
 
     This is the padded layout with nothing to mask, so the kernel skips both the
     metadata load and the epilogue's row predicate.
+
+    Nothing is grouped along N or K, so B is a whole [N, K] per group and takes
+    the MFMA swizzle unchanged.
     """
     assert offsets is None, "3D-3D is a batched GEMM and takes no offsets"
     G, M, K = XQ.shape
@@ -331,7 +344,7 @@ def _rowwise_grouped_mm_3d3d(XQ, WQ, x_scale, w_scale, offsets, out):
         x_scale,
         w_scale,
         _unused_group_meta(XQ.device),
-        b_preshuffled=False,
+        b_preshuffled=b_preshuffled,
         blockscale=False,
         layout="batched",
         out=out.view(G * M, N),
@@ -462,6 +475,44 @@ def matmul_f8f8bf16_rowwise_grouped_mm(
     )
 
 
+def matmul_f8f8bf16_rowwise_grouped_mm_preshuffle(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    offsets: torch.Tensor | None,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Sibling of the grouped mm taking weights already MFMA-preshuffled.
+
+    Only the rank combinations that leave B whole are served: 2D-3D groups along
+    M and 3D-3D groups nothing, so each group owns an entire [N, K] and the
+    swizzle applies to it as it stands. Grouping along N or K cuts across the
+    axes the swizzle interleaves, so 3D-2D and 2D-2D have no preshuffled form
+    and are rejected rather than silently given the plain path.
+    """
+    ranks = (XQ.ndim, WQ.ndim)
+    if ranks == (2, 3):
+        return _rowwise_grouped_mm_2d3d(
+            XQ, WQ, x_scale, w_scale, offsets, out, b_preshuffled=True
+        )
+    if ranks == (3, 3):
+        return _rowwise_grouped_mm_3d3d(
+            XQ, WQ, x_scale, w_scale, offsets, out, b_preshuffled=True
+        )
+    if ranks in ((3, 2), (2, 2)):
+        axis = "N" if ranks == (3, 2) else "K"
+        raise ValueError(
+            f"{ranks[0]}D-{ranks[1]}D groups along {axis}, which the MFMA "
+            f"B-preshuffle layout interleaves across the whole matrix, so a "
+            f"group boundary falls inside the swizzle. Use "
+            f"matmul_f8f8bf16_rowwise_grouped_mm with plain weights instead"
+        )
+    raise ValueError(
+        f"XQ must be 2D or 3D and WQ 2D or 3D, got {XQ.ndim}D and {WQ.ndim}D"
+    )
+
+
 if (
     is_flydsl_available()
     and torch.version.hip is not None
@@ -500,4 +551,8 @@ if (
     _register(
         "mslk::f8f8bf16_rowwise_grouped_dynamic_preshuffle",
         matmul_f8f8bf16_rowwise_grouped_dynamic_preshuffle,
+    )
+    _register(
+        "mslk::f8f8bf16_rowwise_grouped_mm_preshuffle",
+        matmul_f8f8bf16_rowwise_grouped_mm_preshuffle,
     )

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -1,0 +1,159 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""FP8 rowwise-scaled grouped GEMM via FlyDSL.
+
+Registers two ops, both backed by the same kernel as the groupwise sibling in
+fp8_groupwise_grouped_gemm.py, compiled for rowwise scaling instead:
+
+* ``mslk::f8f8bf16_rowwise_grouped_stacked`` -- the ROCm implementation, taking
+  row-major ``[G, N, K]`` weights.
+* ``mslk::f8f8bf16_rowwise_grouped_preshuffle`` -- a sibling that consumes
+  weights already in the MFMA B-preshuffle layout (see
+  ``mslk.quantize.shuffle.preshuffle_b_mfma``). Callers shuffle once at load
+  time; the op does no shuffling.
+
+Rowwise scaling carries one scale per row of A and per column of B, both
+constant along K, so they factor out of the reduction and the kernel applies
+them in the epilogue.
+
+Tensor contract:
+  XQ      : [total_M, K]   FP8   -- all groups concatenated along M
+  WQ      : [G, N, K]      FP8   -- per-group weights, MFMA-preshuffled for the
+                                    preshuffle op
+  x_scale : [total_M]      FP32  -- one scale per row of A
+  w_scale : [G, N]         FP32  -- one scale per column of each group's B
+  M_sizes : [G]            int64 -- rows per group (sum to total_M)
+  Output  : [total_M, N]   BF16
+
+  out[m, n] = (sum_k XQ[m, k] * WQ[g, n, k]) * x_scale[m] * w_scale[g, n]
+"""
+
+import torch
+from mslk.flydsl.common import is_flydsl_available
+from mslk.gemm.flydsl import grouped_dispatch
+from mslk.utils.device import supports_float8_fnuz
+
+_PRESHUFFLE_OP_NAME = "mslk::f8f8bf16_rowwise_grouped_preshuffle"
+
+
+def _f8f8bf16_rowwise_grouped_preshuffle_meta(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    M_sizes: torch.Tensor,
+) -> torch.Tensor:
+    total_M = XQ.shape[0]
+    N = WQ.shape[1]
+    return XQ.new_empty((total_M, N), dtype=torch.bfloat16)
+
+
+def _dispatch_rowwise_grouped(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    M_sizes: torch.Tensor,
+    *,
+    b_preshuffled: bool,
+) -> torch.Tensor:
+    """Shared dispatch for both rowwise ops. WQ is already in the layout the
+    variant expects (MFMA-preshuffled if b_preshuffled else plain [G,N,K]).
+    """
+    assert XQ.ndim == 2, f"XQ must be [total_M, K], got {XQ.shape}"
+    assert WQ.ndim == 3, f"WQ must be [G, N, K], got {WQ.shape}"
+    assert M_sizes.ndim == 1, f"M_sizes must be [G], got {M_sizes.shape}"
+    total_M, K = XQ.shape
+    G, N, Kw = WQ.shape
+    assert Kw == K, f"K mismatch: XQ K={K}, WQ K={Kw}"
+    assert M_sizes.shape[0] == G, f"M_sizes length {M_sizes.shape[0]} must equal G={G}"
+    # The MFMA instructions read the operands in the arch's native FP8 format, and
+    # the kernel passes them through as raw bytes, so an fnuz/OCP mismatch would
+    # be applied with the wrong exponent bias rather than rejected.
+    expected_fp8 = (
+        torch.float8_e4m3fnuz if supports_float8_fnuz() else torch.float8_e4m3fn
+    )
+    assert XQ.dtype == expected_fp8, f"XQ must be {expected_fp8}, got {XQ.dtype}"
+    assert WQ.dtype == expected_fp8, f"WQ must be {expected_fp8}, got {WQ.dtype}"
+    assert M_sizes.dtype == torch.int64, f"M_sizes must be int64, got {M_sizes.dtype}"
+    assert x_scale.numel() == total_M, (
+        f"x_scale must hold one scale per row ({total_M}), got {x_scale.numel()}"
+    )
+    assert w_scale.numel() == G * N, (
+        f"w_scale must hold one scale per group column ({G * N}), got {w_scale.numel()}"
+    )
+
+    return grouped_dispatch.dispatch(
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        M_sizes,
+        b_preshuffled=b_preshuffled,
+        blockscale=False,
+    )
+
+
+def matmul_f8f8bf16_rowwise_grouped(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    M_sizes: torch.Tensor,
+) -> torch.Tensor:
+    """FP8 rowwise-scaled grouped GEMM -> BF16, with plain row-major weights."""
+    return _dispatch_rowwise_grouped(
+        XQ, WQ, x_scale, w_scale, M_sizes, b_preshuffled=False
+    )
+
+
+def matmul_f8f8bf16_rowwise_grouped_preshuffle(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    M_sizes: torch.Tensor,
+) -> torch.Tensor:
+    """Preshuffled-B rowwise grouped GEMM (WQ already MFMA-preshuffled).
+
+    Loads B straight to registers rather than staging it through LDS, in
+    exchange for the caller shuffling the weights once at load time.
+    """
+    return _dispatch_rowwise_grouped(
+        XQ, WQ, x_scale, w_scale, M_sizes, b_preshuffled=True
+    )
+
+
+if (
+    is_flydsl_available()
+    and torch.version.hip is not None
+    and hasattr(torch.ops, "mslk")
+):
+    # FlyDSL supplies the ROCm implementation of both ops; their schemas are
+    # declared in csrc/gemm/gemm_ops.cpp, which also leaves the _stacked slot
+    # free on ROCm so this binding can take it. Skip an op whose schema is
+    # missing, as in a python-only build, and tolerate a repeat import
+    # rebinding it.
+    def _register(op_name, cuda_fn, meta_fn=None) -> None:
+        if not hasattr(torch.ops.mslk, op_name.split("::")[1]):
+            return
+        try:
+            torch.library.impl(op_name, "CUDA")(cuda_fn)
+            if meta_fn is not None:
+                torch.library.impl(op_name, "Meta")(meta_fn)
+        except RuntimeError:
+            pass
+
+    # _stacked already has a Meta implementation registered in mslk/gemm/_meta.py.
+    _register("mslk::f8f8bf16_rowwise_grouped_stacked", matmul_f8f8bf16_rowwise_grouped)
+    _register(
+        _PRESHUFFLE_OP_NAME,
+        matmul_f8f8bf16_rowwise_grouped_preshuffle,
+        _f8f8bf16_rowwise_grouped_preshuffle_meta,
+    )

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -292,6 +292,7 @@ def _rowwise_grouped_mm_2d3d(
     assert tuple(out.shape) == (total_M, N), (
         f"out must be [total_M, N] = {(total_M, N)}, got {tuple(out.shape)}"
     )
+    assert out.is_contiguous(), "out must be contiguous"
     _assert_fp8_operands(XQ, WQ)
 
     grouped_dispatch.dispatch(

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -52,7 +52,7 @@ from mslk.flydsl.common import is_flydsl_available
 from mslk.gemm.flydsl import grouped_dispatch
 from mslk.utils.device import supports_float8_fnuz
 
-_PRESHUFFLE_OP_NAME = "mslk::f8f8bf16_rowwise_grouped_preshuffle"
+_STACKED_PRESHUFFLE_OP_NAME = "mslk::f8f8bf16_rowwise_grouped_stacked_preshuffle"
 
 
 def _assert_fp8_operands(XQ: torch.Tensor, WQ: torch.Tensor) -> None:
@@ -79,7 +79,7 @@ def _unused_group_meta(device: torch.device) -> torch.Tensor:
     return torch.zeros((1,), dtype=torch.int32, device=device)
 
 
-def _f8f8bf16_rowwise_grouped_preshuffle_meta(
+def _f8f8bf16_rowwise_grouped_stacked_preshuffle_meta(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
     x_scale: torch.Tensor,
@@ -130,7 +130,7 @@ def _dispatch_rowwise_grouped(
     )
 
 
-def matmul_f8f8bf16_rowwise_grouped(
+def matmul_f8f8bf16_rowwise_grouped_stacked(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
     x_scale: torch.Tensor,
@@ -249,7 +249,7 @@ def matmul_f8f8bf16_rowwise_grouped_dynamic_preshuffle(
     )
 
 
-def matmul_f8f8bf16_rowwise_grouped_preshuffle(
+def matmul_f8f8bf16_rowwise_grouped_stacked_preshuffle(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
     x_scale: torch.Tensor,
@@ -534,11 +534,14 @@ if (
             pass
 
     # _stacked already has a Meta implementation registered in mslk/gemm/_meta.py.
-    _register("mslk::f8f8bf16_rowwise_grouped_stacked", matmul_f8f8bf16_rowwise_grouped)
     _register(
-        _PRESHUFFLE_OP_NAME,
-        matmul_f8f8bf16_rowwise_grouped_preshuffle,
-        _f8f8bf16_rowwise_grouped_preshuffle_meta,
+        "mslk::f8f8bf16_rowwise_grouped_stacked",
+        matmul_f8f8bf16_rowwise_grouped_stacked,
+    )
+    _register(
+        _STACKED_PRESHUFFLE_OP_NAME,
+        matmul_f8f8bf16_rowwise_grouped_stacked_preshuffle,
+        _f8f8bf16_rowwise_grouped_stacked_preshuffle_meta,
     )
     _register(
         "mslk::f8f8bf16_rowwise_grouped_dynamic",

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -339,6 +339,51 @@ def _rowwise_grouped_mm_3d3d(XQ, WQ, x_scale, w_scale, offsets, out):
     return out
 
 
+def _rowwise_grouped_mm_3d2d(XQ, WQ, x_scale, w_scale, offsets, out):
+    """Groups divide the output's columns rather than its rows.
+
+    Each group still multiplies its own activation slab by its own weights; the
+    results are packed side by side into [M, total_N] instead of end to end, so
+    the weights arrive as one [total_N, K] matrix whose rows the offsets divide.
+
+    Every group's column count must be a multiple of 8, the width of the
+    vectorised epilogue store, so that no store straddles a group boundary. The
+    offsets live on the device, so like CK this cannot be checked on the host;
+    unlike CK, which asserts on the device, a violation here silently leaves the
+    straddling columns unwritten.
+    """
+    assert offsets is not None, "3D-2D grouped mm requires offsets for WQ"
+    assert offsets.dtype == torch.int32, f"offsets must be int32, got {offsets.dtype}"
+    G, M, K = XQ.shape
+    total_N, Kw = WQ.shape
+    assert Kw == K, f"K mismatch: XQ K={K}, WQ K={Kw}"
+    assert offsets.shape[0] == G, f"offsets length {offsets.shape[0]} must equal G={G}"
+    assert x_scale.numel() == G * M, (
+        f"x_scale must hold one scale per row ({G * M}), got {x_scale.numel()}"
+    )
+    assert w_scale.numel() == total_N, (
+        f"w_scale must hold one scale per column ({total_N}), got {w_scale.numel()}"
+    )
+    assert tuple(out.shape) == (M, total_N), (
+        f"out must be [M, total_N] = {(M, total_N)}, got {tuple(out.shape)}"
+    )
+    assert out.is_contiguous(), "out must be contiguous"
+    _assert_fp8_operands(XQ, WQ)
+
+    grouped_dispatch.dispatch(
+        XQ.contiguous().view(G * M, K),
+        WQ,
+        x_scale,
+        w_scale,
+        offsets,
+        b_preshuffled=False,
+        blockscale=False,
+        layout="n_offsets",
+        out=out,
+    )
+    return out
+
+
 def matmul_f8f8bf16_rowwise_grouped_mm(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
@@ -359,11 +404,12 @@ def matmul_f8f8bf16_rowwise_grouped_mm(
         return _rowwise_grouped_mm_2d3d(XQ, WQ, x_scale, w_scale, offsets, out)
     if ranks == (3, 3):
         return _rowwise_grouped_mm_3d3d(XQ, WQ, x_scale, w_scale, offsets, out)
-    if ranks in ((3, 2), (2, 2)):
+    if ranks == (3, 2):
+        return _rowwise_grouped_mm_3d2d(XQ, WQ, x_scale, w_scale, offsets, out)
+    if ranks == (2, 2):
         raise NotImplementedError(
-            f"grouped mm with XQ {XQ.ndim}D and WQ {WQ.ndim}D groups along "
-            f"{'N' if ranks == (3, 2) else 'K'}, which this kernel does not yet "
-            "support"
+            "grouped mm with 2D XQ and 2D WQ groups along K, which this kernel "
+            "does not yet support"
         )
     raise ValueError(
         f"XQ must be 2D or 3D and WQ 2D or 3D, got {XQ.ndim}D and {WQ.ndim}D"

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -360,11 +360,13 @@ def _rowwise_grouped_mm_3d2d(XQ, WQ, x_scale, w_scale, offsets, out):
     results are packed side by side into [M, total_N] instead of end to end, so
     the weights arrive as one [total_N, K] matrix whose rows the offsets divide.
 
-    Every group's column count must be a multiple of 8, the width of the
-    vectorised epilogue store, so that no store straddles a group boundary. The
-    offsets live on the device, so like CK this cannot be checked on the host;
-    unlike CK, which asserts on the device, a violation here silently leaves the
-    straddling columns unwritten.
+    Every group's column count must be a multiple of 8, matching the bound CK
+    asserts, so that no store straddles a group boundary; the epilogue's widest
+    store covers four columns, so four is what the kernel itself needs. The
+    offsets live on the device, so like CK this cannot be checked on the host.
+    Unlike CK, which asserts on the device, a violation here leaves the
+    straddling columns unwritten rather than aborting: the store that would
+    cross the boundary is dropped, so the next group's columns are left to it.
     """
     assert offsets is not None, "3D-2D grouped mm requires offsets for WQ"
     assert offsets.dtype == torch.int32, f"offsets must be int32, got {offsets.dtype}"

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -48,11 +48,9 @@ Tensor contract:
 import functools
 
 import torch
-from mslk.flydsl.common import is_flydsl_available
+from mslk.flydsl.common import require_flydsl
 from mslk.gemm.flydsl import grouped_dispatch
 from mslk.utils.device import supports_float8_fnuz
-
-_STACKED_PRESHUFFLE_OP_NAME = "mslk::f8f8bf16_rowwise_grouped_stacked_preshuffle"
 
 
 def _assert_fp8_operands(XQ: torch.Tensor, WQ: torch.Tensor) -> None:
@@ -79,44 +77,6 @@ def _unused_group_meta(device: torch.device) -> torch.Tensor:
     return torch.zeros((1,), dtype=torch.int32, device=device)
 
 
-def _f8f8bf16_rowwise_grouped_stacked_preshuffle_meta(
-    XQ: torch.Tensor,
-    WQ: torch.Tensor,
-    x_scale: torch.Tensor,
-    w_scale: torch.Tensor,
-    M_sizes: torch.Tensor,
-) -> torch.Tensor:
-    total_M = XQ.shape[0]
-    N = WQ.shape[1]
-    return XQ.new_empty((total_M, N), dtype=torch.bfloat16)
-
-
-def _f8f8bf16_rowwise_grouped_dynamic_meta(
-    XQ: torch.Tensor,
-    WQ: torch.Tensor,
-    x_scale: torch.Tensor,
-    w_scale: torch.Tensor,
-    zero_start_index_M: torch.Tensor,
-    zeroing_output_tensor: bool = True,
-) -> torch.Tensor:
-    G, expected_m, _ = XQ.shape
-    N = WQ.shape[1]
-    return XQ.new_empty((G, expected_m, N), dtype=torch.bfloat16)
-
-
-def _f8f8bf16_rowwise_grouped_mm_meta(
-    XQ: torch.Tensor,
-    WQ: torch.Tensor,
-    x_scale: torch.Tensor,
-    w_scale: torch.Tensor,
-    offsets: torch.Tensor | None,
-    out: torch.Tensor,
-) -> torch.Tensor:
-    # The op writes the caller's buffer in place and returns it, so the result
-    # is that buffer whichever rank combination the operands select.
-    return out
-
-
 def _dispatch_rowwise_grouped(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
@@ -129,6 +89,9 @@ def _dispatch_rowwise_grouped(
     """Shared dispatch for both rowwise ops. WQ is already in the layout the
     variant expects (MFMA-preshuffled if b_preshuffled else plain [G,N,K]).
     """
+    # Registration does not probe for FlyDSL, so this is the first point at
+    # which it is required.
+    require_flydsl()
     assert XQ.ndim == 2, f"XQ must be [total_M, K], got {XQ.shape}"
     assert WQ.ndim == 3, f"WQ must be [G, N, K], got {WQ.shape}"
     assert M_sizes.ndim == 1, f"M_sizes must be [G], got {M_sizes.shape}"
@@ -187,6 +150,9 @@ def _dispatch_rowwise_grouped_dynamic(
     the flattened ``[G * expected_m, ...]`` views and treats the group as a grid
     axis rather than resolving it from row counts.
     """
+    # Registration does not probe for FlyDSL, so this is the first point at
+    # which it is required.
+    require_flydsl()
     assert XQ.ndim == 3, f"XQ must be [G, M, K], got {XQ.shape}"
     assert WQ.ndim == 3, f"WQ must be [G, N, K], got {WQ.shape}"
     assert zero_start_index_M.ndim == 1, (
@@ -493,6 +459,9 @@ def matmul_f8f8bf16_rowwise_grouped_mm(
     whichever axis is grouped, and is None for 3D-3D. ``out`` is written in place
     and returned.
     """
+    # Registration does not probe for FlyDSL, so this is the first point at
+    # which it is required.
+    require_flydsl()
     ranks = (XQ.ndim, WQ.ndim)
     if ranks == (2, 3):
         return _rowwise_grouped_mm_2d3d(XQ, WQ, x_scale, w_scale, offsets, out)
@@ -523,6 +492,9 @@ def matmul_f8f8bf16_rowwise_grouped_mm_preshuffle(
     axes the swizzle interleaves, so 3D-2D and 2D-2D have no preshuffled form
     and are rejected rather than silently given the plain path.
     """
+    # Registration does not probe for FlyDSL, so this is the first point at
+    # which it is required.
+    require_flydsl()
     ranks = (XQ.ndim, WQ.ndim)
     if ranks == (2, 3):
         return _rowwise_grouped_mm_2d3d(
@@ -545,56 +517,9 @@ def matmul_f8f8bf16_rowwise_grouped_mm_preshuffle(
     )
 
 
-if (
-    is_flydsl_available()
-    and torch.version.hip is not None
-    and hasattr(torch.ops, "mslk")
-):
-    # FlyDSL supplies the ROCm implementation of these ops; their schemas are
-    # declared in csrc/gemm/gemm_ops.cpp, which leaves every one of these slots
-    # free on ROCm so these bindings can take them. Skip an op whose schema is
-    # missing, as in a python-only build or against a binary built before the
-    # schema was added, and tolerate a repeat import rebinding it.
-    def _register(op_name, cuda_fn, meta_fn=None) -> None:
-        if not hasattr(torch.ops.mslk, op_name.split("::")[1]):
-            return
-        try:
-            torch.library.impl(op_name, "CUDA")(cuda_fn)
-            if meta_fn is not None:
-                torch.library.impl(op_name, "Meta")(meta_fn)
-        except RuntimeError:
-            pass
-
-    # _stacked already has a Meta implementation registered in mslk/gemm/_meta.py.
-    _register(
-        "mslk::f8f8bf16_rowwise_grouped_stacked",
-        matmul_f8f8bf16_rowwise_grouped_stacked,
-    )
-    _register(
-        _STACKED_PRESHUFFLE_OP_NAME,
-        matmul_f8f8bf16_rowwise_grouped_stacked_preshuffle,
-        _f8f8bf16_rowwise_grouped_stacked_preshuffle_meta,
-    )
-    _register(
-        "mslk::f8f8bf16_rowwise_grouped_dynamic",
-        matmul_f8f8bf16_rowwise_grouped_dynamic,
-        _f8f8bf16_rowwise_grouped_dynamic_meta,
-    )
-    # Every rank combination is served, which this op needs: it is one entry
-    # point covering all four, so taking the slot for some of them would break
-    # the rest.
-    _register(
-        "mslk::f8f8bf16_rowwise_grouped_mm",
-        matmul_f8f8bf16_rowwise_grouped_mm,
-        _f8f8bf16_rowwise_grouped_mm_meta,
-    )
-    _register(
-        "mslk::f8f8bf16_rowwise_grouped_dynamic_preshuffle",
-        matmul_f8f8bf16_rowwise_grouped_dynamic_preshuffle,
-        _f8f8bf16_rowwise_grouped_dynamic_meta,
-    )
-    _register(
-        "mslk::f8f8bf16_rowwise_grouped_mm_preshuffle",
-        matmul_f8f8bf16_rowwise_grouped_mm_preshuffle,
-        _f8f8bf16_rowwise_grouped_mm_meta,
-    )
+# This module registers nothing. All six ops are registered in
+# mslk/gemm/__init__.py, whose impls import this module on the first call.
+# Keeping registration out of here is what lets //mslk:gemm_ops avoid depending
+# on //mslk/mslk/gemm:flydsl_ops, and so keeps the FlyDSL wheel out of every
+# binary that merely imports mslk.gemm. Shape inference lives in
+# mslk/gemm/_meta.py for the same reason.

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -49,10 +49,12 @@ def _tiles(tile_ns):
 BLOCKSCALE_TILES = _tiles((128, 256))
 ROWWISE_TILES = _tiles((64, 128, 256))
 
-# Neither tile has to divide the problem any more: a tile that overruns N or K
-# compiles the tail-masked variant instead of being invalid. Ordering by
-# divisibility is still useful, so keep the hint on tile_n.
-_PRUNE = prune_by_divisibility({"tile_n": "n"})
+# A tile that overruns N or K is no longer invalid -- it compiles the tail-masked
+# variant -- but a tile that wastes part of its work on padding is not going to
+# win, so keep pruning on both axes. When nothing divides, which is exactly the
+# case that needs padding, prune_by_divisibility falls back to the full list and
+# the shape still gets tuned.
+_PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
 _KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "masked"]
 
 

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -58,6 +58,18 @@ _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
 _KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "layout"]
 
 
+def _group_and_n(WQ, group_meta, layout):
+    """Group count and total N, which the weights only carry for some layouts.
+
+    Weights are a stack of per-group [N, K] matrices except where the groups
+    divide N, in which case they are one [total_N, K] matrix and the group count
+    comes from the offsets instead.
+    """
+    if layout == "n_offsets":
+        return group_meta.shape[0], WQ.shape[0]
+    return WQ.shape[0], WQ.shape[1]
+
+
 def launch(
     XQ,
     WQ,
@@ -91,15 +103,17 @@ def launch(
     )
 
     total_M, K = XQ.shape
-    G, N, _ = WQ.shape
+    G, N = _group_and_n(WQ, m_sizes, layout)
     if b_preshuffled and (K % tile_k != 0 or N % tile_n != 0):
         raise ValueError(
             f"n ({N}) and k ({K}) must be divisible by tile_n ({tile_n}) and "
             f"tile_k ({tile_k}) for preshuffled B: the MFMA B layout interleaves "
             "both, so a partial tile cannot be masked a load at a time"
         )
-    if layout in ("padded", "batched"):
-        # One z slice per group, so the M axis only spans a single group's slab.
+    if layout in ("padded", "batched", "n_offsets"):
+        # Each group owns a slab, so the M axis only spans a single one. Under
+        # n_offsets the group rides the N axis instead of z, but its rows are
+        # still one slab.
         num_m_tiles = -(-(total_M // G) // tile_m)
     else:
         # Grid M-extent: host-known upper bound (each group wastes at most one
@@ -124,7 +138,9 @@ def launch(
         # that divide keep the cheaper unmasked loads. This mirrors how CK picks
         # between its KPadding and Default specialisations on the host.
         k_padding=(K % tile_k != 0),
-        n_padding=(N % tile_n != 0),
+        # A group's column end is a runtime value when the groups divide N, so
+        # the tail mask is always needed there.
+        n_padding=(N % tile_n != 0) or layout == "n_offsets",
     )
     # Operands keep their natural shape: argument marshalling packs each memref
     # extent as int32, which a flattened view overflows at 2**31 elements. The
@@ -177,12 +193,20 @@ def dispatch(
     slab layouts, so the shape handling below is common to all of them.
     """
     total_M, K = XQ.shape
-    G, N, _ = WQ.shape
+    G, N = _group_and_n(WQ, M_sizes, layout)
 
     if out is None:
         out = torch.empty((total_M, N), dtype=torch.bfloat16, device=XQ.device)
     if total_M == 0 or N == 0 or K == 0 or G == 0:
         return out
+
+    # Tune on the shape of one group rather than of the concatenation, so that
+    # the key describes the work a block actually does. Only the grouped axis
+    # needs normalising; the others are already per-group.
+    if layout == "n_offsets":
+        m_key, n_key = total_M // G, N // G
+    else:
+        m_key, n_key = total_M, N
 
     tuned_launch = _launch_blockscale if blockscale else _launch_rowwise
     return tuned_launch(
@@ -192,8 +216,8 @@ def dispatch(
         w_scale,
         M_sizes,
         out,
-        next_pow2(total_M),
-        N,
+        next_pow2(m_key),
+        n_key,
         K,
         b_preshuffled,
         blockscale,

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -55,7 +55,7 @@ ROWWISE_TILES = _tiles((64, 128, 256))
 # case that needs padding, prune_by_divisibility falls back to the full list and
 # the shape still gets tuned.
 _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
-_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "masked"]
+_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "layout"]
 
 
 def launch(
@@ -70,7 +70,7 @@ def launch(
     k,
     b_preshuffled,
     blockscale,
-    masked=False,
+    layout="sizes",
     *,
     tile_m,
     tile_n,
@@ -79,7 +79,8 @@ def launch(
     """Compile (cached) and launch the grouped GEMM for one tile config.
 
     ``XQ`` is [total_M, K] with groups packed along M, or the flattened
-    [G * expected_m, K] view of the padded layout when ``masked``.
+    [G * expected_m, K] view of the per-group slabs. ``layout`` says which, and
+    how ``m_sizes`` encodes the group geometry; see the kernel factory.
 
     ``m_bucket`` only feeds the autotune key: bucketing total_M keeps nearby token
     counts on one tuned config. ``n``/``k`` are likewise passed for the key and
@@ -97,7 +98,7 @@ def launch(
             f"tile_k ({tile_k}) for preshuffled B: the MFMA B layout interleaves "
             "both, so a partial tile cannot be masked a load at a time"
         )
-    if masked:
+    if layout == "padded":
         # One z slice per group, so the M axis only spans a single group's slab.
         num_m_tiles = -(-(total_M // G) // tile_m)
     else:
@@ -118,7 +119,7 @@ def launch(
         out_dtype="bf16",
         b_preshuffled=b_preshuffled,
         blockscale=blockscale,
-        masked=masked,
+        layout=layout,
         # Compile the tail-masked variant only when K stops mid-tile, so shapes
         # that divide keep the cheaper unmasked loads. This mirrors how CK picks
         # between its KPadding and Default specialisations on the host.
@@ -166,14 +167,14 @@ def dispatch(
     *,
     b_preshuffled,
     blockscale,
-    masked=False,
+    layout="sizes",
     out=None,
 ):
     """Allocate the output if needed and run the grouped GEMM with a selected tile.
 
     Callers validate their own operand contract first; this only handles the
     parts every variant shares. ``XQ``/``out`` are the flattened 2D views in the
-    padded layout, so the shape handling below is common to both.
+    slab layouts, so the shape handling below is common to all of them.
     """
     total_M, K = XQ.shape
     G, N, _ = WQ.shape
@@ -196,5 +197,5 @@ def dispatch(
         K,
         b_preshuffled,
         blockscale,
-        masked,
+        layout,
     )

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -58,11 +58,11 @@ def _tiles(tile_ns):
 BLOCKSCALE_TILES = _tiles((128, 256))
 ROWWISE_TILES = _tiles((64, 128, 256))
 
-# A tile that overruns N or K is no longer invalid -- it compiles the tail-masked
-# variant -- but a tile that wastes part of its work on padding is not going to
-# win, so keep pruning on both axes. When nothing divides, which is exactly the
-# case that needs padding, prune_by_divisibility falls back to the full list and
-# the shape still gets tuned.
+# A tile that overruns N or K still compiles, as the tail-masked variant, but it
+# wastes part of its work on padding and is not going to win, so prune on both
+# axes. When nothing divides, which is the case that needs the padding,
+# prune_by_divisibility falls back to the full list and the shape still gets
+# tuned.
 _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
 # roll_k is deliberately absent: it is fixed policy rather than something that
 # varies per call, and a tuning space containing a fully unrolled candidate would

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -231,10 +231,17 @@ def dispatch(
     # Tune on the shape of one group rather than of the concatenation, so that
     # the key describes the work a block actually does. Only the grouped axis
     # needs normalising; the others are already per-group.
-    if layout == "n_offsets":
-        m_key, n_key = total_M // G, N // G
+    #
+    # M is grouped wherever a group owns a slab of it, which the slab layouts
+    # and the N-grouped one all do: a block then sees one slab, not the stack.
+    # Packed along M it is not, since the groups differ in height and there is
+    # no single per-group M to key on.
+    if layout in ("padded", "batched", "n_offsets"):
+        m_key = total_M // G
     else:
-        m_key, n_key = total_M, N
+        m_key = total_M
+    # The groups divide N, so one group owns a fraction of the columns.
+    n_key = N // G if layout == "n_offsets" else N
     # The groups divide K, so one group contracts over a fraction of it.
     k_key = K // G if layout == "k_offsets" else K
 

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -138,9 +138,7 @@ def launch(
         b_preshuffled=b_preshuffled,
         blockscale=blockscale,
         layout=layout,
-        # Only the plain-B K loop can be rolled; the preshuffled path still runs
-        # the two-deep ping-pong loop, which is unrolled.
-        roll_k=roll_k and not b_preshuffled,
+        roll_k=roll_k,
         # Compile the tail-masked variant only when K stops mid-tile, so shapes
         # that divide keep the cheaper unmasked loads. This mirrors how CK picks
         # between its KPadding and Default specialisations on the host.

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -55,7 +55,10 @@ ROWWISE_TILES = _tiles((64, 128, 256))
 # case that needs padding, prune_by_divisibility falls back to the full list and
 # the shape still gets tuned.
 _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
-_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "layout", "roll_k"]
+# roll_k is deliberately absent: it is fixed policy rather than something that
+# varies per call, and a tuning space containing a fully unrolled candidate would
+# have to compile one per tile config, at a cost that grows with K.
+_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "layout"]
 
 
 def _group_and_n(WQ, group_meta, layout):
@@ -83,7 +86,7 @@ def launch(
     b_preshuffled,
     blockscale,
     layout="sizes",
-    roll_k=False,
+    roll_k=True,
     *,
     tile_m,
     tile_n,
@@ -135,7 +138,9 @@ def launch(
         b_preshuffled=b_preshuffled,
         blockscale=blockscale,
         layout=layout,
-        roll_k=roll_k,
+        # Only the plain-B K loop can be rolled; the preshuffled path still runs
+        # the two-deep ping-pong loop, which is unrolled.
+        roll_k=roll_k and not b_preshuffled,
         # Compile the tail-masked variant only when K stops mid-tile, so shapes
         # that divide keep the cheaper unmasked loads. This mirrors how CK picks
         # between its KPadding and Default specialisations on the host.
@@ -186,7 +191,7 @@ def dispatch(
     b_preshuffled,
     blockscale,
     layout="sizes",
-    roll_k=False,
+    roll_k=True,
     out=None,
 ):
     """Allocate the output if needed and run the grouped GEMM with a selected tile.

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -50,7 +50,7 @@ BLOCKSCALE_TILES = _tiles((128, 256))
 ROWWISE_TILES = _tiles((64, 128, 256))
 
 _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
-_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale"]
+_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "masked"]
 
 
 def launch(
@@ -65,12 +65,16 @@ def launch(
     k,
     b_preshuffled,
     blockscale,
+    masked=False,
     *,
     tile_m,
     tile_n,
     tile_k,
 ):
     """Compile (cached) and launch the grouped GEMM for one tile config.
+
+    ``XQ`` is [total_M, K] with groups packed along M, or the flattened
+    [G * expected_m, K] view of the padded layout when ``masked``.
 
     ``m_bucket`` only feeds the autotune key: bucketing total_M keeps nearby token
     counts on one tuned config. ``n``/``k`` are likewise passed for the key and
@@ -82,10 +86,15 @@ def launch(
 
     total_M, K = XQ.shape
     G, N, _ = WQ.shape
-    # Grid M-extent: host-known upper bound (each group wastes at most one partial
-    # tile). The kernel resolves group ownership from m_sizes and self-skips
-    # surplus tiles, so this needs no device sync and holds under graph capture.
-    num_m_tiles = total_M // tile_m + G
+    if masked:
+        # One z slice per group, so the M axis only spans a single group's slab.
+        num_m_tiles = -(-(total_M // G) // tile_m)
+    else:
+        # Grid M-extent: host-known upper bound (each group wastes at most one
+        # partial tile). The kernel resolves group ownership from m_sizes and
+        # self-skips surplus tiles, so this needs no device sync and holds under
+        # graph capture.
+        num_m_tiles = total_M // tile_m + G
     launcher = compile_grouped_gemm_blockscale_contiguous(
         n=N,
         k=K,
@@ -98,6 +107,7 @@ def launch(
         out_dtype="bf16",
         b_preshuffled=b_preshuffled,
         blockscale=blockscale,
+        masked=masked,
     )
     # Operands keep their natural shape: argument marshalling packs each memref
     # extent as int32, which a flattened view overflows at 2**31 elements. The
@@ -131,16 +141,29 @@ _launch_rowwise = tunable(
 )(launch)
 
 
-def dispatch(XQ, WQ, x_scale, w_scale, M_sizes, *, b_preshuffled, blockscale):
-    """Allocate the output and run the grouped GEMM with a selected tile.
+def dispatch(
+    XQ,
+    WQ,
+    x_scale,
+    w_scale,
+    M_sizes,
+    *,
+    b_preshuffled,
+    blockscale,
+    masked=False,
+    out=None,
+):
+    """Allocate the output if needed and run the grouped GEMM with a selected tile.
 
     Callers validate their own operand contract first; this only handles the
-    parts every variant shares.
+    parts every variant shares. ``XQ``/``out`` are the flattened 2D views in the
+    padded layout, so the shape handling below is common to both.
     """
     total_M, K = XQ.shape
     G, N, _ = WQ.shape
 
-    out = torch.empty((total_M, N), dtype=torch.bfloat16, device=XQ.device)
+    if out is None:
+        out = torch.empty((total_M, N), dtype=torch.bfloat16, device=XQ.device)
     if total_M == 0 or N == 0 or K == 0 or G == 0:
         return out
 
@@ -157,4 +180,5 @@ def dispatch(XQ, WQ, x_scale, w_scale, M_sizes, *, b_preshuffled, blockscale):
         K,
         b_preshuffled,
         blockscale,
+        masked,
     )

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -114,9 +114,7 @@ def launch(
     counts on one tuned config. ``n``/``k`` are likewise passed for the key and
     for tile pruning, and are read back off the operands here.
     """
-    from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_contiguous import (
-        compile_grouped_gemm_blockscale_contiguous,
-    )
+    from mslk.flydsl.kernels.gemm.fp8_grouped_gemm import compile_fp8_grouped_gemm
 
     total_M, K = XQ.shape
     G, N = _group_and_n(WQ, m_sizes, layout)
@@ -140,7 +138,7 @@ def launch(
         # self-skips surplus tiles, so this needs no device sync and holds under
         # graph capture.
         num_m_tiles = total_M // tile_m + G
-    launcher = compile_grouped_gemm_blockscale_contiguous(
+    launcher = compile_fp8_grouped_gemm(
         n=N,
         k=K,
         num_groups=G,

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -55,7 +55,7 @@ ROWWISE_TILES = _tiles((64, 128, 256))
 # case that needs padding, prune_by_divisibility falls back to the full list and
 # the shape still gets tuned.
 _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
-_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "layout"]
+_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "layout", "roll_k"]
 
 
 def _group_and_n(WQ, group_meta, layout):
@@ -83,6 +83,7 @@ def launch(
     b_preshuffled,
     blockscale,
     layout="sizes",
+    roll_k=False,
     *,
     tile_m,
     tile_n,
@@ -134,6 +135,7 @@ def launch(
         b_preshuffled=b_preshuffled,
         blockscale=blockscale,
         layout=layout,
+        roll_k=roll_k,
         # Compile the tail-masked variant only when K stops mid-tile, so shapes
         # that divide keep the cheaper unmasked loads. This mirrors how CK picks
         # between its KPadding and Default specialisations on the host.
@@ -184,6 +186,7 @@ def dispatch(
     b_preshuffled,
     blockscale,
     layout="sizes",
+    roll_k=False,
     out=None,
 ):
     """Allocate the output if needed and run the grouped GEMM with a selected tile.
@@ -222,4 +225,5 @@ def dispatch(
         b_preshuffled,
         blockscale,
         layout,
+        roll_k,
     )

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -98,7 +98,7 @@ def launch(
             f"tile_k ({tile_k}) for preshuffled B: the MFMA B layout interleaves "
             "both, so a partial tile cannot be masked a load at a time"
         )
-    if layout == "padded":
+    if layout in ("padded", "batched"):
         # One z slice per group, so the M axis only spans a single group's slab.
         num_m_tiles = -(-(total_M // G) // tile_m)
     else:

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -27,7 +27,7 @@ SCALE_BLOCK = 128
 
 # Default tile when autotuning is disabled. Valid for any supported shape
 # (tile_n = tile_k = 128 divide every supported N/K, including a small N=128).
-DEFAULT_TILE = {"tile_m": 128, "tile_n": 128, "tile_k": 128}
+DEFAULT_TILE = {"tile_m": 128, "tile_n": 128, "tile_k": 128, "waves_per_eu": 2}
 
 # Candidate tiles swept by autotune. tile_k is a multiple of the K-loop sub-block
 # size under either scheme. Rowwise scaling additionally allows tile_n below the
@@ -36,13 +36,22 @@ DEFAULT_TILE = {"tile_m": 128, "tile_n": 128, "tile_k": 128}
 _TILE_M = (64, 128, 256)
 _TILE_K = (128, 256)
 
+# Occupancy target, as a minimum waves-per-EU hint to the register allocator; 0
+# leaves the choice to the compiler. Preshuffled B is held in registers across a
+# whole pair of K tiles to cover HBM latency, which puts it right on the 256-VGPR
+# boundary between two waves per SIMD and one, so a shape can land either side of
+# it. Only these two are worth sweeping: three waves needs 170 registers and four
+# needs 128, which no configuration of this kernel comes close to.
+_WAVES_PER_EU = (0, 2)
+
 
 def _tiles(tile_ns):
     return tuple(
-        {"tile_m": tm, "tile_n": tn, "tile_k": tk}
+        {"tile_m": tm, "tile_n": tn, "tile_k": tk, "waves_per_eu": wpe}
         for tm in _TILE_M
         for tn in tile_ns
         for tk in _TILE_K
+        for wpe in _WAVES_PER_EU
     )
 
 
@@ -93,6 +102,7 @@ def launch(
     tile_m,
     tile_n,
     tile_k,
+    waves_per_eu=0,
 ):
     """Compile (cached) and launch the grouped GEMM for one tile config.
 
@@ -144,6 +154,8 @@ def launch(
         blockscale=blockscale,
         layout=layout,
         roll_k=roll_k,
+        # 0 means the compiler picks.
+        waves_per_eu=None if waves_per_eu <= 0 else waves_per_eu,
         # Compile the tail-masked variant only when K stops mid-tile, so shapes
         # that divide keep the cheaper unmasked loads. This mirrors how CK picks
         # between its KPadding and Default specialisations on the host.

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -173,7 +173,7 @@ def launch(
         WQ.contiguous().view(torch.int8),
         x_scale.contiguous(),
         w_scale.contiguous(),
-        m_sizes,
+        m_sizes.contiguous(),
         total_M,
         N,
         K,

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -212,6 +212,10 @@ def dispatch(
     Callers validate their own operand contract first; this only handles the
     parts every variant shares. ``XQ``/``out`` are the flattened 2D views in the
     slab layouts, so the shape handling below is common to all of them.
+
+    An allocated output is [total_M, N], which is its shape only where the
+    groups divide M or own a slab of it. Where they divide N or K it has a
+    different shape, so those layouts pass ``out`` rather than rely on this.
     """
     total_M, K = XQ.shape
     G, N = _group_and_n(WQ, M_sizes, layout)
@@ -219,7 +223,10 @@ def dispatch(
     if out is None:
         out = torch.empty((total_M, N), dtype=torch.bfloat16, device=XQ.device)
     if total_M == 0 or N == 0 or K == 0 or G == 0:
-        return out
+        # The kernel does not launch, so nothing else writes the output. A
+        # contraction over nothing sums to zero, and where the output holds no
+        # elements at all this is a no-op.
+        return out.zero_()
 
     # Tune on the shape of one group rather than of the concatenation, so that
     # the key describes the work a block actually does. Only the grouped axis

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -68,7 +68,9 @@ def _group_and_n(WQ, group_meta, layout):
     divide N, in which case they are one [total_N, K] matrix and the group count
     comes from the offsets instead.
     """
-    if layout == "n_offsets":
+    if layout in ("n_offsets", "k_offsets"):
+        # One matrix rather than a stack, so the group count comes from the
+        # offsets; N is its row count either way.
         return group_meta.shape[0], WQ.shape[0]
     return WQ.shape[0], WQ.shape[1]
 
@@ -114,7 +116,10 @@ def launch(
             f"tile_k ({tile_k}) for preshuffled B: the MFMA B layout interleaves "
             "both, so a partial tile cannot be masked a load at a time"
         )
-    if layout in ("padded", "batched", "n_offsets"):
+    if layout == "k_offsets":
+        # Every group produces a whole output, so the grid covers M exactly.
+        num_m_tiles = -(-total_M // tile_m)
+    elif layout in ("padded", "batched", "n_offsets"):
         # Each group owns a slab, so the M axis only spans a single one. Under
         # n_offsets the group rides the N axis instead of z, but its rows are
         # still one slab.
@@ -213,6 +218,8 @@ def dispatch(
         m_key, n_key = total_M // G, N // G
     else:
         m_key, n_key = total_M, N
+    # The groups divide K, so one group contracts over a fraction of it.
+    k_key = K // G if layout == "k_offsets" else K
 
     tuned_launch = _launch_blockscale if blockscale else _launch_rowwise
     return tuned_launch(
@@ -224,7 +231,7 @@ def dispatch(
         out,
         next_pow2(m_key),
         n_key,
-        K,
+        k_key,
         b_preshuffled,
         blockscale,
         layout,

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -1,0 +1,160 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Shared host dispatch for the FlyDSL grouped FP8 GEMM ops.
+
+One kernel serves every combination of B layout (plain or MFMA-preshuffled) and
+scaling scheme (block or rowwise); this module holds the host-side work common to
+all of them -- operand marshalling, grid extent, and tile selection -- so each op
+module only supplies its own contract checks.
+
+Tile selection is delegated to mslk.flydsl.autotune, which tunes only when
+MSLK_AUTOTUNE_ENABLE is set and otherwise uses a fixed default.
+"""
+
+import torch
+from mslk.flydsl.autotune import next_pow2, prune_by_divisibility, tunable
+from mslk.flydsl.jit import run_compiled
+
+# Scale-block granularity for the block-scaling scheme. It also sets the K-loop
+# sub-block size under either scheme, so tile_k must be a multiple of it.
+SCALE_BLOCK = 128
+
+# Default tile when autotuning is disabled. Valid for any supported shape
+# (tile_n = tile_k = 128 divide every supported N/K, including a small N=128).
+DEFAULT_TILE = {"tile_m": 128, "tile_n": 128, "tile_k": 128}
+
+# Candidate tiles swept by autotune. tile_k is a multiple of the K-loop sub-block
+# size under either scheme. Rowwise scaling additionally allows tile_n below the
+# scale block, which block scaling cannot express, so the two schemes sweep
+# different sets. Tiles that overflow LDS are rejected at compile time.
+_TILE_M = (64, 128, 256)
+_TILE_K = (128, 256)
+
+
+def _tiles(tile_ns):
+    return tuple(
+        {"tile_m": tm, "tile_n": tn, "tile_k": tk}
+        for tm in _TILE_M
+        for tn in tile_ns
+        for tk in _TILE_K
+    )
+
+
+BLOCKSCALE_TILES = _tiles((128, 256))
+ROWWISE_TILES = _tiles((64, 128, 256))
+
+_PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
+_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale"]
+
+
+def launch(
+    XQ,
+    WQ,
+    x_scale,
+    w_scale,
+    m_sizes,
+    out,
+    m_bucket,
+    n,
+    k,
+    b_preshuffled,
+    blockscale,
+    *,
+    tile_m,
+    tile_n,
+    tile_k,
+):
+    """Compile (cached) and launch the grouped GEMM for one tile config.
+
+    ``m_bucket`` only feeds the autotune key: bucketing total_M keeps nearby token
+    counts on one tuned config. ``n``/``k`` are likewise passed for the key and
+    for tile pruning, and are read back off the operands here.
+    """
+    from mslk.flydsl.kernels.gemm.grouped_gemm_blockscale_contiguous import (
+        compile_grouped_gemm_blockscale_contiguous,
+    )
+
+    total_M, K = XQ.shape
+    G, N, _ = WQ.shape
+    # Grid M-extent: host-known upper bound (each group wastes at most one partial
+    # tile). The kernel resolves group ownership from m_sizes and self-skips
+    # surplus tiles, so this needs no device sync and holds under graph capture.
+    num_m_tiles = total_M // tile_m + G
+    launcher = compile_grouped_gemm_blockscale_contiguous(
+        n=N,
+        k=K,
+        num_groups=G,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        scale_block_k=SCALE_BLOCK,
+        scale_block_n=SCALE_BLOCK,
+        out_dtype="bf16",
+        b_preshuffled=b_preshuffled,
+        blockscale=blockscale,
+    )
+    # Operands keep their natural shape: argument marshalling packs each memref
+    # extent as int32, which a flattened view overflows at 2**31 elements. The
+    # kernel addresses them as flat byte buffers regardless. FP8 is viewed as
+    # int8 for the handoff.
+    run_compiled(
+        launcher,
+        out,
+        XQ.contiguous().view(torch.int8),
+        WQ.contiguous().view(torch.int8),
+        x_scale.contiguous(),
+        w_scale.contiguous(),
+        m_sizes,
+        total_M,
+        N,
+        K,
+        G,
+        num_m_tiles,
+        torch.cuda.current_stream(),
+    )
+    return out
+
+
+# The two scaling schemes sweep different tiles, so each gets its own tuned entry
+# point; the cache key carries the scheme as well, since the kernels differ.
+_launch_blockscale = tunable(
+    configs=BLOCKSCALE_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE
+)(launch)
+_launch_rowwise = tunable(
+    configs=ROWWISE_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE
+)(launch)
+
+
+def dispatch(XQ, WQ, x_scale, w_scale, M_sizes, *, b_preshuffled, blockscale):
+    """Allocate the output and run the grouped GEMM with a selected tile.
+
+    Callers validate their own operand contract first; this only handles the
+    parts every variant shares.
+    """
+    total_M, K = XQ.shape
+    G, N, _ = WQ.shape
+
+    out = torch.empty((total_M, N), dtype=torch.bfloat16, device=XQ.device)
+    if total_M == 0 or N == 0 or K == 0 or G == 0:
+        return out
+
+    tuned_launch = _launch_blockscale if blockscale else _launch_rowwise
+    return tuned_launch(
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        M_sizes,
+        out,
+        next_pow2(total_M),
+        N,
+        K,
+        b_preshuffled,
+        blockscale,
+    )

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -49,7 +49,9 @@ def _tiles(tile_ns):
 BLOCKSCALE_TILES = _tiles((128, 256))
 ROWWISE_TILES = _tiles((64, 128, 256))
 
-_PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
+# Only tile_n has to divide the problem: a tile_k that overruns K compiles the
+# tail-masked variant instead of being invalid.
+_PRUNE = prune_by_divisibility({"tile_n": "n"})
 _KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "masked"]
 
 
@@ -86,6 +88,12 @@ def launch(
 
     total_M, K = XQ.shape
     G, N, _ = WQ.shape
+    if b_preshuffled and K % tile_k != 0:
+        raise ValueError(
+            f"k ({K}) must be divisible by tile_k ({tile_k}) for preshuffled B: "
+            "the MFMA B layout interleaves K, so a partial tile cannot be masked "
+            "a load at a time"
+        )
     if masked:
         # One z slice per group, so the M axis only spans a single group's slab.
         num_m_tiles = -(-(total_M // G) // tile_m)
@@ -108,6 +116,10 @@ def launch(
         b_preshuffled=b_preshuffled,
         blockscale=blockscale,
         masked=masked,
+        # Compile the tail-masked variant only when K stops mid-tile, so shapes
+        # that divide keep the cheaper unmasked loads. This mirrors how CK picks
+        # between its KPadding and Default specialisations on the host.
+        k_padding=(K % tile_k != 0),
     )
     # Operands keep their natural shape: argument marshalling packs each memref
     # extent as int32, which a flattened view overflows at 2**31 elements. The

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -49,8 +49,9 @@ def _tiles(tile_ns):
 BLOCKSCALE_TILES = _tiles((128, 256))
 ROWWISE_TILES = _tiles((64, 128, 256))
 
-# Only tile_n has to divide the problem: a tile_k that overruns K compiles the
-# tail-masked variant instead of being invalid.
+# Neither tile has to divide the problem any more: a tile that overruns N or K
+# compiles the tail-masked variant instead of being invalid. Ordering by
+# divisibility is still useful, so keep the hint on tile_n.
 _PRUNE = prune_by_divisibility({"tile_n": "n"})
 _KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "masked"]
 
@@ -88,11 +89,11 @@ def launch(
 
     total_M, K = XQ.shape
     G, N, _ = WQ.shape
-    if b_preshuffled and K % tile_k != 0:
+    if b_preshuffled and (K % tile_k != 0 or N % tile_n != 0):
         raise ValueError(
-            f"k ({K}) must be divisible by tile_k ({tile_k}) for preshuffled B: "
-            "the MFMA B layout interleaves K, so a partial tile cannot be masked "
-            "a load at a time"
+            f"n ({N}) and k ({K}) must be divisible by tile_n ({tile_n}) and "
+            f"tile_k ({tile_k}) for preshuffled B: the MFMA B layout interleaves "
+            "both, so a partial tile cannot be masked a load at a time"
         )
     if masked:
         # One z slice per group, so the M axis only spans a single group's slab.
@@ -120,6 +121,7 @@ def launch(
         # that divide keep the cheaper unmasked loads. This mirrors how CK picks
         # between its KPadding and Default specialisations on the host.
         k_padding=(K % tile_k != 0),
+        n_padding=(N % tile_n != 0),
     )
     # Operands keep their natural shape: argument marshalling packs each memref
     # extent as int32, which a flattened view overflows at 2**31 elements. The

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -864,6 +864,110 @@ class FP8Tests(unittest.TestCase):
 
         self.bf16_loopover_validate(list(X), list(W), list(y))
 
+    @parameterized.expand([("2d3d",), ("3d3d",)])
+    @skipUnlessRocm()
+    def test_grouped_gemm_mm_preshuffle(self, ranks: str) -> None:
+        """The grouped mm ranks that leave each group a whole [N, K].
+
+        Weights arrive already in the MFMA B layout, which the caller applies
+        once at load time.
+        """
+        from mslk.flydsl.common import is_flydsl_available
+        from mslk.quantize.shuffle import preshuffle_b_mfma
+
+        if not is_flydsl_available():
+            self.skipTest("FlyDSL not available")
+        if not hasattr(torch.ops.mslk, "f8f8bf16_rowwise_grouped_mm_preshuffle"):
+            self.skipTest("build predates the preshuffled grouped mm schema")
+
+        G, M, N, K = 4, 128, 256, 256
+        W = torch.randn((G, N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+        wq, w_scale = quantize_fp8_row(W)
+        op = torch.ops.mslk.f8f8bf16_rowwise_grouped_mm_preshuffle
+
+        if ranks == "2d3d":
+            m_sizes = [64, 128, 32, 64]
+            offsets = torch.cumsum(torch.tensor(m_sizes, dtype=torch.int), dim=0).to(
+                device=self.device, dtype=torch.int32
+            )
+            total_m = sum(m_sizes)
+            X = (
+                torch.randn((total_m, K), dtype=torch.bfloat16, device=self.device)
+                * 0.1
+            )
+            xq, x_scale = quantize_fp8_row(X)
+            out = torch.empty((total_m, N), dtype=torch.bfloat16, device=self.device)
+            y = op(xq, preshuffle_b_mfma(wq), x_scale, w_scale, offsets, out)
+            X_list, W_list, y_list, row = [], [], [], 0
+            for g, m_g in enumerate(m_sizes):
+                X_list.append(X[row : row + m_g])
+                W_list.append(W[g])
+                y_list.append(y[row : row + m_g])
+                row += m_g
+        else:
+            X = torch.randn((G, M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+            xq, x_scale = quantize_fp8_row(X)
+            out = torch.empty((G, M, N), dtype=torch.bfloat16, device=self.device)
+            y = op(
+                xq,
+                preshuffle_b_mfma(wq),
+                x_scale.view(G, -1),
+                w_scale.view(G, -1),
+                None,
+                out,
+            )
+            X_list, W_list, y_list = list(X), list(W), list(y)
+
+        self.bf16_loopover_validate(X_list, W_list, y_list)
+
+    @skipUnlessRocm()
+    def test_grouped_gemm_mm_preshuffle_rejects_grouped_n_and_k(self) -> None:
+        """Grouping along N or K puts a group boundary inside the swizzle.
+
+        There is no preshuffled form of those, so they have to be refused rather
+        than quietly served from the plain path.
+        """
+        from mslk.flydsl.common import is_flydsl_available
+
+        if not is_flydsl_available():
+            self.skipTest("FlyDSL not available")
+        from mslk.gemm.flydsl.fp8_rowwise_grouped_gemm import (
+            matmul_f8f8bf16_rowwise_grouped_mm_preshuffle as op,
+        )
+
+        G, M, N, K = 4, 128, 256, 256
+        X3 = torch.randn((G, M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        W2 = torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+        xq3, xs3 = quantize_fp8_row(X3)
+        wq2, ws2 = quantize_fp8_row(W2)
+        n_offsets = torch.cumsum(torch.full((G,), N // G, dtype=torch.int), dim=0).to(
+            device=self.device, dtype=torch.int32
+        )
+        with self.assertRaisesRegex(ValueError, "3D-2D groups along N"):
+            op(
+                xq3,
+                wq2,
+                xs3.view(G, -1),
+                ws2,
+                n_offsets,
+                torch.empty((M, N), dtype=torch.bfloat16, device=self.device),
+            )
+
+        X2 = torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        xq2, xs2 = quantize_fp8_row(X2)
+        k_offsets = torch.cumsum(torch.full((G,), K // G, dtype=torch.int), dim=0).to(
+            device=self.device, dtype=torch.int32
+        )
+        with self.assertRaisesRegex(ValueError, "2D-2D groups along K"):
+            op(
+                xq2,
+                wq2,
+                xs2,
+                ws2,
+                k_offsets,
+                torch.empty((G, M, N), dtype=torch.bfloat16, device=self.device),
+            )
+
     def bf16_loopover_validate(
         self,
         x: Union[torch.Tensor, list[torch.Tensor]],

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -741,6 +741,13 @@ class FP8Tests(unittest.TestCase):
 
         The parameterised cases above keep every group's K a multiple of 16, the
         vectorised load width, since neither implementation supports less.
+
+        Every other group holds constant, single-signed data. A read that runs
+        past a group's K end lands in the next group, and against constants the
+        extra terms accumulate coherently rather than cancelling, which puts the
+        error orders of magnitude above the comparison tolerance. Random
+        neighbours would leave it near the quantisation noise, where the
+        comparison cannot tell the two apart.
         """
         M, N = 128, 256
         G = len(k_sizes)
@@ -750,11 +757,25 @@ class FP8Tests(unittest.TestCase):
 
         X_list, W_list = [], []
         xq_list, wq_list, x_scale_list, w_scale_list = [], [], [], []
-        for k_size in k_sizes:
+        for g, k_size in enumerate(k_sizes):
             # A zero-width group still has to contribute a scale per row.
             width = max(k_size, 1)
-            X = torch.randn((M, width), dtype=torch.bfloat16, device=self.device) * 0.1
-            W = torch.randn((N, width), dtype=torch.bfloat16, device=self.device) * 0.01
+            if g % 2:
+                X = torch.full(
+                    (M, width), 0.1, dtype=torch.bfloat16, device=self.device
+                )
+                W = torch.full(
+                    (N, width), 0.01, dtype=torch.bfloat16, device=self.device
+                )
+            else:
+                X = (
+                    torch.randn((M, width), dtype=torch.bfloat16, device=self.device)
+                    * 0.1
+                )
+                W = (
+                    torch.randn((N, width), dtype=torch.bfloat16, device=self.device)
+                    * 0.01
+                )
             xq, x_scale = quantize_fp8_row(X)
             wq, w_scale = quantize_fp8_row(W)
             X_list.append(X[:, :k_size])

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -721,6 +721,128 @@ class FP8Tests(unittest.TestCase):
         # Compare using loopover BF16 gemm
         self.bf16_loopover_validate(X_list, W_list, y)
 
+    @parameterized.expand(
+        [
+            # Group K that does not divide the K tile while the TOTAL does.
+            # Whether the total is tile-aligned says nothing about a group's
+            # slice, so a tail predicate keyed on the total is not emitted here
+            # and each group reads into the next one's data.
+            ([288] * 4,),  # total 1152
+            ([192, 320],),  # total 512
+            ([16, 512, 128, 368],),  # total 1024, mixed
+            ([0, 256, 256, 512],),  # total 1024, with an empty group
+        ]
+    )
+    @skipUnlessRocm()
+    def test_grouped_gemm_2d_2d_group_k_not_tile_aligned(
+        self, k_sizes: list[int]
+    ) -> None:
+        """Groups divide K at extents that do not land on a tile boundary.
+
+        The parameterised cases above keep every group's K a multiple of 16, the
+        vectorised load width, since neither implementation supports less.
+        """
+        M, N = 128, 256
+        G = len(k_sizes)
+        K_offsets = torch.cumsum(torch.tensor(k_sizes, dtype=torch.int), dim=0).to(
+            device=self.device, dtype=torch.int32
+        )
+
+        X_list, W_list = [], []
+        xq_list, wq_list, x_scale_list, w_scale_list = [], [], [], []
+        for k_size in k_sizes:
+            # A zero-width group still has to contribute a scale per row.
+            width = max(k_size, 1)
+            X = torch.randn((M, width), dtype=torch.bfloat16, device=self.device) * 0.1
+            W = torch.randn((N, width), dtype=torch.bfloat16, device=self.device) * 0.01
+            xq, x_scale = quantize_fp8_row(X)
+            wq, w_scale = quantize_fp8_row(W)
+            X_list.append(X[:, :k_size])
+            W_list.append(W[:, :k_size])
+            xq_list.append(xq[:, :k_size])
+            wq_list.append(wq[:, :k_size])
+            x_scale_list.append(x_scale)
+            w_scale_list.append(w_scale)
+
+        xq = torch.cat(xq_list, dim=1)
+        wq = torch.cat(wq_list, dim=1)
+        x_scale = torch.cat(x_scale_list, dim=0)
+        w_scale = torch.cat(w_scale_list, dim=0)
+        out = torch.empty((G, M, N), dtype=torch.bfloat16, device=self.device)
+
+        y = torch.ops.mslk.f8f8bf16_rowwise_grouped_mm(
+            xq, wq, x_scale, w_scale, K_offsets, out
+        )
+
+        # A group that contracts over nothing contributes nothing; the op leaves
+        # its slab alone, so only the rest is checked.
+        live = [g for g, k in enumerate(k_sizes) if k]
+        self.bf16_loopover_validate(
+            [X_list[g] for g in live],
+            [W_list[g] for g in live],
+            [y[g] for g in live],
+        )
+
+    @parameterized.expand(
+        [
+            ([264, 264],),  # a multiple of 8, not of any tile_n
+            ([8, 504, 128],),  # one group narrower than a single tile
+            ([1024, 264, 8],),
+        ]
+    )
+    @skipUnlessRocm()
+    def test_grouped_gemm_3d_2d_group_n_not_tile_aligned(
+        self, n_sizes: list[int]
+    ) -> None:
+        """Groups divide N at extents that do not land on a tile boundary.
+
+        Every group's N stays a multiple of 8, the widest vectorised store,
+        which CK asserts on the device and this kernel needs for the same reason.
+        """
+        M, K = 128, 256
+        G = len(n_sizes)
+        total_n = sum(n_sizes)
+        N_offsets = torch.cumsum(torch.tensor(n_sizes, dtype=torch.int), dim=0).to(
+            device=self.device, dtype=torch.int32
+        )
+
+        X = torch.randn((G, M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        W = torch.randn((total_n, K), dtype=torch.bfloat16, device=self.device) * 0.01
+        xq, x_scale = quantize_fp8_row(X)
+        wq, w_scale = quantize_fp8_row(W)
+        out = torch.empty((M, total_n), dtype=torch.bfloat16, device=self.device)
+
+        y = torch.ops.mslk.f8f8bf16_rowwise_grouped_mm(
+            xq, wq, x_scale.view(G, -1), w_scale, N_offsets, out
+        )
+
+        self.bf16_loopover_validate(
+            list(X),
+            list(torch.split(W, n_sizes, dim=0)),
+            list(torch.split(y, n_sizes, dim=1)),
+        )
+
+    @parameterized.expand([(1,), (64,), (100,), (192,), (255,)])
+    @skipUnlessRocm()
+    def test_grouped_gemm_3d_3d_slab_not_tile_aligned(self, M: int) -> None:
+        """Batched, with a slab height that does not divide the M tile.
+
+        A full slab does not mean a tile fits inside it: the last tile overhangs
+        into the next group's rows, so the epilogue still has to mask by row.
+        """
+        G, N, K = 4, 256, 256
+        X = torch.randn((G, M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        W = torch.randn((G, N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+        xq, x_scale = quantize_fp8_row(X)
+        wq, w_scale = quantize_fp8_row(W)
+        out = torch.empty((G, M, N), dtype=torch.bfloat16, device=self.device)
+
+        y = torch.ops.mslk.f8f8bf16_rowwise_grouped_mm(
+            xq, wq, x_scale.view(G, -1), w_scale.view(G, -1), None, out
+        )
+
+        self.bf16_loopover_validate(list(X), list(W), list(y))
+
     def bf16_loopover_validate(
         self,
         x: Union[torch.Tensor, list[torch.Tensor]],

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -854,6 +854,65 @@ class FP8Tests(unittest.TestCase):
         # BF16 loopover gemm reference
         self.bf16_loopover_validate(x_group, W, y_fp8_group, y_bf16_group)
 
+    @parameterized.expand(
+        [
+            (1, 512, 512, 512, True),  # small MNK (also small G)
+            (16, 256, 1024, 2048, True),  # medium MNK
+            (64, 128, 6144, 3584, True),  # large MNK
+            (16, 512, 512, 512, True),  # medium G
+            (64, 512, 512, 512, True),  # large G
+            (4, 256, 1024, 512, False),  # padding left uninitialised
+        ]
+    )
+    @skipUnlessRocm()
+    def test_grouped_gemm_dynamic(
+        self,
+        G: int,
+        M: int,
+        N: int,
+        K: int,
+        zeroing_output_tensor: bool,
+    ) -> None:
+        """Padded per-group layout: [G, M, K] with a runtime valid row count.
+
+        Unlike the stacked variant the groups do not share one packed buffer;
+        each gets a fixed slab of M rows of which only the first
+        zero_start_index_M[g] hold real tokens. The rest is padding, so the
+        reference only covers the valid rows, and the padded output rows are
+        checked separately.
+        """
+        # Cover empty, partially filled and completely filled groups.
+        valid_m = torch.randint(0, M + 1, (G,), dtype=torch.int64)
+        valid_m[0] = 0
+        valid_m[-1] = M
+        valid_m_gpu = valid_m.to(device=self.device)
+
+        X = torch.randn((G, M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        W = torch.randn((G, N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+
+        xq, x_scale = quantize_fp8_row(X)
+        wq, w_scale = quantize_fp8_row(W)
+
+        y = torch.ops.mslk.f8f8bf16_rowwise_grouped_dynamic(
+            xq, wq, x_scale, w_scale, valid_m_gpu, zeroing_output_tensor
+        )
+        self.assertEqual(tuple(y.shape), (G, M, N))
+
+        # Only the valid rows of each group are defined by the op, so compare
+        # those and leave the padding to the check below.
+        x_group = [X[g, : valid_m[g]] for g in range(G)]
+        w_group = [W[g] for g in range(G)]
+        y_group = [y[g, : valid_m[g]] for g in range(G)]
+        self.bf16_loopover_validate(x_group, w_group, y_group)
+
+        if zeroing_output_tensor:
+            for g in range(G):
+                padding = y[g, valid_m[g] :]
+                self.assertTrue(
+                    (padding == 0).all().item(),
+                    f"group {g} padding rows must be zeroed",
+                )
+
 
 @skipUnlessGfxArch("gfx942", "gfx950")
 @skipUnlessCudaCapability(9, 10)

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -1277,6 +1277,51 @@ class FP8GroupwiseTests(unittest.TestCase):
         self.assertFalse(out.isinf().any().item(), "Output contains Inf")
         torch.testing.assert_close(out, ref, atol=1.0e-2, rtol=4.0e-2)
 
+    @parameterized.expand([(240,), (144,)])
+    @skipUnlessRocm()
+    def test_f8f8bf16_groupwise_grouped_rejects_partial_scale_block(
+        self, K: int
+    ) -> None:
+        """K covering a partial scale block has to be refused, not truncated.
+
+        Block scaling counts whole scale blocks along K; a partial one is left
+        out of that count and the scales are misindexed from there on, which
+        costs the tail of the contraction. The error that produces is small
+        enough to sit inside the tolerance this file compares with, so it has
+        to be refused at the boundary instead of checked for numerically.
+        """
+        from mslk.flydsl.common import is_flydsl_available
+        from mslk.quantize.triton.fp8_quantize import (
+            quantize_fp8_block,
+            quantize_fp8_group,
+        )
+
+        if not is_flydsl_available():
+            self.skipTest("FlyDSL not available")
+
+        N = 256
+        m_values = [128, 64]
+        G = len(m_values)
+        m_sizes = torch.tensor(m_values, dtype=torch.int64, device=self.device)
+        total_m = sum(m_values)
+        x = torch.randn((total_m, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        ws = [
+            torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+            for _ in range(G)
+        ]
+        wq_list, ws_list = zip(
+            *[
+                quantize_fp8_block(w, block_m=128, block_k=128, k_major=False)
+                for w in ws
+            ]
+        )
+        wq = torch.stack(wq_list, dim=0).contiguous()
+        w_scale = torch.stack(ws_list, dim=0).contiguous()
+        xq, x_scale = quantize_fp8_group(x, m_sizes=m_sizes)
+
+        with self.assertRaisesRegex(ValueError, "scale_block_k"):
+            torch.ops.mslk.f8f8bf16_groupwise_grouped(xq, wq, x_scale, w_scale, m_sizes)
+
 
 @skipUnlessCuda()
 @skipUnlessCudaCapability(9, 9)


### PR DESCRIPTION
## Summary

Implements the FP8 **rowwise**-scaled grouped GEMM entry points with FlyDSL and binds them on
ROCm, extending the grouped kernel added for the groupwise op in #470. On ROCm these ops are now
served by FlyDSL rather than CK; on CUDA nothing changes.

| Op | Group layout | Status |
|---|---|---|
| `f8f8bf16_rowwise_grouped_stacked` | groups packed along M, `[G]` int64 row counts | FlyDSL |
| `f8f8bf16_rowwise_grouped_dynamic` | fixed `[G, M, K]` slabs, runtime valid-row count | FlyDSL |
| `f8f8bf16_rowwise_grouped_mm` | 2D-3D (M), 3D-3D (batched), 3D-2D (N), 2D-2D (K) | FlyDSL |
| `..._stacked_preshuffle`, `..._dynamic_preshuffle`, `..._mm_preshuffle` | as above, MFMA-preshuffled B | FlyDSL (new schemas) |

`f8f8bf16_rowwise_grouped` and `_cat` are left on CK: both are marked
`UNSUPPORTED AND DEPRECATED` in CK's own source, have no in-repo callers and no tests.

## Design notes

**One kernel, not six.** The group geometry is a compile-time `layout` enum — `sizes`, `offsets`,
`padded`, `batched`, `n_offsets`, `k_offsets`. Only the resolution step differs between them; the
loaders, K loop and epilogue are shared. `n_offsets` (groups divide N) and `k_offsets` (groups
divide K) resolve the group from the N-block index and from the grid z axis respectively, rather
than from a row-count scan.

**Scaling scheme is a compile-time flag.** Rowwise carries one scale per row of A and per column
of B, both constant along K, so they factor out of the reduction and apply once in the epilogue
instead of per scale block inside the K loop. This also frees the tile from scale-block alignment,
making `tile_n = 64` available, which block scaling cannot express.

**The K loop is rolled by default.** Unrolling folds the tile index into every address, but traced
IR, compile time and code size then grow linearly with K: at K=8192 the plain loop is 5271 lines of
ISA and 12.9 s to compile unrolled, against 990 lines and 1.5 s rolled, with bitwise-identical
output. Both loop forms share one body. `k_offsets` is always rolled, since a group's K length is
a runtime value.

**Preshuffled B is offered only where a group owns a whole `[N, K]`.** The MFMA swizzle interleaves
N and K across the whole matrix, so a group boundary inside either axis falls inside the swizzle.
`_mm_preshuffle` therefore serves the 2D-3D and 3D-3D ranks and rejects 3D-2D and 2D-2D rather than
silently ignoring weights the caller has already shuffled.

**Tile selection is opt-in.** Tuning runs only under `MSLK_AUTOTUNE_ENABLE`, matching the CK and
CUTLASS paths; otherwise a fixed default tile is used with no benchmarking. `mslk/flydsl/autotune.py`
is generic and carries nothing specific to this kernel.

## Performance

FlyDSL vs CK, CUDA-graph replay, G=8, gfx950, idle GPU. Figures are the reduction in kernel time
against CK,

```
(ck_time - fly_time) / ck_time * 100
```

so a positive number is the share of CK's time saved and a negative one is the share added.
**59 of 72 shapes are faster.**

| Variant | Shapes faster | Median | Worst | Best |
|---|---|---|---|---|
| `_mm` 2D-3D | 18/24 | +10.3% | -16.7% | +39.8% |
| `_mm` 3D-3D | 11/12 | +11.7% | -12.9% | +20.4% |
| `_mm` 3D-2D | 8/12 | +12.0% | -12.2% | +35.9% |
| `_mm` 2D-2D | 12/12 | +22.4% | +0.9% | +41.3% |
| `_dynamic` | 10/12 | +30.5% | -38.5% | +60.2% |

Two caveats belong with these numbers:

- **CK runs on its heuristic; FlyDSL is autotuned.** `MSLK_AUTOTUNE_ENABLE` is read by both, and
  CK's tuning path raises `Kernels to tune over is empty` for these entry points, so the benchmark
  toggles it per side. Each is at its best *available* setting, not the same setting.
- **The largest cluster of slower shapes is narrow N.** Six of the thirteen are `1280x8192`, where
  there are too few N-blocks to fill the machine; the same weakness is reported in #470 against
  Triton, so it reproduces across two kernels and two baselines. Most of the remainder are
  total_M=1 at large N, where launch overhead dominates.

Both sides are timed after a 0.5 s clock ramp. Without it, a short window on an idle GPU measures
the clock ramp as much as the kernel — about 12% on these shapes — and whichever side is timed
second inherits the other's warm-up.

<details>
<summary>Per-shape detail</summary>

`_mm` 2D-3D — M is total rows across all groups

| Family | M | N×K | CK µs | FlyDSL µs | Time saved |
|---|---|---|---|---|---|
| ds_v3 | 1 | 2048×7168 | 30.1 | 25.5 | +15.3% |
| ds_v3 | 128 | 2048×7168 | 31.8 | 33.7 | -6.0% |
| ds_v3 | 1024 | 2048×7168 | 47.6 | 39.8 | +16.4% |
| ds_v3 | 4096 | 2048×7168 | 99.5 | 89.8 | +9.7% |
| ds_v3 | 1 | 7168×2304 | 19.7 | 13.1 | +33.5% |
| ds_v3 | 128 | 7168×2304 | 44.0 | 26.5 | +39.8% |
| ds_v3 | 1024 | 7168×2304 | 39.1 | 36.3 | +7.2% |
| ds_v3 | 4096 | 7168×2304 | 105.9 | 103.0 | +2.7% |
| llama3_70b | 1 | 1280×8192 | 32.5 | 28.0 | +13.8% |
| llama3_70b | 128 | 1280×8192 | 33.3 | 35.9 | -7.8% |
| llama3_70b | 1024 | 1280×8192 | 50.8 | 44.4 | +12.6% |
| llama3_70b | 4096 | 1280×8192 | 81.9 | 95.6 | -16.7% |
| llama3_70b | 1 | 8192×1024 | 16.0 | 9.9 | +38.1% |
| llama3_70b | 128 | 8192×1024 | 22.1 | 18.1 | +18.1% |
| llama3_70b | 1024 | 8192×1024 | 27.9 | 23.9 | +14.3% |
| llama3_70b | 4096 | 8192×1024 | 69.2 | 55.7 | +19.5% |
| llama3_405b | 1 | 13312×16384 | 56.6 | 58.9 | -4.1% |
| llama3_405b | 128 | 13312×16384 | 352.9 | 362.2 | -2.6% |
| llama3_405b | 1024 | 13312×16384 | 479.5 | 430.0 | +10.3% |
| llama3_405b | 4096 | 13312×16384 | 1295.6 | 1271.5 | +1.9% |
| llama3_405b | 1 | 16384×6656 | 28.3 | 31.4 | -11.0% |
| llama3_405b | 128 | 16384×6656 | 173.1 | 162.7 | +6.0% |
| llama3_405b | 1024 | 16384×6656 | 229.4 | 211.1 | +8.0% |
| llama3_405b | 4096 | 16384×6656 | 664.0 | 589.2 | +11.3% |

`_dynamic` — M is the per-group slab height, 75% of rows valid

| Family | M | N×K | CK µs | FlyDSL µs | Time saved |
|---|---|---|---|---|---|
| ds_v3 | 128 | 2048×7168 | 74.7 | 44.1 | +41.0% |
| ds_v3 | 512 | 2048×7168 | 96.1 | 86.6 | +9.9% |
| ds_v3 | 128 | 7168×2304 | 104.6 | 41.6 | +60.2% |
| ds_v3 | 512 | 7168×2304 | 123.1 | 99.1 | +19.5% |
| llama3_70b | 128 | 1280×8192 | 48.3 | 48.6 | -0.6% |
| llama3_70b | 512 | 1280×8192 | 69.6 | 96.4 | -38.5% |
| llama3_70b | 128 | 8192×1024 | 47.6 | 29.2 | +38.7% |
| llama3_70b | 512 | 8192×1024 | 76.7 | 61.7 | +19.6% |
| llama3_405b | 128 | 13312×16384 | 630.0 | 443.6 | +29.6% |
| llama3_405b | 512 | 13312×16384 | 2072.9 | 1097.2 | +47.1% |
| llama3_405b | 128 | 16384×6656 | 313.0 | 217.4 | +30.5% |
| llama3_405b | 512 | 16384×6656 | 890.3 | 551.2 | +38.1% |

`_mm` 3D-3D, 3D-2D and 2D-2D follow the same pattern; medians are in the summary table.

</details>

## Correctness

`test/gemm/gemm_test.py -k "grouped or batched_gemm"`: **92 passed, 67 skipped, 0 failed** on
gfx950. The existing upstream contract tests for `_stacked`, `_dynamic` and all four `_mm` rank
combinations now exercise FlyDSL rather than CK, so they are the primary coverage.

Added tests cover the boundaries the existing cases did not reach:

- group extents that do not land on a tile boundary, along K (2D-2D), N (3D-2D) and the slab height
  (3D-3D)
- the preshuffled grouped `mm`, and rejection of the two ranks that cannot take preshuffled weights
- block scaling refusing a K or N that covers only part of a scale block

The group-K boundary test gives alternate groups constant, single-signed data. A read that runs
past a group's K end then accumulates coherently rather than cancelling; with random data on both
sides the resulting error is the same order as the FP8 quantisation noise and sits inside this
file's comparison tolerance, so the test would pass whether or not the boundary is respected.

Across the benchmark, `max|fly − ck|` is at most 0.0039 on every row.

Unit tests pass on MI350 (gfx950) and MI300 (gfx942).

## Notes for reviewers

- **`gemm_ops.cpp` frees the CK slots on ROCm** for `_stacked`, `_dynamic` and `_mm`, so the Python
  binding is the only implementation there rather than an override of one. A consequence is that a
  ROCm build without FlyDSL has no implementation for these ops; this already held for `_stacked`.
  CK continues to serve every one of them on CUDA.
- **This requires a rebuild.** Three schemas are new, and the registration guards only take effect
  once `gemm_ops.cpp` is recompiled.
- **Two kernel modules are renamed.** `grouped_gemm_blockscale_{common,contiguous}.py` become
  `fp8_grouped_gemm{_common,}.py`: the kernel serves both scaling schemes and six layouts, so
  neither "blockscale" nor "contiguous" described it. No behaviour change — the compile-cache key
  is built from its own strings and is unaffected.
- **Per-group contracts that cannot be checked on the host.** The offsets live on the device, so
  like CK these are documented rather than asserted: group K a multiple of 16 (2D-2D) and group N a
  multiple of 8 (3D-2D). Measured against a dequantised reference, CK and FlyDSL are equally
  inaccurate when group K is not a multiple of 16, so this is not a change in what works. For
  ragged N, the epilogue drops the store that would cross a group boundary, leaving those columns
  unwritten, rather than overrunning into the next group.
- **ROCm CI now triggers on `mslk/gemm/flydsl/**`**, which the path filter did not previously cover.
