### PR TITLE
Apply the last k scale block in `_kernel_matmul_fp8_block_fastacc` (#503)

### DIFF
--- a/mslk/gemm/triton/fp8_gemm.py
+++ b/mslk/gemm/triton/fp8_gemm.py
@@ -1689,7 +1689,7 @@ def _kernel_matmul_fp8_block_fastacc(
         # And have s_k+1 be 1.
         # Scale_i = pid_i * BLOCK_I / scale_block_i
         pid_k = k * SPLIT_K + pid_z
-        if ((pid_k + 1) % k_multiple == 0) or (k_remaining < BLOCK_K * SPLIT_K):
+        if ((pid_k + 1) % k_multiple == 0) or (k + 1 == tl.cdiv(K, BLOCK_K * SPLIT_K)):
             # Note: Due to split_k access "pid_k" = k * SPLIT_K + pid_z
             # Access a_scale[pid_m, k * SPLIT_K + pid_z]
             # and b_scale[k * SPLIT_K + pid_z, pid_n]

--- a/test/gemm/triton/fp8_gemm_test.py
+++ b/test/gemm/triton/fp8_gemm_test.py
@@ -286,3 +286,12 @@ class TestFp8Matmul(unittest.TestCase):
         _test_matmul_fp8_block((3, 4, 5), (256, 256, 256), False)
         _test_matmul_fp8_block((3, 4, 5), (256, 256, 256), True, device="cpu")
         _test_matmul_fp8_block((1024, 2048, 4096), (256, 512, 1024), True, device="cpu")
+        # K values that leave a partial trailing scale block while still making
+        # EVEN_K true, so the last iteration is reached with
+        # k_remaining == BLOCK_K * SPLIT_K. The K=5 shapes above make EVEN_K
+        # false, which is why they already took the tail branch and never
+        # covered this case. scale_block_m/n are kept at M/N so that no tile can
+        # span two M/N scale blocks whichever BLOCK_M/BLOCK_N autotuning picks.
+        _test_matmul_fp8_block((256, 256, 640), (256, 256, 256), True)
+        _test_matmul_fp8_block((256, 256, 64), (256, 256, 256), True)
+        _test_matmul_fp8_block((256, 256, 192), (256, 256, 128), True)


### PR DESCRIPTION
Summary:

NOTE: No linked task. Please associate a task with this diff.

Companion to D116065233, which fixed the same bug in the FBGEMM copy of this
kernel. `mslk/mslk/gemm/triton/fp8_gemm.py` is a line-for-line fork of
`_kernel_matmul_fp8_block_fastacc` and carried the identical defect.

- `mslk/gemm/triton/fp8_gemm.py`: replace the dead tail clause
  `k_remaining < BLOCK_K * SPLIT_K` with a direct last-iteration test,
  `k + 1 == tl.cdiv(K, BLOCK_K * SPLIT_K)`. `k_remaining` is computed at the top
  of the iteration, so on the last iteration it equals exactly
  `BLOCK_K * SPLIT_K` whenever `K` is tile aligned and the clause never fires.
  The trailing partial scale block then went unapplied, leaving the tail of the
  K reduction in raw quantized units — a silent ~10^4 relative error for any `K`
  that is a multiple of `BLOCK_K * SPLIT_K` but not of `scale_block_k`. Because
  `BLOCK_K` comes from autotuning, which shapes broke varied by machine. The new
  predicate fires on a strict superset of the old one, so previously correct
  shapes are bit identical.
- `test/gemm/triton/fp8_gemm_test.py`: add three regression shapes covering that
  case.

This copy is imported by `gen_ai/llm_inference/fb/llm/quantization/ops.py` for
the production LLM inference stack and benchmarked by tritonbench, so without
this diff FBGEMM and MSLK silently produce different results for equal inputs.

`_kernel_matmul_fp8_block_slowacc` re-applies the scale every tile and was never
affected. Two copies remain unpatched and out of scope: the vendored
`third-party/pypi/mslk-cuda/1.0.0/.../mslk/gemm/triton/fp8_gemm.py` wheel and
`fbcode/triton_mtia/python/test/triton_mslk/kernels/fp8_gemm.py`.

Differential Revision: D116406748


