### PR TITLE
Suppress new Pyrefly `constexpr` errors in mslk fmha and moe kernels

### DIFF
--- a/mslk/attention/fmha/_triton/splitk_kernels.py
+++ b/mslk/attention/fmha/_triton/splitk_kernels.py
@@ -534,7 +534,9 @@ def _fwd_kernel_splitK(  # noqa: C901
                 PACKED_D_PER_GROUP,
                 FP8_QUANTIZED,
                 Q.dtype.element_ty,
+                # pyrefly: ignore [bad-argument-type]
                 v_dtype,
+                # pyrefly: ignore [bad-argument-type]
                 i,
                 IS_HIP,
                 QUANTIZE_PV_TO_FP8,
@@ -544,16 +546,16 @@ def _fwd_kernel_splitK(  # noqa: C901
 
             # Unpack results based on quantization configuration
             if QUANTIZE_PV_TO_FP8 and QUANTIZE_QK_TO_FP8:
-                # pyrefly: ignore [unbound-name]
+                # pyrefly: ignore [bad-unpacking, unbound-name]
                 k[i], v[i], v_scale, k_scale = result  # noqa: F821
             elif QUANTIZE_PV_TO_FP8:
-                # pyrefly: ignore [unbound-name]
+                # pyrefly: ignore [bad-unpacking, unbound-name]
                 k[i], v[i], v_scale = result  # noqa: F821
             elif QUANTIZE_QK_TO_FP8:
-                # pyrefly: ignore [unbound-name]
+                # pyrefly: ignore [bad-unpacking, unbound-name]
                 k[i], v[i], k_scale = result  # noqa: F821
             else:
-                # pyrefly: ignore [unbound-name]
+                # pyrefly: ignore [bad-unpacking, unbound-name]
                 k[i], v[i] = result  # noqa: F821
         # -- compute qk ---
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
@@ -958,6 +960,7 @@ def _process_fp8_quantization(
             k_t = dequantize(
                 tl.trans(k),
                 tl.trans(k_scale),
+                # pyrefly: ignore [bad-argument-type]
                 tl.trans(k_shift) if not USE_FP32_SCALES else None,
                 PACKED_PER_VAL,
                 IS_HIP,

--- a/mslk/attention/fmha/triton_splitk.py
+++ b/mslk/attention/fmha/triton_splitk.py
@@ -1104,6 +1104,7 @@ def merge_attentions(
         lse_out,
         # pyrefly: ignore [bad-argument-type]
         split_k=split_k,
+        # pyrefly: ignore [bad-argument-type]
         splitK_pow2=splitK_pow2,
         # pyrefly: ignore [bad-argument-type]
         **_strides(attn_split, "osk_z", "osk_g", "osk_h", "osk_s", "osk_m", "osk_k"),
@@ -1115,6 +1116,7 @@ def merge_attentions(
         **_strides(lse_out, "lse_z", "lse_g", "lse_h", "lse_m"),
         # pyrefly: ignore [bad-argument-type]
         head_dim=head_dim,
+        # pyrefly: ignore [bad-argument-type]
         head_dim_pow_2=triton.next_power_of_2(head_dim),
         # pyrefly: ignore [bad-argument-type]
         G=G,

--- a/mslk/moe/activation.py
+++ b/mslk/moe/activation.py
@@ -123,6 +123,7 @@ def silu_mul_quant(
         valid_token_count,
         T,
         D,  # pyre-ignore
+        # pyrefly: ignore [bad-argument-type]
         BLOCK_T,
         TL_FP8_DTYPE=tl_dtype,  # pyre-ignore
         MAX_FP8=max_fp8,  # pyre-ignore
@@ -193,6 +194,7 @@ def _mslk_silu_mul(
         if token_index >= valid_token_count:
             return
 
+    # pyrefly: ignore [bad-argument-type]
     for _ in tl.range(0, BLOCK_D_OUTER // BLOCK_D_INNER, num_stages=3):
         x0 = tl.load(
             x0_ptr + token_index * stride_0 + feature_offset,
@@ -254,6 +256,7 @@ def _mslk_silu_mul_quant(
     else:
         ub = float("inf")
 
+    # pyrefly: ignore [bad-argument-type]
     for token_index in tl.range(start_idx, end_idx, 1, num_stages=2):
         x0 = tl.load(
             x0_ptr + token_index * stride_0 + offsets,


### PR DESCRIPTION
Summary:
D115081437 (`[triton][stable] Promote 3.8.0+fb`) pulls in upstream PR #10048
("Python typing improvements"), which types `JITFunction.__call__` with a
`ParamSpec` bound to the wrapped kernel signature:

```
def __call__(self: "JITFunction[Callable[P, R]]", *args: P.args, **kwargs: P.kwargs) -> R
```

Previously this was an untyped `(*args, **kwargs)`. Pyrefly now validates
call-site arguments against kernel parameters annotated `X: tl.constexpr`, so
the standard Triton idiom of passing a plain `int` / `bool` / `float` / `str` to a
`tl.constexpr` parameter is reported as `bad-argument-type`. The more precise
return types also make `tl.make_block_ptr(...).dtype.element_ty` and similar
report `missing-attribute`. These are false positives -- `constexpr`-ness is a
Triton JIT concept the type checker cannot model.

No runtime code changes -- only `# pyrefly: ignore` comments, plus `black`
reflowing a few call argument lists that the inserted comments pushed over the
line limit. Generated mechanically with `arc pyre check-owning-targets` +
`arc pyre suppress` followed by `arc f`, then re-run and re-suppressed, because
`black` relocates some inserted comments off the argument they were meant to
cover.

This follows the established remediation for this exact breakage on the `beta`
channel -- D111539315, D110101874, D108930935 -- which suppress at the call site
and leave the vendored Triton bundle untouched.

Suppressions added in this diff: 8 `bad-argument-type`, 8 `bad-unpacking`.

Differential Revision: D115322860


