### PR TITLE
Fix E4M3 zero-scale floors in NVFP4 quantize kernels (#486)

### DIFF
--- a/mslk/quantize/triton/legacy/quantize_stacked.py
+++ b/mslk/quantize/triton/legacy/quantize_stacked.py
@@ -57,7 +57,8 @@ def _nvfp4_quantize_stacked_kernel(
         M_PER_BLOCK: Rows per block (constexpr, power of 2, <= 128, autotuned).
     """
     tl.static_assert(M_PER_BLOCK <= 128)
-    E4M3_EPS: tl.constexpr = 1.5258789e-05  # type: ignore[Incompatible variable type]
+    # Smallest positive fp8 e4m3 subnormal. A smaller floor rounds to zero.
+    E4M3_EPS: tl.constexpr = 0.001953125  # type: ignore[Incompatible variable type]
     FP8_E4M3_MAX = 448.0  # type: ignore[Incompatible variable type]
     FP4_E2M1_MAX: tl.constexpr = 6  # type: ignore[Incompatible variable type]
 
@@ -177,7 +178,8 @@ def _nvfp4_quantize_stacked_token_scale_fused_row_kernel(
     CHUNK_SIZE: tl.constexpr,
     CHUNK_SCALE_BLOCKS: tl.constexpr,
 ):
-    E4M3_EPS: tl.constexpr = 1.5258789e-05  # type: ignore[Incompatible variable type]
+    # Smallest positive fp8 e4m3 subnormal. A smaller floor rounds to zero.
+    E4M3_EPS: tl.constexpr = 0.001953125  # type: ignore[Incompatible variable type]
     FP8_E4M3_MAX = 448.0  # type: ignore[Incompatible variable type]
     FP4_E2M1_MAX: tl.constexpr = 6  # type: ignore[Incompatible variable type]
     MIN_NORMAL: tl.constexpr = 1.0e-8  # type: ignore[Incompatible variable type]

--- a/mslk/quantize/triton/quantize_kernels/nvfp4.py
+++ b/mslk/quantize/triton/quantize_kernels/nvfp4.py
@@ -166,7 +166,8 @@ def quantize_nvfp4_kernel(
     USE_GLOBAL_SCALE: tl.constexpr,
     USE_INT64_INDEXING: tl.constexpr,
 ):
-    E4M3_EPS = 1.5258789e-05
+    # Smallest positive fp8 e4m3 subnormal. A smaller floor rounds to zero.
+    E4M3_EPS = 0.001953125
     FP8_E4M3_MAX = 448.0
     FP4_E2M1_MAX = 6.0
     INV_FP4_E2M1_MAX = 1.0 / 6.0

--- a/test/quantize/triton/fp4_quantize_test.py
+++ b/test/quantize/triton/fp4_quantize_test.py
@@ -546,6 +546,25 @@ class TestNVFP4QuantizeStacked:
         expected = torch.clamp(row_amax, min=1.0e-8) / (FP8_E4M3_MAX * FP4_E2M1_MAX)
         torch.testing.assert_close(token_scale_inv, expected, atol=1e-12, rtol=1e-6)
 
+    def test_token_scale_all_zero_block_packs_to_zero(self) -> None:
+        """An all-zero 16-element block must not quantize to a zero e4m3 scale.
+
+        The per-block scale is floored by a clamp before the ``.to(float8e4nv)``
+        cast; a floor below the smallest positive e4m3 subnormal (``2**-9``)
+        rounds to zero, so ``total_scale = row_scale / 0 -> inf`` and
+        ``0 * inf -> NaN`` saturates the block's packed FP4 nibbles to 0x7
+        (+6.0) instead of zero.
+        """
+        K = 64
+        m_sizes = torch.tensor([1], dtype=torch.int64, device=self.device)
+        x = torch.ones(1, K, dtype=torch.bfloat16, device=self.device)
+        x[0, 16:32] = 0.0
+
+        xq, _, _ = nvfp4_quantize_stacked_with_token_scale(m_sizes, x)
+
+        block1 = xq.view(torch.uint8)[0, 8:16]
+        assert torch.all(block1 == 0), f"zero block corrupted: {block1.tolist()}"
+
     @pytest.mark.parametrize("num_experts,m_sizes_list,K", TOKEN_SCALE_MOE_SHAPES)
     def test_token_scale_matches_per_row_reference(
         self,


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/meta-pytorch/MSLK/pull/486

Reviewed By: summerdengfb

Differential Revision: D115876514


