### PR TITLE
Bind Conda CUDA compiler during wheel builds (#505)

### DIFF
--- a/ci/scripts/mslk_build.bash
+++ b/ci/scripts/mslk_build.bash
@@ -93,12 +93,10 @@ __configure_mslk_build_nvcc () {
   echo "[BUILD] Looking up CUDA version ..."
   # shellcheck disable=SC2155,SC2086
   local cxx_path=$(conda run ${env_prefix} which c++)
-  # shellcheck disable=SC2155,SC2086
-  local cuda_version=$(conda run ${env_prefix} nvcc --version | sed -n 's/^.*release \([0-9]\+\.[0-9]\+\).*$/\1/p')
-  # shellcheck disable=SC2206
-  local cuda_version_arr=(${cuda_version//./ })
+  __fetch_cuda_version_array "${env_name}" || return 1
 
   # Only NVCC 12+ supports C++20
+  # shellcheck disable=SC2154
   if [[ ${cuda_version_arr[0]} -lt 12 ]]; then
     local cppstd_ver=17
   else
@@ -165,10 +163,14 @@ __configure_mslk_cuda_home () {
     echo "[BUILD] No need to set CUDA_TOOLKIT_ROOT_DIR and CUDAToolkit_ROOT on older CUDA installations ..."
 
   else
-    echo "[BUILD] Setting CUDA_TOOLKIT_ROOT_DIR and CUDAToolkit_ROOT ..."
+    echo "[BUILD] Setting CUDA compiler and toolkit paths ..."
     # shellcheck disable=SC2155,SC2086
     local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
-    local new_cuda_home="${conda_prefix}/targets/${MACHINE_NAME_LC}-linux"
+    local conda_cuda_target="${MACHINE_NAME_LC}"
+    if [[ "${conda_cuda_target}" == "aarch64" || "${conda_cuda_target}" == "arm64" ]]; then
+      conda_cuda_target="sbsa"
+    fi
+    local new_cuda_home="${conda_prefix}/targets/${conda_cuda_target}-linux"
 
     # shellcheck disable=SC2206
     build_args+=(
@@ -180,6 +182,52 @@ __configure_mslk_cuda_home () {
       # https://github.com/Kitware/CMake/blob/master/Modules/FindCUDA.cmake#L40
       -DCUDA_TOOLKIT_ROOT_DIR="${new_cuda_home}"
       -DCUDAToolkit_ROOT="${new_cuda_home}"
+    )
+
+    if [[ "${BUILD_CUDA_VERSION}" =~ ^cu[0-9]+$ ]]; then
+      echo "[BUILD] Using Nova-provided CUDA compiler for ${BUILD_CUDA_VERSION} ..."
+      return 0
+    fi
+
+    if [[ "${BUILD_CUDA_VERSION}" =~ ^([0-9]+)(\.([0-9]+))?(\.[0-9]+)?$ ]]; then
+      local requested_cuda_major="${BASH_REMATCH[1]}"
+      local requested_cuda_minor="${BASH_REMATCH[3]:-0}"
+    else
+      echo "[BUILD] Invalid BUILD_CUDA_VERSION '${BUILD_CUDA_VERSION:-<unset>}'; expected X, X.Y, X.Y.Z, or cuNNN for Nova builds"
+      return 1
+    fi
+
+    local conda_nvcc="${conda_prefix}/bin/nvcc"
+    if [ ! -x "${conda_nvcc}" ]; then
+      echo "[BUILD] Conda NVCC is missing or not executable: ${conda_nvcc}"
+      return 1
+    fi
+    if [ ! -f "${new_cuda_home}/include/cuda_runtime.h" ]; then
+      echo "[BUILD] Conda CUDA runtime header is missing: ${new_cuda_home}/include/cuda_runtime.h"
+      return 1
+    fi
+
+    local requested_cuda_version="${requested_cuda_major}.${requested_cuda_minor}"
+    __fetch_cuda_version_array "${env_name}" || return 1
+    # shellcheck disable=SC2154
+    local installed_cuda_version="${cuda_version_arr[0]}.${cuda_version_arr[1]}"
+    if [ "${installed_cuda_version}" != "${requested_cuda_version}" ]; then
+      echo "[BUILD] Conda NVCC version ${installed_cuda_version} does not match requested CUDA ${requested_cuda_version}"
+      return 1
+    fi
+
+    # MSLK's setup.py checks CUDA_BIN_PATH before system CUDA installations.
+    # Bind the compiler explicitly while retaining the conda target directory
+    # as the toolkit root for headers and libraries.
+    # shellcheck disable=SC2086
+    print_exec conda env config vars set ${env_prefix} \
+      CUDA_BIN_PATH="${conda_prefix}" \
+      CUDACXX="${conda_nvcc}" || return 1
+    # shellcheck disable=SC2086
+    print_exec conda run ${env_prefix} printenv CUDA_BIN_PATH CUDACXX || return 1
+
+    build_args+=(
+      -DCMAKE_CUDA_COMPILER="${conda_nvcc}"
     )
   fi
 }
@@ -320,10 +368,10 @@ __configure_mslk_build_cuda () {
   )
 
   # Explicitly set CUDA_HOME
-  __configure_mslk_cuda_home
+  __configure_mslk_cuda_home || return 1
 
   # Set NVCC flags
-  __configure_mslk_build_nvcc
+  __configure_mslk_build_nvcc || return 1
 }
 
 # shellcheck disable=SC2120

--- a/ci/scripts/utils_base.bash
+++ b/ci/scripts/utils_base.bash
@@ -310,15 +310,26 @@ set_clang_symlinks () {
 
 __fetch_cuda_version_array () {
   local env_name="$1"
-  # shellcheck disable=SC2155
-  local env_prefix=$(env_name_or_prefix "${env_name}")
+  local env_prefix
+  env_prefix=$(env_name_or_prefix "${env_name}") || return 1
 
-  # shellcheck disable=SC2155,SC2086
-  local cuda_version=$(conda run ${env_prefix} nvcc --version | sed -n 's/^.*release \([0-9]\+\.[0-9]\+\).*$/\1/p')
+  local nvcc_version_output
+  # shellcheck disable=SC2086
+  if ! nvcc_version_output=$(conda run ${env_prefix} nvcc --version); then
+    echo "[INFO] Could not query NVCC in Conda environment ${env_name}!" >&2
+    return 1
+  fi
+
+  local cuda_version
+  cuda_version=$(sed -n 's/^.*release \([0-9]\+\.[0-9]\+\).*$/\1/p' <<< "${nvcc_version_output}")
+  if [[ ! "${cuda_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    echo "[INFO] Could not extract CUDA version from Conda NVCC output!" >&2
+    return 1
+  fi
   echo "[INFO] Extracted CUDA version: ${cuda_version}"
 
-  # shellcheck disable=SC2206
-  export cuda_version_arr=(${cuda_version//./ })
+  # shellcheck disable=SC2034
+  IFS=. read -r -a cuda_version_arr <<< "${cuda_version}"
 }
 
 __fetch_rocm_version_array () {


### PR DESCRIPTION
Summary:

Prevent MSLK Python 3.14/CUDA 13 builds from mixing the system `nvcc` with Conda toolkit headers. Bind `CUDA_BIN_PATH`, `CUDACXX`, and `CMAKE_CUDA_COMPILER` to the Conda environment, validate the compiler/header layout, and propagate configuration failures.

Reviewed By: cthi

Differential Revision: D117320125


