### PR TITLE
Fix the ROCm x86 wheel builds (#476)

### DIFF
--- a/.github/scripts/nova_prescript.bash
+++ b/.github/scripts/nova_prescript.bash
@@ -143,7 +143,7 @@ fi
 # have no control over the invocation of setup.py in the actual build stage.
 ################################################################################
 
-build_mslk_package "${BUILD_ENV_NAME}" "${CHANNEL}" "${mslk_build_target}/${mslk_build_variant}"
+build_mslk_package "${BUILD_ENV_NAME}" "${CHANNEL}" "${mslk_build_target}/${mslk_build_variant}" || exit 1
 end_time=$(date +%s)
 runtime=$((end_time-start_time))
 echo "[NOVA] Time taken to build the package: ${runtime} seconds / $(display_time ${runtime})"

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -57,12 +57,16 @@ jobs:
       # Nova Coordinate Filters:
       # cuda/12.6: No longer supported in MSLK
       # rocm/3.13t: causes segfaults at runtime
+      # rocm/{3.14t,3.15,3.15t}: FlyDSL, which is a mandatory dependency for the
+      #   ROCm variant (see ci/flydsl_version.txt), publishes no wheels for the
+      #   free-threaded builds or for 3.x >= 3.15.  Drop the coordinates again
+      #   as the wheels become available.
       # python/3.14: torch.compile support is missing, see https://github.com/pytorch/pytorch/issues/156856
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'desired_cuda:cu126' --filter 'gpu_arch_type:rocm;python_version:3.13t' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'desired_cuda:cu126' --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t,3.15,3.15t' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,28 @@ set(mslk_include_directories
   ${THIRDPARTY}/composable_kernel/library/include
   ${NCCL_INCLUDE_DIRS})
 
+# The vendored composable_kernel submodule ships `ck/config.h.in` but not the
+# generated `ck/config.h` that `ck/ck.hpp` includes.  ROCm installations provide
+# the generated header under ${ROCM_PATH}/include, but toolchains coming from
+# the `rocm-sdk-devel` wheel (e.g. the ROCm 7.14 manylinux builder image) don't.
+#
+# Only the presence of the header matters here: MSLK passes none of CK's
+# `-DCK_USE_*` build flags, and the `CK_USE_{OCP,FNUZ}_FP8` values written by
+# `configure_file()` are the literal token `ON`, which `#if` evaluates to 0.
+if(MSLK_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
+  find_file(CK_CONFIG_H ck/config.h PATHS ${ROCM_PATH}/include NO_DEFAULT_PATH)
+
+  if(NOT CK_CONFIG_H)
+    message(STATUS "generating ck/config.h")
+    set(CK_ENABLE_ALL_DTYPES "ON")
+    configure_file(
+      ${THIRDPARTY}/composable_kernel/include/ck/config.h.in
+      ${CMAKE_BINARY_DIR}/ck_config/ck/config.h
+      @ONLY)
+    list(APPEND mslk_include_directories ${CMAKE_BINARY_DIR}/ck_config)
+  endif()
+endif()
+
 
 ################################################################################
 # HIP Code Generation

--- a/cmake/RocmSetup.cmake
+++ b/cmake/RocmSetup.cmake
@@ -17,11 +17,11 @@ if(MSLK_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
   include(Hipify)
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_link_options(-fuse-ld=/opt/rocm/llvm/bin/ld.lld)
+    add_link_options(-fuse-ld=${ROCM_PATH}/llvm/bin/ld.lld)
   else()
     # GCC doesn't support -fuse-ld= with full paths. Use -B to add the
     # ROCm LLVM directory to GCC's tool search path.
-    add_link_options(-B/opt/rocm/llvm/bin/ -fuse-ld=lld)
+    add_link_options(-B${ROCM_PATH}/llvm/bin/ -fuse-ld=lld)
   endif()
 
   # Configure compiler for HIP


### PR DESCRIPTION
Summary:
The "Build MSLK x86 Linux Wheels" workflow has been red on mai. Two independent failures, plus one that made them hard to diagnose:

* All `rocm7.14` coordinates fail to compile with `fatal error: 'ck/config.h' file not found`.  The vendored composable_kernel submodule ships only `ck/config.h.in`; the generated header is silently picked up from `${ROCM_PATH}/include`, which works for the `/opt/rocm` installs used by rocm7.1/7.2 but not for the `rocm-sdk-devel` wheel toolchain in the ROCm 7.14 builder image, which ships no CK at all.  Generate the header from the submodule's template when the ROCm install does not provide one.

* The rocm7.2 builds for 3.14t/3.15/3.15t build fine but fail in Smoke Test on `pip install`, because FlyDSL - a mandatory dependency of the ROCm variant - publishes no wheels for free-threaded or 3.15 interpreters.  Filter those coordinates out of the Nova matrix, in the same way as the existing rocm/3.13t exclusion.

* `nova_prescript.bash` builds the wheel but discards the exit code, so a failed build reported success and only surfaced ~90s later as a confusing `dist/*.whl: No such file or directory` in Smoke Test. Propagate the failure.

Also stop hardcoding /opt/rocm for the linker path, for the same reason that ck/config.h could not be found.


Reviewed By: cthi

Differential Revision: D115457066

Pulled By: bottler


