### PR TITLE
Mask the column-scale load in _kernel_scale_fp8_row (#504)

### DIFF
--- a/mslk/quantize/triton/fp8_quantize.py
+++ b/mslk/quantize/triton/fp8_quantize.py
@@ -457,7 +457,7 @@ def _kernel_scale_fp8_row(
         a = tl.load(
             A + pid * stride_am + n_offset * stride_an, mask=n_offset < N, other=0.0
         )
-        col_scale = tl.load(w_scale + n_offset)
+        col_scale = tl.load(w_scale + n_offset, mask=n_offset < N, other=0.0)
         scaled_a = a * row_scale * col_scale
         tl.store(
             scaled_out + pid * stride_om + n_offset * stride_on,

--- a/test/quantize/triton/fp8_quantize_test.py
+++ b/test/quantize/triton/fp8_quantize_test.py
@@ -281,6 +281,10 @@ class TestFp8Quantize(unittest.TestCase):
 
         _test_scale_fp8_row((2, 3), torch.device("cuda"))
         _test_scale_fp8_row((2, 3), torch.device("cpu"))
+        # Shapes whose last block of columns is partial, including ones that
+        # take more than one iteration of the kernel's column loop.
+        for shape in [(4, 513), (3, 1000), (2, 1025)]:
+            _test_scale_fp8_row(shape, torch.device("cuda"))
 
     def test_quantize_fp8_group(self) -> None:
         def _test_quantize_fp8_group(


### PR DESCRIPTION
Summary:

NOTE: No linked task. Please associate a task with this diff.

Mirrors D116065381 (FBGEMM, upstream PR pytorch/FBGEMM#6158 / issue #6157) into MSLK, which carries a byte-identical copy of the same kernel with the same out-of-bounds read.

The column loop in `_kernel_scale_fp8_row` masks its activation load and its store with `n_offset < N`, but loads `w_scale` unmasked. `w_scale` holds exactly `N` elements, so the kernel reads past its end on the final iteration whenever `N` is not a multiple of `BLOCK_SIZE` — and since the smallest autotune block is 512, on every call with `N < 512`. The garbage lanes are discarded by the already-masked store, so this is a pure memory-safety defect: output is bit-identical before and after.

MSLK's copy is a hard fork of the FBGEMM GenAI kernel (ported in `cbec63fa5ddc` "[MSLK] Port and Refactor Quantize Ops", then independently maintained), so the FBGEMM fix does not propagate here on its own.

## Changes

- `mslk/quantize/triton/fp8_quantize.py` — mask the `w_scale` load with `mask=n_offset < N, other=0.0`, matching the predicate already used by the activation load and the store in the same loop body.
- `test/quantize/triton/fp8_quantize_test.py` — add CUDA shapes `(4, 513)`, `(3, 1000)`, `(2, 1025)` to `test_scale_fp8_row`, covering partial trailing column blocks and multi-iteration column loops. The existing coverage was `(2, 3)` only.

## Not in scope

- `third-party/pypi/mslk-cuda/1.0.0/wheels/_whl_common_files/mslk/quantize/triton/fp8_quantize.py:790` — vendored published wheel artifact; resolves when the pinned release is bumped, should not be hand-patched.
- `fbcode/triton_mtia/python/test/triton_mslk/kernels/fp8_quantize.py:151` — MTIA compile-test fixture snapshot; its test uses `N=64, BLOCK_SIZE=64` (exact multiple) and never reaches the tail.

Differential Revision: D116415826


