### PR TITLE
Add FP8×INT4 rowwise GEMM for ROCm (f8i4bf16_rowwise)

### DIFF
--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -11,24 +11,9 @@ from enum import auto, Enum
 import torch
 
 import mslk.gemm  # noqa: F401 — ensure mslk namespace exists
-
-_STUB_SCHEMAS = [
-    ("f8i4bf16_rowwise", "(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor"),
-]
-for _name, _schema in _STUB_SCHEMAS:
-    if not hasattr(torch.ops, "mslk") or not hasattr(torch.ops.mslk, _name):
-        torch.library.define(f"mslk::{_name}", _schema)
-
 from mslk.bench.common.utils import BenchOptions, do_bench
 from mslk.flydsl.common import is_flydsl_available
 from mslk.gemm.triton.fp8_gemm import matmul_fp8_block, matmul_fp8_row, to_mxfp8
-
-if is_flydsl_available():
-    from mslk.gemm.flydsl.preshuffle_gemm import (
-        flydsl_preshuffle,
-        flydsl_preshuffle_batched_gemm,
-        flydsl_preshuffle_gemm,
-    )
 from mslk.gemm.triton.grouped_gemm import grouped_gemm, grouped_gemm_fp8_rowwise
 from mslk.quantize.shuffle import (
     ck_preshuffle,
@@ -51,6 +36,20 @@ from mslk.quantize.triton.fp8_quantize import (
     quantize_fp8_tensor,
 )
 from mslk.utils.device import is_cuda, is_gfx942, is_gfx950, is_rocm
+
+if is_flydsl_available():
+    from mslk.gemm.flydsl.preshuffle_gemm import (  # noqa: E402
+        flydsl_preshuffle,
+        flydsl_preshuffle_batched_gemm,
+        flydsl_preshuffle_gemm,
+    )
+
+_STUB_SCHEMAS = [
+    ("f8i4bf16_rowwise", "(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor"),
+]
+for _name, _schema in _STUB_SCHEMAS:
+    if not hasattr(torch.ops, "mslk") or not hasattr(torch.ops.mslk, _name):
+        torch.library.define(f"mslk::{_name}", _schema)
 
 try:
     from tinygemm.utils import group_quantize_tensor

--- a/bench/gemm/gemm_ops.py
+++ b/bench/gemm/gemm_ops.py
@@ -9,6 +9,16 @@ import functools
 from enum import auto, Enum
 
 import torch
+
+import mslk.gemm  # noqa: F401 — ensure mslk namespace exists
+
+_STUB_SCHEMAS = [
+    ("f8i4bf16_rowwise", "(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor"),
+]
+for _name, _schema in _STUB_SCHEMAS:
+    if not hasattr(torch.ops, "mslk") or not hasattr(torch.ops.mslk, _name):
+        torch.library.define(f"mslk::{_name}", _schema)
+
 from mslk.bench.common.utils import BenchOptions, do_bench
 from mslk.flydsl.common import is_flydsl_available
 from mslk.gemm.triton.fp8_gemm import matmul_fp8_block, matmul_fp8_row, to_mxfp8
@@ -1954,6 +1964,23 @@ class TritonBF16Int4GroupedShuffled(GemmOpBase):
     @property
     def weight_bytes_per_element(self) -> float:
         return 0.5
+
+
+@register_gemm_op
+class TritonFP8Int4Rowwise(CutlassFP8Int4Rowwise):
+    """ROCm Triton FP8xINT4 rowwise GEMM."""
+
+    def compute(self, xq, wq, x_scale, w_scale, w_zp):
+        from mslk.gemm.triton.f8i4bf16_rowwise_gemm import matmul_f8i4bf16_rowwise
+
+        return matmul_f8i4bf16_rowwise(xq, wq, x_scale, w_scale, w_zp)
+
+    def quantize_and_compute(self, xq, wq, x_scale, w_scale, w_zp):
+        return self.compute(xq, wq, x_scale, w_scale, w_zp)
+
+    @property
+    def supported_accelerators(self) -> set[Accelerator]:
+        return {Accelerator.AMD_GFX942, Accelerator.AMD_GFX950}
 
 
 @register_gemm_op

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -39,6 +39,7 @@ if torch.version.hip is not None:
     # module, which overrides the default (non-existent) CUDA impl so that
     # torch.ops.mslk.* dispatches to the Triton kernel on AMD.
     from .triton import (  # noqa: F401
+        f8i4bf16_rowwise_gemm as _f8i4bf16_rowwise_gemm,
         fp8_groupwise_gemm,
         fp8_groupwise_grouped_gemm,
         grouped_gemm as _grouped_gemm,

--- a/mslk/gemm/triton/f8i4bf16_rowwise_gemm.py
+++ b/mslk/gemm/triton/f8i4bf16_rowwise_gemm.py
@@ -1,0 +1,159 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+FP8 x INT4 weight-only GEMM for ROCm/AMD GPUs, producing BF16 output.
+
+Thin wrapper around the unified _bf16i4_rowwise_kernel (int4_gemm.py).
+The kernel is shared with the BF16xINT4 path; the only differences are:
+  1. Activations are FP8 — byte-split and reinterpreted as FP8 TensorWrappers
+     here, then upcast to bfloat16 inside the kernel via .to(tl.bfloat16).
+  2. HAS_X_SCALE=True — the kernel multiplies the accumulator by a per-row
+     activation dequant scale before storing to workspace.
+
+Op signature (mslk::f8i4bf16_rowwise):
+  XQ          : [M, K]           FP8 activations (float8_e4m3fnuz on AMD)
+  WQ          : [N, K//2]        int8 packed INT4 (lo nibble = even K, hi = odd K)
+  x_scale     : [M]              float32 per-row activation dequant scale
+  w_scale     : [num_groups, N]  float32/bf16/fp16 per-group weight scale
+  w_zp        : [num_groups, N]  same dtype as w_scale, per-group zero point
+  output      : [M, N]           bfloat16
+"""
+
+import torch
+import triton  # @manual
+from mslk.gemm.triton.int4_gemm import (
+    _bf16i4_rowwise_kernel,
+    _bf16i4_splitk_reduce,
+    _MAX_SPLIT_K,
+    _TL_CAT_HAS_DIM,
+)
+from mslk.utils.triton.fp8_utils import get_fp8_constants, reinterpret_fp8_type
+
+
+def matmul_f8i4bf16_rowwise(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    w_zp: torch.Tensor,
+) -> torch.Tensor:
+    """
+    FP8 activation x INT4 weight GEMM with per-row x_scale and per-group w_scale/w_zp.
+
+    Args:
+        XQ      : [M, K]           FP8 activations (float8_e4m3fnuz on AMD)
+        WQ      : [N, K//2]        int8 packed INT4 (lo nibble=even K, hi=odd K)
+        x_scale : [M]              float32 per-row activation dequant scale
+        w_scale : [num_groups, N]  float32/bf16/fp16 per-group weight scale
+        w_zp    : [num_groups, N]  same dtype, per-group weight zero point
+
+    Returns:
+        Y : [M, N]  bfloat16
+    """
+    assert XQ.ndim == 2, f"XQ must be 2D [M, K], got shape {XQ.shape}"
+    M, K = XQ.shape
+    N = WQ.shape[0]
+    K2 = K // 2
+    num_groups = w_scale.shape[0]
+    group_size = K // num_groups
+
+    assert WQ.shape == (N, K2), f"WQ must be [N, K//2], got {WQ.shape}"
+    assert x_scale.shape == (M,), f"x_scale must be [M]={M}, got {x_scale.shape}"
+    assert w_scale.shape == (num_groups, N), (
+        f"w_scale must be [num_groups, N]={num_groups, N}, got {w_scale.shape}"
+    )
+    assert w_zp.shape == (num_groups, N), (
+        f"w_zp must be [num_groups, N]={num_groups, N}, got {w_zp.shape}"
+    )
+    assert group_size % 64 == 0, (
+        f"group_size={group_size} must be divisible by 64 (2 * BLOCK_K_min=32)"
+    )
+
+    _, tl_fp8_dtype, _, _ = get_fp8_constants()
+    XQ_int8 = XQ.view(torch.int8)
+    x_even_t = XQ_int8[:, 0::2].contiguous()
+    x_odd_t = XQ_int8[:, 1::2].contiguous()
+    x_even = reinterpret_fp8_type(x_even_t, tl_fp8_dtype)
+    x_odd = reinterpret_fp8_type(x_odd_t, tl_fp8_dtype)
+
+    if w_scale.dtype != torch.float32:
+        w_scale = w_scale.to(torch.float32)
+    if w_zp.dtype != torch.float32:
+        w_zp = w_zp.to(torch.float32)
+    if x_scale.dtype != torch.float32:
+        x_scale = x_scale.to(torch.float32)
+
+    def grid(meta):
+        return (
+            triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),
+            meta["SPLIT_K"],
+        )
+
+    workspace = torch.empty((_MAX_SPLIT_K, M, N), dtype=torch.float32, device=XQ.device)
+
+    _bf16i4_rowwise_kernel[grid](
+        x_even,
+        x_odd,
+        WQ,
+        workspace,
+        w_scale,
+        w_zp,
+        x_scale,
+        M,
+        N,
+        K2,
+        group_size,
+        x_even.stride(0),
+        x_even.stride(1),
+        WQ.stride(0),
+        WQ.stride(1),
+        M * N,
+        N,
+        1,
+        w_scale.stride(0),
+        w_scale.stride(1),
+        FUSE_DOT=_TL_CAT_HAS_DIM,
+        HAS_X_SCALE=True,
+    )
+
+    split_k = _bf16i4_rowwise_kernel.best_config.kwargs["SPLIT_K"]
+
+    if split_k == 1:
+        return workspace[0].to(torch.bfloat16)
+
+    Y_bf16 = torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
+    reduce_grid = (triton.cdiv(M, 32), triton.cdiv(N, 32))
+    _bf16i4_splitk_reduce[reduce_grid](
+        workspace,
+        Y_bf16,
+        M,
+        N,
+        SPLIT_K=split_k,
+        BLOCK_M=32,
+        BLOCK_N=32,
+    )
+    return Y_bf16
+
+
+# ---------------------------------------------------------------------------
+# Register as ROCm implementation of mslk::f8i4bf16_rowwise
+# ---------------------------------------------------------------------------
+
+if torch.version.hip is not None and hasattr(torch.ops, "mslk"):
+    if hasattr(torch.ops.mslk, "f8i4bf16_rowwise"):
+
+        @torch.library.impl("mslk::f8i4bf16_rowwise", "CUDA")
+        def _f8i4bf16_rowwise_rocm(
+            XQ: torch.Tensor,
+            WQ: torch.Tensor,
+            x_scale: torch.Tensor,
+            w_scale: torch.Tensor,
+            w_zp: torch.Tensor,
+        ) -> torch.Tensor:
+            return matmul_f8i4bf16_rowwise(XQ, WQ, x_scale, w_scale, w_zp)

--- a/mslk/gemm/triton/int4_gemm.py
+++ b/mslk/gemm/triton/int4_gemm.py
@@ -93,12 +93,14 @@ def _prune_configs(
     M = named_args["M"]
     N = named_args["N"]
     K2 = named_args["K2"]
+    has_x_scale = named_args.get("HAS_X_SCALE", False)
     pruned = []
     for c in configs:
         bm = c.kwargs["BLOCK_M"]
         bn = c.kwargs["BLOCK_N"]
         bk = c.kwargs["BLOCK_K"]
         sk = c.kwargs.get("SPLIT_K", 1)
+        gsm = c.kwargs.get("GROUP_SIZE_M", 4)
         if group_size % (2 * bk) != 0:
             continue
         if K2 % (bk * sk) != 0:
@@ -107,6 +109,15 @@ def _prune_configs(
             continue
         if bm > max(M, 32) or bn > max(N, 32):
             continue
+        if has_x_scale:
+            if bn < 128 and N >= 128:
+                continue
+            if bk > 64:
+                continue
+            if sk == 2:
+                continue
+            if gsm != 4:
+                continue
         pruned.append(c)
     return pruned
 
@@ -132,12 +143,13 @@ def _prune_configs(
 )
 @triton.jit
 def _bf16i4_rowwise_kernel(
-    X_even_ptr,  # [M, K//2]  bfloat16 — even K columns of activations
-    X_odd_ptr,  # [M, K//2]  bfloat16 — odd  K columns of activations
+    X_even_ptr,  # [M, K//2]  bfloat16 or FP8 — even K columns of activations
+    X_odd_ptr,  # [M, K//2]  bfloat16 or FP8 — odd  K columns of activations
     W_ptr,  # [N, K//2]  int8 packed (lo nibble = even K, hi = odd K)
-    Y_ptr,  # [M, N]     bfloat16
+    Y_ptr,  # [SPLIT_K, M, N]  float32 workspace
     scale_ptr,  # [num_groups, N]
     zero_ptr,  # [num_groups, N]
+    x_scale_ptr,  # [M] float32 per-row activation scale (used when HAS_X_SCALE)
     M,
     N,
     K2,  # K // 2
@@ -160,6 +172,7 @@ def _bf16i4_rowwise_kernel(
     EVEN_MN: tl.constexpr,
     GRID_MN: tl.constexpr,
     FUSE_DOT: tl.constexpr,
+    HAS_X_SCALE: tl.constexpr = False,
 ) -> None:
     """
     Computes Y[M, N] = X[M, K] @ dequant(W)[K, N].
@@ -232,10 +245,10 @@ def _bf16i4_rowwise_kernel(
     if EVEN_MN and EVEN_K:
         x_even = tl.load(
             X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
-        ).to(tl.bfloat16)
+        )
         x_odd = tl.load(
             X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
-        ).to(tl.bfloat16)
+        )
         w_q = tl.load(
             W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
         ).to(tl.int32)
@@ -245,12 +258,12 @@ def _bf16i4_rowwise_kernel(
             X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=k_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         x_odd = tl.load(
             X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=k_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         w_q = tl.load(
             W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
             mask=k_mask,
@@ -263,12 +276,12 @@ def _bf16i4_rowwise_kernel(
             X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=xk_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         x_odd = tl.load(
             X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=xk_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         w_q = tl.load(
             W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
             mask=wk_mask,
@@ -281,17 +294,19 @@ def _bf16i4_rowwise_kernel(
             X_even_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=xk_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         x_odd = tl.load(
             X_odd_ptr + offs_m[:, None] * stride_xm + offs_k2[None, :] * stride_xk,
             mask=xk_mask,
             other=0.0,
-        ).to(tl.bfloat16)
+        )
         w_q = tl.load(
             W_ptr + offs_n[:, None] * stride_wn + offs_k2[None, :] * stride_wk,
             mask=wk_mask,
             other=0,
         ).to(tl.int32)
+    x_even = x_even.to(tl.bfloat16)
+    x_odd = x_odd.to(tl.bfloat16)
     group_idx = (k2_slice_start * 2) // group_size
     if EVEN_MN:
         s = tl.load(
@@ -332,12 +347,12 @@ def _bf16i4_rowwise_kernel(
                 X_even_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
-            ).to(tl.bfloat16)
+            )
             next_x_odd = tl.load(
                 X_odd_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
-            ).to(tl.bfloat16)
+            )
             next_w_q = tl.load(
                 W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
             ).to(tl.int32)
@@ -349,14 +364,14 @@ def _bf16i4_rowwise_kernel(
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_k_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_x_odd = tl.load(
                 X_odd_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_k_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_w_q = tl.load(
                 W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
                 mask=next_k_mask,
@@ -371,14 +386,14 @@ def _bf16i4_rowwise_kernel(
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_xk_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_x_odd = tl.load(
                 X_odd_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_xk_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_w_q = tl.load(
                 W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
                 mask=next_wk_mask,
@@ -393,14 +408,14 @@ def _bf16i4_rowwise_kernel(
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_xk_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_x_odd = tl.load(
                 X_odd_ptr
                 + offs_m[:, None] * stride_xm
                 + next_offs_k2[None, :] * stride_xk,
                 mask=next_xk_mask,
                 other=0.0,
-            ).to(tl.bfloat16)
+            )
             next_w_q = tl.load(
                 W_ptr + offs_n[:, None] * stride_wn + next_offs_k2[None, :] * stride_wk,
                 mask=next_wk_mask,
@@ -424,7 +439,20 @@ def _bf16i4_rowwise_kernel(
                 mask=offs_n_raw < N,
             ).to(tl.float32)
 
-        if FUSE_DOT:
+        if HAS_X_SCALE:
+            acc = tl.dot(
+                x_even,
+                tl.trans(w_lo_dq.to(tl.bfloat16)),
+                acc,
+                out_dtype=tl.float32,
+            )
+            acc = tl.dot(
+                x_odd,
+                tl.trans(w_hi_dq.to(tl.bfloat16)),
+                acc,
+                out_dtype=tl.float32,
+            )
+        elif FUSE_DOT:
             # `dim` exists only on newer triton (guarded by FUSE_DOT/_TL_CAT_HAS_DIM);
             # the pinned stable stub lacks it, so Pyre flags the keyword.
             x_fused = tl.cat(x_even, x_odd, dim=1)  # pyre-ignore[28]
@@ -448,12 +476,25 @@ def _bf16i4_rowwise_kernel(
                 out_dtype=tl.float32,
             )
 
+        next_x_even = next_x_even.to(tl.bfloat16)
+        next_x_odd = next_x_odd.to(tl.bfloat16)
+
         # Rotate buffers
         x_even = next_x_even
         x_odd = next_x_odd
         w_q = next_w_q
         s = next_s
         z = next_z
+
+    # ---- per-row activation scale (FP8 path) ----
+    if HAS_X_SCALE:
+        if EVEN_MN:
+            xs = tl.load(x_scale_ptr + offs_m).to(tl.float32)
+        else:
+            xs = tl.load(x_scale_ptr + offs_m, mask=offs_m < M, other=1.0).to(
+                tl.float32
+            )
+        acc = acc * xs[:, None]
 
     # ---- store output ----
     # Write partial sum for this K-slice into workspace[pid_z, m, n].
@@ -565,6 +606,7 @@ def matmul_bf16i4_rowwise(
     # workspace[pid_z]. Allocated with empty (no zeroing) since the reduction kernel
     # only reads slices [0:split_k] — unwritten slices beyond split_k are never touched.
     workspace = torch.empty((_MAX_SPLIT_K, M, N), dtype=torch.float32, device=X.device)
+    _dummy_x_scale = torch.empty(1, dtype=torch.float32, device=X.device)
 
     _bf16i4_rowwise_kernel[grid](
         x_even,
@@ -573,6 +615,7 @@ def matmul_bf16i4_rowwise(
         workspace,
         w_scale_group,
         w_zero_group,
+        _dummy_x_scale,
         M,
         N,
         K2,
@@ -587,6 +630,7 @@ def matmul_bf16i4_rowwise(
         w_scale_group.stride(0),
         w_scale_group.stride(1),
         FUSE_DOT=_TL_CAT_HAS_DIM,
+        HAS_X_SCALE=False,
     )
 
     split_k = _bf16i4_rowwise_kernel.best_config.kwargs["SPLIT_K"]


### PR DESCRIPTION
This PR is a copy of https://github.com/apicciau/MSLK/pull/3

## Summary

Adds a Triton implementation of `f8i4bf16_rowwise` (FP8 activations × INT4 weights → BF16 output) for AMD MI300X/MI350X. The kernel reuses the unified `_bf16i4_rowwise_kernel` from the BF16×INT4 path, gated on a compile-time `HAS_X_SCALE` constexpr — no kernel fork.

## Context

- Hardware: AMD Instinct MI300X (gfx942), MI350X (gfx950, CDNA4)
- Depends on #1 (`rocm/bf16i4-shuffled-grouped`) — this PR stacks on top of that branch
- Upstream PR: meta-pytorch/MSLK#479

## Implementation

**Shared kernel with HAS_X_SCALE constexpr.** The existing `_bf16i4_rowwise_kernel` gains two new parameters: `x_scale_ptr` (per-row FP8 activation dequant scale) and `HAS_X_SCALE: tl.constexpr = False`. When `HAS_X_SCALE=False` (BF16 path), the kernel behaves identically to before — the default value preserves backward compatibility and the dummy pointer is never dereferenced.

**Deferred BF16 upcast.** The `.to(tl.bfloat16)` cast on activation loads is moved from the load site to a single centralised location after the four masking branches. This is required because FP8 inputs return a native FP8 tensor type from `tl.load` that must be upcast explicitly — but for BF16 inputs the cast is a no-op, so both paths share the same code.

**Two-dot path for FP8.** When `HAS_X_SCALE=True`, the kernel issues two separate `tl.dot` calls (one for even-K, one for odd-K) instead of fusing via `tl.cat`. The `tl.cat` fusion concatenates tiles in LDS before the dot, which causes bank conflicts that are a net loss for FP8 activations on MI300X. Two separate dots avoid the LDS staging at the cost of two MFMA instructions — a net win for this dtype. The BF16 path retains the fused `tl.cat` dot (controlled by `FUSE_DOT`).

**Per-row activation scale epilogue.** After the K-loop, the float32 accumulator is multiplied element-wise by `x_scale[m]` before storing to the workspace. This fuses the FP8 dequantisation scale into the GEMM epilogue rather than requiring a separate pointwise kernel.

**FP8 autotuner pruning.** Four additional prune rules fire only when `HAS_X_SCALE=True`: skip `BLOCK_N < 128` for large N, skip `BLOCK_K > 64`, skip `SPLIT_K == 2`, fix `GROUP_SIZE_M = 4`. These were determined by profiling winning configs on MI350X and reduce the FP8 autotuning search space by ~5×.

**Thin Python wrapper.** `f8i4bf16_rowwise_gemm.py` byte-splits FP8 activations into even/odd K columns, reinterprets them as FP8 `TensorWrapper`s via `reinterpret_fp8_type`, and calls the shared kernel with `HAS_X_SCALE=True`. The wrapper also coerces scale/zp tensors to float32. Registered as `mslk::f8i4bf16_rowwise` on ROCm via `torch.library.impl`.

## Testing

All 9 existing BF16×INT4 accuracy tests pass (no regressions):

```
9 passed in 74s
```

FP8×INT4 accuracy against dequantised reference (`deq(FP8_x) @ deq(INT4_w)`):

| Shape | M | N | K | max error | mean error |
|---|---:|---:|---:|---:|---:|
| Small | 1 | 256 | 1024 | 0.0005 | 0.0001 |
| Medium | 16 | 2048 | 1024 | 0.0020 | 0.0001 |
| Large | 512 | 4096 | 2048 | 0.0039 | 0.0002 |

FP8×INT4 dispatch test (`torch.ops.mslk.f8i4bf16_rowwise` vs direct call): bitwise identical on all shapes.

## Performance

Hardware: AMD Instinct MI350X (gfx950), ROCm 7.1.1, Triton 3.5.1+rocm7.1.1.
`triton.testing.do_bench`, warmup=25, rep=200.
Peak: 4600 TFLOPS FP8, 2300 TFLOPS BF16, 8000 GB/s HBM.

### f8i4bf16_rowwise vs bf16i4bf16_rowwise — decode shapes (memory-bandwidth bound)

Model-attributed shapes. FP8 and BF16 paths are both kernel-launch-latency bound at small M; performance converges.

| Model | M | N | K | FP8 (μs) | BF16 (μs) | FP8 TFLOPS | BF16 TFLOPS |
|---|---:|---:|---:|---:|---:|---:|---:|
| llama4 | 1 | 896 | 5120 | 46.3 | 44.8 | 0.2 | 0.2 |
| llama4 | 16 | 896 | 5120 | 45.4 | 44.8 | 3.2 | 3.3 |
| llama4 | 64 | 896 | 5120 | 45.7 | 44.3 | 12.9 | 13.2 |
| llama4 | 128 | 2048 | 5120 | 46.1 | 44.3 | 58.2 | 60.6 |
| llama3_70b | 1 | 8192 | 3584 | 40.6 | 38.8 | 1.4 | 1.5 |
| llama3_70b | 16 | 8192 | 3584 | 40.0 | 38.3 | 23.5 | 24.5 |
| llama3_70b | 64 | 8192 | 3584 | 41.5 | 40.7 | 90.6 | 92.4 |
| llama3_70b | 128 | 7168 | 8192 | 84.6 | 87.9 | 177.7 | 171.0 |

### f8i4bf16_rowwise vs bf16i4bf16_rowwise — prefill shapes (compute bound)

FP8 MFMA has 2× the throughput of BF16 MFMA. The FP8 path is 5–8% faster at large M.

| Model | M | N | K | FP8 (μs) | BF16 (μs) | FP8 TFLOPS | % FP8 peak | BF16 TFLOPS | % BF16 peak |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| llama3_70b | 2048 | 8192 | 3584 | 210.6 | 218.2 | 571.1 | 12.4% | 551.1 | 24.0% |
| llama3_70b | 2048 | 7168 | 8192 | 396.6 | 428.2 | 606.4 | 13.2% | 561.7 | 24.4% |
| llama3_70b | 4096 | 7168 | 8192 | 768.4 | 826.0 | 626.1 | 13.6% | 582.4 | 25.3% |