### PR TITLE
Make the FlyDSL backend opt-in to stop an import SIGSEGV

### DIFF
--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -6,6 +6,11 @@
 
 # pyre-strict
 
+import functools
+import importlib
+from collections.abc import Callable
+from types import ModuleType
+
 from mslk.utils.torch.library import load_library_buck
 
 load_library_buck("//mslk/csrc/gemm:gemm_ops")
@@ -29,8 +34,6 @@ import torch  # noqa: E402
 from . import _meta  # noqa: F401, E402
 
 if torch.version.hip is not None:
-    from mslk.flydsl.common import is_flydsl_available
-
     # Register the Triton ROCm implementations for mx8mx4bf16, mx8mx8bf16, and
     # f8f8bf16_groupwise(_grouped).  Each import triggers a
     # @torch.library.impl(..., "CUDA") decoration that overrides the default
@@ -43,9 +46,97 @@ if torch.version.hip is not None:
         mx8mx8_gemm,
     )
 
-    if is_flydsl_available():
-        # Registers mslk::f8f8bf16_groupwise_grouped and its _preshuffle
-        # sibling (FlyDSL).
-        from .flydsl import (  # noqa: F401
-            fp8_groupwise_grouped_gemm as _flydsl_groupwise_grouped,
-        )
+    # FlyDSL is an opt-in backend: this package deliberately does NOT depend on
+    # //mslk/mslk/gemm:flydsl_ops. That dependency drags the FlyDSL wheel into
+    # the binary of everything that reaches mslk.gemm transitively (torchao
+    # does), and its mere presence is enough to break the process: FlyDSL ships
+    # its own MLIR/LLVM 23, so any consumer that gates a module-scope import on
+    # `importlib.util.find_spec("flydsl")` -- torchao's
+    # prototype/moe_training/kernels/mxfp8/flydsl_utils.py does -- will load it
+    # next to Triton's copy, the two interpose, and the process dies on SIGSEGV
+    # inside mlirRegisterAllDialects. No `except` can catch that.
+    #
+    # Targets that want the FlyDSL kernels depend on flydsl_ops themselves; the
+    # lazy imports below then resolve, and Triton serves everyone else.
+    @functools.lru_cache(maxsize=1)
+    def _flydsl_gemm_module() -> ModuleType | None:
+        """The FlyDSL grouped-gemm module, or None when it is not opted into.
+
+        Resolved through ``importlib`` rather than a static ``from .flydsl
+        import ...``: this package deliberately does not depend on
+        ``//mslk/mslk/gemm:flydsl_ops``, so the module is genuinely absent
+        unless the caller opted in, and a static import would not resolve.
+        """
+        try:
+            from mslk.flydsl.common import is_flydsl_available
+
+            if not is_flydsl_available():
+                return None
+            return importlib.import_module(
+                "mslk.gemm.flydsl.fp8_groupwise_grouped_gemm"
+            )
+        except ImportError:
+            return None
+
+    if hasattr(torch.ops, "mslk") and hasattr(
+        torch.ops.mslk, "f8f8bf16_groupwise_grouped"
+    ):
+        # FlyDSL owns this op wherever it is opted into and Triton is the
+        # fallback, but only one CUDA implementation can win, so neither kernel
+        # module registers it and the choice is arbitrated here, on first call.
+        @functools.lru_cache(maxsize=1)
+        def _groupwise_grouped_impl() -> Callable[..., torch.Tensor]:
+            mod = _flydsl_gemm_module()
+            if mod is not None:
+                return mod.matmul_f8f8bf16_groupwise_grouped
+            from .triton.fp8_groupwise_grouped_gemm import (
+                matmul_f8f8bf16_groupwise_grouped as _impl,
+            )
+
+            return _impl
+
+        try:
+
+            @torch.library.impl("mslk::f8f8bf16_groupwise_grouped", "CUDA")
+            def _f8f8bf16_groupwise_grouped_rocm(
+                XQ: torch.Tensor,
+                WQ: torch.Tensor,
+                x_scale: torch.Tensor,
+                w_scale: torch.Tensor,
+                M_sizes: torch.Tensor,
+            ) -> torch.Tensor:
+                return _groupwise_grouped_impl()(XQ, WQ, x_scale, w_scale, M_sizes)
+
+        except RuntimeError:
+            pass  # already registered (e.g. module imported more than once)
+
+    if hasattr(torch.ops, "mslk") and hasattr(
+        torch.ops.mslk, "f8f8bf16_groupwise_grouped_preshuffle"
+    ):
+        # ROCm-only, and FlyDSL is its only implementation, so there is nothing
+        # to arbitrate -- but registering still must not import FlyDSL, hence
+        # the same first-call resolution. Calling it without having opted into
+        # flydsl_ops raises rather than silently doing something else.
+        try:
+
+            @torch.library.impl("mslk::f8f8bf16_groupwise_grouped_preshuffle", "CUDA")
+            def _f8f8bf16_groupwise_grouped_preshuffle_rocm(
+                XQ: torch.Tensor,
+                WQ: torch.Tensor,
+                x_scale: torch.Tensor,
+                w_scale: torch.Tensor,
+                M_sizes: torch.Tensor,
+            ) -> torch.Tensor:
+                mod = _flydsl_gemm_module()
+                if mod is None:
+                    raise RuntimeError(
+                        "mslk::f8f8bf16_groupwise_grouped_preshuffle requires the "
+                        "FlyDSL backend. Add //mslk/mslk/gemm:flydsl_ops to your "
+                        "target's deps."
+                    )
+                return mod.matmul_f8f8bf16_groupwise_grouped_preshuffle(
+                    XQ, WQ, x_scale, w_scale, M_sizes
+                )
+
+        except RuntimeError:
+            pass  # already registered (e.g. module imported more than once)

