### PR TITLE
Enable 2SM schedule for MXFP4_16 grouped GEMM (#501)

### DIFF
--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_128_128_256_1_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_128_128_256_1_1_1.cu
@@ -35,12 +35,6 @@ at::Tensor f4f4bf16_grouped_128_128_256_1_1_1(
         global_scale,
         starting_row_after_padding);
   } else if (mxfp4_block_size == 16) {
-    // NOTE: deliberately 128,128,256,1,1,1 and not this file's own tile shape.
-    // The other MXFP4_16 tile instantiations fault with an illegal memory
-    // access (see mslk/test/gemm/test_mxfp4_16_grouped_mm.py, which was written
-    // to reproduce it), so every MXFP4_16 workload is routed to the one shape
-    // that is known good. This does mean per-name tuning does not select a
-    // tile for MXFP4_16 yet.
     return f4f4bf16_grouped_impl<MXFP4_16, 128, 128, 256, 1, 1, 1>(
         XQ,
         WQ,

--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_128_64_256_1_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_128_64_256_1_1_1.cu
@@ -35,13 +35,7 @@ at::Tensor f4f4bf16_grouped_128_64_256_1_1_1(
         global_scale,
         starting_row_after_padding);
   } else if (mxfp4_block_size == 16) {
-    // NOTE: deliberately 128,128,256,1,1,1 and not this file's own tile shape.
-    // The other MXFP4_16 tile instantiations fault with an illegal memory
-    // access (see mslk/test/gemm/test_mxfp4_16_grouped_mm.py, which was written
-    // to reproduce it), so every MXFP4_16 workload is routed to the one shape
-    // that is known good. This does mean per-name tuning does not select a
-    // tile for MXFP4_16 yet.
-    return f4f4bf16_grouped_impl<MXFP4_16, 128, 128, 256, 1, 1, 1>(
+    return f4f4bf16_grouped_impl<MXFP4_16, 128, 64, 256, 1, 1, 1>(
         XQ,
         WQ,
         x_scale,

--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_256_128_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_256_128_256_2_1_1.cu
@@ -35,13 +35,7 @@ at::Tensor f4f4bf16_grouped_256_128_256_2_1_1(
         global_scale,
         starting_row_after_padding);
   } else if (mxfp4_block_size == 16) {
-    // NOTE: deliberately 128,128,256,1,1,1 and not this file's own tile shape.
-    // The other MXFP4_16 tile instantiations fault with an illegal memory
-    // access (see mslk/test/gemm/test_mxfp4_16_grouped_mm.py, which was written
-    // to reproduce it), so every MXFP4_16 workload is routed to the one shape
-    // that is known good. This does mean per-name tuning does not select a
-    // tile for MXFP4_16 yet.
-    return f4f4bf16_grouped_impl<MXFP4_16, 128, 128, 256, 1, 1, 1>(
+    return f4f4bf16_grouped_impl<MXFP4_16, 256, 128, 256, 2, 1, 1>(
         XQ,
         WQ,
         x_scale,

--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_256_256_128_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_256_256_128_2_1_1.cu
@@ -35,13 +35,7 @@ at::Tensor f4f4bf16_grouped_256_256_128_2_1_1(
         global_scale,
         starting_row_after_padding);
   } else if (mxfp4_block_size == 16) {
-    // NOTE: deliberately 128,128,256,1,1,1 and not this file's own tile shape.
-    // The other MXFP4_16 tile instantiations fault with an illegal memory
-    // access (see mslk/test/gemm/test_mxfp4_16_grouped_mm.py, which was written
-    // to reproduce it), so every MXFP4_16 workload is routed to the one shape
-    // that is known good. This does mean per-name tuning does not select a
-    // tile for MXFP4_16 yet.
-    return f4f4bf16_grouped_impl<MXFP4_16, 128, 128, 256, 1, 1, 1>(
+    return f4f4bf16_grouped_impl<MXFP4_16, 256, 256, 128, 2, 1, 1>(
         XQ,
         WQ,
         x_scale,

--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_256_256_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_256_256_256_2_1_1.cu
@@ -35,13 +35,7 @@ at::Tensor f4f4bf16_grouped_256_256_256_2_1_1(
         global_scale,
         starting_row_after_padding);
   } else if (mxfp4_block_size == 16) {
-    // NOTE: deliberately 128,128,256,1,1,1 and not this file's own tile shape.
-    // The other MXFP4_16 tile instantiations fault with an illegal memory
-    // access (see mslk/test/gemm/test_mxfp4_16_grouped_mm.py, which was written
-    // to reproduce it), so every MXFP4_16 workload is routed to the one shape
-    // that is known good. This does mean per-name tuning does not select a
-    // tile for MXFP4_16 yet.
-    return f4f4bf16_grouped_impl<MXFP4_16, 128, 128, 256, 1, 1, 1>(
+    return f4f4bf16_grouped_impl<MXFP4_16, 256, 256, 256, 2, 1, 1>(
         XQ,
         WQ,
         x_scale,

--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_256_64_256_2_1_1.cu
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_256_64_256_2_1_1.cu
@@ -35,13 +35,7 @@ at::Tensor f4f4bf16_grouped_256_64_256_2_1_1(
         global_scale,
         starting_row_after_padding);
   } else if (mxfp4_block_size == 16) {
-    // NOTE: deliberately 128,128,256,1,1,1 and not this file's own tile shape.
-    // The other MXFP4_16 tile instantiations fault with an illegal memory
-    // access (see mslk/test/gemm/test_mxfp4_16_grouped_mm.py, which was written
-    // to reproduce it), so every MXFP4_16 workload is routed to the one shape
-    // that is known good. This does mean per-name tuning does not select a
-    // tile for MXFP4_16 yet.
-    return f4f4bf16_grouped_impl<MXFP4_16, 128, 128, 256, 1, 1, 1>(
+    return f4f4bf16_grouped_impl<MXFP4_16, 256, 64, 256, 2, 1, 1>(
         XQ,
         WQ,
         x_scale,

--- a/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_common.cuh
+++ b/csrc/gemm/cutlass/f4f4bf16_grouped/f4f4bf16_grouped_common.cuh
@@ -252,12 +252,16 @@ at::Tensor f4f4bf16_grouped_impl(
   // Sm90ScalarBroadcastPtrArray: it requires non-void C type to maintain proper
   // stride layout for pointer-array access. For MXFP4, we can safely use void C
   // type since it doesn't use alpha_ptr_array.
-  using EpilogueElementC = cute::conditional_t<is_nvfp4, ElementC, void>;
+  // 2SM epilogue requires non-void C type for proper stride layout.
+  // MXFP4 1SM can use void C, but MXFP4_16 needs 2SM support, so
+  // use non-void C for both NVFP4 and MXFP4_16 when 2SM is selected.
+  static constexpr bool needs_nonvoid_c = is_nvfp4 || use_2sm;
+  using EpilogueElementC = cute::conditional_t<needs_nonvoid_c, ElementC, void>;
   using EpilogueLayoutC = cute::conditional_t<
-      is_nvfp4,
+      needs_nonvoid_c,
       typename cutlass::layout::LayoutTranspose<LayoutC>::type*,
       void>;
-  static constexpr int EpilogueAlignmentC = is_nvfp4 ? AlignmentC : 0;
+  static constexpr int EpilogueAlignmentC = needs_nonvoid_c ? AlignmentC : 0;
 
   using CollectiveEpilogue =
       typename cutlass::epilogue::collective::CollectiveBuilder<

--- a/test/gemm/test_mxfp4_16_grouped_mm.py
+++ b/test/gemm/test_mxfp4_16_grouped_mm.py
@@ -6,9 +6,12 @@
 # LICENSE file in the root directory of this source tree.
 """Test f4f4bf16_grouped_mm with mxfp4_block_size=16 (offset-based API).
 
-Reproduces the crash seen in MetaShuffling MoE with MXFP4_16:
-- Some workers crash with 'illegal memory access'
-- Pattern suggests certain M_group_size values trigger the issue
+Written to reproduce an 'illegal memory access' seen in MetaShuffling MoE with
+MXFP4_16, which reproduced for M >= 192 per expert. The 2SM epilogue was being
+built with a void C type, which misconfigures its stride layout; the tile
+configs worked around it by routing every MXFP4_16 workload to a single 1SM
+shape. Both are fixed, so the large-M cases below are now a regression guard
+against reintroducing either.
 """
 
 import unittest
@@ -183,6 +186,17 @@ class TestMXFP4_16GroupedMM(unittest.TestCase):
         """Test with N=8192 (w13 GEMM dimension)."""
         print("\ntest_n8192:")
         self._run_test(4, [64, 64, 64, 64], 8192, 4096)
+
+    def test_1sm_tile_small_n_k(self):
+        """E=4, 64 tokens/expert, N=K=2048.
+
+        The only shape family in this file that the heuristic routes to a 1SM
+        tile (`128_64_256_1_1_1`): M <= 64 with N <= 2048 and K <= 2048. Every
+        other case here lands on a 2SM tile, so without this the 1SM MXFP4_16
+        path -- which keeps a void epilogue C type -- would be uncovered.
+        """
+        print("\ntest_1sm_tile_small_n_k:")
+        self._run_test(4, [64, 64, 64, 64], 2048, 2048)
 
     def test_mixed_counts(self):
         """E=32 with varying token counts."""


### PR DESCRIPTION
Summary:

Fix the 2SM NvF4 kernel schedule crash for MXFP4_16 (E8M0 scales with
SFVecSize=16) by using non-void EpilogueElementC for 2SM tile configs.

Root cause: the 2SM epilogue (PtrArrayTmaWarpSpecialized2Sm) requires
non-void C type for correct stride layout configuration. With void C,
the epilogue misconfigures memory access patterns, causing illegal
memory access for M >= 192 per expert. NVFP4 worked because it always
uses non-void C (for alpha_ptr_array global_scale support).

Fix: set EpilogueElementC = ElementC (bfloat16) whenever 2SM is
selected, not just for NVFP4. This adds minimal overhead (C tensor
pointer is set but not used for the actual computation when
global_scale is absent).

Also updates MXFP4_16 tile configs to use native 2SM tiles instead
of forcing 1SM fallback, enabling full 2SM performance.

Reviewed By: jwfromm

Differential Revision: D101508914


