### PR TITLE
Burn down OMH test issue debt (#481)

### DIFF
--- a/ci/scripts/utils_build.bash
+++ b/ci/scripts/utils_build.bash
@@ -119,12 +119,15 @@ __conda_install_gcc () {
   local cc_path=$(conda run ${env_prefix} printenv CC)
   # shellcheck disable=SC2155,SC2086
   local cxx_path=$(conda run ${env_prefix} printenv CXX)
+  # shellcheck disable=SC2155,SC2086
+  local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
 
-  # Set the symlinks, override if needed
-  print_exec ln -sf "${cc_path}" "$(dirname "$cc_path")/cc"
-  print_exec ln -sf "${cc_path}" "$(dirname "$cc_path")/gcc"
-  print_exec ln -sf "${cxx_path}" "$(dirname "$cxx_path")/c++"
-  print_exec ln -sf "${cxx_path}" "$(dirname "$cxx_path")/g++"
+  # Keep compiler aliases inside the Conda environment even when CC/CXX resolve
+  # to a read-only system path on a build host.
+  print_exec ln -sf "${cc_path}" "${conda_prefix}/bin/cc"
+  print_exec ln -sf "${cc_path}" "${conda_prefix}/bin/gcc"
+  print_exec ln -sf "${cxx_path}" "${conda_prefix}/bin/c++"
+  print_exec ln -sf "${cxx_path}" "${conda_prefix}/bin/g++"
 
   if [ "$SET_GLIBCXX_PRELOAD" == "1" ]; then
     # Set libstdc++ preload options
@@ -163,12 +166,13 @@ __remove_gcc_activation_scripts () {
   # Clang.
   #   https://stackoverflow.com/questions/64289376/how-to-circumvent-anaconda-gcc-compiler
   #
-  # shellcheck disable=SC2155,SC2086
   echo "[INSTALL] Removing GCC package activation scripts ..."
-  local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
-  print_exec ls -la ${conda_prefix}/etc/conda/activate.d
-  print_exec rm -rf ${conda_prefix}/etc/conda/activate.d/activate-gcc_linux-${COMPILER_ARCHNAME}.sh
-  print_exec rm -rf ${conda_prefix}/etc/conda/activate.d/activate-gxx_linux-${COMPILER_ARCHNAME}.sh
+  local conda_prefix
+  # shellcheck disable=SC2086
+  conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
+  print_exec ls -la "${conda_prefix}/etc/conda/activate.d"
+  print_exec rm -rf "${conda_prefix}/etc/conda/activate.d/activate-gcc_linux-${COMPILER_ARCHNAME}.sh"
+  print_exec rm -rf "${conda_prefix}/etc/conda/activate.d/activate-gxx_linux-${COMPILER_ARCHNAME}.sh"
 }
 
 __conda_install_clang () {
@@ -431,7 +435,7 @@ print_library_infos () {
     print_exec "nm -gDCu ${library} > ${usymbols_file}"
     # shellcheck disable=SC2086
     echo "[CHECK] Listing out undefined symbols ($(wc -l ${usymbols_file} | awk '{print $1}') total):"
-    cat "${usymbols_file}" | sort
+    sort "${usymbols_file}"
 
     echo "[CHECK] Listing out external shared libraries linked:"
     print_exec ldd "${library}"

--- a/ci/scripts/utils_pytorch.bash
+++ b/ci/scripts/utils_pytorch.bash
@@ -26,13 +26,22 @@ __verify_pytorch_gpu_integration () {
   # shellcheck disable=SC2086,SC2155
   local torch_version_hip=$(conda run ${env_prefix} python -c "import torch; print(torch.version.hip)")
   # shellcheck disable=SC2086,SC2155
-  local torch_device_compatibility=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_capability())")
-  # shellcheck disable=SC2086,SC2155
-  local torch_device_name=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_name(torch.cuda.current_device()))")
-  # shellcheck disable=SC2086,SC2155
   local torch_device_count=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.device_count())")
-  # shellcheck disable=SC2086,SC2155
-  local torch_device_properties=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_properties(0))")
+
+  local torch_device_compatibility="unavailable"
+  local torch_device_name="unavailable"
+  local torch_device_properties="unavailable"
+  if [[ "${torch_cuda_available}" == "True" ]]; then
+    # shellcheck disable=SC2086,SC2155
+    torch_device_compatibility=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_capability())")
+    # shellcheck disable=SC2086,SC2155
+    torch_device_name=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_name(torch.cuda.current_device()))")
+    # shellcheck disable=SC2086,SC2155
+    torch_device_properties=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_properties(0))")
+  elif [[ "${ENFORCE_CUDA_DEVICE:-0}" == "1" ]]; then
+    echo "[CHECK] PyTorch cannot access a required GPU."
+    return 1
+  fi
 
   echo ""
   echo "################################################################################"

--- a/test/moe/parallelism.py
+++ b/test/moe/parallelism.py
@@ -9,7 +9,7 @@
 import functools
 import os
 from datetime import timedelta
-from typing import Optional
+from typing import cast, Optional
 
 import torch
 from fairscale.nn.model_parallel.initialize import (
@@ -98,7 +98,8 @@ def init_parallel(
 
     if not model_parallel_is_initialized():
         assert get_world_size() == model_parallel_size * data_parallel_size, (
-            f"world size must be equal to mp*dp, but got {get_world_size()} != {model_parallel_size} * {data_parallel_size}"
+            "world size must be equal to mp*dp, but got "
+            f"{get_world_size()} != {model_parallel_size} * {data_parallel_size}"
         )
         initialize_model_parallel(model_parallel_size)
 
@@ -118,7 +119,7 @@ def init_parallel(
             ranks = list(range(base_rank, base_rank + mp_size_for_routed_experts))
             group = torch.distributed.new_group(ranks, timeout=timeout)
             if global_rank in ranks:
-                _ROUTED_EXPERTS_MP_GROUP = group
+                _ROUTED_EXPERTS_MP_GROUP = cast(ProcessGroup, group)
 
     global _EP_GROUP
     assert _EP_GROUP is None
@@ -129,4 +130,4 @@ def init_parallel(
         ranks = list(range(i, get_world_size(), num_ep_groups))
         group = torch.distributed.new_group(ranks, timeout=timeout)
         if global_rank in ranks:
-            _EP_GROUP = group
+            _EP_GROUP = cast(ProcessGroup, group)


### PR DESCRIPTION
Summary:

Remove invalid H100 and unavailable GB200 continuous registrations while
preserving their manual GPU workflows. Fix the FlashAttention import guard,
MOE ProcessGroup typing, ROCm test teardown dependencies, and build-only
Conda host assumptions. Document the complete 179-to-0 burn-down plan and
the shared feedstock blocker.

Differential Revision: D115772671


