### PR TITLE
Upgrade Composable Kernel integration to 1.2 (#506)

### DIFF
--- a/.github/workflows/mslk_ci_rocm.yml
+++ b/.github/workflows/mslk_ci_rocm.yml
@@ -19,6 +19,7 @@ on:
       - '.github/scripts/generate_ci_matrix.py'
       - '.github/workflows/mslk_ci_rocm.yml'
       - '.github/workflows/_mslk_rocm_test.yml'
+      - 'ci/scripts/mslk_external_repos.bash'
       - 'ci/scripts/utils_rocm.bash'
       - 'ci/scripts/utils_flydsl.bash'
       - 'setup.py'

--- a/ci/scripts/mslk_external_repos.bash
+++ b/ci/scripts/mslk_external_repos.bash
@@ -28,7 +28,7 @@ fetch_external_repos () {
   print_exec pushd "${mslk_root}/external"  || return 1
 
   declare -A repos=(
-    ["composable_kernel"]="https://github.com/ROCm/composable_kernel.git@7fe50dc3da2069d6645d9deb8c017a876472a977"
+    ["composable_kernel"]="https://github.com/ROCm/composable_kernel.git@fcc9372c009c8e0a23fece77b582da83b04a654f"
     ["cutlass"]="https://github.com/jwfromm/cutlass.git@571edeb2d0ac872a8392fc49285b156b07884b4e"
     ["hipify_torch"]="https://github.com/ROCmSoftwarePlatform/hipify_torch.git@63b6a7b541fa7f08f8475ca7d74054db36ff2691"
   )

--- a/cmake/Hip.cmake
+++ b/cmake/Hip.cmake
@@ -78,6 +78,7 @@ if(HIP_FOUND)
   list(APPEND HIP_CXX_FLAGS -mf16c)
   list(APPEND HIP_CXX_FLAGS -mfma)
   list(APPEND HIP_CXX_FLAGS -std=c++20)
+  list(APPEND HIP_CXX_FLAGS -Wno-c++11-narrowing)
 
   set(HIP_HCC_FLAGS ${HIP_CXX_FLAGS})
   # Ask hcc to generate device code during compilation so we can use

--- a/csrc/attention/ck/fmha/hip_decoder/attention_forward_splitk.hip
+++ b/csrc/attention/ck/fmha/hip_decoder/attention_forward_splitk.hip
@@ -73,9 +73,14 @@ void instantiate_and_launch_kernels(
       kLoopUnroll,
       kLoopUnrollTail,
       kMaxKVSequenceLength,
-      compute_t>{};
-  auto reduce_kernel_impl = ck_tile::
-      ForwardDecoderSplitKReduceKernelImpl<ck_data_t, vec_size, compute_t>{};
+      compute_t,
+      kThreadsPerWavefront * kWavefrontsPerBlock>{};
+  auto reduce_kernel_impl =
+      ck_tile::ForwardDecoderSplitKReduceKernelImpl<
+          ck_data_t,
+          vec_size,
+          compute_t,
+          kThreadsPerWavefront>{};
 
   (void)ck_tile::launch_kernel(
       ck_tile::stream_config{stream, /* benchmark */ false},

--- a/csrc/attention/ck/fmha/hip_decoder/ck_tile_attention_forward_decoder_splitk.h
+++ b/csrc/attention/ck/fmha/hip_decoder/ck_tile_attention_forward_decoder_splitk.h
@@ -83,8 +83,14 @@ struct ForwardDecoderSplitKArgument {
   const int32_t split_k;
 };
 
-template <typename scalar_t, int32_t vec_size = 4, typename compute_t = float>
+template <
+    typename scalar_t,
+    int32_t vec_size = 4,
+    typename compute_t = float,
+    int32_t BlockSize = 64>
 struct ForwardDecoderSplitKReduceKernelImpl {
+  static constexpr int32_t kBlockSize = BlockSize;
+
   CK_TILE_DEVICE void operator()(
       ForwardDecoderSplitKArgument<scalar_t, compute_t> arg) {
     // Each block handles a single batch and head and query and group
@@ -178,8 +184,11 @@ template <
     int32_t n_loop_unroll,
     int32_t n_loop_unroll_tail,
     int32_t KV_M_MAX,
-    typename compute_t>
+    typename compute_t,
+    int32_t BlockSize>
 struct ForwardDecoderSplitKAttnKernelImpl {
+  static constexpr int32_t kBlockSize = BlockSize;
+
   CK_TILE_DEVICE void operator()(
       ForwardDecoderSplitKArgument<scalar_t, compute_t> arg) {
     static_assert(

--- a/csrc/attention/ck/fmha/hip_fmha/attention_ck_rand_uniform.cpp
+++ b/csrc/attention/ck/fmha/hip_fmha/attention_ck_rand_uniform.cpp
@@ -82,12 +82,12 @@ at::Tensor rand_uniform_int(
         static_cast<int>(num_heads),
         static_cast<int>(M),
         static_cast<int>(N));
-    constexpr dim3 kBlockSize = FmhaRandUniformKernel_::BlockSize();
+    const dim3 kBlockSize = FmhaRandUniformKernel_::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaRandUniformKernel_::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaRandUniformKernel_{}, kGridSize, kBlockSize, 0, kargs));
   }
 

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_backward.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_backward.h
@@ -49,6 +49,7 @@ struct batched_backward_mask_bias_dropout_dispatch {
       false, // kIsDeterministic
       FmhaMask,
       FmhaBlockDropout,
+      false, // kUseTrLoad
       FmhaTraits>;
 
   static constexpr bool NeedConvertGradQ = !std::is_same<
@@ -111,28 +112,18 @@ struct batched_backward_mask_bias_dropout_dispatch {
 
       BOOL_SWITCH_2(
           pad_headdim_q, kPadHeadDimQ, pad_headdim_v, kPadHeadDimV, [&] {
-            using FmhaBwdTraits_ = ck_tile::TileFmhaTraits<
-                kPadSeqLenQ,
-                kPadSeqLenK,
+            using FmhaBwdTraits_ = ck_tile::TileFmhaBwdTraits<
                 kPadHeadDimQ,
                 kPadHeadDimV,
-                false, // kHasLogitsSoftCap
                 kBiasEnum,
                 kHasBiasGrad,
-                false, // kStoreLSE
-                false, // place-holder for kHasDropout, not used actually
-                false, // kDoFp8StaticQuant place-holder
                 occupancy>;
 
             using FmhaBwdPipelineProblem =
                 FmhaBwdPipelineProblemTemp<FmhaBwdTraits_, FmhaMask>;
 
-            constexpr auto FmhaBwdPipelineEnum_ =
-                FmhaBwdPipelineEnumSelector<MaxK>::value;
-
-            using FmhaBwdPipeline_ = typename FmhaBwdPipelineMaker<
-                FmhaBwdPipelineEnum_,
-                FmhaBwdPipelineProblem>::pipeline;
+            using FmhaBwdPipeline_ =
+                ck_tile::BlockFmhaBwdDQDKDVPipeline<FmhaBwdPipelineProblem>;
 
             using FmhaBwdKGradEpilogue_ =
                 ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -221,13 +212,13 @@ struct batched_backward_mask_bias_dropout_dispatch {
 
     dim3 kGridSize =
         FmhaBwdOGradDotOKernel::GridSize(param.B, param.Hq, param.M);
-    constexpr dim3 kBlockSize = FmhaBwdOGradDotOKernel::BlockSize();
+    const dim3 kBlockSize = FmhaBwdOGradDotOKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaBwdOGradDotOKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaBwdOGradDotOKernel{}, kGridSize, kBlockSize, 0, kargs));
   }
 
@@ -236,7 +227,7 @@ struct batched_backward_mask_bias_dropout_dispatch {
       BatchedBackwardParams& param,
       hipStream_t stream) {
     const auto kargs = [&] {
-      return FmhaBwdDQDKDVKernel::MakeKargs(
+      return FmhaBwdDQDKDVKernel::MakeKargsImpl(
           param.q_ptr,
           param.k_ptr,
           param.v_ptr,
@@ -304,12 +295,12 @@ struct batched_backward_mask_bias_dropout_dispatch {
     }();
 
     dim3 kGridSize = FmhaBwdDQDKDVKernel::GridSize(param.B, param.Hq, param.N);
-    constexpr dim3 kBlockSize = FmhaBwdDQDKDVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaBwdDQDKDVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaBwdDQDKDVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaBwdDQDKDVKernel{}, kGridSize, kBlockSize, 0, kargs));
   }
 
@@ -335,13 +326,13 @@ struct batched_backward_mask_bias_dropout_dispatch {
 
     dim3 kGridSize =
         FmhaBwdConvertQGradKernel::GridSize(param.B, param.Hq, param.M);
-    constexpr dim3 kBlockSize = FmhaBwdConvertQGradKernel::BlockSize();
+    const dim3 kBlockSize = FmhaBwdConvertQGradKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaBwdConvertQGradKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaBwdConvertQGradKernel{}, kGridSize, kBlockSize, 0, kargs));
   }
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_forward_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_forward_dispatch.h
@@ -46,6 +46,7 @@ struct batched_forward_mask_bias_dropout_dispatch {
       false, // kIsGroupMode
       AttentionVariant<FmhaTraits>,
       FmhaMask,
+      false, // kUseTrLoad
       FmhaTraits>;
 
   static void Run(BatchedForwardParams& param, hipStream_t stream) {
@@ -90,7 +91,7 @@ struct batched_forward_mask_bias_dropout_dispatch {
               false, // kHasBiasGrad place-holder
               true, // kStoreLSE
               kHasDropout,
-              false, // kDoFp8StaticQuant place-holder
+              ck_tile::BlockAttentionQuantScaleEnum::NO_SCALE,
               occupancy>;
 
           using FmhaPipelineProblem =
@@ -99,7 +100,7 @@ struct batched_forward_mask_bias_dropout_dispatch {
           using FmhaFwdPipeline_ = std::conditional_t<
               MaxK <= 256,
               ck_tile::BlockFmhaPipelineQRKSVS<FmhaPipelineProblem>,
-              ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
+              MslkBlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
 
           using FmhaFwdEpilogue_ =
               ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -123,6 +124,9 @@ struct batched_forward_mask_bias_dropout_dispatch {
           param.k_ptr,
           param.v_ptr,
           param.attn_bias_ptr,
+          nullptr, // q_descale_ptr
+          nullptr, // k_descale_ptr
+          nullptr, // v_descale_ptr
           nullptr, // rand_val_ptr
           param.logsumexp_ptr,
           param.out_ptr,
@@ -133,8 +137,6 @@ struct batched_forward_mask_bias_dropout_dispatch {
           param.Hq, // nhead_q
           param.Hq / param.Hkv, // nhead_ratio_qk
           param.scale,
-          1.0f, // scale_p
-          1.0f, // scale_o
           0.0f, // logits_soft_cap
           param.q_strides[1], // q, k, v, bias, randval, out tensor seq-dim
                               // stride
@@ -162,6 +164,7 @@ struct batched_forward_mask_bias_dropout_dispatch {
           (param.window_size > 0) ? param.window_size - 1
                                   : -1, // window_left_size
           (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+          0, // sink_size
           param.custom_mask_type,
           param.dropout_prob, // dropout ratio
           false, // is_store_randval
@@ -170,12 +173,12 @@ struct batched_forward_mask_bias_dropout_dispatch {
 
     dim3 kGridSize =
         FmhaFwdKernel::GridSize(param.B, param.Hq, param.M, param.Kv, false);
-    constexpr dim3 kBlockSize = FmhaFwdKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
@@ -262,6 +262,7 @@ struct batched_forward_splitkv_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
       else
         return FmhaFwdSplitKVKernel::MakeKargs(
@@ -311,17 +312,18 @@ struct batched_forward_splitkv_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
     }();
 
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
         param.B, param.Hq, param.Hkv, param.M, param.Kv, param.num_kv_splits);
-    constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdSplitKVKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 
@@ -356,13 +358,13 @@ struct batched_forward_splitkv_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaSplitKVCombineKernel::GridSize(
         param.B, param.Hq, param.M, param.Kv);
-    constexpr dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
+    const dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaSplitKVCombineKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaSplitKVCombineKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
@@ -261,6 +261,7 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
       else
         return FmhaFwdSplitKVKernel::MakeKargs(
@@ -310,17 +311,18 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
     }();
 
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
         param.B, param.Hq, param.Hkv, param.M, param.Kv, param.num_kv_splits);
-    constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdSplitKVKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 
@@ -355,13 +357,13 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaSplitKVCombineKernel::GridSize(
         param.B, param.Hq, param.M, param.Kv);
-    constexpr dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
+    const dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaSplitKVCombineKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaSplitKVCombineKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_infer_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_infer_dispatch.h
@@ -56,6 +56,7 @@ struct batched_infer_mask_bias_dropout_dispatch {
       false, // kIsGroupMode
       AttentionVariant<FmhaTraits>,
       FmhaMask,
+      false, // kUseTrLoad
       FmhaTraits>;
 
   static void Run(BatchedForwardParams& param, hipStream_t stream) {
@@ -99,7 +100,7 @@ struct batched_infer_mask_bias_dropout_dispatch {
                 false, // kHasBiasGrad place-holder
                 false, // kStoreLSE
                 kHasDropout,
-                false, // kDoFp8StaticQuant place-holder
+                ck_tile::BlockAttentionQuantScaleEnum::NO_SCALE,
                 occupancy>;
 
             using FmhaPipelineProblem =
@@ -114,7 +115,7 @@ struct batched_infer_mask_bias_dropout_dispatch {
 
             if constexpr (kUseWholeKPrefetchPipeline) {
               using FmhaPipeline =
-                  ck_tile::BlockFmhaPipelineQRKSVSWholeKPrefetch<
+                  MslkBlockFmhaPipelineQRKSVSWholeKPrefetch<
                       FmhaPipelineProblem>;
               using FmhaKernel =
                   ck_tile::FmhaFwdKernel<FmhaPipeline, FmhaEpilogue>;
@@ -129,7 +130,7 @@ struct batched_infer_mask_bias_dropout_dispatch {
               RunWithKernel<FmhaKernel>(param, stream);
             } else {
               using FmhaPipeline =
-                  ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>;
+                  MslkBlockFmhaPipelineQSKSVS<FmhaPipelineProblem>;
               using FmhaKernel =
                   ck_tile::FmhaFwdKernel<FmhaPipeline, FmhaEpilogue>;
 
@@ -149,7 +150,7 @@ struct batched_infer_mask_bias_dropout_dispatch {
               false, // kHasBiasGrad place-holder
               false, // kStoreLSE
               kHasDropout,
-              false, // kDoFp8StaticQuant place-holder
+              ck_tile::BlockAttentionQuantScaleEnum::NO_SCALE,
               occupancy>;
 
           using FmhaPipelineProblem =
@@ -183,6 +184,9 @@ struct batched_infer_mask_bias_dropout_dispatch {
           param.k_ptr,
           param.v_ptr,
           param.attn_bias_ptr,
+          nullptr, // q_descale_ptr
+          nullptr, // k_descale_ptr
+          nullptr, // v_descale_ptr
           nullptr, // rand_val_ptr
           nullptr, // lse_ptr
           param.out_ptr,
@@ -193,8 +197,6 @@ struct batched_infer_mask_bias_dropout_dispatch {
           param.Hq, // nhead_q
           param.Hq / param.Hkv, // nhead_ratio_qk
           param.scale,
-          1.0f, // scale_p
-          1.0f, // scale_o
           0.0f, // logits_soft_cap
           param.q_strides[1], // q, k, v, bias, randval, out tensor seq-dim
                               // stride
@@ -222,6 +224,7 @@ struct batched_infer_mask_bias_dropout_dispatch {
           (param.window_size > 0) ? param.window_size - 1
                                   : -1, // window_left_size
           (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+          0, // sink_size
           param.custom_mask_type,
           param.dropout_prob, // dropout ratio
           false, // is_store_randval
@@ -230,12 +233,12 @@ struct batched_infer_mask_bias_dropout_dispatch {
 
     dim3 kGridSize =
         FmhaKernel::GridSize(param.B, param.Hq, param.M, param.Kv, false);
-    constexpr dim3 kBlockSize = FmhaKernel::BlockSize();
+    const dim3 kBlockSize = FmhaKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_dispatch.h
@@ -277,6 +277,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
       else
         return FmhaFwdSplitKVKernel::MakeKargs(
@@ -326,17 +327,18 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
     }();
 
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
         param.B, param.Hq, param.Hkv, param.M, param.Kv, param.num_kv_splits);
-    constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdSplitKVKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 
@@ -371,13 +373,13 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaSplitKVCombineKernel::GridSize(
         param.B, param.Hq, param.M, param.Kv);
-    constexpr dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
+    const dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaSplitKVCombineKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaSplitKVCombineKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
@@ -367,6 +367,7 @@ struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
       else
         return FmhaFwdSplitKVKernel::MakeKargs(
@@ -416,17 +417,18 @@ struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
     }();
 
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
         param.B, param.Hq, param.Hkv, param.M, param.Kv, param.num_kv_splits);
-    constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdSplitKVKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 
@@ -461,13 +463,13 @@ struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaSplitKVCombineKernel::GridSize(
         param.B, param.Hq, param.M, param.Kv);
-    constexpr dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
+    const dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaSplitKVCombineKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaSplitKVCombineKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_bwd_setting.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_bwd_setting.h
@@ -173,29 +173,6 @@ struct FmhaBwdShape<256> : ck_tile::TileFmhaBwdShape<
                                typename FmhaBwdBlockTile<256>::gemm4_warps,
                                FmhaBwdWarpTile2> {};
 
-template <ck_tile::index_t MaxK>
-struct FmhaBwdPipelineEnumSelector {
-  static constexpr ck_tile::BlockFmhaBwdPipelineEnum value =
-      ck_tile::BlockFmhaBwdPipelineEnum::KRKTRVR_IGLP;
-};
-
-template <ck_tile::BlockFmhaBwdPipelineEnum value, typename problem>
-struct FmhaBwdPipelineMaker;
-
-template <typename problem>
-struct FmhaBwdPipelineMaker<
-    ck_tile::BlockFmhaBwdPipelineEnum::KRKTRVR,
-    problem> {
-  using pipeline = ck_tile::BlockFmhaBwdDQDKDVPipelineKRKTRVR<problem>;
-};
-
-template <typename problem>
-struct FmhaBwdPipelineMaker<
-    ck_tile::BlockFmhaBwdPipelineEnum::KRKTRVR_IGLP,
-    problem> {
-  using pipeline = ck_tile::BlockFmhaBwdDQDKDVPipelineKRKTRVRIGLP<problem>;
-};
-
 template <bool kHasDropout, ck_tile::index_t MaxK>
 struct FmhaBwdBlockDropoutMaker;
 

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_fwd_setting.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_fwd_setting.h
@@ -79,6 +79,117 @@ using FmhaFwdWarpTile1 = ck_tile::sequence<32, 32, 16>;
 using FmhaFwdWarpTile2 = ck_tile::sequence<16, 16, 16>;
 using FmhaFwdWarpTile3 = ck_tile::sequence<16, 16, 32>;
 
+template <typename Base>
+struct MslkBlockFmhaPipelineAdapter : Base {
+  using Base::operator();
+
+  template <
+      typename QDramBlockWindow,
+      typename KDramBlockWindow,
+      typename VDramBlockWindow,
+      typename BiasDramBlockWindow,
+      typename RandValDramBlockWindow,
+      typename LSEDramBlockWindow,
+      typename Mask,
+      typename PositionEncoding,
+      typename AttentionVariant,
+      typename AttentionVariantParams,
+      typename BlockIndices,
+      typename Dropout,
+      typename SinkValue>
+  CK_TILE_HOST_DEVICE auto operator()(
+      const QDramBlockWindow& q_dram_block_window,
+      const KDramBlockWindow& k_dram_block_window,
+      const VDramBlockWindow& v_dram_block_window,
+      const BiasDramBlockWindow& bias_dram_block_window,
+      RandValDramBlockWindow& randval_dram_block_window,
+      LSEDramBlockWindow& lse_dram_block_window,
+      Mask mask,
+      PositionEncoding position_encoding,
+      float scale_s,
+      const AttentionVariant& variant,
+      const AttentionVariantParams& variant_params,
+      const BlockIndices& block_indices,
+      void* smem_ptr,
+      Dropout& dropout,
+      const SinkValue&) const {
+    return Base::operator()(
+        q_dram_block_window,
+        k_dram_block_window,
+        v_dram_block_window,
+        bias_dram_block_window,
+        randval_dram_block_window,
+        lse_dram_block_window,
+        mask,
+        position_encoding,
+        scale_s,
+        variant,
+        variant_params,
+        block_indices,
+        smem_ptr,
+        dropout);
+  }
+
+  template <
+      typename QDramBlockWindow,
+      typename KDramBlockWindow,
+      typename VDramBlockWindow,
+      typename BiasDramBlockWindow,
+      typename RandValDramBlockWindow,
+      typename LSEDramBlockWindow,
+      typename Mask,
+      typename PositionEncoding,
+      typename AttentionVariant,
+      typename AttentionVariantParams,
+      typename BlockIndices,
+      typename Dropout,
+      typename SinkValue,
+      typename BlockMaskRowPtr>
+  CK_TILE_HOST_DEVICE auto operator()(
+      const QDramBlockWindow& q_dram_block_window,
+      const KDramBlockWindow& k_dram_block_window,
+      const VDramBlockWindow& v_dram_block_window,
+      const BiasDramBlockWindow& bias_dram_block_window,
+      RandValDramBlockWindow& randval_dram_block_window,
+      LSEDramBlockWindow& lse_dram_block_window,
+      Mask mask,
+      PositionEncoding position_encoding,
+      float scale_s,
+      const AttentionVariant& variant,
+      const AttentionVariantParams& variant_params,
+      const BlockIndices& block_indices,
+      void* smem_ptr,
+      Dropout& dropout,
+      const SinkValue& sink_value,
+      const BlockMaskRowPtr&) const {
+    return (*this)(
+        q_dram_block_window,
+        k_dram_block_window,
+        v_dram_block_window,
+        bias_dram_block_window,
+        randval_dram_block_window,
+        lse_dram_block_window,
+        mask,
+        position_encoding,
+        scale_s,
+        variant,
+        variant_params,
+        block_indices,
+        smem_ptr,
+        dropout,
+        sink_value);
+  }
+};
+
+template <typename Problem>
+using MslkBlockFmhaPipelineQSKSVS = MslkBlockFmhaPipelineAdapter<
+    ck_tile::BlockFmhaPipelineQSKSVS<Problem>>;
+
+template <typename Problem>
+using MslkBlockFmhaPipelineQRKSVSWholeKPrefetch =
+    MslkBlockFmhaPipelineAdapter<
+        ck_tile::BlockFmhaPipelineQRKSVSWholeKPrefetch<Problem>>;
+
 template <ck_tile::index_t MaxK, ck_tile::index_t MTile>
 struct FmhaFwdShape;
 

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_backward.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_backward.h
@@ -49,6 +49,7 @@ struct grouped_backward_mask_bias_dropout_dispatch {
       false, // non-deterministic
       FmhaMask,
       FmhaBlockDropout,
+      false, // kUseTrLoad
       FmhaTraits>;
 
   static constexpr bool NeedConvertGradQ = !std::is_same<
@@ -109,28 +110,18 @@ struct grouped_backward_mask_bias_dropout_dispatch {
 
       BOOL_SWITCH_2(
           pad_headdim_q, kPadHeadDimQ, pad_headdim_v, kPadHeadDimV, [&] {
-            using FmhaBwdTraits_ = ck_tile::TileFmhaTraits<
-                kPadSeqLenQ,
-                kPadSeqLenK,
+            using FmhaBwdTraits_ = ck_tile::TileFmhaBwdTraits<
                 kPadHeadDimQ,
                 kPadHeadDimV,
-                false, // kHasLogitsSoftCap
                 kBiasEnum,
                 kHasBiasGrad,
-                false, // kStoreLSE
-                false, // place-holder for kHasDropout, not used actually
-                false, // kDoFp8StaticQuant place-holder
                 occupancy>;
 
             using FmhaBwdPipelineProblem =
                 FmhaBwdPipelineProblemTemp<FmhaBwdTraits_, FmhaMask>;
 
-            constexpr auto FmhaBwdPipelineEnum_ =
-                FmhaBwdPipelineEnumSelector<MaxK>::value;
-
-            using FmhaBwdPipeline_ = typename FmhaBwdPipelineMaker<
-                FmhaBwdPipelineEnum_,
-                FmhaBwdPipelineProblem>::pipeline;
+            using FmhaBwdPipeline_ =
+                ck_tile::BlockFmhaBwdDQDKDVPipeline<FmhaBwdPipelineProblem>;
 
             using FmhaBwdKGradEpilogue_ =
                 ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -207,6 +198,8 @@ struct grouped_backward_mask_bias_dropout_dispatch {
           param.dot_out_ptr,
           1.0f - param.dropout_prob,
           param.seqstart_q_dev_ptr,
+          nullptr, // seqlen_q_ptr
+          nullptr, // cu_seqlen_q_ptr
           param.Kv,
           param.grad_out_strides[0], // stride_do
           param.out_strides[0], // stride_o
@@ -217,13 +210,13 @@ struct grouped_backward_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaBwdOGradDotOKernel::GridSize(
         param.num_batches, param.Hq, param.max_seqlen_q);
-    constexpr dim3 kBlockSize = FmhaBwdOGradDotOKernel::BlockSize();
+    const dim3 kBlockSize = FmhaBwdOGradDotOKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaBwdOGradDotOKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaBwdOGradDotOKernel{}, kGridSize, kBlockSize, 0, kargs));
   }
 
@@ -232,7 +225,7 @@ struct grouped_backward_mask_bias_dropout_dispatch {
       GroupedBackwardParams& param,
       hipStream_t stream) {
     const auto kargs = [&] {
-      return FmhaBwdDQDKDVKernel::MakeKargs(
+      return FmhaBwdDQDKDVKernel::MakeKargsImpl(
           param.q_ptr,
           param.k_ptr,
           param.v_ptr,
@@ -247,7 +240,10 @@ struct grouped_backward_mask_bias_dropout_dispatch {
           NeedConvertGradQ ? param.grad_q_f32_ptr : param.grad_q_ptr,
           param.seqstart_q_dev_ptr,
           param.seqstart_k_dev_ptr,
+          nullptr, // seqlen_q_ptr
           param.seqlen_k_dev_ptr,
+          nullptr, // cu_seqlen_q_ptr
+          nullptr, // cu_seqlen_k_ptr
           param.K,
           param.Kv,
           param.Hq,
@@ -289,12 +285,12 @@ struct grouped_backward_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaBwdDQDKDVKernel::GridSize(
         param.num_batches, param.Hq, param.max_seqlen_k);
-    constexpr dim3 kBlockSize = FmhaBwdDQDKDVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaBwdDQDKDVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaBwdDQDKDVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaBwdDQDKDVKernel{}, kGridSize, kBlockSize, 0, kargs));
   }
 
@@ -308,6 +304,10 @@ struct grouped_backward_mask_bias_dropout_dispatch {
           param.grad_q_ptr,
           param.seqstart_q_dev_ptr,
           param.seqstart_k_dev_ptr,
+          nullptr, // seqlen_q_ptr
+          param.seqlen_k_dev_ptr,
+          nullptr, // cu_seqlen_q_ptr
+          nullptr, // cu_seqlen_k_ptr
           param.K, // headdim of q/k
           param.q_strides[0],
           param.grad_q_f32_strides[0],
@@ -318,13 +318,13 @@ struct grouped_backward_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaBwdConvertQGradKernel::GridSize(
         param.num_batches, param.Hq, param.max_seqlen_q);
-    constexpr dim3 kBlockSize = FmhaBwdConvertQGradKernel::BlockSize();
+    const dim3 kBlockSize = FmhaBwdConvertQGradKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaBwdConvertQGradKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaBwdConvertQGradKernel{}, kGridSize, kBlockSize, 0, kargs));
   }
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_forward_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_forward_dispatch.h
@@ -46,6 +46,7 @@ struct grouped_forward_mask_bias_dropout_dispatch {
       true, // kIsGroupMode
       AttentionVariant<FmhaTraits>,
       FmhaMask,
+      false, // kUseTrLoad
       FmhaTraits>;
 
   static void Run(GroupedForwardParams& param, hipStream_t stream) {
@@ -79,7 +80,7 @@ struct grouped_forward_mask_bias_dropout_dispatch {
               false, // kHasBiasGrad place-holder
               true, // kStoreLSE
               kHasDropout,
-              false, // kDoFp8StaticQuant place-holder
+              ck_tile::BlockAttentionQuantScaleEnum::NO_SCALE,
               occupancy>;
 
           using FmhaPipelineProblem =
@@ -88,7 +89,7 @@ struct grouped_forward_mask_bias_dropout_dispatch {
           using FmhaFwdPipeline_ = std::conditional_t<
               MaxK <= 256,
               ck_tile::BlockFmhaPipelineQRKSVS<FmhaPipelineProblem>,
-              ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
+              MslkBlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
 
           using FmhaFwdEpilogue_ =
               ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -112,19 +113,21 @@ struct grouped_forward_mask_bias_dropout_dispatch {
           param.k_ptr,
           param.v_ptr,
           param.attn_bias_ptr,
+          nullptr, // q_descale_ptr
+          nullptr, // k_descale_ptr
+          nullptr, // v_descale_ptr
           nullptr, // rand_val_ptr
           param.logsumexp_ptr,
           param.out_ptr,
           param.seqstart_q_dev_ptr,
           param.seqstart_k_dev_ptr,
+          nullptr, // seqlen_q_ptr
           param.seqlen_k_dev_ptr,
           param.K, // hdim_q
           param.Kv, // hdim_v
           param.Hq, // nhead_q
           param.Hq / param.Hkv, // nhead_ratio_qk
           param.scale,
-          1.0f, // scale_p
-          1.0f, // scale_o
           0.0f, // logits_soft_cap
           param.q_strides[0], // q, k, v, bias, randval, out tensor seq-dim
                               // stride
@@ -144,6 +147,7 @@ struct grouped_forward_mask_bias_dropout_dispatch {
           (param.window_size > 0) ? param.window_size - 1
                                   : -1, // window_left_size
           (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+          0, // sink_size
           param.custom_mask_type,
           0, // min_seqlen_q, most recently added kernel argument
           param.dropout_prob,
@@ -157,12 +161,12 @@ struct grouped_forward_mask_bias_dropout_dispatch {
         param.max_seqlen_q,
         param.Kv,
         param.seqlen_k_dev_ptr != nullptr);
-    constexpr dim3 kBlockSize = FmhaFwdKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
@@ -244,6 +244,7 @@ struct grouped_forward_splitkv_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
       else
         return FmhaFwdSplitKVKernel::MakeKargs(
@@ -288,6 +289,7 @@ struct grouped_forward_splitkv_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
     }();
 
@@ -298,12 +300,12 @@ struct grouped_forward_splitkv_mask_bias_dropout_dispatch {
         param.max_seqlen_q,
         param.Kv,
         param.num_kv_splits);
-    constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdSplitKVKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 
@@ -334,13 +336,13 @@ struct grouped_forward_splitkv_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaSplitKVCombineKernel::GridSize(
         param.num_batches, param.Hq, param.max_seqlen_q, param.Kv);
-    constexpr dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
+    const dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaSplitKVCombineKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaSplitKVCombineKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h
@@ -241,6 +241,7 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
       else
         return FmhaFwdSplitKVKernel::MakeKargs(
@@ -285,6 +286,7 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
     }();
 
@@ -295,12 +297,12 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
         param.max_seqlen_q,
         param.Kv,
         param.num_kv_splits);
-    constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdSplitKVKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 
@@ -331,13 +333,13 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaSplitKVCombineKernel::GridSize(
         param.num_batches, param.Hq, param.max_seqlen_q, param.Kv);
-    constexpr dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
+    const dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaSplitKVCombineKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaSplitKVCombineKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
@@ -56,6 +56,7 @@ struct grouped_infer_mask_bias_dropout_dispatch {
       true, // kIsGroupMode
       AttentionVariant<FmhaTraits>,
       FmhaMask,
+      false, // kUseTrLoad
       FmhaTraits>;
 
   static void Run(GroupedForwardParams& param, hipStream_t stream) {
@@ -93,7 +94,7 @@ struct grouped_infer_mask_bias_dropout_dispatch {
                 false, // kHasBiasGrad place-holder
                 false, // kStoreLSE
                 kHasDropout,
-                false, // kDoFp8StaticQuant place-holder
+                ck_tile::BlockAttentionQuantScaleEnum::NO_SCALE,
                 occupancy>;
 
             using FmhaPipelineProblem =
@@ -108,7 +109,7 @@ struct grouped_infer_mask_bias_dropout_dispatch {
 
             if constexpr (kUseWholeKPrefetchPipeline) {
               using FmhaPipeline =
-                  ck_tile::BlockFmhaPipelineQRKSVSWholeKPrefetch<
+                  MslkBlockFmhaPipelineQRKSVSWholeKPrefetch<
                       FmhaPipelineProblem>;
               using FmhaKernel =
                   ck_tile::FmhaFwdKernel<FmhaPipeline, FmhaEpilogue>;
@@ -123,7 +124,7 @@ struct grouped_infer_mask_bias_dropout_dispatch {
               RunWithKernel<FmhaKernel>(param, stream);
             } else {
               using FmhaPipeline =
-                  ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>;
+                  MslkBlockFmhaPipelineQSKSVS<FmhaPipelineProblem>;
               using FmhaKernel =
                   ck_tile::FmhaFwdKernel<FmhaPipeline, FmhaEpilogue>;
 
@@ -142,7 +143,7 @@ struct grouped_infer_mask_bias_dropout_dispatch {
             false, // kHasBiasGrad place-holder
             false, // kStoreLSE
             kHasDropout,
-            false, // kDoFp8StaticQuant place-holder
+            ck_tile::BlockAttentionQuantScaleEnum::NO_SCALE,
             occupancy>;
 
         using FmhaPipelineProblem =
@@ -175,19 +176,21 @@ struct grouped_infer_mask_bias_dropout_dispatch {
           param.k_ptr,
           param.v_ptr,
           param.attn_bias_ptr,
+          nullptr, // q_descale_ptr
+          nullptr, // k_descale_ptr
+          nullptr, // v_descale_ptr
           nullptr, // rand_val_ptr
           nullptr, // lse_ptr
           param.out_ptr,
           param.seqstart_q_dev_ptr,
           param.seqstart_k_dev_ptr,
+          nullptr, // seqlen_q_ptr
           param.seqlen_k_dev_ptr,
           param.K, // hdim_q
           param.Kv, // hdim_v
           param.Hq, // nhead_q
           param.Hq / param.Hkv, // nhead_ratio_qk
           param.scale,
-          1.0f, // scale_p
-          1.0f, // scale_o
           0.f, // logits_soft_cap
           param.q_strides[0], // q, k, v, bias, randval, out tensor seq-dim
                               // stride
@@ -207,6 +210,7 @@ struct grouped_infer_mask_bias_dropout_dispatch {
           (param.window_size > 0) ? param.window_size - 1
                                   : -1, // window_left_size
           (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+          0, // sink_size
           param.custom_mask_type,
           0, // min_seqlen_q, most recently added kernel argument
           param.dropout_prob,
@@ -220,12 +224,12 @@ struct grouped_infer_mask_bias_dropout_dispatch {
         param.max_seqlen_q,
         param.Kv,
         param.seqlen_k_dev_ptr != nullptr);
-    constexpr dim3 kBlockSize = FmhaKernel::BlockSize();
+    const dim3 kBlockSize = FmhaKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_dispatch.h
@@ -268,6 +268,7 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
       else
         return FmhaFwdSplitKVKernel::MakeKargs(
@@ -315,6 +316,7 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
     }();
 
@@ -325,12 +327,12 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
         param.max_seqlen_q,
         param.Kv,
         param.num_kv_splits);
-    constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdSplitKVKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 
@@ -361,13 +363,13 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaSplitKVCombineKernel::GridSize(
         param.num_batches, param.Hq, param.max_seqlen_q, param.Kv);
-    constexpr dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
+    const dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaSplitKVCombineKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaSplitKVCombineKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };

--- a/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
+++ b/csrc/attention/ck/fmha/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
@@ -362,6 +362,7 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
       else
         return FmhaFwdSplitKVKernel::MakeKargs(
@@ -409,6 +410,7 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
             (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
+            0, // sink_size
             param.custom_mask_type);
     }();
 
@@ -419,12 +421,12 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
         param.max_seqlen_q,
         param.Kv,
         param.num_kv_splits);
-    constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
+    const dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaFwdSplitKVKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 
@@ -455,13 +457,13 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
 
     dim3 kGridSize = FmhaSplitKVCombineKernel::GridSize(
         param.num_batches, param.Hq, param.max_seqlen_q, param.Kv);
-    constexpr dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
+    const dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaSplitKVCombineKernel::kBlockPerCu;
 
     (void)ck_tile::launch_kernel(
         ck_tile::stream_config{stream, false},
-        ck_tile::make_kernel<kBlockSize.x, kBlockPerCu>(
+        ck_tile::make_kernel<kBlockPerCu>(
             FmhaSplitKVCombineKernel{}, kGridSize, kBlockSize, 0, kargs));
   };
 };


### PR DESCRIPTION
Summary:

NOTE: No linked task. Please associate a task with this diff.

Update MSLK's OSS CK pin to `fcc9372c009c8e0a23fece77b582da83b04a654f` and add the external-repository fetch script to the ROCm workflow path filter.

Switch internal MSLK GEMM and FMHA BUCK targets to the shared `//third-party/rocm_composable_kernel:ck-utility` alias, then port the CK-backed FMHA and decoder code to the CK 1.2 launch, trait, pipeline, and kernel-argument APIs. Preserve MSLK's 512-wide-head and whole-K-prefetch paths with a compatibility adapter for CK pipelines that do not yet accept the new sink/block-mask arguments.

Reviewed By: bottler

Differential Revision: D117441615
