### PR TITLE
Fix fbcode Conda build setup

### DIFF
--- a/ci/scripts/mslk_build.bash
+++ b/ci/scripts/mslk_build.bash
@@ -188,7 +188,7 @@ __configure_mslk_build_rocm () {
   local mslk_variant_targets="$1"
 
   # Fetch ROCm version to $rocm_version_arr
-  __fetch_rocm_version_array ${env_name} || return 1
+  __fetch_rocm_version_array "${env_name}" || return 1
 
   # By default, we build for a limited number of target architectures to save on
   # build time.  This list needs to be updated if the CI ROCm machines have
@@ -214,6 +214,7 @@ __configure_mslk_build_rocm () {
   else
     # If BUILD_FROM_NOVA is unset, then we are building from a compute host with
     # sufficient resources, so we can build for more AMD Instinct architectures.
+    # shellcheck disable=SC2154
     if [[ ${rocm_version_arr[0]} -ge 7 ]]; then
       local arch_list="gfx908,gfx90a,gfx942,gfx950"
     else
@@ -525,9 +526,11 @@ __build_mslk_common_pre_steps () {
   # shellcheck disable=SC2086
   print_exec conda run --no-capture-output ${env_prefix} python setup.py clean
 
-  echo "[BUILD] Printing git status ..."
-  print_exec git status
-  print_exec git diff
+  if [[ -z "${BUILD_FB_CODE}" || "${BUILD_FB_CODE}" == "0" ]]; then
+    echo "[BUILD] Printing git status ..."
+    print_exec git status
+    print_exec git diff
+  fi
 }
 
 __verify_library_symbols () {

--- a/ci/scripts/utils_base.bash
+++ b/ci/scripts/utils_base.bash
@@ -275,13 +275,22 @@ set_clang_symlinks () {
     return 1
   fi
 
-  # shellcheck disable=SC2155
-  local env_prefix=$(env_name_or_prefix "${env_name}")
+  local env_prefix
+  env_prefix=$(env_name_or_prefix "${env_name}") || return 1
 
-  # shellcheck disable=SC2155,SC2086
-  local cc_path=$(conda run ${env_prefix} which clang)
-  # shellcheck disable=SC2155,SC2086
-  local cxx_path=$(conda run ${env_prefix} which clang++)
+  local cc_path
+  # shellcheck disable=SC2086
+  cc_path=$(conda run ${env_prefix} which clang) || return 1
+  local cxx_path
+  # shellcheck disable=SC2086
+  cxx_path=$(conda run ${env_prefix} which clang++) || return 1
+  local conda_prefix
+  # shellcheck disable=SC2086
+  conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX) || return 1
+  if [ -z "${conda_prefix}" ]; then
+    echo "Unable to resolve CONDA_PREFIX for ${env_name}" >&2
+    return 1
+  fi
 
   # Set the symlinks, override if needed
   #
@@ -293,10 +302,10 @@ set_clang_symlinks () {
   #
   # As such, clang is installed only during the build step, where we are
   # exercising building MSLK in clang.
-  print_exec ln -sf "${cc_path}" "$(dirname "$cc_path")/cc"
-  print_exec ln -sf "${cc_path}" "$(dirname "$cc_path")/gcc"
-  print_exec ln -sf "${cxx_path}" "$(dirname "$cxx_path")/c++"
-  print_exec ln -sf "${cxx_path}" "$(dirname "$cxx_path")/g++"
+  print_exec ln -sf "${cc_path}" "${conda_prefix}/bin/cc" || return 1
+  print_exec ln -sf "${cc_path}" "${conda_prefix}/bin/gcc" || return 1
+  print_exec ln -sf "${cxx_path}" "${conda_prefix}/bin/c++" || return 1
+  print_exec ln -sf "${cxx_path}" "${conda_prefix}/bin/g++" || return 1
 }
 
 __fetch_cuda_version_array () {
@@ -324,6 +333,7 @@ __fetch_rocm_version_array () {
     echo "[INFO] Extracted ROCm version: ${rocm_version}"
     # Extract version numbers (e.g., "5.7.0" -> array of [5, 7, 0])
     IFS='.' read -ra rocm_version_arr <<< "$rocm_version"
+    # shellcheck disable=SC2206
     export rocm_version_arr=(${rocm_version//./ })
 
   else


### PR DESCRIPTION
Summary:
Repair the fbcode MSLK Conda build path so it completes in a Sapling checkout.

- Create compiler aliases under `CONDA_PREFIX/bin` instead of attempting to write beside a system Clang in `/usr/bin`.
- Initialize `BUILD_VARIANT=cuda` for the fbcode entrypoint so the Triton installer selects the CUDA package.
- Skip Git-only status diagnostics when `BUILD_FB_CODE=1`, preventing `git diff` from becoming the build function return code in fbsource.
- Propagate compiler-alias creation failures.

Differential Revision: D117080149


