### PR TITLE
Add Triton FP8×INT4 rowwise GEMM for ROCm gfx942/gfx950

### DIFF
--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -9,6 +9,16 @@ import functools
 from enum import auto, Enum
 
 import torch
+
+import mslk.gemm  # noqa: F401 — ensure mslk namespace exists
+
+_STUB_SCHEMAS = [
+    ("f8i4bf16_rowwise", "(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor"),
+]
+for _name, _schema in _STUB_SCHEMAS:
+    if not hasattr(torch.ops, "mslk") or not hasattr(torch.ops.mslk, _name):
+        torch.library.define(f"mslk::{_name}", _schema)
+
 from mslk.bench.common.utils import BenchOptions, do_bench
 from mslk.flydsl.common import is_flydsl_version_at_least
 from mslk.gemm.triton.fp8_gemm import matmul_fp8_block, matmul_fp8_row, to_mxfp8
@@ -1922,6 +1932,23 @@ class TritonBF16Int4GroupedShuffled(CutlassFP8Int4Rowwise):
     @property
     def weight_bytes_per_element(self) -> float:
         return 0.5
+
+
+@register_gemm_op
+class TritonFP8Int4Rowwise(CutlassFP8Int4Rowwise):
+    """ROCm Triton FP8xINT4 rowwise GEMM."""
+
+    def compute(self, xq, wq, x_scale, w_scale, w_zp):
+        from mslk.gemm.triton.f8i4bf16_rowwise_gemm import matmul_f8i4bf16_rowwise
+
+        return matmul_f8i4bf16_rowwise(xq, wq, x_scale, w_scale, w_zp)
+
+    def quantize_and_compute(self, xq, wq, x_scale, w_scale, w_zp):
+        return self.compute(xq, wq, x_scale, w_scale, w_zp)
+
+    @property
+    def supported_accelerators(self) -> set[Accelerator]:
+        return {Accelerator.AMD_GFX942, Accelerator.AMD_GFX950}
 
 
 @register_gemm_op

--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -1865,7 +1865,63 @@ class TritonBF16Int4Rowwise(CutlassBF16Int4Rowwise):
 
     @property
     def supported_accelerators(self) -> set[Accelerator]:
-        return {Accelerator.AMD_GFX942}
+        return {Accelerator.AMD_GFX942, Accelerator.AMD_GFX950}
+
+
+@register_gemm_op
+class TritonBF16Int4Shuffled(TritonBF16Int4Rowwise):
+    """ROCm Triton BF16xINT4 shuffled GEMM (routes to rowwise on AMD)."""
+
+    pass
+
+
+@register_gemm_op
+class TritonBF16Int4GroupedShuffled(CutlassFP8Int4Rowwise):
+    """ROCm Triton BF16xINT4 grouped shuffled GEMM."""
+
+    def preprocess(self, x, w):
+        assert isinstance(x, list) and isinstance(w, list)
+        m_values = [i.shape[0] for i in x]
+        m_sizes = torch.tensor(m_values).to(dtype=torch.int64, device=x[0].device)
+        wq_list, scale_list, zero_list = [], [], []
+        for wi in w:
+            wq_i, s_i, z_i = int4_row_quantize_zp(wi)
+            wq_list.append(pack_int4(wq_i))
+            scale_list.append(s_i)
+            zero_list.append(z_i)
+        wq = torch.stack(wq_list, dim=0).contiguous()
+        group_scale = torch.stack(scale_list, dim=0).contiguous()
+        group_zero = torch.stack(zero_list, dim=0).contiguous()
+        x = torch.concat(x, dim=0).contiguous()
+        return x, wq, group_scale, group_zero, m_sizes
+
+    def quantize(self, x, wq, group_scale, group_zero, m_sizes):
+        return x, wq, group_scale, group_zero, m_sizes
+
+    def compute(self, x, wq, group_scale, group_zero, m_sizes):
+        from mslk.gemm.triton.int4_grouped_gemm import matmul_bf16i4_rowwise_grouped
+
+        return matmul_bf16i4_rowwise_grouped(x, wq, group_scale, group_zero, m_sizes)
+
+    @property
+    def supported_accelerators(self) -> set[Accelerator]:
+        return {Accelerator.AMD_GFX942, Accelerator.AMD_GFX950}
+
+    @property
+    def supported_gemm_types(self) -> set[GemmType]:
+        return {GemmType.GROUPED}
+
+    @property
+    def compute_dtype(self) -> ComputeDtype:
+        return ComputeDtype.BF16
+
+    @property
+    def input_bytes_per_element(self) -> float:
+        return 2.0
+
+    @property
+    def weight_bytes_per_element(self) -> float:
+        return 0.5
 
 
 @register_gemm_op

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -64,6 +64,21 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   // mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py.
   m.def(
       "f8f8bf16_groupwise_grouped(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes) -> Tensor");