--- a/mslk/gemm/_meta.py
+++ b/mslk/gemm/_meta.py
@@ -706,3 +706,21 @@ if (
         total_M = XQ.shape[0]
         N = WQ.shape[1]  # WQ is [G, N, K//2] for grouped_stacked (no transpose)
         return torch.empty((total_M, N), dtype=torch.bfloat16, device=XQ.device)
+
+
+if hasattr(torch.ops.mslk, "f8f8bf16_groupwise_grouped_preshuffle"):
+
+    @torch.library.register_fake("mslk::f8f8bf16_groupwise_grouped_preshuffle")
+    def _f8f8bf16_groupwise_grouped_preshuffle_meta(
+        XQ: torch.Tensor,
+        WQ: torch.Tensor,
+        x_scale: torch.Tensor,
+        w_scale: torch.Tensor,
+        M_sizes: torch.Tensor,
+    ) -> torch.Tensor:
+        # Lives here rather than beside the FlyDSL kernel so that shape
+        # inference does not require depending on //mslk/mslk/gemm:flydsl_ops,
+        # which would drag the FlyDSL wheel into the binary.
+        TotalM = XQ.shape[0]
+        N = WQ.shape[1]
+        return XQ.new_empty((TotalM, N), dtype=torch.bfloat16)

--- a/mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py
@@ -32,7 +32,7 @@ Tensor contract:
 import os
 
 import torch
-from mslk.flydsl.common import is_flydsl_available
+from mslk.flydsl.common import require_flydsl
 from mslk.flydsl.jit import run_compiled
 from mslk.utils.device import supports_float8_fnuz
 
@@ -227,7 +227,11 @@ def _dispatch_grouped_gemm(
     persists the winner (keyed on nextPow2(TotalM) and b_preshuffled); otherwise
     a fixed default tile is used with no benchmarking (the CI / graph-capture-safe
     path).
+
+    The registrations below deliberately do not probe for FlyDSL, so this is
+    the first point at which it is required.
     """
+    require_flydsl()
     assert XQ.ndim == 2, f"XQ must be [TotalM, K], got {XQ.shape}"
     assert WQ.ndim == 3, f"WQ must be [G, N, K], got {WQ.shape}"
     assert M_sizes.ndim == 1, f"M_sizes must be [G], got {M_sizes.shape}"
@@ -312,27 +316,9 @@ def matmul_f8f8bf16_groupwise_grouped(
     )
 
 
-if (
-    is_flydsl_available()
-    and torch.version.hip is not None
-    and hasattr(torch.ops, "mslk")
-):
-    # FlyDSL supplies the ROCm implementation of both ops; their schemas are
-    # declared in csrc/gemm/gemm_ops.cpp. Skip an op whose schema is missing, as
-    # in a python-only build, and tolerate a repeat import rebinding it.
-    def _register(op_name, cuda_fn, meta_fn=None) -> None:
-        if not hasattr(torch.ops.mslk, op_name.split("::")[1]):
-            return
-        try:
-            torch.library.impl(op_name, "CUDA")(cuda_fn)
-            if meta_fn is not None:
-                torch.library.impl(op_name, "Meta")(meta_fn)
-        except RuntimeError:
-            pass
-
-    _register(
-        _OP_NAME,
-        matmul_f8f8bf16_groupwise_grouped_preshuffle,
-        _f8f8bf16_groupwise_grouped_preshuffle_meta,
-    )
-    _register("mslk::f8f8bf16_groupwise_grouped", matmul_f8f8bf16_groupwise_grouped)
+# This module registers nothing. Both mslk::f8f8bf16_groupwise_grouped and its
+# _preshuffle sibling are registered in mslk/gemm/__init__.py, whose impls import
+# this module on the first call. Keeping registration out of here is what lets
+# //mslk:gemm_ops avoid depending on //mslk/mslk/gemm:flydsl_ops, and so keeps the
+# FlyDSL wheel out of every binary that merely imports mslk.gemm. Shape inference
+# for the preshuffle op lives in mslk/gemm/_meta.py for the same reason.

--- a/mslk/gemm/triton/fp8_groupwise_grouped_gemm.py
+++ b/mslk/gemm/triton/fp8_groupwise_grouped_gemm.py
@@ -288,31 +288,9 @@ def matmul_f8f8bf16_groupwise_grouped(
 # On ROCm the CUDA C++ implementation is absent; this module registers the
 # Triton kernel above as the dispatch target via torch.library.impl.
 #
-# FALLBACK ONLY: FlyDSL owns this op where it is available (see
-# mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py), so Triton registers it only
-# when FlyDSL is absent. Only one CUDA implementation can win, hence the explicit
-# gate rather than a dependence on import order.
-from mslk.flydsl.common import is_flydsl_available as _is_flydsl_available  # noqa: E402
-
-if (
-    torch.version.hip is not None
-    and hasattr(torch.ops, "mslk")
-    and not _is_flydsl_available()
-):
-    if hasattr(torch.ops.mslk, "f8f8bf16_groupwise_grouped"):
-        try:
-
-            @torch.library.impl("mslk::f8f8bf16_groupwise_grouped", "CUDA")
-            def _f8f8bf16_groupwise_grouped_rocm(
-                XQ: torch.Tensor,
-                WQ: torch.Tensor,
-                x_scale: torch.Tensor,
-                w_scale: torch.Tensor,
-                M_sizes: torch.Tensor,
-            ) -> torch.Tensor:
-                return matmul_f8f8bf16_groupwise_grouped(
-                    XQ, WQ, x_scale, w_scale, M_sizes
-                )
-
-        except RuntimeError:
-            pass  # already registered (e.g. module imported more than once)
+# FALLBACK ONLY: FlyDSL owns this op wherever it is usable (see
+# mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py) and Triton is the fallback.
+# Only one CUDA implementation can win, so the two are arbitrated in
+# mslk/gemm/__init__.py, which registers whichever one applies. Registering here
+# as well would need the FlyDSL probe at import time, and importing FlyDSL is
+# fatal in a process that already holds Triton's MLIR/LLVM.

--- a/test/flydsl/lazy_gemm_import_test.py
+++ b/test/flydsl/lazy_gemm_import_test.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Importing ``mslk.gemm`` must not import FlyDSL.
+
+FlyDSL bundles its own MLIR/LLVM. Loading it into a process that already holds
+Triton's makes the two interpose on each other, and the process dies on SIGSEGV
+during ``flydsl._mlir`` initialization -- which no ``except`` can catch, so the
+graceful-degradation paths in ``mslk.flydsl.common`` do not help. Any consumer
+that reaches ``mslk.gemm`` transitively (torchao does) would take the whole
+process down at import.
+
+This test owns its own target so that nothing else in the process can import
+FlyDSL first and mask a regression.
+"""
+
+import sys
+import unittest
+
+
+class LazyGemmImportTest(unittest.TestCase):
+    def test_importing_gemm_does_not_import_flydsl(self) -> None:
+        self.assertNotIn("flydsl", sys.modules, "FlyDSL imported before the test ran")
+
+        import mslk.gemm  # noqa: F401
+
+        self.assertNotIn("flydsl", sys.modules)


### PR DESCRIPTION
Summary:
Make the FlyDSL GEMM backend opt-in, to prevent a SIGSEGV at import time.

## Problem

FlyDSL contains its own copy of MLIR and LLVM. Triton contains a different copy
of LLVM. If a process loads both copies, the two copies conflict. The process
then stops with a SIGSEGV in `mlirRegisterAllDialects`. A SIGSEGV is not a
Python exception. Thus the `try/except` block in `is_flydsl_available()` gives
no protection.

One Python import is not the cause. The cause is the FlyDSL package in the
environment. Some libraries start a module-scope FlyDSL import if
`importlib.util.find_spec("flydsl")` finds the package. The file
`torchao/prototype/moe_training/kernels/mxfp8/flydsl_utils.py` does this. Thus
the package alone is sufficient to stop the process.

Before this change, `mslk.gemm` made the FlyDSL package a dependency of every
program that imports it. Programs that never call a FlyDSL kernel got the
package, and then stopped at import time.

## Solution

FlyDSL becomes an opt-in backend. No MSLK library on a shared import path
depends on the FlyDSL package. Only the targets that run FlyDSL kernels depend
on it. All FlyDSL imports below those targets are already lazy. Thus only the
callers need the package.

- `mslk/gemm/__init__.py`: this module registers
  `mslk::f8f8bf16_groupwise_grouped` and its `_preshuffle` sibling. It does not
  import FlyDSL. The function `_flydsl_gemm_module()` selects the backend at the
  first call. The first op uses Triton if FlyDSL is absent. The second op gives
  an error that names the dependency to add.
- `mslk/gemm/_meta.py`: this module gets the shape function for the preshuffle
  op. Thus shape inference does not need the FlyDSL modules.
- `mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py`: this module registers no op.
  The function `_dispatch_grouped_gemm()` calls `require_flydsl()` at the first
  call.
- `mslk/gemm/triton/fp8_groupwise_grouped_gemm.py`: this module registers no op.
- Build files: `mslk.gemm` no longer depends on the FlyDSL GEMM modules. The
  FlyDSL attention library no longer includes the FlyDSL package. The attention
  tests now declare the package, because they call FlyDSL kernels.
- `test/flydsl/lazy_gemm_import_test.py`: this new test makes sure that `flydsl`
  is not in `sys.modules` after `import mslk.gemm`.

## Effect on other targets

On ROCm, `mslk::f8f8bf16_groupwise_grouped` now uses Triton if the caller does
not depend on the FlyDSL GEMM modules. Without that dependency,
`mslk::f8f8bf16_groupwise_grouped_preshuffle` gives an error. No code outside
`mslk` calls these two ops. The GEMM tests, the GEMM benchmarks and the
attention tests keep the dependency. Thus no target loses the FlyDSL backend.

Verified on MI300X (gfx942). A program that imports `mslk.gemm` starts
correctly. The GEMM and FlyDSL tests pass with no skips, which shows that the
opt-in targets still select FlyDSL and still give correct results.

Reviewed By: stevenlysc

Differential Revision: D116378980


