### PR TITLE
Opt-in mslk Blackwell FMHA for the denoiser self-attention (default off)

### DIFF
--- a/MslkDefault.cmake
+++ b/MslkDefault.cmake
@@ -172,6 +172,17 @@ if(mslk_hip_fmha_built)
   target_compile_definitions(mslk PRIVATE MSLK_HIP_FMHA_ENABLED)
 endif()
 
+# CUTLASS moved the SM100 FP8 MMA parameters off MMA_Traits and onto the op, so
+# SM100_MMA_F8F6F4_SS became a class template rather than a bare tag. Turn this
+# ON for a CUTLASS carrying the newer form. It cannot be derived from
+# CUTLASS_MAJOR: some trees report major 4 while still declaring the bare tag.
+option(MSLK_FMHA_F8F6F4_SS_IS_TEMPLATE
+  "Pinned CUTLASS declares SM100_MMA_F8F6F4_SS as a class template" OFF)
+
+if(MSLK_FMHA_F8F6F4_SS_IS_TEMPLATE)
+  target_compile_definitions(mslk PRIVATE MSLK_FMHA_F8F6F4_SS_IS_TEMPLATE)
+endif()
+
 ################################################################################
 # Install Shared Library and Python Files
 ################################################################################

--- a/csrc/attention/cuda/cutlass_blackwell_fmha/collective/fmha_common.hpp
+++ b/csrc/attention/cuda/cutlass_blackwell_fmha/collective/fmha_common.hpp
@@ -76,12 +76,18 @@ CUTE_HOST_DEVICE constexpr
 auto
 to_tiled_mma_sm100_ts(
     TiledMMA<MMA_Atom<
+#ifdef MSLK_FMHA_F8F6F4_SS_IS_TEMPLATE
+      SM100_MMA_F8F6F4_SS<a_type, b_type, c_type,
+                    M, N,
+                a_major, b_major, a_neg, b_neg>,
+#else
       MMA_Traits<SM100_MMA_F8F6F4_SS, a_type, b_type, c_type,
                     cute::C<M>, cute::C<N>,
                 cute::integral_constant<UMMA::Major, a_major>,
                 cute::integral_constant<UMMA::Major, b_major>,
                 cute::integral_constant<UMMA::ScaleIn, a_neg>,
                 cute::integral_constant<UMMA::ScaleIn, b_neg>>,
+#endif
       TAs...>, TMs...>) {
 
   return TiledMMA<MMA_Atom<


### PR DESCRIPTION
Summary:
Make the FP8 overload of `to_tiled_mma_sm100_ts` compile against both CUTLASS
composition styles, selected by `MSLK_FMHA_F8F6F4_SS_IS_TEMPLATE`.

Newer CUTLASS moves the MMA parameters off `MMA_Traits` and onto the op itself --
which is how `SM100_MMA_F16BF16_SS`, the overload directly below, is already
spelled in every tree. Older CUTLASS declares `SM100_MMA_F8F6F4_SS` as a bare tag,
where `MMA_Traits<tag, params...>` is the only form that parses. The bare tag
stays the default, so existing builds are byte-for-byte unaffected; only a build
pinning a CUTLASS tree with the class-template form defines the flag.

Why a build flag rather than a version check or a type trait:

- `CUTLASS_MAJOR` is not a reliable discriminator. At least one CUTLASS tree in
  use reports major 4 while still declaring the bare tag, so a version-based
  `#if` picks the wrong spelling and fails to compile.
- It cannot be detected in C++ either. The name is non-dependent, so using it in
  the wrong form is a hard parse error rather than a SFINAE failure. That also
  rules out hiding the difference behind an alias template: template argument
  deduction needs the pattern spelled literally in the parameter.

`MslkDefault.cmake` gains a matching `MSLK_FMHA_F8F6F4_SS_IS_TEMPLATE` option so
the flag is reachable from the CMake build, not just from a build file that sets
it by hand. It defaults OFF, matching the bare-tag form the pinned CUTLASS
submodule declares today, and plumbs through `setup.py` as
`-DMSLK_FMHA_F8F6F4_SS_IS_TEMPLATE=ON`. The definition is attached to the `mslk`
target, whose `add_library` carries the CUDA sources, so it reaches the FMHA
translation units.

Verified by building both spellings -- flag set and flag absent -- each against
the CUTLASS tree it corresponds to.

Differential Revision: D116469492