+  // BF16xINT4 GEMMs: shared schema between CUDA and ROCm.  On CUDA the
+  // implementations are CUTLASS-based; on ROCm they are registered by the
+  // Triton modules (int4_gemm.py, int4_grouped_gemm.py) via torch.library.impl
+  // at Python import time.
+  m.def(
+      "bf16i4bf16_rowwise(Tensor X, Tensor W, Tensor w_scale_group, Tensor w_zero_group) -> Tensor");
+  m.def(
+      "bf16i4bf16_rowwise_batched(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
+  m.def(
+      "bf16i4bf16_shuffled(Tensor X, Tensor W, Tensor w_scale_group, Tensor w_zero_group) -> Tensor");
+  m.def(
+      "bf16i4bf16_shuffled_grouped(Tensor X, Tensor WQ, Tensor w_scale_group, Tensor w_zero_group, Tensor M_sizes) -> Tensor");
+  m.def(
+      "bf16i4bf16_shuffled_batched(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
+  m.def("preshuffle_i4(Tensor WQ, Tensor w_scale) -> (Tensor, Tensor)");
 #ifdef USE_ROCM
   // Sibling of f8f8bf16_groupwise_grouped taking weights already swizzled into
   // the MFMA B layout; schema only on ROCm, implemented by the same FlyDSL
@@ -79,13 +94,6 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   // Generic PyTorch grouped GEMM API is only available on AMD for now.
   m.def(
       "f8f8bf16_rowwise_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? offsets, Tensor(a!) output) -> Tensor");
-  // BF16xINT4 rowwise GEMMs: schema only on ROCm; implementations are
-  // registered by mslk.gemm.triton.int4_gemm via torch.library.impl at
-  // Python import time.
-  m.def(
-      "bf16i4bf16_rowwise(Tensor X, Tensor W, Tensor w_scale_group, Tensor w_zero_group) -> Tensor");
-  m.def(
-      "bf16i4bf16_rowwise_batched(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
   // INT8 GEMM via Triton — static and dynamic scale variants.
   m.def("i8i8bf16(Tensor XQ, Tensor WQ, float scale, int split_k=1) -> Tensor");
   m.def(
@@ -110,20 +118,9 @@ TORCH_LIBRARY_FRAGMENT(mslk, m) {
   m.def(
       "f8i4bf16_shuffled(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_scale_group) -> Tensor");
   m.def(
-      "bf16i4bf16_shuffled(Tensor X, Tensor W, Tensor w_scale_group, Tensor w_zero_group) -> Tensor");
-  m.def(
       "f8i4bf16_shuffled_grouped(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_scale_group, Tensor M_sizes) -> Tensor");
   m.def(
-      "bf16i4bf16_shuffled_grouped(Tensor X, Tensor WQ, Tensor w_scale_group, Tensor w_zero_group, Tensor M_sizes) -> Tensor");
-  m.def(
-      "bf16i4bf16_rowwise(Tensor X, Tensor W, Tensor w_scale_group, Tensor w_zero_group) -> Tensor");
-  m.def(
-      "bf16i4bf16_shuffled_batched(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
-  m.def(
-      "bf16i4bf16_rowwise_batched(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
-  m.def(
       "i8i8bf16_dynamic(Tensor XQ, Tensor WQ, Tensor scale, int split_k=1) -> Tensor");
-  m.def("preshuffle_i4(Tensor WQ, Tensor w_scale) -> (Tensor, Tensor)");
 #endif
 }
 

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -36,6 +36,7 @@ if torch.version.hip is not None:
     # module, which overrides the default (non-existent) CUDA impl so that
     # torch.ops.mslk.* dispatches to the Triton kernel on AMD.
     from .triton import (  # noqa: F401
+        f8i4bf16_rowwise_gemm as _f8i4bf16_rowwise_gemm,
         fp8_groupwise_gemm,
         fp8_groupwise_grouped_gemm,
         grouped_gemm as _grouped_gemm,

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -31,14 +31,16 @@ from . import _meta, fp4_autograd  # noqa: F401, E402
 if torch.version.hip is not None:
     from mslk.flydsl.common import is_flydsl_available
 
-    # Register the Triton ROCm implementations for mx8mx4bf16, mx8mx8bf16, and
-    # f8f8bf16_groupwise(_grouped).  Each import triggers a
-    # @torch.library.impl(..., "CUDA") decoration that overrides the default
-    # (non-existent) CUDA impl so the ops dispatch to the Triton kernels on AMD.
+    # Register Triton implementations for ROCm.  Each import triggers the
+    # @torch.library.impl("mslk::...", "CUDA") decoration in the respective
+    # module, which overrides the default (non-existent) CUDA impl so that
+    # torch.ops.mslk.* dispatches to the Triton kernel on AMD.
     from .triton import (  # noqa: F401
         fp8_groupwise_gemm,
         fp8_groupwise_grouped_gemm,
         grouped_gemm as _grouped_gemm,
+        int4_gemm as _int4_gemm,
+        int4_grouped_gemm as _int4_grouped_gemm,
         mx8mx4_gemm,
         mx8mx8_gemm,
     )

--- a/mslk/gemm/_meta.py
+++ b/mslk/gemm/_meta.py
@@ -447,6 +447,21 @@ if hasattr(torch.ops.mslk, "bf16i4bf16_shuffled_batched"):
         return torch.empty((B, M, N), dtype=torch.bfloat16, device=X.device)
 
 
+if hasattr(torch.ops.mslk, "bf16i4bf16_shuffled_grouped"):
+
+    @torch.library.register_fake("mslk::bf16i4bf16_shuffled_grouped")
+    def bf16i4bf16_shuffled_grouped_meta(
+        X: torch.Tensor,
+        WQ: torch.Tensor,
+        w_scale_group: torch.Tensor,
+        w_zero_group: torch.Tensor,
+        M_sizes: torch.Tensor,
+    ) -> torch.Tensor:
+        M_total = X.shape[0]
+        N = WQ.shape[1]
+        return torch.empty((M_total, N), dtype=torch.bfloat16, device=X.device)
+
+
 if hasattr(torch.ops.mslk, "bf16i4bf16_rowwise_batched"):
 
     @torch.library.register_fake("mslk::bf16i4bf16_rowwise_batched")

--- a/mslk/gemm/triton/f8i4bf16_rowwise_gemm.py
+++ b/mslk/gemm/triton/f8i4bf16_rowwise_gemm.py
@@ -1,0 +1,159 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+FP8 x INT4 weight-only GEMM for ROCm/AMD GPUs, producing BF16 output.
+
+Thin wrapper around the unified _bf16i4_rowwise_kernel (int4_gemm.py).
+The kernel is shared with the BF16xINT4 path; the only differences are:
+  1. Activations are FP8 — byte-split and reinterpreted as FP8 TensorWrappers
+     here, then upcast to bfloat16 inside the kernel via .to(tl.bfloat16).
+  2. HAS_X_SCALE=True — the kernel multiplies the accumulator by a per-row
+     activation dequant scale before storing to workspace.
+
+Op signature (mslk::f8i4bf16_rowwise):
+  XQ          : [M, K]           FP8 activations (float8_e4m3fnuz on AMD)
+  WQ          : [N, K//2]        int8 packed INT4 (lo nibble = even K, hi = odd K)
+  x_scale     : [M]              float32 per-row activation dequant scale
+  w_scale     : [num_groups, N]  float32/bf16/fp16 per-group weight scale
+  w_zp        : [num_groups, N]  same dtype as w_scale, per-group zero point
+  output      : [M, N]           bfloat16
+"""
+
+import torch
+import triton  # @manual
+from mslk.gemm.triton.int4_gemm import (
+    _bf16i4_rowwise_kernel,
+    _bf16i4_splitk_reduce,
+    _MAX_SPLIT_K,
+    _TL_CAT_HAS_DIM,
+)
+from mslk.utils.triton.fp8_utils import get_fp8_constants, reinterpret_fp8_type
+
+
+def matmul_f8i4bf16_rowwise(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    w_zp: torch.Tensor,
+) -> torch.Tensor:
+    """
+    FP8 activation x INT4 weight GEMM with per-row x_scale and per-group w_scale/w_zp.
+
+    Args:
+        XQ      : [M, K]           FP8 activations (float8_e4m3fnuz on AMD)
+        WQ      : [N, K//2]        int8 packed INT4 (lo nibble=even K, hi=odd K)
+        x_scale : [M]              float32 per-row activation dequant scale
+        w_scale : [num_groups, N]  float32/bf16/fp16 per-group weight scale
+        w_zp    : [num_groups, N]  same dtype, per-group weight zero point
+
+    Returns:
+        Y : [M, N]  bfloat16
+    """
+    assert XQ.ndim == 2, f"XQ must be 2D [M, K], got shape {XQ.shape}"
+    M, K = XQ.shape
+    N = WQ.shape[0]
+    K2 = K // 2
+    num_groups = w_scale.shape[0]
+    group_size = K // num_groups
+
+    assert WQ.shape == (N, K2), f"WQ must be [N, K//2], got {WQ.shape}"
+    assert x_scale.shape == (M,), f"x_scale must be [M]={M}, got {x_scale.shape}"
+    assert w_scale.shape == (num_groups, N), (
+        f"w_scale must be [num_groups, N]={num_groups, N}, got {w_scale.shape}"
+    )
+    assert w_zp.shape == (num_groups, N), (
+        f"w_zp must be [num_groups, N]={num_groups, N}, got {w_zp.shape}"
+    )
+    assert group_size % 64 == 0, (
+        f"group_size={group_size} must be divisible by 64 (2 * BLOCK_K_min=32)"
+    )
+
+    _, tl_fp8_dtype, _, _ = get_fp8_constants()
+    XQ_int8 = XQ.view(torch.int8)
+    x_even_t = XQ_int8[:, 0::2].contiguous()
+    x_odd_t = XQ_int8[:, 1::2].contiguous()
+    x_even = reinterpret_fp8_type(x_even_t, tl_fp8_dtype)
+    x_odd = reinterpret_fp8_type(x_odd_t, tl_fp8_dtype)
+
+    if w_scale.dtype != torch.float32:
+        w_scale = w_scale.to(torch.float32)
+    if w_zp.dtype != torch.float32:
+        w_zp = w_zp.to(torch.float32)
+    if x_scale.dtype != torch.float32:
+        x_scale = x_scale.to(torch.float32)
+
+    def grid(meta):
+        return (
+            triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),
+            meta["SPLIT_K"],
+        )
+
+    workspace = torch.empty((_MAX_SPLIT_K, M, N), dtype=torch.float32, device=XQ.device)
+
+    _bf16i4_rowwise_kernel[grid](
+        x_even,
+        x_odd,
+        WQ,
+        workspace,
+        w_scale,
+        w_zp,
+        x_scale,
+        M,
+        N,
+        K2,
+        group_size,
+        x_even.stride(0),
+        x_even.stride(1),
+        WQ.stride(0),
+        WQ.stride(1),
+        M * N,
+        N,
+        1,
+        w_scale.stride(0),
+        w_scale.stride(1),
+        FUSE_DOT=_TL_CAT_HAS_DIM,
+        HAS_X_SCALE=True,
+    )
+
+    split_k = _bf16i4_rowwise_kernel.best_config.kwargs["SPLIT_K"]
+
+    if split_k == 1:
+        return workspace[0].to(torch.bfloat16)
+
+    Y_bf16 = torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
+    reduce_grid = (triton.cdiv(M, 32), triton.cdiv(N, 32))
+    _bf16i4_splitk_reduce[reduce_grid](
+        workspace,
+        Y_bf16,
+        M,
+        N,
+        SPLIT_K=split_k,
+        BLOCK_M=32,
+        BLOCK_N=32,
+    )
+    return Y_bf16
+
+
+# ---------------------------------------------------------------------------
+# Register as ROCm implementation of mslk::f8i4bf16_rowwise
+# ---------------------------------------------------------------------------
+
+if torch.version.hip is not None and hasattr(torch.ops, "mslk"):
+    if hasattr(torch.ops.mslk, "f8i4bf16_rowwise"):
+
+        @torch.library.impl("mslk::f8i4bf16_rowwise", "CUDA")
+        def _f8i4bf16_rowwise_rocm(
+            XQ: torch.Tensor,
+            WQ: torch.Tensor,
+            x_scale: torch.Tensor,
+            w_scale: torch.Tensor,
+            w_zp: torch.Tensor,
+        ) -> torch.Tensor:
+            return matmul_f8i4bf16_rowwise(XQ, WQ, x_scale, w_scale, w_zp)

--- a/mslk/gemm/triton/int4_gemm.py
+++ b/mslk/gemm/triton/int4_gemm.py
@@ -53,28 +53,36 @@ _TL_CAT_HAS_DIM = "dim" in inspect.signature(tl.cat).parameters
 _MAX_SPLIT_K = 8  # largest SPLIT_K value in the config sweep
 
 
+def _num_warps_for_tile(bm: int, bn: int) -> List[int]:
+    tile = bm * bn
+    if tile <= 2048:
+        return [4]
+    elif tile >= 16384:
+        return [8]
+    else:
+        return [4, 8]
+
+
 def _get_configs() -> List[Config]:
     configs = []
     for bm in [32, 64, 128, 256]:
         for bn in [32, 64, 128, 256]:
             for bk in [32, 64, 128]:
-                for nw in [4, 8]:
-                    for ns in [1, 2]:
-                        for gsm in [4, 8]:
-                            for sk in [1, 2, 4, 8]:
-                                configs.append(
-                                    Config(
-                                        {
-                                            "BLOCK_M": bm,
-                                            "BLOCK_N": bn,
-                                            "BLOCK_K": bk,
-                                            "GROUP_SIZE_M": gsm,
-                                            "SPLIT_K": sk,
-                                        },
-                                        num_warps=nw,
-                                        num_stages=ns,
-                                    )
-                                )
+                for sk in [1, 2, 4, 8]:
+                    for nw in _num_warps_for_tile(bm, bn):
+                        configs.append(
+                            Config(
+                                {
+                                    "BLOCK_M": bm,
+                                    "BLOCK_N": bn,
+                                    "BLOCK_K": bk,
+                                    "GROUP_SIZE_M": 8,
+                                    "SPLIT_K": sk,
+                                },
+                                num_warps=nw,
+                                num_stages=2,
+                            )
+                        )
     return configs
 
 
@@ -89,28 +97,13 @@ def _prune_configs(configs, named_args, **kwargs):
         bn = c.kwargs["BLOCK_N"]
         bk = c.kwargs["BLOCK_K"]
         sk = c.kwargs.get("SPLIT_K", 1)
-        nw = c.num_warps
-        ns = c.num_stages
-        # 2*BLOCK_K must divide group_size (dequant alignment)
         if group_size % (2 * bk) != 0:
             continue
-        # K2 must be cleanly divisible by BLOCK_K * SPLIT_K
         if K2 % (bk * sk) != 0:
             continue
-        # SPLIT_K > 1 only helps small M (otherwise adds atomic overhead for no gain)
         if sk > 1 and M >= 512:
             continue
-        # Skip tiles much larger than the problem dimension
         if bm > max(M, 32) or bn > max(N, 32):
-            continue
-        # Small tiles don't need 8 warps; large tiles don't benefit from 4
-        tile_elems = bm * bn
-        if tile_elems <= 2048 and nw == 8:
-            continue
-        if tile_elems >= 16384 and nw == 4:
-            continue
-        # Large tiles with many stages cause register spills
-        if tile_elems >= 16384 and ns >= 3:
             continue
         pruned.append(c)
     return pruned

--- a/mslk/gemm/triton/int4_gemm.py
+++ b/mslk/gemm/triton/int4_gemm.py
@@ -91,12 +91,14 @@ def _prune_configs(configs, named_args, **kwargs):
     M = named_args["M"]
     N = named_args["N"]
     K2 = named_args["K2"]
+    has_x_scale = named_args.get("HAS_X_SCALE", False)
     pruned = []
     for c in configs:
         bm = c.kwargs["BLOCK_M"]
         bn = c.kwargs["BLOCK_N"]
         bk = c.kwargs["BLOCK_K"]
         sk = c.kwargs.get("SPLIT_K", 1)
+        gsm = c.kwargs.get("GROUP_SIZE_M", 4)
         if group_size % (2 * bk) != 0:
             continue
         if K2 % (bk * sk) != 0:
@@ -105,6 +107,15 @@ def _prune_configs(configs, named_args, **kwargs):
             continue
         if bm > max(M, 32) or bn > max(N, 32):
             continue
+        if has_x_scale:
+            if bn < 128 and N >= 128:
+                continue
+            if bk > 64:
+                continue
+            if sk == 2:
+                continue
+            if gsm != 4:
+                continue
         pruned.append(c)
     return pruned
 
@@ -130,12 +141,13 @@ def _prune_configs(configs, named_args, **kwargs):
 )
 @triton.jit
 def _bf16i4_rowwise_kernel(
-    X_even_ptr,  # [M, K//2]  bfloat16 — even K columns of activations
-    X_odd_ptr,  # [M, K//2]  bfloat16 — odd  K columns of activations
+    X_even_ptr,  # [M, K//2]  bfloat16 or FP8 — even K columns of activations
+    X_odd_ptr,  # [M, K//2]  bfloat16 or FP8 — odd  K columns of activations
     W_ptr,  # [N, K//2]  int8 packed (lo nibble = even K, hi = odd K)
-    Y_ptr,  # [M, N]     bfloat16
+    Y_ptr,  # [SPLIT_K, M, N]  float32 workspace
     scale_ptr,  # [num_groups, N]
     zero_ptr,  # [num_groups, N]
+    x_scale_ptr,  # [M] float32 per-row activation scale (used when HAS_X_SCALE)
     M,
     N,
     K2,  # K // 2
@@ -158,6 +170,7 @@ def _bf16i4_rowwise_kernel(
     EVEN_MN: tl.constexpr,
     GRID_MN: tl.constexpr,
     FUSE_DOT: tl.constexpr,
+    HAS_X_SCALE: tl.constexpr = False,
 ) -> None:
     """
     Computes Y[M, N] = X[M, K] @ dequant(W)[K, N].
@@ -225,10 +238,10 @@ def _bf16i4_rowwise_kernel(
     if EVEN_MN and EVEN_K:
         x_even = tl.load(
             X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
-        ).to(tl.bfloat16)
+        )
         x_odd = tl.load(
             X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
-        ).to(tl.bfloat16)
+        )
         w_q = tl.load(
             W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
         ).to(tl.int32)
@@ -238,12 +251,12 @@ def _bf16i4_rowwise_kernel(
             X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=k_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         x_odd = tl.load(
             X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=k_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         w_q = tl.load(
             W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
             mask=k_mask,
@@ -256,12 +269,12 @@ def _bf16i4_rowwise_kernel(
             X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=xk_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         x_odd = tl.load(
             X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=xk_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         w_q = tl.load(
             W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
             mask=wk_mask,
@@ -274,17 +287,19 @@ def _bf16i4_rowwise_kernel(
             X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=xk_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         x_odd = tl.load(
             X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=xk_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         w_q = tl.load(
             W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
             mask=wk_mask,
             other=0,
         ).to(tl.int32)
+    x_even = x_even.to(tl.bfloat16)
+    x_odd = x_odd.to(tl.bfloat16)
     group_idx = (k2_slice_start * 2) // group_size
     if EVEN_MN:
         s = tl.load(
@@ -325,12 +340,12 @@ def _bf16i4_rowwise_kernel(
                 X_even_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
-            ).to(tl.bfloat16)
+            )
             next_x_odd = tl.load(
                 X_odd_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
-            ).to(tl.bfloat16)
+            )
             next_w_q = tl.load(
                 W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
             ).to(tl.int32)
@@ -342,14 +357,14 @@ def _bf16i4_rowwise_kernel(
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_k_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_x_odd = tl.load(
                 X_odd_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_k_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_w_q = tl.load(
                 W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
                 mask=next_k_mask,
@@ -364,14 +379,14 @@ def _bf16i4_rowwise_kernel(
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_xk_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_x_odd = tl.load(
                 X_odd_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_xk_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_w_q = tl.load(
                 W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
                 mask=next_wk_mask,
@@ -386,14 +401,14 @@ def _bf16i4_rowwise_kernel(
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_xk_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_x_odd = tl.load(
                 X_odd_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_xk_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_w_q = tl.load(
                 W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
                 mask=next_wk_mask,
@@ -417,7 +432,20 @@ def _bf16i4_rowwise_kernel(
                 mask=offs_n < N,
             ).to(tl.float32)
 
-        if FUSE_DOT:
+        if HAS_X_SCALE:
+            acc = tl.dot(
+                x_even,
+                tl.trans(w_lo_dq.to(tl.bfloat16)),
+                acc,
+                out_dtype=tl.float32,
+            )
+            acc = tl.dot(
+                x_odd,
+                tl.trans(w_hi_dq.to(tl.bfloat16)),
+                acc,
+                out_dtype=tl.float32,
+            )
+        elif FUSE_DOT:
             x_fused = tl.cat(x_even, x_odd, dim=1)
             w_fused = tl.cat(w_lo_dq.to(tl.bfloat16), w_hi_dq.to(tl.bfloat16), dim=1)
             acc = tl.dot(x_fused, tl.trans(w_fused), acc, out_dtype=tl.float32)
@@ -435,12 +463,25 @@ def _bf16i4_rowwise_kernel(
                 out_dtype=tl.float32,
             )
 
+        next_x_even = next_x_even.to(tl.bfloat16)
+        next_x_odd = next_x_odd.to(tl.bfloat16)
+
         # Rotate buffers
         x_even = next_x_even
         x_odd = next_x_odd
         w_q = next_w_q
         s = next_s
         z = next_z
+
+    # ---- per-row activation scale (FP8 path) ----
+    if HAS_X_SCALE:
+        if EVEN_MN:
+            xs = tl.load(x_scale_ptr + offs_m).to(tl.float32)
+        else:
+            xs = tl.load(x_scale_ptr + offs_m, mask=offs_m < M, other=1.0).to(
+                tl.float32
+            )
+        acc = acc * xs[:, None]
 
     # ---- store output ----
     # Write partial sum for this K-slice into workspace[pid_z, m, n].
@@ -550,6 +591,7 @@ def matmul_bf16i4_rowwise(
     # workspace[pid_z]. Allocated with empty (no zeroing) since the reduction kernel
     # only reads slices [0:split_k] — unwritten slices beyond split_k are never touched.
     workspace = torch.empty((_MAX_SPLIT_K, M, N), dtype=torch.float32, device=X.device)
+    _dummy_x_scale = torch.empty(1, dtype=torch.float32, device=X.device)
 
     _bf16i4_rowwise_kernel[grid](
         x_even,
@@ -558,6 +600,7 @@ def matmul_bf16i4_rowwise(
         workspace,
         w_scale_group,
         w_zero_group,
+        _dummy_x_scale,
         M,
         N,
         K2,
@@ -572,6 +615,7 @@ def matmul_bf16i4_rowwise(
         w_scale_group.stride(0),
         w_scale_group.stride(1),
         FUSE_DOT=_TL_CAT_HAS_DIM,
+        HAS_X_SCALE=False,
     )
 
     split_k = _bf16i4_rowwise_kernel.best_config.kwargs["SPLIT_K"]

--- a/mslk/gemm/triton/int4_gemm.py
+++ b/mslk/gemm/triton/int4_gemm.py
@@ -30,11 +30,12 @@ Activation pre-split strategy (avoids LDS bank conflicts):
   data movement that ROCm Triton lowers through LDS, causing severe bank
   conflicts.  Instead, the Python wrapper splits the activation matrix X into
   two contiguous [M, K//2] tensors (even and odd K columns) before kernel
-  launch using optimised PyTorch/HIP strided copies.  The kernel then issues
-  two tl.dot calls — one against the lo nibbles, one against the hi nibbles —
-  with fully coalesced loads and no LDS involvement.
+  launch using optimised PyTorch/HIP strided copies.  The kernel concatenates
+  x_even and x_odd along K via tl.cat and issues a single fused tl.dot against
+  the concatenated dequantised weights — one LDS staging pass instead of two.
 """
 
+import inspect
 from typing import List
 
 import torch
@@ -42,31 +43,77 @@ import triton  # @manual
 import triton.language as tl  # @manual
 from triton import Config  # @manual
 
+_TL_CAT_HAS_DIM = "dim" in inspect.signature(tl.cat).parameters
 
 # ---------------------------------------------------------------------------
 # Autotuning configs
 # ---------------------------------------------------------------------------
 
 
+_MAX_SPLIT_K = 8  # largest SPLIT_K value in the config sweep
+
+
 def _get_configs() -> List[Config]:
     configs = []
-    for bm in [16, 32, 64, 128]:
-        for bn in [64, 128, 256]:
-            # BLOCK_K is the tile size over the K2 = K//2 dimension, which is
-            # also the inner-dot K for each tl.dot call.  Must divide
-            # group_size // 2 (so 2*BLOCK_K divides group_size).  With the
-            # common group_size=128, BLOCK_K <= 64.
-            for bk in [32, 64]:
+    for bm in [32, 64, 128, 256]:
+        for bn in [32, 64, 128, 256]:
+            for bk in [32, 64, 128]:
                 for nw in [4, 8]:
-                    for ns in [2, 3]:
-                        configs.append(
-                            Config(
-                                {"BLOCK_M": bm, "BLOCK_N": bn, "BLOCK_K": bk},
-                                num_warps=nw,
-                                num_stages=ns,
-                            )
-                        )
+                    for ns in [1, 2]:
+                        for gsm in [4, 8]:
+                            for sk in [1, 2, 4, 8]:
+                                configs.append(
+                                    Config(
+                                        {
+                                            "BLOCK_M": bm,
+                                            "BLOCK_N": bn,
+                                            "BLOCK_K": bk,
+                                            "GROUP_SIZE_M": gsm,
+                                            "SPLIT_K": sk,
+                                        },
+                                        num_warps=nw,
+                                        num_stages=ns,
+                                    )
+                                )
     return configs
+
+
+def _prune_configs(configs, named_args, **kwargs):
+    group_size = named_args["group_size"]
+    M = named_args["M"]
+    N = named_args["N"]
+    K2 = named_args["K2"]
+    pruned = []
+    for c in configs:
+        bm = c.kwargs["BLOCK_M"]
+        bn = c.kwargs["BLOCK_N"]
+        bk = c.kwargs["BLOCK_K"]
+        sk = c.kwargs.get("SPLIT_K", 1)
+        nw = c.num_warps
+        ns = c.num_stages
+        # 2*BLOCK_K must divide group_size (dequant alignment)
+        if group_size % (2 * bk) != 0:
+            continue
+        # K2 must be cleanly divisible by BLOCK_K * SPLIT_K
+        if K2 % (bk * sk) != 0:
+            continue
+        # SPLIT_K > 1 only helps small M (otherwise adds atomic overhead for no gain)
+        if sk > 1 and M >= 512:
+            continue
+        # Skip tiles much larger than the problem dimension
+        if bm > max(M, 32) or bn > max(N, 32):
+            continue
+        # Small tiles don't need 8 warps; large tiles don't benefit from 4
+        tile_elems = bm * bn
+        if tile_elems <= 2048 and nw == 8:
+            continue
+        if tile_elems >= 16384 and nw == 4:
+            continue
+        # Large tiles with many stages cause register spills
+        if tile_elems >= 16384 and ns >= 3:
+            continue
+        pruned.append(c)
+    return pruned
 
 
 # ---------------------------------------------------------------------------
@@ -74,7 +121,20 @@ def _get_configs() -> List[Config]:
 # ---------------------------------------------------------------------------
 
 
-@triton.autotune(configs=_get_configs(), key=["M", "N", "K2", "group_size"])
+@triton.autotune(
+    configs=_get_configs(),
+    key=["M", "N", "K2", "group_size"],
+    prune_configs_by={"early_config_prune": _prune_configs},
+)
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K2"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0,
+        "EVEN_MN": lambda args: (args["M"] % args["BLOCK_M"] == 0)
+        and (args["N"] % args["BLOCK_N"] == 0),
+        "GRID_MN": lambda args: triton.cdiv(args["M"], args["BLOCK_M"])
+        * triton.cdiv(args["N"], args["BLOCK_N"]),
+    }
+)
 @triton.jit
 def _bf16i4_rowwise_kernel(
     X_even_ptr,  # [M, K//2]  bfloat16 — even K columns of activations
@@ -91,6 +151,7 @@ def _bf16i4_rowwise_kernel(
     stride_xk,  # strides for x_even / x_odd (same shape [M, K2])
     stride_wn,
     stride_wk,
+    stride_yz,  # stride of SPLIT_K dimension in workspace [SPLIT_K, M, N]
     stride_ym,
     stride_yn,
     stride_sg,
@@ -98,31 +159,106 @@ def _bf16i4_rowwise_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,  # tile size over K2; inner-dot K for each tl.dot
+    GROUP_SIZE_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    EVEN_MN: tl.constexpr,
+    GRID_MN: tl.constexpr,
+    FUSE_DOT: tl.constexpr,
 ) -> None:
     """
     Computes Y[M, N] = X[M, K] @ dequant(W)[K, N].
 
     X has been pre-split into x_even [M, K//2] (even K columns) and
     x_odd [M, K//2] (odd K columns) by the Python wrapper.  Each kernel
-    iteration loads BLOCK_K elements from each and issues two tl.dot calls
-    against the unpacked lo/hi weight halves — no interleave, no LDS.
+    iteration concatenates x_even and x_odd along K and issues a single
+    fused tl.dot against the concatenated dequantised weights.
 
     Constraint: 2 * BLOCK_K must divide group_size.
     """
-    pid_m = tl.program_id(0)
-    pid_n = tl.program_id(1)
+    NUM_XCDS: tl.constexpr = 8
+    pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
 
-    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    # XCD remapping: spread PIDs evenly across 8 chiplets
+    pids_per_xcd = (GRID_MN + NUM_XCDS - 1) // NUM_XCDS
+    xcd = pid % NUM_XCDS
+    local_pid = pid // NUM_XCDS
+    tall_xcds = GRID_MN % NUM_XCDS
+    tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+    if xcd < tall_xcds:
+        pid = xcd * pids_per_xcd + local_pid
+    else:
+        pid = (
+            tall_xcds * pids_per_xcd
+            + (xcd - tall_xcds) * (pids_per_xcd - 1)
+            + local_pid
+        )
+
+    # Grouped PID → (pid_m, pid_n) with L2-friendly M-grouping
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = tl.minimum(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    tl.assume(stride_xm > 0)
+    tl.assume(stride_xk > 0)
+    tl.assume(stride_wn > 0)
+    tl.assume(stride_wk > 0)
+    tl.assume(stride_ym > 0)
+    tl.assume(stride_yn > 0)
+    tl.assume(stride_sg > 0)
+    tl.assume(stride_sn > 0)
+
+    if EVEN_MN:
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    else:
+        offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
+        offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
 
     acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+    pid_z = tl.program_id(1)
+    k2_per_split = tl.cdiv(K2, SPLIT_K)
+    k2_slice_start = pid_z * k2_per_split
+    k2_slice_end = tl.minimum(k2_slice_start + k2_per_split, K2)
+    num_iters = tl.cdiv(k2_slice_end - k2_slice_start, BLOCK_K)
 
-    for k2_idx in tl.range(0, tl.cdiv(K2, BLOCK_K)):
-        k2_start = k2_idx * BLOCK_K
-        offs_k2 = k2_start + tl.arange(0, BLOCK_K)
-
-        # ---- activation tiles [BLOCK_M, BLOCK_K] — fully coalesced ----
-        xk_mask = (offs_m[:, None] < M) & (offs_k2[None, :] < K2)
+    # ---- prologue: issue loads for iteration 0 ----
+    offs_k2 = k2_slice_start + tl.arange(0, BLOCK_K)
+    if EVEN_MN and EVEN_K:
+        x_even = tl.load(
+            X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
+        ).to(tl.bfloat16)
+        x_odd = tl.load(
+            X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
+        ).to(tl.bfloat16)
+        w_q = tl.load(
+            W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
+        ).to(tl.int32)
+    elif EVEN_MN:
+        k_mask = offs_k2[None, :] < K2
+        x_even = tl.load(
+            X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
+            mask=k_mask,
+            other=0.0,
+        ).to(tl.bfloat16)
+        x_odd = tl.load(
+            X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
+            mask=k_mask,
+            other=0.0,
+        ).to(tl.bfloat16)
+        w_q = tl.load(
+            W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
+            mask=k_mask,
+            other=0,
+        ).to(tl.int32)
+    elif EVEN_K:
+        xk_mask = offs_m[:, None] < M
+        wk_mask = offs_n[:, None] < N
         x_even = tl.load(
             X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=xk_mask,
@@ -133,24 +269,38 @@ def _bf16i4_rowwise_kernel(
             mask=xk_mask,
             other=0.0,
         ).to(tl.bfloat16)
-
-        # ---- packed weight tile [BLOCK_N, BLOCK_K] ----
-        wk_mask = (offs_n[:, None] < N) & (offs_k2[None, :] < K2)
         w_q = tl.load(
             W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
             mask=wk_mask,
             other=0,
         ).to(tl.int32)
-
-        # ---- unpack nibbles ----
-        # lo nibble (bits 0-3) -> even K weight values
-        # hi nibble (bits 4-7) -> odd  K weight values
-        w_lo = w_q & 0x0F  # [BLOCK_N, BLOCK_K]
-        w_hi = (w_q >> 4) & 0x0F  # [BLOCK_N, BLOCK_K]
-
-        # ---- per-group scale and zero ----
-        # k2_start indexes K//2; the corresponding full-K position is 2*k2_start.
-        group_idx = (k2_start * 2) // group_size
+    else:
+        xk_mask = (offs_m[:, None] < M) & (offs_k2[None, :] < K2)
+        wk_mask = (offs_n[:, None] < N) & (offs_k2[None, :] < K2)
+        x_even = tl.load(
+            X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
+            mask=xk_mask,
+            other=0.0,
+        ).to(tl.bfloat16)
+        x_odd = tl.load(
+            X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
+            mask=xk_mask,
+            other=0.0,
+        ).to(tl.bfloat16)
+        w_q = tl.load(
+            W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
+            mask=wk_mask,
+            other=0,
+        ).to(tl.int32)
+    group_idx = (k2_slice_start * 2) // group_size
+    if EVEN_MN:
+        s = tl.load(
+            scale_ptr + group_idx * stride_sg + offs_n * stride_sn,
+        ).to(tl.float32)
+        z = tl.load(
+            zero_ptr + group_idx * stride_sg + offs_n * stride_sn,
+        ).to(tl.float32)
+    else:
         s = tl.load(
             scale_ptr + group_idx * stride_sg + offs_n * stride_sn,
             mask=offs_n < N,
@@ -159,29 +309,190 @@ def _bf16i4_rowwise_kernel(
             zero_ptr + group_idx * stride_sg + offs_n * stride_sn,
             mask=offs_n < N,
         ).to(tl.float32)
+
+    # ---- main loop: compute iteration i, prefetch iteration i+1 ----
+    # The prefetch always runs (even on the last iteration where results are
+    # discarded) to avoid Triton SSA scoping issues with conditional defines.
+    for k2_idx in tl.range(0, num_iters):
+        k2_start = k2_slice_start + k2_idx * BLOCK_K
+
+        # Unpack and dequant current tile (uses already-loaded data)
+        w_lo = w_q & 0x0F
+        w_hi = (w_q >> 4) & 0x0F
         s_col = s[:, None]
         z_col = z[:, None]
+        w_lo_dq = ((w_lo ^ 8) - 8).to(tl.float32) * s_col + z_col
+        w_hi_dq = ((w_hi ^ 8) - 8).to(tl.float32) * s_col + z_col
 
-        # ---- dequantise: signed = (nibble ^ 8) - 8, w_float = signed * scale + zero ----
-        w_lo_dq = ((w_lo ^ 8) - 8).to(tl.float32) * s_col + z_col  # [BLOCK_N, BLOCK_K]
-        w_hi_dq = ((w_hi ^ 8) - 8).to(tl.float32) * s_col + z_col  # [BLOCK_N, BLOCK_K]
+        # Prefetch next iteration (clamp to last valid tile on final iteration)
+        next_k2_start = tl.minimum(k2_start + BLOCK_K, k2_slice_end - BLOCK_K)
+        next_offs_k2 = next_k2_start + tl.arange(0, BLOCK_K)
+        if EVEN_MN and EVEN_K:
+            next_x_even = tl.load(
+                X_even_ptr
+                + offs_m[:, None] * stride_xm
+                + next_offs_k2[None, :] * stride_xk,
+            ).to(tl.bfloat16)
+            next_x_odd = tl.load(
+                X_odd_ptr
+                + offs_m[:, None] * stride_xm
+                + next_offs_k2[None, :] * stride_xk,
+            ).to(tl.bfloat16)
+            next_w_q = tl.load(
+                W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
+            ).to(tl.int32)
+        elif EVEN_MN:
+            next_k_mask = next_offs_k2[None, :] < K2
+            next_x_even = tl.load(
+                X_even_ptr
+                + offs_m[:, None] * stride_xm
+                + next_offs_k2[None, :] * stride_xk,
+                mask=next_k_mask,
+                other=0.0,
+            ).to(tl.bfloat16)
+            next_x_odd = tl.load(
+                X_odd_ptr
+                + offs_m[:, None] * stride_xm
+                + next_offs_k2[None, :] * stride_xk,
+                mask=next_k_mask,
+                other=0.0,
+            ).to(tl.bfloat16)
+            next_w_q = tl.load(
+                W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
+                mask=next_k_mask,
+                other=0,
+            ).to(tl.int32)
+        elif EVEN_K:
+            next_xk_mask = offs_m[:, None] < M
+            next_wk_mask = offs_n[:, None] < N
+            next_x_even = tl.load(
+                X_even_ptr
+                + offs_m[:, None] * stride_xm
+                + next_offs_k2[None, :] * stride_xk,
+                mask=next_xk_mask,
+                other=0.0,
+            ).to(tl.bfloat16)
+            next_x_odd = tl.load(
+                X_odd_ptr
+                + offs_m[:, None] * stride_xm
+                + next_offs_k2[None, :] * stride_xk,
+                mask=next_xk_mask,
+                other=0.0,
+            ).to(tl.bfloat16)
+            next_w_q = tl.load(
+                W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
+                mask=next_wk_mask,
+                other=0,
+            ).to(tl.int32)
+        else:
+            next_xk_mask = (offs_m[:, None] < M) & (next_offs_k2[None, :] < K2)
+            next_wk_mask = (offs_n[:, None] < N) & (next_offs_k2[None, :] < K2)
+            next_x_even = tl.load(
+                X_even_ptr
+                + offs_m[:, None] * stride_xm
+                + next_offs_k2[None, :] * stride_xk,
+                mask=next_xk_mask,
+                other=0.0,
+            ).to(tl.bfloat16)
+            next_x_odd = tl.load(
+                X_odd_ptr
+                + offs_m[:, None] * stride_xm
+                + next_offs_k2[None, :] * stride_xk,
+                mask=next_xk_mask,
+                other=0.0,
+            ).to(tl.bfloat16)
+            next_w_q = tl.load(
+                W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
+                mask=next_wk_mask,
+                other=0,
+            ).to(tl.int32)
+        next_group_idx = (next_k2_start * 2) // group_size
+        if EVEN_MN:
+            next_s = tl.load(
+                scale_ptr + next_group_idx * stride_sg + offs_n * stride_sn,
+            ).to(tl.float32)
+            next_z = tl.load(
+                zero_ptr + next_group_idx * stride_sg + offs_n * stride_sn,
+            ).to(tl.float32)
+        else:
+            next_s = tl.load(
+                scale_ptr + next_group_idx * stride_sg + offs_n * stride_sn,
+                mask=offs_n < N,
+            ).to(tl.float32)
+            next_z = tl.load(
+                zero_ptr + next_group_idx * stride_sg + offs_n * stride_sn,
+                mask=offs_n < N,
+            ).to(tl.float32)
 
-        # ---- two dot products, no interleave, no LDS ----
-        # x_even [BLOCK_M, BLOCK_K] @ w_lo_dq.T [BLOCK_K, BLOCK_N]  (even K)
-        # x_odd  [BLOCK_M, BLOCK_K] @ w_hi_dq.T [BLOCK_K, BLOCK_N]  (odd  K)
-        acc = tl.dot(
-            x_even, tl.trans(w_lo_dq.to(tl.bfloat16)), acc, out_dtype=tl.float32
-        )
-        acc = tl.dot(
-            x_odd, tl.trans(w_hi_dq.to(tl.bfloat16)), acc, out_dtype=tl.float32
-        )
+        if FUSE_DOT:
+            x_fused = tl.cat(x_even, x_odd, dim=1)
+            w_fused = tl.cat(w_lo_dq.to(tl.bfloat16), w_hi_dq.to(tl.bfloat16), dim=1)
+            acc = tl.dot(x_fused, tl.trans(w_fused), acc, out_dtype=tl.float32)
+        else:
+            acc = tl.dot(
+                x_even,
+                tl.trans(w_lo_dq.to(tl.bfloat16)),
+                acc,
+                out_dtype=tl.float32,
+            )
+            acc = tl.dot(
+                x_odd,
+                tl.trans(w_hi_dq.to(tl.bfloat16)),
+                acc,
+                out_dtype=tl.float32,
+            )
+
+        # Rotate buffers
+        x_even = next_x_even
+        x_odd = next_x_odd
+        w_q = next_w_q
+        s = next_s
+        z = next_z
 
     # ---- store output ----
-    y_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    # Write partial sum for this K-slice into workspace[pid_z, m, n].
+    # When SPLIT_K=1, pid_z=0 and this is a direct store to [M, N].
+    # When SPLIT_K>1, the caller launches _bf16i4_splitk_reduce to sum slices.
+    y_ptrs = (
+        Y_ptr
+        + pid_z * stride_yz
+        + offs_m[:, None] * stride_ym
+        + offs_n[None, :] * stride_yn
+    )
+    if EVEN_MN:
+        tl.store(y_ptrs, acc)
+    else:
+        tl.store(y_ptrs, acc, mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+
+# ---------------------------------------------------------------------------
+# SPLIT_K reduction kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _bf16i4_splitk_reduce(
+    workspace_ptr,  # [SPLIT_K, M, N] float32
+    Y_ptr,  # [M, N] bfloat16
+    M,
+    N,
+    SPLIT_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+    for k in tl.range(0, SPLIT_K):
+        acc += tl.load(
+            workspace_ptr + k * M * N + offs_m[:, None] * N + offs_n[None, :],
+            mask=mask,
+        )
     tl.store(
-        Y_ptr + offs_m[:, None] * stride_ym + offs_n[None, :] * stride_yn,
-        acc.to(tl.bfloat16),
-        mask=y_mask,
+        Y_ptr + offs_m[:, None] * N + offs_n[None, :], acc.to(tl.bfloat16), mask=mask
     )
 
 
@@ -217,10 +528,10 @@ def matmul_bf16i4_rowwise(
 
     assert W.shape == (N, K2), f"W must be [N, K//2], got {W.shape}"
     assert w_scale_group.shape == (num_groups, N), (
-        f"w_scale_group must be [num_groups, N]={num_groups, N}, got {w_scale_group.shape}"
+        f"w_scale_group must be [{num_groups}, {N}], got {w_scale_group.shape}"
     )
     assert w_zero_group.shape == (num_groups, N), (
-        f"w_zero_group must be [num_groups, N]={num_groups, N}, got {w_zero_group.shape}"
+        f"w_zero_group must be [{num_groups}, {N}], got {w_zero_group.shape}"
     )
     group_size = K // num_groups
     assert group_size % 64 == 0, (
@@ -236,17 +547,22 @@ def matmul_bf16i4_rowwise(
     x_even = X_2d[:, 0::2].contiguous()  # [M, K//2]
     x_odd = X_2d[:, 1::2].contiguous()  # [M, K//2]
 
-    Y = torch.empty((M, N), dtype=torch.bfloat16, device=X.device)
+    def grid(meta):
+        return (
+            triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),
+            meta["SPLIT_K"],
+        )
 
-    grid = lambda meta: (  # noqa: E731
-        triton.cdiv(M, meta["BLOCK_M"]),
-        triton.cdiv(N, meta["BLOCK_N"]),
-    )
+    # Workspace: [MAX_SPLIT_K, M, N] float32. Each K-slice stores its partial sum at
+    # workspace[pid_z]. Allocated with empty (no zeroing) since the reduction kernel
+    # only reads slices [0:split_k] — unwritten slices beyond split_k are never touched.
+    workspace = torch.empty((_MAX_SPLIT_K, M, N), dtype=torch.float32, device=X.device)
+
     _bf16i4_rowwise_kernel[grid](
         x_even,
         x_odd,
         W,
-        Y,
+        workspace,
         w_scale_group,
         w_zero_group,
         M,
@@ -257,12 +573,32 @@ def matmul_bf16i4_rowwise(
         x_even.stride(1),
         W.stride(0),
         W.stride(1),
-        Y.stride(0),
-        Y.stride(1),
+        M * N,
+        N,
+        1,
         w_scale_group.stride(0),
         w_scale_group.stride(1),
+        FUSE_DOT=_TL_CAT_HAS_DIM,
     )
-    return Y.reshape(*leading, N)
+
+    split_k = _bf16i4_rowwise_kernel.best_config.kwargs["SPLIT_K"]
+
+    if split_k == 1:
+        return workspace[0].to(torch.bfloat16).reshape(*leading, N)
+
+    # SPLIT_K > 1: sum partial sums across K-slices and cast to bf16.
+    Y_bf16 = torch.empty((M, N), dtype=torch.bfloat16, device=X.device)
+    reduce_grid = (triton.cdiv(M, 32), triton.cdiv(N, 32))
+    _bf16i4_splitk_reduce[reduce_grid](
+        workspace,
+        Y_bf16,
+        M,
+        N,
+        SPLIT_K=split_k,
+        BLOCK_M=32,
+        BLOCK_N=32,
+    )
+    return Y_bf16.reshape(*leading, N)
 
 
 def matmul_bf16i4_rowwise_batched(
@@ -329,3 +665,37 @@ if torch.version.hip is not None and hasattr(torch.ops, "mslk"):
             w_zp: torch.Tensor,
         ) -> torch.Tensor:
             return matmul_bf16i4_rowwise_batched(X, W, w_scale, w_zp)
+
+    # bf16i4bf16_shuffled: on ROCm the CUTLASS shuffle layout does not exist,
+    # so the shuffled ops route through the same rowwise kernels.
+    if hasattr(torch.ops.mslk, "bf16i4bf16_shuffled"):
+
+        @torch.library.impl("mslk::bf16i4bf16_shuffled", "CUDA")
+        def _bf16i4bf16_shuffled_rocm(
+            X: torch.Tensor,
+            W: torch.Tensor,
+            w_scale_group: torch.Tensor,
+            w_zero_group: torch.Tensor,
+        ) -> torch.Tensor:
+            return matmul_bf16i4_rowwise(X, W, w_scale_group, w_zero_group)
+
+    if hasattr(torch.ops.mslk, "bf16i4bf16_shuffled_batched"):
+
+        @torch.library.impl("mslk::bf16i4bf16_shuffled_batched", "CUDA")
+        def _bf16i4bf16_shuffled_batched_rocm(
+            X: torch.Tensor,
+            W: torch.Tensor,
+            w_scale: torch.Tensor,
+            w_zp: torch.Tensor,
+        ) -> torch.Tensor:
+            return matmul_bf16i4_rowwise_batched(X, W, w_scale, w_zp)
+
+    # preshuffle_i4: CUTLASS SM90 pre-processing; identity on ROCm.
+    if hasattr(torch.ops.mslk, "preshuffle_i4"):
+
+        @torch.library.impl("mslk::preshuffle_i4", "CUDA")
+        def _preshuffle_i4_rocm(
+            WQ: torch.Tensor,
+            w_scale: torch.Tensor,
+        ) -> tuple:
+            return WQ, w_scale

--- a/mslk/gemm/triton/int4_grouped_gemm.py
+++ b/mslk/gemm/triton/int4_grouped_gemm.py
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+BF16 x INT4 grouped GEMM for ROCm/AMD GPUs.
+
+Delegates to the fused grouped kernel in int4_grouped_gemm_fused.py, which
+handles all G groups in a single launch with no device-to-host sync
+(CUDA-graph safe).  On ROCm, bf16i4bf16_shuffled_grouped routes through
+this path.
+
+Weight layout:
+  WQ          : [G, N, K//2]        int8
+  w_scale_group: [G, num_groups, N]  float32 or bfloat16
+  w_zero_group : [G, num_groups, N]  float32 or bfloat16
+  M_sizes      : [G]                 int64 -- rows per group
+
+Output: [M_total, N] bfloat16, where M_total = sum(M_sizes).
+"""
+
+import torch
+from mslk.gemm.triton.int4_grouped_gemm_fused import matmul_bf16i4_rowwise_grouped_fused
+
+
+def matmul_bf16i4_rowwise_grouped(
+    X: torch.Tensor,
+    WQ: torch.Tensor,
+    w_scale_group: torch.Tensor,
+    w_zero_group: torch.Tensor,
+    M_sizes: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Grouped BF16 x INT4 GEMM — CUDA-graph safe.
+
+    Args:
+        X             : [M_total, K]          bfloat16 activations (rows packed)
+        WQ            : [G, N, K//2]          int8 packed weights per group
+        w_scale_group : [G, num_groups, N]    per-group scales
+        w_zero_group  : [G, num_groups, N]    per-group zero points
+        M_sizes       : [G]                   rows per group
+
+    Returns:
+        Y : [M_total, N]  bfloat16
+    """
+    return matmul_bf16i4_rowwise_grouped_fused(
+        X, WQ, w_scale_group, w_zero_group, M_sizes
+    )
+
+
+# Register as ROCm implementation of mslk::bf16i4bf16_shuffled_grouped.
+if torch.version.hip is not None and hasattr(torch.ops, "mslk"):
+    if hasattr(torch.ops.mslk, "bf16i4bf16_shuffled_grouped"):
+
+        @torch.library.impl("mslk::bf16i4bf16_shuffled_grouped", "CUDA")
+        def _bf16i4bf16_shuffled_grouped_rocm(
+            X: torch.Tensor,
+            WQ: torch.Tensor,
+            w_scale_group: torch.Tensor,
+            w_zero_group: torch.Tensor,
+            M_sizes: torch.Tensor,
+        ) -> torch.Tensor:
+            return matmul_bf16i4_rowwise_grouped(
+                X, WQ, w_scale_group, w_zero_group, M_sizes
+            )

--- a/mslk/gemm/triton/int4_grouped_gemm_fused.py
+++ b/mslk/gemm/triton/int4_grouped_gemm_fused.py
@@ -287,16 +287,18 @@ def matmul_bf16i4_rowwise_grouped_fused(
     assert WQ.dtype == torch.int8, "WQ must be int8"
     assert X.is_contiguous(), "X must be contiguous"
     assert group_size % 64 == 0, f"group_size={group_size} must be divisible by 64"
-    assert M_sizes.dtype == torch.int64, f"M_sizes must be int64, got {M_sizes.dtype}"
-    assert M_sizes.is_cuda, "M_sizes must be on the GPU"
-    assert w_scale_group.dtype == torch.float32, (
-        f"w_scale_group must be float32, got {w_scale_group.dtype}"
-    )
-    assert w_zero_group.dtype == torch.float32, (
-        f"w_zero_group must be float32, got {w_zero_group.dtype}"
-    )
-    assert w_scale_group.is_contiguous(), "w_scale_group must be contiguous"
-    assert w_zero_group.is_contiguous(), "w_zero_group must be contiguous"
+
+    # M_sizes must be on device and int64 for pointer arithmetic in kernel
+    if M_sizes.dtype != torch.int64:
+        M_sizes = M_sizes.to(torch.int64)
+    if not M_sizes.is_cuda:
+        M_sizes = M_sizes.to(X.device)
+
+    # Scale/zero: ensure float32
+    if w_scale_group.dtype != torch.float32:
+        w_scale_group = w_scale_group.to(torch.float32)
+    if w_zero_group.dtype != torch.float32:
+        w_zero_group = w_zero_group.to(torch.float32)
 
     Y = torch.empty((M_total, N), dtype=torch.bfloat16, device=X.device)
 

--- a/mslk/gemm/triton/int4_grouped_gemm_fused.py
+++ b/mslk/gemm/triton/int4_grouped_gemm_fused.py
@@ -65,9 +65,10 @@ def _get_grouped_configs() -> List[Config]:
 
 
 def _prune_grouped_configs(configs, named_args, **kwargs):
-    group_size = named_args["group_size"]
-    N = named_args["N"]
-    K2 = named_args["K2"]
+    all_args = {**named_args, **kwargs}
+    group_size = all_args["group_size"]
+    N = all_args["N"]
+    K2 = all_args["K2"]
     pruned = []
     for c in configs:
         bn = c.kwargs["BLOCK_N"]

--- a/mslk/gemm/triton/int4_grouped_gemm_fused.py
+++ b/mslk/gemm/triton/int4_grouped_gemm_fused.py
@@ -1,0 +1,341 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Native fused BF16xINT4 grouped GEMM for ROCm/AMD GPUs.
+
+A single kernel handles all G groups via a 3D grid (G, M-tiles, N-tiles).
+Over-provisioned M-tiles that exceed their group's row count early-exit,
+following the pattern in fp8_groupwise_grouped_gemm.py.  No device-to-host
+sync is needed, so the wrapper captures cleanly inside a CUDA graph.
+
+Unlike the rowwise kernel, activations X are loaded directly from the
+interleaved [M_total, K] layout using stride-2 column access, avoiding
+the pre-split strided copies done in the Python wrapper.
+
+Weight layout:
+  WQ           : [G, N, K//2]        int8 — packed INT4
+  w_scale_group: [G, num_groups, N]  float32 or bfloat16
+  w_zero_group : [G, num_groups, N]  float32 or bfloat16
+  M_sizes      : [G]                 int64 — rows per group
+
+Constraint: 2 * BLOCK_K must divide group_size.
+"""
+
+import inspect
+from typing import List
+
+import torch
+import triton  # @manual
+import triton.language as tl  # @manual
+from triton import Config  # @manual
+
+_TL_CAT_HAS_DIM = "dim" in inspect.signature(tl.cat).parameters
+
+
+# ---------------------------------------------------------------------------
+# Autotuning configs
+# ---------------------------------------------------------------------------
+
+
+def _get_grouped_configs() -> List[Config]:
+    configs = []
+    for bm in [32, 64, 128]:
+        for bn in [32, 64, 128, 256]:
+            for bk in [32, 64, 128]:
+                for nw in [4, 8]:
+                    for ns in [1, 2]:
+                        configs.append(
+                            Config(
+                                {
+                                    "BLOCK_M": bm,
+                                    "BLOCK_N": bn,
+                                    "BLOCK_K": bk,
+                                },
+                                num_warps=nw,
+                                num_stages=ns,
+                            )
+                        )
+    return configs
+
+
+def _prune_grouped_configs(configs, named_args, **kwargs):
+    group_size = named_args["group_size"]
+    N = named_args["N"]
+    K2 = named_args["K2"]
+    pruned = []
+    for c in configs:
+        bn = c.kwargs["BLOCK_N"]
+        bk = c.kwargs["BLOCK_K"]
+        nw = c.num_warps
+        ns = c.num_stages
+        if group_size % (2 * bk) != 0:
+            continue
+        if K2 % bk != 0:
+            continue
+        if bn > max(N, 32):
+            continue
+        bm = c.kwargs["BLOCK_M"]
+        tile_elems = bm * bn
+        if tile_elems <= 2048 and nw == 8:
+            continue
+        if tile_elems >= 16384 and nw == 4:
+            continue
+        if tile_elems >= 16384 and ns >= 3:
+            continue
+        pruned.append(c)
+    return pruned
+
+
+# ---------------------------------------------------------------------------
+# Core Triton kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.autotune(
+    configs=_get_grouped_configs(),
+    key=["G", "M_TOTAL", "N", "K2", "group_size"],
+    prune_configs_by={"early_config_prune": _prune_grouped_configs},
+)
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K2"] % args["BLOCK_K"] == 0,
+    }
+)
+@triton.jit
+def _bf16i4_grouped_kernel(
+    X_ptr,  # [M_total, K]         bfloat16 — interleaved even/odd K columns
+    WQ_ptr,  # [G, N, K//2]        int8 packed (lo nibble = even K, hi = odd K)
+    Y_ptr,  # [M_total, N]         bfloat16
+    scale_ptr,  # [G, num_groups, N]
+    zero_ptr,  # [G, num_groups, N]
+    m_sizes_ptr,  # [G]            int64 — rows per group
+    m_starts_ptr,  # [G]           int64 — cumulative row offsets per group
+    M_TOTAL,
+    G,
+    N,
+    K2,  # K // 2
+    group_size,
+    stride_xm,  # X row stride (= K)
+    stride_wg,  # WQ group stride (= N * K2)
+    stride_wn,  # WQ row stride (= K2)
+    stride_wk,  # WQ col stride (= 1)
+    stride_ym,  # Y row stride (= N)
+    stride_sg,  # scale quant-group stride (= N)
+    stride_sng,  # scale expert stride (= num_groups * N)
+    stride_sn,  # scale col stride (= 1)
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    FUSE_DOT: tl.constexpr,
+) -> None:
+    """
+    Fused grouped BF16xINT4 GEMM.
+
+    Grid: (G, ceil(M_total / BLOCK_M), ceil(N / BLOCK_N)).
+    Tiles whose pid_m falls outside their group's M are discarded early.
+
+    Activations are loaded from the interleaved [M_total, K] layout with
+    stride-2 column offsets (even col k2 -> X column 2*k2, odd -> 2*k2+1).
+
+    Constraint: 2 * BLOCK_K must divide group_size.
+    """
+    pid_g = tl.program_id(0)
+    pid_m = tl.program_id(1)
+    pid_n = tl.program_id(2)
+
+    m_size = tl.load(m_sizes_ptr + pid_g).to(tl.int64)
+    M_start = tl.load(m_starts_ptr + pid_g).to(tl.int64)
+
+    if pid_m * BLOCK_M >= m_size:
+        return
+
+    # Offsets
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_m_abs = M_start + offs_m
+    offs_n_g = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    m_mask = offs_m < m_size
+    n_mask = offs_n_g < N
+
+    acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+
+    W_g = WQ_ptr + pid_g.to(tl.int64) * stride_wg
+    S_g = scale_ptr + pid_g.to(tl.int64) * stride_sng
+    Z_g = zero_ptr + pid_g.to(tl.int64) * stride_sng
+
+    for k2_idx in tl.range(0, tl.cdiv(K2, BLOCK_K)):
+        k2_start = k2_idx * BLOCK_K
+        offs_k2 = k2_start + tl.arange(0, BLOCK_K)
+
+        # X[m, 2*k] = even activations, X[m, 2*k+1] = odd activations
+        x_even_offs = offs_m_abs[:, None] * stride_xm + offs_k2[None, :] * 2
+        x_odd_offs = x_even_offs + 1
+
+        if EVEN_K:
+            xm_mask = m_mask[:, None]
+            x_even = tl.load(X_ptr + x_even_offs, mask=xm_mask, other=0.0).to(
+                tl.bfloat16
+            )
+            x_odd = tl.load(X_ptr + x_odd_offs, mask=xm_mask, other=0.0).to(tl.bfloat16)
+            w_q = tl.load(
+                W_g + offs_n_g[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
+                mask=n_mask[:, None],
+                other=0,
+            ).to(tl.int32)
+        else:
+            k_mask = offs_k2[None, :] < K2
+            xmk_mask = m_mask[:, None] & k_mask
+            x_even = tl.load(X_ptr + x_even_offs, mask=xmk_mask, other=0.0).to(
+                tl.bfloat16
+            )
+            x_odd = tl.load(X_ptr + x_odd_offs, mask=xmk_mask, other=0.0).to(
+                tl.bfloat16
+            )
+            w_q = tl.load(
+                W_g + offs_n_g[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
+                mask=n_mask[:, None] & k_mask,
+                other=0,
+            ).to(tl.int32)
+
+        group_idx = (k2_start * 2) // group_size
+        s = tl.load(
+            S_g + group_idx * stride_sg + offs_n_g * stride_sn,
+            mask=n_mask,
+            other=0.0,
+        ).to(tl.float32)
+        z = tl.load(
+            Z_g + group_idx * stride_sg + offs_n_g * stride_sn,
+            mask=n_mask,
+            other=0.0,
+        ).to(tl.float32)
+
+        w_lo = w_q & 0x0F
+        w_hi = (w_q >> 4) & 0x0F
+        s_col = s[:, None]
+        z_col = z[:, None]
+        w_lo_dq = ((w_lo ^ 8) - 8).to(tl.float32) * s_col + z_col
+        w_hi_dq = ((w_hi ^ 8) - 8).to(tl.float32) * s_col + z_col
+
+        if FUSE_DOT:
+            x_fused = tl.cat(x_even, x_odd, dim=1)
+            w_fused = tl.cat(w_lo_dq.to(tl.bfloat16), w_hi_dq.to(tl.bfloat16), dim=1)
+            acc = tl.dot(x_fused, tl.trans(w_fused), acc, out_dtype=tl.float32)
+        else:
+            acc = tl.dot(
+                x_even,
+                tl.trans(w_lo_dq.to(tl.bfloat16)),
+                acc,
+                out_dtype=tl.float32,
+            )
+            acc = tl.dot(
+                x_odd,
+                tl.trans(w_hi_dq.to(tl.bfloat16)),
+                acc,
+                out_dtype=tl.float32,
+            )
+
+    y_ptrs = Y_ptr + offs_m_abs[:, None] * stride_ym + offs_n_g[None, :] * 1
+    out_mask = m_mask[:, None] & n_mask[None, :]
+    tl.store(y_ptrs, acc.to(tl.bfloat16), mask=out_mask)
+
+
+# ---------------------------------------------------------------------------
+# Python wrapper
+# ---------------------------------------------------------------------------
+
+
+def matmul_bf16i4_rowwise_grouped_fused(
+    X: torch.Tensor,
+    WQ: torch.Tensor,
+    w_scale_group: torch.Tensor,
+    w_zero_group: torch.Tensor,
+    M_sizes: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Fused grouped BF16xINT4 GEMM — single kernel launch for all G groups.
+
+    CUDA-graph safe: no device-to-host sync.  The grid is over-provisioned
+    using M_total (a host int from tensor metadata) instead of max(M_sizes);
+    tiles that exceed their group's row count early-exit in the kernel.
+
+    Args:
+        X             : [M_total, K]          bfloat16 activations
+        WQ            : [G, N, K//2]          int8 packed weights per group
+        w_scale_group : [G, num_groups, N]    per-group scales
+        w_zero_group  : [G, num_groups, N]    per-group zero points
+        M_sizes       : [G]                   rows per group (int64, on device)
+
+    Returns:
+        Y : [M_total, N]  bfloat16
+    """
+    G = WQ.shape[0]
+    M_total = X.shape[0]
+    N = WQ.shape[1]
+    K = X.shape[1]
+    K2 = K // 2
+    num_groups = w_scale_group.shape[1]
+    group_size = K // num_groups
+
+    assert X.dtype == torch.bfloat16, "X must be bfloat16"
+    assert WQ.dtype == torch.int8, "WQ must be int8"
+    assert X.is_contiguous(), "X must be contiguous"
+    assert group_size % 64 == 0, f"group_size={group_size} must be divisible by 64"
+    assert M_sizes.dtype == torch.int64, f"M_sizes must be int64, got {M_sizes.dtype}"
+    assert M_sizes.is_cuda, "M_sizes must be on the GPU"
+    assert w_scale_group.dtype == torch.float32, (
+        f"w_scale_group must be float32, got {w_scale_group.dtype}"
+    )
+    assert w_zero_group.dtype == torch.float32, (
+        f"w_zero_group must be float32, got {w_zero_group.dtype}"
+    )
+    assert w_scale_group.is_contiguous(), "w_scale_group must be contiguous"
+    assert w_zero_group.is_contiguous(), "w_zero_group must be contiguous"
+
+    Y = torch.empty((M_total, N), dtype=torch.bfloat16, device=X.device)
+
+    # Derive M_starts (cumulative row offsets) on the GPU — no device-to-host
+    # sync, so this captures cleanly inside a CUDA graph.
+    M_starts = M_sizes.cumsum(0) - M_sizes
+
+    # The M dimension of the grid is bounded by M_total (a host int already in
+    # hand) rather than max group size, avoiding a .item() sync.  Tiles that
+    # fall outside their group's M are discarded early in the kernel, so the
+    # extra launches for uneven groups are cheap no-ops.
+    grid = lambda meta: (  # noqa: E731
+        G,
+        triton.cdiv(M_total, meta["BLOCK_M"]),
+        triton.cdiv(N, meta["BLOCK_N"]),
+    )
+
+    _bf16i4_grouped_kernel[grid](
+        X,
+        WQ,
+        Y,
+        w_scale_group,
+        w_zero_group,
+        M_sizes,
+        M_starts,
+        M_TOTAL=M_total,
+        G=G,
+        N=N,
+        K2=K2,
+        group_size=group_size,
+        stride_xm=X.stride(0),
+        stride_wg=WQ.stride(0),
+        stride_wn=WQ.stride(1),
+        stride_wk=WQ.stride(2),
+        stride_ym=Y.stride(0),
+        stride_sg=w_scale_group.stride(1),
+        stride_sng=w_scale_group.stride(0),
+        stride_sn=w_scale_group.stride(2),
+        FUSE_DOT=_TL_CAT_HAS_DIM,
+    )
+
+    return Y

--- a/test/gemm/gemm_test.py
+++ b/test/gemm/gemm_test.py
@@ -1370,6 +1370,66 @@ class BF16Int4TritonROCmTests(unittest.TestCase):
         torch.testing.assert_close(y_op, y_direct, atol=0.0, rtol=0.0)
 
 
+@skipUnlessRocm()
+class BF16Int4TritonROCmGroupedTests(unittest.TestCase):
+    """
+    Tests for the Triton BF16xINT4 grouped GEMM on AMD GPUs.
+
+    bf16i4bf16_shuffled_grouped is routed through the rowwise kernel on ROCm
+    (the CUTLASS shuffle layout does not exist on AMD).
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.device = "cuda"
+
+    @parameterized.expand(
+        [
+            (2, 64, 512, 256, 128),
+            (2, 128, 1024, 512, 128),
+            (4, 64, 512, 256, 128),
+        ]
+    )
+    def test_grouped_accuracy(
+        self,
+        G: int,
+        M: int,
+        N: int,
+        K: int,
+        group_size: int,
+    ) -> None:
+        device = self.device
+        M_sizes = torch.full((G,), M, dtype=torch.int64, device=device)
+        M_total = G * M
+
+        X = torch.randn(M_total, K, dtype=torch.bfloat16, device=device) * 0.1
+
+        wq_list, scale_list, zero_list, w_ref_list = [], [], [], []
+        for _ in range(G):
+            w = torch.randn(N, K, dtype=torch.bfloat16, device=device) * 0.01
+            wq, w_scale, w_zp = int4_row_quantize(w, group_size)
+            wq_list.append(pack_int4(wq).contiguous())
+            scale_list.append(w_scale.contiguous())
+            zero_list.append(w_zp.contiguous())
+            w_ref_list.append(w)
+
+        WQ = torch.stack(wq_list, dim=0)
+        w_scale_group = torch.stack(scale_list, dim=0)
+        w_zero_group = torch.stack(zero_list, dim=0)
+
+        y = torch.ops.mslk.bf16i4bf16_shuffled_grouped(
+            X, WQ, w_scale_group, w_zero_group, M_sizes
+        )
+        self.assertEqual(y.shape, (M_total, N))
+        self.assertEqual(y.dtype, torch.bfloat16)
+
+        x_splits = torch.split(X, M, dim=0)
+        for g in range(G):
+            y_g = y[g * M : (g + 1) * M]
+            y_ref = (x_splits[g].float() @ w_ref_list[g].float().T).to(torch.bfloat16)
+            torch.testing.assert_close(y_g, y_ref, atol=1.0e-1, rtol=8.0e-2)
+
+
 @skipUnlessCuda()
 @skipUnlessCudaCapability(9, 9)
 class FP8Int4Tests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds a Triton implementation of `f8i4bf16_rowwise` (FP8 activations × INT4 weights → BF16 output) for AMD MI300X/MI350X. The kernel reuses the unified `_bf16i4_rowwise_kernel` from the BF16×INT4 path, gated on a compile-time `HAS_X_SCALE` constexpr — no kernel fork.

## Context

- Hardware: AMD Instinct MI300X (gfx942), MI350X (gfx950, CDNA4)
- Depends on #420 (`rocm/bf16i4-shuffled-grouped`) — this PR stacks on top of that branch

## Implementation

**Shared kernel with HAS_X_SCALE constexpr.** The existing `_bf16i4_rowwise_kernel` gains two new parameters: `x_scale_ptr` (per-row FP8 activation dequant scale) and `HAS_X_SCALE: tl.constexpr = False`. When `HAS_X_SCALE=False` (BF16 path), the kernel behaves identically to before — the default value preserves backward compatibility and the dummy pointer is never dereferenced.

**Deferred BF16 upcast.** The `.to(tl.bfloat16)` cast on activation loads is moved from the load site to a single centralised location after the four masking branches. This is required because FP8 inputs return a native FP8 tensor type from `tl.load` that must be upcast explicitly — but for BF16 inputs the cast is a no-op, so both paths share the same code.

**Two-dot path for FP8.** When `HAS_X_SCALE=True`, the kernel issues two separate `tl.dot` calls (one for even-K, one for odd-K) instead of fusing via `tl.cat`. The `tl.cat` fusion concatenates tiles in LDS before the dot, which causes bank conflicts that are a net loss for FP8 activations on MI300X. Two separate dots avoid the LDS staging at the cost of two MFMA instructions — a net win for this dtype. The BF16 path retains the fused `tl.cat` dot (controlled by `FUSE_DOT`).

**Per-row activation scale epilogue.** After the K-loop, the float32 accumulator is multiplied element-wise by `x_scale[m]` before storing to the workspace. This fuses the FP8 dequantisation scale into the GEMM epilogue rather than requiring a separate pointwise kernel.

**FP8 autotuner pruning.** Four additional prune rules fire only when `HAS_X_SCALE=True`: skip `BLOCK_N < 128` for large N, skip `BLOCK_K > 64`, skip `SPLIT_K == 2`, fix `GROUP_SIZE_M = 4`. These were determined by profiling winning configs on MI350X and reduce the FP8 autotuning search space by ~5×.

**Thin Python wrapper.** `f8i4bf16_rowwise_gemm.py` byte-splits FP8 activations into even/odd K columns, reinterprets them as FP8 `TensorWrapper`s via `reinterpret_fp8_type`, and calls the shared kernel with `HAS_X_SCALE=True`. The wrapper also coerces scale/zp tensors to float32. Registered as `mslk::f8i4bf16_rowwise` on ROCm via `torch.library.impl`.

## Testing

All 9 existing BF16×INT4 accuracy tests pass (no regressions):

```
9 passed in 74s
```

FP8×INT4 accuracy against dequantised reference (`deq(FP8_x) @ deq(INT4_w)`):

| Shape | M | N | K | max error | mean error |
|---|---:|---:|---:|---:|---:|
| Small | 1 | 256 | 1024 | 0.0005 | 0.0001 |
| Medium | 16 | 2048 | 1024 | 0.0020 | 0.0001 |
| Large | 512 | 4096 | 2048 | 0.0039 | 0.0002 |

FP8×INT4 dispatch test (`torch.ops.mslk.f8i4bf16_rowwise` vs direct call): bitwise identical on all shapes.

## Performance

Hardware: AMD Instinct MI350X (gfx950), ROCm 7.1.1, Triton 3.5.1+rocm7.1.1.
`triton.testing.do_bench`, warmup=25, rep=200.
Peak: 4600 TFLOPS FP8, 2300 TFLOPS BF16, 8000 GB/s HBM.

### f8i4bf16_rowwise vs bf16i4bf16_rowwise — decode shapes (memory-bandwidth bound)

Model-attributed shapes. FP8 and BF16 paths are both kernel-launch-latency bound at small M; performance converges.

| Model | M | N | K | FP8 (μs) | BF16 (μs) | FP8 TFLOPS | BF16 TFLOPS |
|---|---:|---:|---:|---:|---:|---:|---:|
| llama4 | 1 | 896 | 5120 | 46.3 | 44.8 | 0.2 | 0.2 |
| llama4 | 16 | 896 | 5120 | 45.4 | 44.8 | 3.2 | 3.3 |
| llama4 | 64 | 896 | 5120 | 45.7 | 44.3 | 12.9 | 13.2 |
| llama4 | 128 | 2048 | 5120 | 46.1 | 44.3 | 58.2 | 60.6 |
| llama3_70b | 1 | 8192 | 3584 | 40.6 | 38.8 | 1.4 | 1.5 |
| llama3_70b | 16 | 8192 | 3584 | 40.0 | 38.3 | 23.5 | 24.5 |
| llama3_70b | 64 | 8192 | 3584 | 41.5 | 40.7 | 90.6 | 92.4 |
| llama3_70b | 128 | 7168 | 8192 | 84.6 | 87.9 | 177.7 | 171.0 |

### f8i4bf16_rowwise vs bf16i4bf16_rowwise — prefill shapes (compute bound)

FP8 MFMA has 2× the throughput of BF16 MFMA. The FP8 path is 5–8% faster at large M.

| Model | M | N | K | FP8 (μs) | BF16 (μs) | FP8 TFLOPS | % FP8 peak | BF16 TFLOPS | % BF16 peak |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| llama3_70b | 2048 | 8192 | 3584 | 210.6 | 218.2 | 571.1 | 12.4% | 551.1 | 24.0% |
| llama3_70b | 2048 | 7168 | 8192 | 396.6 | 428.2 | 606.4 | 13.2% | 561.7 | 24.4% |
| llama3_70b | 4096 | 7168 | 8192 | 768.4 | 826.0 | 626.1 | 13.6% | 582.4 | 25.3% |