### PR TITLE
improve mx4 perf (#472)

### DIFF
--- a/mslk/quantize/triton/fp4_primitives/scale.py
+++ b/mslk/quantize/triton/fp4_primitives/scale.py
@@ -45,7 +45,7 @@ def _floor_log2(x):
         x: FP32 input tensor. Must be positive (undefined for x <= 0).
 
     Returns:
-        floor(log2(x)) as float32 tensor.
+        floor(log2(x)) as int32 tensor.
     """
     FP32_EXP_MASK: tl.constexpr = 0x7F800000  # type: ignore[Incompatible variable type]
     FP32_EXP_OFFSET: tl.constexpr = 23  # type: ignore[Incompatible variable type]
@@ -53,7 +53,7 @@ def _floor_log2(x):
 
     x = x.to(tl.int32, bitcast=True) & FP32_EXP_MASK
     x = x >> FP32_EXP_OFFSET
-    return (x - FP32_EXP_BIAS).to(tl.float32)
+    return x - FP32_EXP_BIAS
 
 
 @triton.jit
@@ -83,7 +83,7 @@ def _round_log2_via_bits(x, val_to_add: tl.constexpr):
             mode (see above).
 
     Returns:
-        Rounded ``log2(x)`` as a float32 tensor.
+        Rounded ``log2(x)`` as an int32 tensor.
     """
     FP32_EXP_MASK: tl.constexpr = 0x7F800000  # type: ignore[Incompatible variable type]
     FP32_EXP_OFFSET: tl.constexpr = 23  # type: ignore[Incompatible variable type]
@@ -91,7 +91,7 @@ def _round_log2_via_bits(x, val_to_add: tl.constexpr):
 
     bits = x.to(tl.int32, bitcast=True) + val_to_add
     bits = (bits & FP32_EXP_MASK) >> FP32_EXP_OFFSET
-    return (bits - FP32_EXP_BIAS).to(tl.float32)
+    return bits - FP32_EXP_BIAS
 
 
 @triton.jit
@@ -120,7 +120,7 @@ def _compute_exp(
         MBITS: Number of mantissa bits in the target MX4 format (compile-time constant).
 
     Returns:
-        Shared exponent for each group as float32 tensor.
+        Shared exponent for each group as int32 tensor.
     """
     MBITS_FP32: tl.constexpr = 23  # type: ignore[Incompatible variable type]
     M_ROUND: tl.constexpr = (1 << (MBITS_FP32 - MBITS - 1)) - 1  # type: ignore
@@ -132,7 +132,7 @@ def _compute_exp(
         # transition is at x = 2^k * sqrt(2), which does not correspond
         # to a clean bit-trick threshold, so we keep the legacy
         # ``floor(log2(x) + 0.5)`` formulation here.
-        return tl.floor(tl.log2(group_max) + 0.5)
+        return tl.floor(tl.log2(group_max) + 0.5).to(tl.int32)
     if rounding_mode == 1:
         return _floor_log2(group_max)
     elif rounding_mode == 2:
@@ -159,8 +159,8 @@ def encode_mx4_exponent(group_exp):
     the inverse of decoding: ``original_exp = stored_value - 127``.
 
     Args:
-        group_exp: Integer-valued shared exponent (float32 tensor), typically
-            in the range [-127, 125] after clamping.
+        group_exp: Shared exponent (int32 tensor), typically in the range
+            [-127, 125] after clamping.
 
     Returns:
         Biased exponent as int8 tensor, with values in [0, 252].
@@ -187,11 +187,12 @@ def mx4_scale_normalize_encode(
     """Shared MX4 scale + normalize + (optional stochastic) + E8M0 encode.
 
     Given the fp32 tile ``x_blocks`` and its per-group ``block_amax``, this:
-      1. zero-guards amax with ``BF16_MIN_NORMAL``;
+      1. zero-guards amax with ``BF16_MIN_NORMAL`` when required by the selected
+         rounding mode;
       2. computes the shared exponent via ``_compute_exp`` (per-group stochastic
          rand bits when ``STOCHASTIC``), subtracts ``EBITS``, clamps to [-127, 125];
-      3. builds the fp32 scale via an **fp64** ``exp2`` intermediate and divides
-         ``x_blocks`` by it;
+      3. builds the exact reciprocal fp32 power-of-two scale from its IEEE 754
+         bits and multiplies ``x_blocks`` by it;
       4. optionally adds per-element mantissa-LSB noise for stochastic rounding of
          the FP32→FP4 cast (decorrelated stream via ``seed ^ 0x5A5A5A5A``);
       5. encodes the exponent as biased E8M0 int8.
@@ -202,7 +203,12 @@ def mx4_scale_normalize_encode(
     Returns ``(x_blocks, encoded_scales)`` where ``x_blocks`` is the normalized
     (and stochastically perturbed) tile and ``encoded_scales`` is int8 E8M0.
     """
-    safe_amax = tl.where(block_amax == 0, BF16_MIN_NORMAL, block_amax)
+    if ROUNDING_MODE != 0:
+        # Bit-based modes map zero below the supported exponent range, and the
+        # clamp below produces the same -127 exponent as BF16_MIN_NORMAL.
+        safe_amax = block_amax
+    else:
+        safe_amax = tl.where(block_amax == 0, BF16_MIN_NORMAL, block_amax)
 
     # Stochastic rounding (OCP MX v1.0): per-group rand bits feed the
     # ``rounding_mode == 3`` branch of ``_compute_exp``. When
@@ -218,13 +224,13 @@ def mx4_scale_normalize_encode(
     else:
         group_exp = _compute_exp(safe_amax, ROUNDING_MODE, 0, MBITS)
     group_exp = group_exp - EBITS
-    group_exp = tl.clamp(group_exp, -127, 125)
+    group_exp = tl.maximum(tl.minimum(group_exp, 125), -127)
 
-    # Use float64 intermediate for exp2 precision
-    scale_float = tl.exp2(group_exp.to(tl.float64)).to(tl.float32)
-
-    # Normalize input by dividing by scale
-    x_blocks = x_blocks / scale_float[:, :, None]
+    # The reciprocal exponent is in [-125, 127], so it is always a normal
+    # FP32 value, including when the original scale is the subnormal 2^-127.
+    inv_scale_bits = (-group_exp + E8M0_EXPONENT_BIAS) << 23
+    inv_scale_float = inv_scale_bits.to(tl.float32, bitcast=True)
+    x_blocks = x_blocks * inv_scale_float[:, :, None]
 
     # Per-element stochastic rounding on the FP32→FP4 cast. Add uniform noise in
     # the discarded mantissa bits before the ``cvt.rn.satfinite.e2m1x2.f32`` PTX

--- a/mslk/quantize/triton/quantize_kernels/mx4.py
+++ b/mslk/quantize/triton/quantize_kernels/mx4.py
@@ -44,6 +44,7 @@ def quantize_mx4_kernel(
     EBITS: tl.constexpr,  # exponent bits in target FP4 format (2 for E2M1)
     MBITS: tl.constexpr,  # mantissa bits in target FP4 format (1 for E2M1)
     N_COL_BLOCKS: tl.constexpr,  # ceil(num_scale_cols / 4) — blocked layout offset
+    HAS_PADDING_PROGRAM: tl.constexpr,  # True when the N grid includes a padding CTA
     STOCHASTIC: tl.constexpr,  # True → enable software stochastic rounding
     IS_ROCM: tl.constexpr,  # True → plain [M, K//32] scale layout (AMD GEMM contract)
     IS_GFX950: tl.constexpr,  # True → gfx950 native FP4 packing instruction
@@ -54,8 +55,10 @@ def quantize_mx4_kernel(
     bytes and per-group E8M0 (power-of-two biased int8) scales in the Blackwell
     blocked layout. MX4 has no global scale.
 
-    Grid: (cdiv(N, 64), cdiv(M, M_PER_BLOCK) [+1 for tail zeroing when
-    M_PER_BLOCK != 128]).
+    On NVIDIA, the N grid covers complete four-column scale layouts. On ROCm,
+    it covers the input's 64-element tiles. The M grid is
+    cdiv(M, M_PER_BLOCK), plus one for NVIDIA tail zeroing when
+    M_PER_BLOCK != 128.
     """
     TILE_N: tl.constexpr = 64  # type: ignore[Incompatible variable type]
     NUM_GROUPS: tl.constexpr = TILE_N // GROUP_SIZE
@@ -76,6 +79,26 @@ def quantize_mx4_kernel(
         oob_mask = (offs_m >= M) & tl.full((NUM_GROUPS,), True, dtype=tl.int1)[None, :]
         zero_scales = tl.full([128, NUM_GROUPS], 0, dtype=tl.int8)
         tl.store(s_ptr + scale_offs, zero_scales, mask=oob_mask)
+        return
+
+    # A padded MX4-32 scale layout can require one more N program than the
+    # input. That program owns only scale padding and must not load input data.
+    if HAS_PADDING_PROGRAM and pid_n * TILE_N >= N:
+        ROW_TILES_PER_LAYOUT: tl.constexpr = 128 // M_PER_BLOCK
+        offs_m_in_layout = (
+            (pid_m % ROW_TILES_PER_LAYOUT) * M_PER_BLOCK + tl.arange(0, M_PER_BLOCK)
+        )[:, None]
+        row_block = pid_m // ROW_TILES_PER_LAYOUT
+        scale_pid_n = pid_n
+        if USE_INT64_INDEXING:
+            row_block = row_block.to(tl.int64)
+            scale_pid_n = scale_pid_n.to(tl.int64)
+        layout_off = row_block * N_COL_BLOCKS * 512
+        scale_offs = layout_off + mx4_scale_swizzle(
+            offs_m_in_layout, scale_pid_n, NUM_GROUPS
+        )
+        zero_scales = tl.full([M_PER_BLOCK, NUM_GROUPS], 0, dtype=tl.int8)
+        tl.store(s_ptr + scale_offs, zero_scales)
         return
 
     # Compute tile offsets and load [M_PER_BLOCK, 64] tile.
@@ -160,11 +183,7 @@ def quantize_mx4_kernel(
         scale_offs = layout_off + mx4_scale_swizzle(
             offs_m_in_layout, scale_pid_n, NUM_GROUPS
         )
-        # Mask out scale columns beyond num_scale_cols (= N // GROUP_SIZE).
-        # Without this mask, writes for col >= num_scale_cols collide with
-        # valid scales of subsequent rows in the swizzled layout. Rows are
-        # already on-tile by construction in the non-stacked path.
-        scale_store_mask = logical_col < num_scale_cols
+        scale_store_mask = None
     tl.store(
         s_ptr + scale_offs,
         encoded_scales,
@@ -264,20 +283,34 @@ def quantize_mx4(
     else:
         padded_rows = triton.cdiv(M, 128) * 128
         padded_cols = n_col_blocks * 4
-        # Zero-init so OOB positions (where the kernel does not write) are zero.
-        scales = torch.zeros(
+        scales = torch.empty(
             padded_rows, padded_cols, dtype=torch.int8, device=x.device
         )
 
     # M_PER_BLOCK: rows per program. Capped at 128 (scale layout alignment).
     M_PER_BLOCK = min(triton.next_power_of_2(M), 128)
     USE_MASK = M % M_PER_BLOCK != 0 or N % 64 != 0
-    grid = (triton.cdiv(N, 64), triton.cdiv(M, M_PER_BLOCK))
+    data_grid_n = triton.cdiv(N, 64)
+    if rocm:
+        grid_n = data_grid_n
+    else:
+        groups_per_program = 64 // group_size
+        programs_per_scale_layout = 4 // groups_per_program
+        grid_n = n_col_blocks * programs_per_scale_layout
+    grid = (grid_n, triton.cdiv(M, M_PER_BLOCK))
     # Extra row of blocks to zero out tail scales when M_PER_BLOCK < 128
     # (NVIDIA padded layout only; ROCm has no padded tail).
     if M_PER_BLOCK != 128 and not rocm:
         grid = (grid[0], grid[1] + 1)
     use_int64 = M * N > 2**31 - 1
+    launch_options: dict[str, int | str] = {
+        "num_stages": 3 if M >= 256 else 1,
+        "num_warps": 4,
+    }
+    if not rocm and not use_int64:
+        launch_options["ptx_options"] = "--minnctapersm=1"
+        if not stochastic:
+            launch_options["maxnreg"] = 80
 
     quantize_mx4_kernel[grid](  # pyre-ignore[28]
         x_2d,  # [M, N] input (2D-flattened)
@@ -305,15 +338,14 @@ def quantize_mx4(
         # pyre-ignore[6]
         N_COL_BLOCKS=n_col_blocks,
         # pyre-ignore[6]
+        HAS_PADDING_PROGRAM=not rocm and grid_n > data_grid_n,
+        # pyre-ignore[6]
         STOCHASTIC=stochastic,
         # pyre-ignore[6]
         IS_ROCM=rocm,
         # pyre-ignore[6]
         IS_GFX950=gfx950,
-        # pyre-ignore[28]
-        num_stages=3 if M >= 256 else 1,
-        # pyre-ignore[28]
-        num_warps=4,
+        **launch_options,  # pyre-ignore[28]
     )
 
     xq = xq.view(*orig_leading_dims, -1, N // 2)

--- a/mslk/quantize/triton/quantize_kernels/mx4_stacked.py
+++ b/mslk/quantize/triton/quantize_kernels/mx4_stacked.py
@@ -39,6 +39,7 @@ def quantize_mx4_stacked_kernel(
     stride_xm,  # row stride of x_ptr (elements to skip per row)
     stride_xn,  # col stride of x_ptr (usually 1 for contiguous)
     N,  # number of columns in the input matrix
+    padded_total_M,  # CUDA-graph-safe upper bound on padded rows
     seed,  # int64 seed for tl.randint (Philox-3); only consulted when STOCHASTIC=True
     NUM_SEGMENTS: tl.constexpr,  # number of expert segments
     PREFIX_NUM: tl.constexpr,  # next_power_of_2(NUM_SEGMENTS) for tl.cumsum
@@ -54,6 +55,7 @@ def quantize_mx4_stacked_kernel(
     STOCHASTIC: tl.constexpr,  # True → enable software stochastic rounding
     IS_ROCM: tl.constexpr,  # True → plain [M, K//32] scale layout (AMD GEMM contract)
     IS_GFX950: tl.constexpr,  # True → gfx950 native FP4 packing instruction
+    ZERO_SLACK: tl.constexpr,  # True → initialize trailing over-allocation in-kernel
 ):
     """Stacked MX4 quantization kernel processing [M_PER_BLOCK, 64] tiles.
 
@@ -62,9 +64,8 @@ def quantize_mx4_stacked_kernel(
     segment + logical row via ``stacked_segment_map``, and per-group E8M0 scales
     are stored at the row's padded offset so each segment is 128-row aligned in
     the scale buffer. Padding rows within ``[0, padded_total)`` get
-    ``is_valid_row=False`` → zero scales, written in-kernel; the over-allocated
-    slack rows ``[padded_total, padded_total_M)`` are zeroed by the host
-    ``torch.zeros`` allocation.
+    ``is_valid_row=False`` → zero scales, written in-kernel. For aligned scale
+    layouts, fully slack tiles initialize the trailing over-allocation.
 
     Grid: (cdiv(N, 64), cdiv(padded_total_M, M_PER_BLOCK)).
     """
@@ -88,8 +89,21 @@ def quantize_mx4_stacked_kernel(
     ) = stacked_segment_map(
         m_sizes_ptr, pid_m, M_PER_BLOCK, NUM_SEGMENTS, PREFIX_NUM, BSEARCH_ITERS
     )
-    # Skip fully-slack tiles (beyond the last segment's padded rows).
+    # Handle fully-slack tiles beyond the last segment's padded rows.
     if pid_m * M_PER_BLOCK >= padded_total:
+        if ZERO_SLACK:
+            slack_rows = (
+                pid_m.to(tl.int64) * M_PER_BLOCK
+                + tl.arange(0, M_PER_BLOCK).to(tl.int64)[:, None]
+            )
+            slack_cols = (
+                pid_n.to(tl.int64) * NUM_GROUPS
+                + tl.arange(0, NUM_GROUPS).to(tl.int64)[None, :]
+            )
+            padded_cols: tl.constexpr = N_COL_BLOCKS * 4
+            slack_offs = slack_rows * padded_cols + slack_cols
+            slack_mask = (slack_rows < padded_total_M) & (slack_cols < padded_cols)
+            tl.store(s_ptr + slack_offs, 0, mask=slack_mask)
         return
 
     # Compute tile offsets and load [M_PER_BLOCK, 64] tile. Rows are indexed by
@@ -282,13 +296,9 @@ def quantize_mx4_stacked(
         # rows are masked out by the kernel). No per-segment 128-row pad.
         scales = torch.zeros(M, scale_K, dtype=torch.int8, device=x.device)
     else:
-        # Zero-init the scale buffer. The kernel writes scales only for rows in
-        # ``[0, padded_total)`` where ``padded_total = sum(round_up(m_i, 128))``;
-        # the CUDA-graph-safe buffer is over-allocated to the upper bound
-        # ``padded_total_M = M + num_segments * 127`` (to avoid a GPU→CPU sync),
-        # so the slack rows ``[padded_total, padded_total_M)`` are never touched
-        # by the kernel and must be zeroed here.
-        scales = torch.zeros(
+        # Aligned layouts are fully overwritten by data, padding, and slack CTAs.
+        scale_factory = torch.empty if scale_K % 4 == 0 else torch.zeros
+        scales = scale_factory(
             padded_total_M, padded_cols, dtype=torch.int8, device=x.device
         )
 
@@ -304,11 +314,12 @@ def quantize_mx4_stacked(
     quantize_mx4_stacked_kernel[grid](  # pyre-ignore[28]
         x_2d,  # [M, N] input (2D-flattened)
         xq,  # [M, N//2] output packed FP4
-        scales,  # [padded_total_M_ub, padded_cols] output scales (pre-zeroed)
+        scales,  # [padded_total_M_ub, padded_cols] output scales
         m_sizes,  # [num_segments] int64 rows per segment
         x_2d.stride(0),  # stride_xm
         x_2d.stride(1),  # stride_xn
         N,  # number of columns
+        padded_total_M,  # padded-row allocation upper bound
         seed_int,  # int64 seed for tl.randint (unused when STOCHASTIC=False)
         # pyre-ignore[6]
         NUM_SEGMENTS=num_segments,
@@ -338,6 +349,8 @@ def quantize_mx4_stacked(
         IS_ROCM=rocm,
         # pyre-ignore[6]
         IS_GFX950=gfx950,
+        # pyre-ignore[6]
+        ZERO_SLACK=not rocm and scale_K % 4 == 0,
         # pyre-ignore[28]
         num_stages=3 if M >= 256 else 1,
         # pyre-ignore[28]

--- a/test/quantize/triton/test_quantize_mx4.py
+++ b/test/quantize/triton/test_quantize_mx4.py
@@ -37,6 +37,8 @@ class QuantizeMX4Test(unittest.TestCase):
             ("n_pad_gs32", 128, 32, 32),
             ("n_unaligned_gs32", 128, 96, 32),
             ("single_row_gs32", 1, 64, 32),
+            ("subblock_tail_aligned_gs32", 63, 128, 32),
+            ("partial_block_aligned_gs32", 129, 128, 32),
             ("large_gs32", 512, 4096, 32),
             ("canonical_gs16", 128, 256, 16),
             ("n_pad_gs16", 128, 16, 16),
@@ -83,6 +85,66 @@ class QuantizeMX4Test(unittest.TestCase):
 
     @parameterized.expand(
         [
+            ("bf16", torch.bfloat16),
+            ("fp16", torch.float16),
+        ]
+    )
+    def test_extreme_finite_bitwise_torch_ref(self, _name, dtype):
+        finfo = torch.finfo(dtype)
+        min_subnormal = torch.tensor([1], dtype=torch.uint16).view(dtype).item()
+        low = torch.tensor(
+            [0.0, -0.0, min_subnormal, -min_subnormal, finfo.tiny, -finfo.tiny],
+            dtype=dtype,
+            device="cuda",
+        ).repeat(6)[:32]
+        high = torch.tensor(
+            [min_subnormal, -min_subnormal, 1.0, -1.0, finfo.max, -finfo.max],
+            dtype=dtype,
+            device="cuda",
+        ).repeat(6)[:32]
+        x = torch.stack((low, high))
+
+        xq, scales = quantize_mx4(x, rounding_mode=RoundingMode.ceil)
+        ref_xq, ref_scales = torch_quantize_mx4_ref(x, group_size=32)
+        self.assertTrue(torch.equal(xq, ref_xq))
+        if is_rocm():
+            actual_scales = scales.view(torch.uint8).reshape(2, -1)
+        else:
+            actual_scales = _unblock_mx4_scales(scales.view(torch.int8), 2, 1).view(
+                torch.uint8
+            )
+        self.assertTrue(torch.equal(actual_scales, ref_scales.view(torch.uint8)))
+
+    @parameterized.expand(
+        [
+            ("nearest", RoundingMode.nearest),
+            ("floor", RoundingMode.floor),
+            ("even", RoundingMode.even),
+            ("stochastic", RoundingMode.stochastic),
+            ("ceil", RoundingMode.ceil),
+        ]
+    )
+    def test_zero_group_behavior_for_every_rounding_mode(self, _name, mode):
+        if is_rocm() and mode == RoundingMode.stochastic:
+            self.skipTest("stochastic MX4 quantization is unsupported on ROCm")
+        x = torch.zeros(1, 32, dtype=torch.bfloat16, device="cuda")
+        xq, scales = quantize_mx4(x, rounding_mode=mode, seed=0x12345678)
+        if is_rocm():
+            scale = scales.view(torch.uint8).reshape(1, -1)
+        else:
+            scale = _unblock_mx4_scales(scales.view(torch.int8), 1, 1).view(torch.uint8)
+        if mode == RoundingMode.stochastic:
+            replay_xq, replay_scales = quantize_mx4(
+                x, rounding_mode=mode, seed=0x12345678
+            )
+            self.assertTrue(torch.equal(xq, replay_xq))
+            self.assertTrue(torch.equal(scales, replay_scales))
+        else:
+            self.assertTrue(torch.equal(xq, torch.zeros_like(xq)))
+        self.assertEqual(0, scale[0, 0].item())
+
+    @parameterized.expand(
+        [
             # (name, group_max, expected_biased_exponent):
             # byte = ceil(log2(group_max)) - EBITS(2) + 127, stored as int8.
             ("pow2_4", 4.0, 127),
@@ -106,18 +168,26 @@ class QuantizeMX4Test(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("nan", float("nan")),
-            ("pos_inf", float("inf")),
-            ("neg_inf", float("-inf")),
+            ("nan", float("nan"), RoundingMode.ceil, None),
+            ("pos_inf_nearest", float("inf"), RoundingMode.nearest, 252),
+            ("pos_inf_floor", float("inf"), RoundingMode.floor, 252),
+            ("pos_inf_even", float("inf"), RoundingMode.even, 252),
+            ("pos_inf_stochastic", float("inf"), RoundingMode.stochastic, 252),
+            ("pos_inf_ceil", float("inf"), RoundingMode.ceil, 252),
+            ("neg_inf", float("-inf"), RoundingMode.ceil, None),
         ]
     )
-    def test_quantize_mx4_special_value_saturation(self, _name, bad_value):
+    def test_quantize_mx4_special_value_saturation(
+        self, _name, bad_value, mode, expected_scale
+    ):
         """A single NaN/±Inf is saturated; scales stay finite."""
+        if is_rocm() and mode == RoundingMode.stochastic:
+            self.skipTest("stochastic MX4 quantization is unsupported on ROCm")
         torch.manual_seed(701)
         M, N = 64, 128
         x = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
         x[0, 0] = bad_value
-        xq, scales = quantize_mx4(x)
+        xq, scales = quantize_mx4(x, rounding_mode=mode, seed=0x12345678)
         self.assertEqual(xq.shape, (M, N // 2))
         self.assertFalse(
             torch.isnan(scales.to(torch.float32)).any(), "scales contain NaN"
@@ -125,3 +195,11 @@ class QuantizeMX4Test(unittest.TestCase):
         self.assertFalse(
             torch.isinf(scales.to(torch.float32)).any(), "scales contain Inf"
         )
+        if expected_scale is not None:
+            if is_rocm():
+                scale = scales.view(torch.uint8).reshape(M, -1)
+            else:
+                scale = _unblock_mx4_scales(scales.view(torch.int8), M, 1).view(
+                    torch.uint8
+                )
+            self.assertEqual(expected_scale, scale[0, 0].item())

--- a/test/quantize/triton/test_stacked_quantize_mx4.py
+++ b/test/quantize/triton/test_stacked_quantize_mx4.py
@@ -154,6 +154,18 @@ class StackedQuantizeMX4Test(unittest.TestCase):
             f"FP4 data mismatch for m_sizes={m_sizes_list}, N={N}, gs={group_size}",
         )
 
+        if not is_rocm():
+            padded_rows = sum(
+                math.ceil(m_i / 128) * 128 for m_i in m_sizes_list if m_i > 0
+            )
+            slack_start = padded_rows * padded_cols
+            slack = b_scales[slack_start:]
+            expected_slack_bytes = (
+                sum(m_sizes_list) + len(m_sizes_list) * 127 - padded_rows
+            ) * padded_cols
+            self.assertEqual(expected_slack_bytes, slack.numel())
+            self.assertTrue(torch.equal(slack, torch.zeros_like(slack)))
+
     # NaN/Inf saturation: a special value in one segment must not corrupt the
     # per-segment output (each segment still matches independent quantize_mx4).
 


### PR DESCRIPTION
Summary:

- Move more math to use bit shifting instead of `exp2` and leave them as ints. Bitwise with existing code.
- I found that the reduced instructions from removal of `exp2` seems to have some side effect of moving the `LDG` instructions further in the final SASS which makes some small M worse, using `minnctapersm=1` helps prevent this.
- Move the MX4 kernel to always compute SF layout over the grid, which enables fusion of padded scale zeroing and removal of `torch.zeros`.
- Set `maxnreg=80` to prevent some spills.

```

  ### Dense K=5120


       M    Before µs    After µs    Reduction    MBU before    MBU after
  ━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━━━
       1        3.205       1.953        39.1%         0.14%        0.22%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
      64        3.538       1.934        45.3%         3.09%        5.66%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
     128        3.646       1.938        46.8%         5.93%       11.16%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
     256        4.244       2.192        48.4%        10.19%       19.73%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
     512        4.780       2.658        44.4%        18.09%       32.54%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
    1024        6.450       3.336        48.3%        26.82%       51.86%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
    2048        8.815       4.724        46.4%        39.25%       73.23%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
    4096       16.088      11.080        31.1%        43.01%       62.45%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
    6144       24.076      16.940        29.6%        43.11%       61.27%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
    8192       30.892      21.852        29.3%        44.79%       63.32%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
   10240       37.944      27.236        28.2%        45.59%       63.51%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
   12288       45.128      32.202        28.6%        46.00%       64.46%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
   14336       51.959      37.466        27.9%        46.61%       64.64%
  ───────  ───────────  ──────────  ───────────  ────────────  ───────────
   16384       58.692      42.620        27.4%        47.15%       64.94%
```

Differential Revision: D115053078


