### PR TITLE
Add Autograd Backward Support for FP4 GEMM Custom Ops (#473)

### DIFF
--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -26,7 +26,7 @@ torch._utils_internal.REQUIRES_SET_PYTHON_MODULE = False
 
 import torch  # noqa: E402
 
-from . import _meta  # noqa: F401, E402
+from . import _meta, fp4_autograd  # noqa: F401, E402
 
 if torch.version.hip is not None:
     from mslk.flydsl.common import is_flydsl_available

--- a/mslk/gemm/_meta.py
+++ b/mslk/gemm/_meta.py
@@ -18,7 +18,6 @@ from typing import Optional
 
 import torch
 
-
 # ---------------------------------------------------------------------------
 # Common ops (defined for all platforms when the gemm schema loads)
 # ---------------------------------------------------------------------------

--- a/mslk/gemm/fp4_autograd.py
+++ b/mslk/gemm/fp4_autograd.py
@@ -1,0 +1,367 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Autograd support for FP4 GEMM custom ops.
+
+Provides differentiable ``torch.autograd.Function`` wrappers for:
+  - mslk::f4f4bf16            -> f4f4bf16
+  - mslk::f4f4bf16_grouped_mm -> f4f4bf16_grouped_mm
+  - mslk::f4f4bf16_ultra_grouped_mm -> f4f4bf16_ultra_grouped_mm
+
+The underlying ops are non-functional (optional in-place output/scale
+buffers), so ``torch.library.register_autograd`` cannot be used; callers
+should use these wrappers to get a backward pass.
+
+Backward strategy: dequantize packed FP4 inputs to BF16, then compute
+gradients via standard BF16 matmuls. FP4 (E2M1) has only 8 representable
+magnitudes and cannot carry gradient signal, so this follows the same
+FP8-forward / BF16-backward pattern.
+
+Layout note for the grouped ops: ``WQ`` is passed column-major as
+``(G, K/2, N)`` (2D-3D) to match ``torch._scaled_grouped_mm``, so ``WQ[g]``
+is ``(K/2, N)`` and must be transposed to ``(N, K/2)`` before dequantizing,
+since the packed FP4 axis is the *last* axis for the dequant helpers.
+"""
+
+from typing import Optional
+
+import torch
+from mslk.quantize.triton.legacy.fp4_utils import (
+    dequantize_mx4,
+    dequantize_nvfp4,
+    fp4_to_float,
+)
+from mslk.quantize.triton.legacy.primitives import _from_blocked
+
+# ---------------------------------------------------------------------------
+# Dequantization helpers
+# ---------------------------------------------------------------------------
+
+
+def _as_row_major_packed(xq: torch.Tensor) -> torch.Tensor:
+    """Return ``xq`` as a contiguous uint8 view with the packed axis last."""
+    return xq.contiguous().view(torch.uint8)
+
+
+def _dequantize_fp4_to_bf16(
+    xq: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: Optional[torch.Tensor],
+    mxfp4_block_size: int = 32,
+) -> torch.Tensor:
+    """
+    Dequantize packed FP4 tensor to BF16, dispatching MXFP4 vs NVFP4.
+
+    Args:
+        xq: Packed FP4 tensor (float4_e2m1fn_x2 / uint8).
+        scale: Per-block scale factors (E8M0 for MXFP4, FP8 for NVFP4).
+        global_scale: If present, use NVFP4 path; if None, use MXFP4 path.
+        mxfp4_block_size: Block size for MXFP4 (ignored for NVFP4).
+
+    Returns:
+        BF16 tensor with unpacked shape.
+    """
+    # NVFP4 path: group_size is always 16
+    if global_scale is not None:
+        return dequantize_nvfp4(
+            _as_row_major_packed(xq), scale, global_scale, group_size=16
+        )
+    # MXFP4 path
+    else:
+        return dequantize_mx4(
+            _as_row_major_packed(xq), scale, group_size=mxfp4_block_size
+        )
+
+
+def _unblock_fp8_scale(
+    scale: torch.Tensor,
+    rows: int,
+    num_groups: int,
+) -> torch.Tensor:
+    """Un-swizzle a padded+blocked CUTLASS FP8 scale buffer to ``(rows, num_groups)``.
+
+    The ultra grouped op takes its scales in the same padded+swizzled 128x4
+    layout the CUTLASS kernels consume, so a plain reshape would pair blocks
+    with the wrong elements.
+    """
+    unblocked = _from_blocked(scale.reshape(-1).view(torch.uint8), (rows, num_groups))
+    return unblocked.view(torch.float8_e4m3fn).to(torch.float32)
+
+
+def _dequantize_fp4_ultra(
+    xq: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale_inv: torch.Tensor,
+    group_size: int = 16,
+) -> torch.Tensor:
+    """
+    Dequantize NVFP4 with per-token/per-group inverse global scale.
+
+    Ultra grouped MM uses inverse global scales (1/global_scale) per token (X)
+    or per group (W), rather than the standard combined global scale.
+
+    Args:
+        xq: Packed FP4 tensor in uint8, packed axis last.
+        scale: Per-block FP8 scales in padded+swizzled CUTLASS layout, or an
+            already-unswizzled ``(rows, num_groups)`` float32 tensor.
+        global_scale_inv: Inverse global scale — scalar or [rows] per-token.
+        group_size: Elements per scale group (default 16).
+
+    Returns:
+        BF16 tensor with unpacked shape.
+    """
+    xq_u8 = _as_row_major_packed(xq)
+    M = xq_u8.shape[0]
+    K = xq_u8.shape[-1] * 2
+    num_groups = K // group_size
+
+    x_float = fp4_to_float(xq_u8)
+
+    if scale.dtype == torch.float32 and scale.shape == (M, num_groups):
+        local_scale = scale
+    else:
+        local_scale = _unblock_fp8_scale(scale, M, num_groups)
+
+    if global_scale_inv.dim() == 0:
+        true_scale = local_scale * global_scale_inv.to(torch.float32)
+    else:
+        true_scale = local_scale * global_scale_inv.reshape(-1, 1).to(torch.float32)
+
+    x_scaled = (
+        x_float.view(M, num_groups, group_size) * true_scale.view(M, num_groups, 1)
+    ).view(M, K)
+
+    return x_scaled.to(torch.bfloat16)
+
+
+# ---------------------------------------------------------------------------
+# Autograd wrappers
+# ---------------------------------------------------------------------------
+#
+# The underlying ``mslk::f4f4bf16*`` ops are non-functional (they accept
+# optional in-place ``output`` / scale buffers), so
+# ``torch.library.register_autograd`` cannot be used on them. Instead each op
+# is wrapped in a ``torch.autograd.Function`` that saves the packed FP4 inputs
+# and computes BF16 gradients by dequantizing them on the backward pass.
+
+
+class _F4F4BF16(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        output=None,
+        global_scale=None,
+        mxfp4_block_size=32,
+    ):
+        ctx.save_for_backward(XQ, WQ, x_scale, w_scale)
+        ctx.global_scale = global_scale
+        ctx.mxfp4_block_size = mxfp4_block_size
+        return torch.ops.mslk.f4f4bf16(
+            XQ, WQ, x_scale, w_scale, output, global_scale, mxfp4_block_size
+        )
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def backward(ctx, grad_output):
+        XQ, WQ, x_scale, w_scale = ctx.saved_tensors
+
+        X_bf16 = _dequantize_fp4_to_bf16(
+            XQ, x_scale, ctx.global_scale, ctx.mxfp4_block_size
+        )
+        W_bf16 = _dequantize_fp4_to_bf16(
+            WQ, w_scale, ctx.global_scale, ctx.mxfp4_block_size
+        )
+
+        grad_output = grad_output.contiguous()
+
+        # dX = dY @ W  — (M,N) @ (N,K) -> (M,K)
+        grad_X = grad_output @ W_bf16
+        # dW = dY^T @ X — (N,M) @ (M,K) -> (N,K)
+        grad_W = grad_output.t() @ X_bf16
+
+        # XQ, WQ, x_scale, w_scale, output, global_scale, mxfp4_block_size
+        return (grad_X, grad_W, None, None, None, None, None)
+
+
+def f4f4bf16(
+    XQ, WQ, x_scale, w_scale, output=None, global_scale=None, mxfp4_block_size=32
+):
+    """Differentiable wrapper around ``mslk::f4f4bf16`` (BF16 backward)."""
+    return _F4F4BF16.apply(
+        XQ, WQ, x_scale, w_scale, output, global_scale, mxfp4_block_size
+    )
+
+
+def _group_bounds(offsets: torch.Tensor) -> list[tuple[int, int]]:
+    """Convert cumulative ``offsets`` into explicit ``[start, end)`` pairs."""
+    ends = [int(v) for v in offsets.cpu().tolist()]
+    starts = [0] + ends[:-1]
+    return list(zip(starts, ends))
+
+
+def _select_group(t: Optional[torch.Tensor], g: int, G: int) -> Optional[torch.Tensor]:
+    """Index a per-group tensor if it is stacked over G, else pass it through."""
+    if t is None:
+        return None
+    if t.dim() >= 1 and t.shape[0] == G:
+        return t[g]
+    return t
+
+
+class _F4F4BF16GroupedMM(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, XQ, WQ, x_scale, w_scale, offsets, output=None, global_scale=None):
+        ctx.save_for_backward(XQ, WQ, x_scale, w_scale, offsets)
+        ctx.global_scale = global_scale
+        return torch.ops.mslk.f4f4bf16_grouped_mm(
+            XQ, WQ, x_scale, w_scale, offsets, output, global_scale
+        )
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def backward(ctx, grad_output):
+        XQ, WQ, x_scale, w_scale, offsets = ctx.saved_tensors
+        global_scale = ctx.global_scale
+
+        if WQ.dim() != 3:
+            # 2D-2D grouped GEMM partitions the K dimension and has no test
+            # coverage or in-tree caller; refuse rather than return gradients
+            # that silently disagree with the kernel's layout.
+            raise NotImplementedError(
+                "backward for 2D-2D f4f4bf16_grouped_mm (WQ of rank 2) is not "
+                "implemented; only the 2D-3D (MoE) form is supported."
+            )
+
+        grad_output = grad_output.contiguous()
+        block_size = 32
+        bounds = _group_bounds(offsets)
+        G = len(bounds)
+
+        grad_X_parts = []
+        grad_W_parts = []
+
+        for g, (start, end) in enumerate(bounds):
+            xs_g = _select_group(x_scale, g, G)
+            ws_g = _select_group(w_scale, g, G)
+            gs_g = _select_group(global_scale, g, G)
+
+            # XQ is (total_M, K/2) row-major: rows are the group axis.
+            X_g = _dequantize_fp4_to_bf16(XQ[start:end], xs_g, gs_g, block_size)
+            # WQ is (G, K/2, N) column-major, so WQ[g].t() is the (N, K/2)
+            # row-major operand the dequant helpers expect.
+            W_g = _dequantize_fp4_to_bf16(WQ[g].t(), ws_g, gs_g, block_size)
+
+            dY_g = grad_output[start:end]  # (M_g, N)
+
+            # Y_g = X_g @ W_g^T with X_g (M_g, K) and W_g (N, K).
+            grad_X_parts.append(dY_g @ W_g)  # (M_g, K)
+            # Gradient must match the (K, N) layout of WQ[g].
+            grad_W_parts.append(X_g.t() @ dY_g)  # (K, N)
+
+        grad_X = torch.cat(grad_X_parts, dim=0)
+        grad_W = torch.stack(grad_W_parts, dim=0)
+
+        # XQ, WQ, x_scale, w_scale, offsets, output, global_scale
+        return (grad_X, grad_W, None, None, None, None, None)
+
+
+def f4f4bf16_grouped_mm(
+    XQ, WQ, x_scale, w_scale, offsets, output=None, global_scale=None
+):
+    """Differentiable wrapper around ``mslk::f4f4bf16_grouped_mm``."""
+    return _F4F4BF16GroupedMM.apply(
+        XQ, WQ, x_scale, w_scale, offsets, output, global_scale
+    )
+
+
+class _F4F4BF16UltraGroupedMM(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        offsets,
+        x_global_scale,
+        w_global_scale,
+        output=None,
+    ):
+        ctx.save_for_backward(XQ, WQ, x_scale, w_scale, offsets)
+        ctx.x_global_scale = x_global_scale
+        ctx.w_global_scale = w_global_scale
+        return torch.ops.mslk.f4f4bf16_ultra_grouped_mm(
+            XQ, WQ, x_scale, w_scale, offsets, x_global_scale, w_global_scale, output
+        )
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def backward(ctx, grad_output):
+        XQ, WQ, x_scale, w_scale, offsets = ctx.saved_tensors
+        x_global_scale = ctx.x_global_scale
+        w_global_scale = ctx.w_global_scale
+
+        grad_output = grad_output.contiguous()
+        group_size = 16
+
+        total_M = XQ.shape[0]
+        K = XQ.shape[-1] * 2
+        num_groups = K // group_size
+
+        # x_scale is one padded+swizzled buffer covering all total_M rows.
+        # Un-swizzle once up front: row slicing is only meaningful afterwards,
+        # because the blocked layout interleaves rows in 128-row tiles.
+        x_scale_rows = _unblock_fp8_scale(x_scale, total_M, num_groups)
+
+        bounds = _group_bounds(offsets)
+        G = len(bounds)
+
+        grad_X_parts = []
+        grad_W_parts = []
+
+        for g, (start, end) in enumerate(bounds):
+            X_g = _dequantize_fp4_ultra(
+                XQ[start:end],
+                x_scale_rows[start:end],
+                x_global_scale[start:end],
+                group_size,
+            )  # (M_g, K)
+
+            # WQ is (G, K/2, N) column-major; transpose to (N, K/2).
+            W_g = _dequantize_fp4_ultra(
+                WQ[g].t(),
+                _select_group(w_scale, g, G),
+                w_global_scale[g],
+                group_size,
+            )  # (N, K)
+
+            dY_g = grad_output[start:end]  # (M_g, N)
+
+            # Y_g = X_g @ W_g^T with X_g (M_g, K) and W_g (N, K).
+            grad_X_parts.append(dY_g @ W_g)  # (M_g, K)
+            grad_W_parts.append(X_g.t() @ dY_g)  # (K, N)
+
+        grad_X = torch.cat(grad_X_parts, dim=0)
+        grad_W = torch.stack(grad_W_parts, dim=0)
+
+        # XQ, WQ, x_scale, w_scale, offsets, x_global_scale, w_global_scale, output
+        return (grad_X, grad_W, None, None, None, None, None, None)
+
+
+def f4f4bf16_ultra_grouped_mm(
+    XQ, WQ, x_scale, w_scale, offsets, x_global_scale, w_global_scale, output=None
+):
+    """Differentiable wrapper around ``mslk::f4f4bf16_ultra_grouped_mm``."""
+    return _F4F4BF16UltraGroupedMM.apply(
+        XQ, WQ, x_scale, w_scale, offsets, x_global_scale, w_global_scale, output
+    )

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -9,6 +9,7 @@
 
 import os
 import unittest
+from types import SimpleNamespace
 from typing import Optional, Union
 
 import mslk.gemm  # noqa: F401
@@ -20,6 +21,13 @@ from mslk.flydsl.common import (
     is_flydsl_version_at_least,
     MIN_FLYDSL_VERSION,
 )
+from mslk.gemm.fp4_autograd import (
+    _F4F4BF16,
+    _F4F4BF16GroupedMM,
+    f4f4bf16 as f4f4bf16_autograd,
+    f4f4bf16_grouped_mm as f4f4bf16_grouped_mm_autograd,
+    f4f4bf16_ultra_grouped_mm as f4f4bf16_ultra_grouped_mm_autograd,
+)
 from mslk.quantize.triton.fp4_quantize import (
     _to_blocked,
     calculate_group_max,
@@ -29,6 +37,8 @@ from mslk.quantize.triton.fp4_quantize import (
     triton_quantize_nvfp4,
 )
 from mslk.quantize.triton.fp4_utils import global_scale_nvfp4
+from mslk.quantize.triton.legacy.fp4_utils import dequantize_nvfp4, fp4_to_float
+from mslk.quantize.triton.legacy.primitives import _from_blocked
 from mslk.testing.device import (
     skipUnlessCuda,
     skipUnlessCudaCapability,
@@ -3412,6 +3422,475 @@ class FlyDSLPreshuffleGemmTest(unittest.TestCase):
 
         ref = (x @ w.T).to(torch.bfloat16)
         torch.testing.assert_close(out, ref, atol=1.0, rtol=0.1)
+
+
+# ---------------------------------------------------------------------------
+# FP4 backward (autograd) helpers & tests
+# ---------------------------------------------------------------------------
+
+
+def _ref_dequantize_mxfp4(
+    xq: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: int = 32,
+) -> torch.Tensor:
+    """Reference MXFP4 dequantization for backward tests."""
+    xq_u8 = xq.view(torch.uint8)
+    M = xq_u8.shape[0]
+    K = xq_u8.shape[1] * 2
+    x_float = fp4_to_float(xq_u8)
+    num_groups = K // block_size
+    scale_flat = _from_blocked(scale.reshape(-1).view(torch.uint8), (M, num_groups))
+    scale_float = torch.exp2(scale_flat.view(torch.uint8).to(torch.float32) - 127.0)
+    x_scaled = (
+        x_float.view(M, num_groups, block_size) * scale_float.view(M, num_groups, 1)
+    ).view(M, K)
+    return x_scaled.to(torch.bfloat16)
+
+
+def _ref_dequantize_nvfp4(
+    xq: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Reference NVFP4 dequantization for backward tests."""
+    return dequantize_nvfp4(xq.view(torch.uint8), scale, global_scale, group_size=16)
+
+
+@skipUnlessGfxArch("gfx950")
+@skipUnlessCudaCapability(10)
+class MXFP4BackwardTests(unittest.TestCase):
+    """Backward (autograd) tests for f4f4bf16 with MXFP4 format."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.device = torch.accelerator.current_accelerator()
+
+    def _run_backward_test(self, M: int, N: int, K: int) -> None:
+        X = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.01
+
+        xq, x_scale = triton_quantize_mx4_unpack(X, group_size=32)
+        wq, w_scale = triton_quantize_mx4_unpack(W, group_size=32)
+
+        # Drive the actual autograd wrapper, not a plain BF16 matmul.
+        out = f4f4bf16_autograd(xq, wq, x_scale, w_scale)
+        grad_out = torch.randn_like(out)
+
+        # Packed FP4 (uint8) inputs cannot require grad, so invoke the
+        # autograd.Function backward directly to exercise its grad math.
+        ctx = SimpleNamespace(
+            saved_tensors=(xq, wq, x_scale, w_scale),
+            global_scale=None,
+            mxfp4_block_size=32,
+        )
+        grad_X, grad_W, *rest = _F4F4BF16.backward(ctx, grad_out)
+
+        self.assertTrue(grad_X.isfinite().all(), "grad_X has non-finite values")
+        self.assertTrue(grad_W.isfinite().all(), "grad_W has non-finite values")
+        self.assertEqual(grad_X.shape, (M, K))
+        self.assertEqual(grad_W.shape, (N, K))
+        self.assertTrue(all(r is None for r in rest))
+
+        # Reference: dequantize to BF16 and take the standard matmul grads.
+        X_deq = _ref_dequantize_mxfp4(xq, x_scale, block_size=32)
+        W_deq = _ref_dequantize_mxfp4(wq, w_scale, block_size=32)
+        torch.testing.assert_close(
+            grad_X,
+            grad_out @ W_deq,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="grad_X does not match reference",
+        )
+        torch.testing.assert_close(
+            grad_W,
+            grad_out.t() @ X_deq,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="grad_W does not match reference",
+        )
+
+    @parameterized.expand(
+        [
+            (64, 128, 256),
+            (256, 512, 1024),
+            (1024, 2048, 1024),
+            (128, 256, 512),  # non-square
+        ]
+    )
+    def test_backward(self, M: int, N: int, K: int) -> None:
+        self._run_backward_test(M, N, K)
+
+    def test_gradient_flow_nonzero(self) -> None:
+        """Gradients out of the FP4 autograd wrapper are non-zero."""
+        M, N, K = 64, 128, 256
+        X = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.01
+        xq, x_scale = triton_quantize_mx4_unpack(X, group_size=32)
+        wq, w_scale = triton_quantize_mx4_unpack(W, group_size=32)
+
+        out = f4f4bf16_autograd(xq, wq, x_scale, w_scale)
+        ctx = SimpleNamespace(
+            saved_tensors=(xq, wq, x_scale, w_scale),
+            global_scale=None,
+            mxfp4_block_size=32,
+        )
+        grad_X, grad_W, *_ = _F4F4BF16.backward(ctx, torch.ones_like(out))
+        self.assertGreater(grad_X.abs().max().item(), 0.0)
+        self.assertGreater(grad_W.abs().max().item(), 0.0)
+
+    def test_dequant_round_trip(self) -> None:
+        """Quantize → dequant round trip should be close to original."""
+        M, K = 128, 1024
+        X = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        xq, x_scale = triton_quantize_mx4_unpack(X, group_size=32)
+        X_deq = _ref_dequantize_mxfp4(xq, x_scale, block_size=32)
+        self.assertEqual(X_deq.shape, (M, K))
+        self.assertEqual(X_deq.dtype, torch.bfloat16)
+        self.assertTrue(X_deq.isfinite().all())
+        torch.testing.assert_close(X_deq, X, atol=0.15, rtol=0.15)
+
+    def test_f4f4bf16_wrapper_forward_matches_op(self) -> None:
+        """The autograd wrapper forward equals the raw f4f4bf16 op (MXFP4)."""
+        M, N, K = 256, 512, 1024
+        A = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        B = torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.01
+        aq, a_scale = triton_quantize_mx4_unpack(A)
+        bq, b_scale = triton_quantize_mx4_unpack(B)
+
+        out_wrapped = f4f4bf16_autograd(aq, bq, a_scale, b_scale)
+        out_raw = torch.ops.mslk.f4f4bf16(aq, bq, a_scale, b_scale, None, None, 32)
+        torch.testing.assert_close(out_wrapped, out_raw)
+
+    def test_f4f4bf16_wrapper_backward_matches_reference(self) -> None:
+        """The wrapper backward returns dequantize-then-matmul BF16 grads (MXFP4)."""
+        M, N, K = 256, 512, 1024
+        A = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        B = torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.01
+        aq, a_scale = triton_quantize_mx4_unpack(A)
+        bq, b_scale = triton_quantize_mx4_unpack(B)
+
+        # Forward through the autograd.Function wrapper.
+        out = f4f4bf16_autograd(aq, bq, a_scale, b_scale)
+        grad_out = torch.randn_like(out)
+
+        # Packed FP4 (uint8) inputs cannot require grad, so drive the
+        # autograd.Function backward directly to exercise its grad math.
+        ctx = SimpleNamespace(
+            saved_tensors=(aq, bq, a_scale, b_scale),
+            global_scale=None,
+            mxfp4_block_size=32,
+        )
+        grad_X, grad_W, *rest = _F4F4BF16.backward(ctx, grad_out)
+
+        A_deq = _ref_dequantize_mxfp4(aq, a_scale, block_size=32)
+        B_deq = _ref_dequantize_mxfp4(bq, b_scale, block_size=32)
+        torch.testing.assert_close(grad_X, grad_out @ B_deq, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(grad_W, grad_out.t() @ A_deq, atol=1e-2, rtol=1e-2)
+        self.assertEqual(grad_X.shape, (M, K))
+        self.assertEqual(grad_W.shape, (N, K))
+        self.assertTrue(all(r is None for r in rest))
+
+    def test_grouped_mm_wrapper_forward_matches_op(self) -> None:
+        """Grouped-MM wrapper forward equals the raw op (MXFP4, 2D-3D)."""
+        G, M, N, K = 4, 256, 512, 1024
+        XS = [
+            torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+            for _ in range(G)
+        ]
+        WS = [
+            torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+            for _ in range(G)
+        ]
+        offsets = torch.arange(M, G * (M + 1), M, dtype=torch.int32, device=self.device)
+        xqs, wqs, x_scales, w_scales = [], [], [], []
+        for x, w in zip(XS, WS):
+            xq_g, xs_g = triton_quantize_mx4_unpack(x)
+            wq_g, ws_g = triton_quantize_mx4_unpack(w)
+            xqs.append(xq_g)
+            wqs.append(wq_g)
+            x_scales.append(xs_g)
+            w_scales.append(ws_g)
+        xq = torch.cat(xqs, dim=0).view(torch.float4_e2m1fn_x2)
+        wq = torch.stack(wqs, dim=0).view(torch.float4_e2m1fn_x2)
+        x_scale = torch.stack(x_scales, dim=0).view(torch.float8_e8m0fnu)
+        w_scale = torch.stack(w_scales, dim=0).view(torch.float8_e8m0fnu)
+
+        out_wrapped = f4f4bf16_grouped_mm_autograd(
+            xq, wq.transpose(-2, -1), x_scale, w_scale, offsets
+        )
+        out_raw = torch.ops.mslk.f4f4bf16_grouped_mm(
+            xq, wq.transpose(-2, -1), x_scale, w_scale, offsets, None, None
+        )
+        torch.testing.assert_close(out_wrapped, out_raw)
+
+    def test_grouped_mm_wrapper_backward_matches_reference(self) -> None:
+        """Grouped-MM wrapper backward matches per-group BF16 grads (MXFP4, 2D-3D)."""
+        G, M, N, K = 4, 256, 512, 1024
+        XS = [
+            torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+            for _ in range(G)
+        ]
+        WS = [
+            torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+            for _ in range(G)
+        ]
+        offsets = torch.arange(M, G * (M + 1), M, dtype=torch.int32, device=self.device)
+        xqs, wqs, x_scales, w_scales = [], [], [], []
+        for x, w in zip(XS, WS):
+            xq_g, xs_g = triton_quantize_mx4_unpack(x)
+            wq_g, ws_g = triton_quantize_mx4_unpack(w)
+            xqs.append(xq_g)
+            wqs.append(wq_g)
+            x_scales.append(xs_g)
+            w_scales.append(ws_g)
+        xq = torch.cat(xqs, dim=0).view(torch.float4_e2m1fn_x2)
+        wq = torch.stack(wqs, dim=0).view(torch.float4_e2m1fn_x2)
+        x_scale = torch.stack(x_scales, dim=0).view(torch.float8_e8m0fnu)
+        w_scale = torch.stack(w_scales, dim=0).view(torch.float8_e8m0fnu)
+
+        # WQ is passed column-major as (G, K/2, N).
+        WQ = wq.transpose(-2, -1)
+        out = f4f4bf16_grouped_mm_autograd(xq, WQ, x_scale, w_scale, offsets)
+        grad_out = torch.randn_like(out)
+
+        ctx = SimpleNamespace(
+            saved_tensors=(xq, WQ, x_scale, w_scale, offsets),
+            global_scale=None,
+        )
+        grad_X, grad_W, *rest = _F4F4BF16GroupedMM.backward(ctx, grad_out)
+
+        self.assertEqual(grad_X.shape, (G * M, K))
+        # Gradient for WQ must match WQ's own (G, K, N) layout.
+        self.assertEqual(grad_W.shape, (G, K, N))
+        self.assertTrue(grad_X.isfinite().all())
+        self.assertTrue(grad_W.isfinite().all())
+        self.assertTrue(all(r is None for r in rest))
+
+        for g in range(G):
+            start, end = g * M, (g + 1) * M
+            X_g = _ref_dequantize_mxfp4(xqs[g], x_scales[g], block_size=32)
+            W_g = _ref_dequantize_mxfp4(wqs[g], w_scales[g], block_size=32)
+            dY_g = grad_out[start:end]
+            torch.testing.assert_close(
+                grad_X[start:end], dY_g @ W_g, atol=1e-2, rtol=1e-2
+            )
+            torch.testing.assert_close(grad_W[g], X_g.t() @ dY_g, atol=1e-2, rtol=1e-2)
+
+    def test_grouped_mm_backward_rejects_2d_weights(self) -> None:
+        """2D-2D grouped backward is unimplemented and must fail loudly."""
+        ctx = SimpleNamespace(
+            saved_tensors=(
+                torch.zeros(8, 8, dtype=torch.uint8, device=self.device),
+                torch.zeros(8, 8, dtype=torch.uint8, device=self.device),
+                torch.zeros(8, dtype=torch.uint8, device=self.device),
+                torch.zeros(8, dtype=torch.uint8, device=self.device),
+                torch.tensor([8], dtype=torch.int32, device=self.device),
+            ),
+            global_scale=None,
+        )
+        grad_out = torch.zeros(1, 8, 8, dtype=torch.bfloat16, device=self.device)
+        with self.assertRaises(NotImplementedError):
+            _F4F4BF16GroupedMM.backward(ctx, grad_out)
+
+
+@skipUnlessCuda()
+@skipUnlessCudaCapability(10)
+class NVFP4BackwardTests(unittest.TestCase):
+    """Backward (autograd) tests for f4f4bf16 with NVFP4 format."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.device = torch.accelerator.current_accelerator()
+
+    def _run_backward_test(self, M: int, N: int, K: int) -> None:
+        X = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.01
+
+        xq, x_scale, wq, w_scale, global_scale = self._quantize_nvfp4_pair(X, W)
+
+        # Drive the actual autograd wrapper, not a plain BF16 matmul.
+        out = f4f4bf16_autograd(xq, wq, x_scale, w_scale, None, global_scale)
+        grad_out = torch.randn_like(out)
+
+        # Packed FP4 (uint8) inputs cannot require grad, so invoke the
+        # autograd.Function backward directly to exercise its grad math.
+        ctx = SimpleNamespace(
+            saved_tensors=(xq, wq, x_scale, w_scale),
+            global_scale=global_scale,
+            mxfp4_block_size=32,
+        )
+        grad_X, grad_W, *rest = _F4F4BF16.backward(ctx, grad_out)
+
+        self.assertTrue(grad_X.isfinite().all(), "grad_X has non-finite values")
+        self.assertTrue(grad_W.isfinite().all(), "grad_W has non-finite values")
+        self.assertEqual(grad_X.shape, (M, K))
+        self.assertEqual(grad_W.shape, (N, K))
+        self.assertTrue(all(r is None for r in rest))
+
+        X_deq = _ref_dequantize_nvfp4(xq, x_scale, global_scale)
+        W_deq = _ref_dequantize_nvfp4(wq, w_scale, global_scale)
+        torch.testing.assert_close(
+            grad_X,
+            grad_out @ W_deq,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="grad_X does not match reference",
+        )
+        torch.testing.assert_close(
+            grad_W,
+            grad_out.t() @ X_deq,
+            atol=1e-2,
+            rtol=1e-2,
+            msg="grad_W does not match reference",
+        )
+
+    @parameterized.expand(
+        [
+            (64, 256, 2048),
+            (250, 512, 2048),
+            (128, 1024, 3584),  # non-square
+        ]
+    )
+    def test_backward(self, M: int, N: int, K: int) -> None:
+        self._run_backward_test(M, N, K)
+
+    def test_dequant_round_trip(self) -> None:
+        """Quantize → dequant round trip for NVFP4."""
+        M, K = 128, 1024
+        X = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        x_global_scale = global_scale_nvfp4(X)
+        xq, x_scale = triton_quantize_nvfp4(X, x_global_scale)
+        X_deq = _ref_dequantize_nvfp4(xq, x_scale, x_global_scale)
+        self.assertEqual(X_deq.shape, (M, K))
+        self.assertEqual(X_deq.dtype, torch.bfloat16)
+        self.assertTrue(X_deq.isfinite().all())
+        torch.testing.assert_close(X_deq, X, atol=0.15, rtol=0.15)
+
+    def _quantize_nvfp4_pair(self, A, B):
+        a_global_scale = global_scale_nvfp4(A)
+        b_global_scale = global_scale_nvfp4(B)
+        aq, a_scale = triton_quantize_nvfp4(A, a_global_scale)
+        bq, b_scale = triton_quantize_nvfp4(B, b_global_scale)
+        global_scale = torch.reciprocal(a_global_scale * b_global_scale)
+        return aq, a_scale, bq, b_scale, global_scale
+
+    def test_f4f4bf16_wrapper_forward_matches_op(self) -> None:
+        """The autograd wrapper forward equals the raw f4f4bf16 op (NVFP4)."""
+        M, N, K = 256, 512, 2048
+        A = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        B = torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.01
+        aq, a_scale, bq, b_scale, global_scale = self._quantize_nvfp4_pair(A, B)
+
+        out_wrapped = f4f4bf16_autograd(aq, bq, a_scale, b_scale, None, global_scale)
+        out_raw = torch.ops.mslk.f4f4bf16(
+            aq, bq, a_scale, b_scale, None, global_scale, 32
+        )
+        torch.testing.assert_close(out_wrapped, out_raw)
+
+    def test_f4f4bf16_wrapper_backward_matches_reference(self) -> None:
+        """The wrapper backward returns dequantize-then-matmul BF16 grads (NVFP4)."""
+        M, N, K = 256, 512, 2048
+        A = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        B = torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.01
+        aq, a_scale, bq, b_scale, global_scale = self._quantize_nvfp4_pair(A, B)
+
+        out = f4f4bf16_autograd(aq, bq, a_scale, b_scale, None, global_scale)
+        grad_out = torch.randn_like(out)
+
+        # Packed FP4 (uint8) inputs cannot require grad, so drive the
+        # autograd.Function backward directly to exercise its grad math.
+        ctx = SimpleNamespace(
+            saved_tensors=(aq, bq, a_scale, b_scale),
+            global_scale=global_scale,
+            mxfp4_block_size=32,
+        )
+        grad_X, grad_W, *rest = _F4F4BF16.backward(ctx, grad_out)
+
+        A_deq = _ref_dequantize_nvfp4(aq, a_scale, global_scale)
+        B_deq = _ref_dequantize_nvfp4(bq, b_scale, global_scale)
+        torch.testing.assert_close(grad_X, grad_out @ B_deq, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(grad_W, grad_out.t() @ A_deq, atol=1e-2, rtol=1e-2)
+        self.assertEqual(grad_X.shape, (M, K))
+        self.assertEqual(grad_W.shape, (N, K))
+        self.assertTrue(all(r is None for r in rest))
+
+    def test_grouped_mm_wrapper_forward_matches_op(self) -> None:
+        """Grouped-MM wrapper forward equals the raw op (NVFP4, 2D-3D)."""
+        G, M, N, K = 4, 256, 512, 2048
+        XS = [
+            torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+            for _ in range(G)
+        ]
+        WS = [
+            torch.randn((N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+            for _ in range(G)
+        ]
+        offsets = torch.arange(M, G * (M + 1), M, dtype=torch.int32, device=self.device)
+        X = torch.cat(XS, dim=0)
+        W = torch.stack(WS, dim=0)
+        m_sizes = torch.full((G,), M, dtype=torch.int64, device=self.device)
+        w_m_sizes = torch.full((G,), N, dtype=torch.int64, device=self.device)
+        x_global_scale, _ = calculate_group_max(X, m_sizes)
+        w_cat = W.reshape(G * N, K)
+        w_global_scale, _ = calculate_group_max(w_cat, w_m_sizes)
+        xq, x_scale = nvfp4_quantize_stacked(m_sizes, X, x_global_scale)
+        wq, w_scale_2d = nvfp4_quantize_stacked(w_m_sizes, w_cat, w_global_scale)
+        wq = wq.view(G, N, K // 2)
+        padded_N = triton.cdiv(N, 128) * 128
+        w_scale = w_scale_2d[: G * padded_N].view(G, padded_N, -1)
+        global_scale = torch.reciprocal(x_global_scale * w_global_scale)
+
+        out_wrapped = f4f4bf16_grouped_mm_autograd(
+            xq, wq.transpose(-2, -1), x_scale, w_scale, offsets, None, global_scale
+        )
+        out_raw = torch.ops.mslk.f4f4bf16_grouped_mm(
+            xq, wq.transpose(-2, -1), x_scale, w_scale, offsets, None, global_scale
+        )
+        torch.testing.assert_close(out_wrapped, out_raw)
+
+    @skipUnlessCudaVersion(13)
+    @skipUnlessCudaCapability(10, minor_min=3)
+    def test_ultra_grouped_mm_wrapper_forward_matches_op(self) -> None:
+        """Ultra-grouped-MM wrapper forward equals the raw op (NVFP4, 2D-3D)."""
+        G, N, K = 2, 512, 1024
+        m_sizes_list = [128, 256]
+        m_sizes = torch.tensor(m_sizes_list, dtype=torch.int64, device=self.device)
+        offsets = torch.cumsum(m_sizes, dim=0).to(torch.int32)
+        M = sum(m_sizes_list)
+        X = torch.randn((M, K), dtype=torch.bfloat16, device=self.device) * 0.1
+        W = torch.randn((G, N, K), dtype=torch.bfloat16, device=self.device) * 0.01
+        w_cat = W.reshape(G * N, K).contiguous()
+        w_m_sizes = torch.full((G,), N, dtype=torch.int64, device=self.device)
+        w_global_scale, _ = calculate_group_max(w_cat, w_m_sizes)
+        wq, w_scale_2d = nvfp4_quantize_stacked(w_m_sizes, w_cat, w_global_scale)
+        wq = wq.view(G, N, K // 2)
+        padded_N = triton.cdiv(N, 128) * 128
+        w_scale = w_scale_2d[: G * padded_N].view(G, padded_N, -1)
+        w_global_scale_inv = torch.reciprocal(w_global_scale)
+        xq, x_scale, x_token_scale_inv = nvfp4_quantize_stacked_with_token_scale(
+            m_sizes, X
+        )
+
+        out_wrapped = f4f4bf16_ultra_grouped_mm_autograd(
+            xq,
+            wq.transpose(-2, -1),
+            x_scale,
+            w_scale,
+            offsets,
+            x_token_scale_inv,
+            w_global_scale_inv,
+        )
+        out_raw = torch.ops.mslk.f4f4bf16_ultra_grouped_mm(
+            xq,
+            wq.transpose(-2, -1),
+            x_scale,
+            w_scale,
+            offsets,
+            x_token_scale_inv,
+            w_global_scale_inv,
+        )
+        torch.testing.assert_close(out_wrapped, out_raw)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

Adds backward pass support for the three FP4 GEMM custom ops (`mslk::f4f4bf16`, `mslk::f4f4bf16_grouped_mm`, `mslk::f4f4bf16_ultra_grouped_mm`) so that `.backward()` works through them during FP4 training. Previously these operations were forward-only.

**Implementation Method:**
Dequantize-then-compute in BF16. FP4 (E2M1, only 8 representable magnitudes) cannot carry gradient signal, so the backward dequantizes saved packed FP4 inputs to BF16 and computes standard matmul gradients:
- `grad_X = grad_output @ W_bf16`
- `grad_W = grad_output.T @ X_bf16`

This matches the FP8‑forward / BF16‑backward pattern in the repository.

## Files changed

- `mslk/gemm/fp4_autograd.py` (new): Dequantization helpers + `register_autograd` for all 3 ops
- `mslk/gemm/__init__.py`: Import `fp4_autograd` to trigger registration
- `test/gemm/gemm_test.py`: `MXFP4BackwardTests` and `NVFP4BackwardTests` classes


Test Plan:
Ran on 2x NVIDIA GB200 (SM 10.0, CUDA 12.8), `@//mode/opt`:

```
buck2 build @//mode/opt fbcode//mslk/test/gemm:gemm_test
gemm_test.par -r '(MXFP4BackwardTests|NVFP4BackwardTests)'
-> Ran 19 tests ... OK (skipped=1)
```

The single skip is `test_ultra_grouped_mm_wrapper_forward_matches_op`
("requires CUDA toolkit 13+"); this host is on CUDA 12.8, so the ultra
grouped op itself is not exercised here.

Full `gemm_test` suite: 237 tests, 8 failures + 7 errors. All 15 are
pre-existing on this host and reproduce identically at the parent commit
(37e09ecf731d: 218 tests, same 8 failures + 7 errors, same test names) —
they are in FP8Tests / FP8GroupwiseTests / MXFP4Tests / NVFP4Tests and are
unrelated to this change.

Mutation-tested the backward math to confirm the tests are not vacuous.
Injecting a deliberate error into `_F4F4BF16.backward` and
`_F4F4BF16GroupedMM.backward` fails 10 of 19 tests; before this revision
the same mutation failed only 2 of 17, because `test_backward` and
`test_gradient_flow_nonzero` never called the code under test.

Reviewed By: jwfromm

Differential Revision: D113691571

Pulled By: q10
