### PR TITLE
Serve the FP8 groupwise GEMM from a gfx950 kernel written for it

### DIFF
--- a/.github/workflows/mslk_ci_rocm.yml
+++ b/.github/workflows/mslk_ci_rocm.yml
@@ -44,6 +44,8 @@ on:
       - 'test/attention/fmha/**'
       # FlyDSL GEMM ops
       - 'mslk/gemm/flydsl/**'
+      # Arbitrates which backend serves each GEMM op on ROCm
+      - 'mslk/gemm/__init__.py'
       # GEMM tests
       - 'test/gemm/gemm_test.py'
       # AMD/ROCm Triton GEMM kernels

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -48,17 +48,9 @@ import functools
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
-from flydsl._mlir.dialects import llvm
-from flydsl._mlir.dialects import math as math_dialect
-from flydsl._mlir.dialects import memref as memref_dialect
+from flydsl._mlir.dialects import llvm, math as math_dialect, memref as memref_dialect
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import (
-    arith,
-    buffer_ops,
-    gpu,
-    range_constexpr,
-    rocdl,
-)
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl
 from flydsl.expr.typing import T, Vector
 from flydsl.expr.utils.arith import _to_raw as _raw
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
@@ -190,9 +182,7 @@ def compile_groupwise_wide_gemm(
 
     gpu_arch = get_hip_arch()
     if not str(gpu_arch).startswith("gfx95"):
-        raise ValueError(
-            f"the wide f8f6f4 MFMA is gfx950-only; arch is {gpu_arch}"
-        )
+        raise ValueError(f"the wide f8f6f4 MFMA is gfx950-only; arch is {gpu_arch}")
 
     allocator = SmemAllocator(None, arch=gpu_arch, global_sym_name="smem_gw_wide")
     lds_a_elems = tile_m * tile_k
@@ -213,8 +203,7 @@ def compile_groupwise_wide_gemm(
     # much as the tile and the wave grid do.
     _wpe = f"_wpe{int(waves_per_eu)}" if waves_per_eu else ""
     module_name = (
-        f"gw_wide_n{n}_k{k}_t{tile_m}x{tile_n}x{tile_k}"
-        f"_w{waves_m}x{waves_n}{_wpe}"
+        f"gw_wide_n{n}_k{k}_t{tile_m}x{tile_n}x{tile_k}_w{waves_m}x{waves_n}{_wpe}"
     )
 
     # The AMDGPU default caps a workgroup at 256 threads; an eight-wave block
@@ -410,7 +399,9 @@ def compile_groupwise_wide_gemm(
                 ld = llvm.LoadOp(v4i32, ptr, alignment=16)
                 tag_alias(ld, _SCOPE_READS)
                 halves.append(Vector(ld.result))
-            return Vector(halves[0]).shuffle(Vector(halves[1]), list(range(8))).ir_value()
+            return (
+                Vector(halves[0]).shuffle(Vector(halves[1]), list(range(8))).ir_value()
+            )
 
         def mfma(a_op, b_op, c_in):
             # The scale operands are the neutral exponent, so the instruction's
@@ -418,9 +409,15 @@ def compile_groupwise_wide_gemm(
             # afterwards instead.
             return rocdl.mfma_scale_f32_32x32x64_f8f6f4(
                 v_acc_ty,
-                _raw(a_op), _raw(b_op), _raw(c_in),
-                0, 0, 0,
-                _raw(fx.Int32(NEUTRAL_E8M0)), 0, _raw(fx.Int32(NEUTRAL_E8M0)),
+                _raw(a_op),
+                _raw(b_op),
+                _raw(c_in),
+                0,
+                0,
+                0,
+                _raw(fx.Int32(NEUTRAL_E8M0)),
+                0,
+                _raw(fx.Int32(NEUTRAL_E8M0)),
             ).result
 
         zero_acc = Vector.from_elements(
@@ -513,7 +510,9 @@ def compile_groupwise_wide_gemm(
                     out.append(Vector.from_elements(vals, fx.Float32))
             return out
 
-        accs = [Vector(zero_acc, (ACC_REGS,), fx.Float32) for _ in range_constexpr(n_acc)]
+        accs = [
+            Vector(zero_acc, (ACC_REGS,), fx.Float32) for _ in range_constexpr(n_acc)
+        ]
 
         # One tile deep: tile kt is read out of LDS while tile kt+1 is in flight
         # towards the other slot. Both operands go straight from global memory to

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -53,7 +53,14 @@ from flydsl._mlir.dialects import llvm
 from flydsl._mlir.dialects import math as math_dialect
 from flydsl._mlir.dialects import memref as memref_dialect
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl
+from flydsl.expr import (
+    arith,
+    buffer_ops,
+    const_expr,
+    gpu,
+    range_constexpr,
+    rocdl,
+)
 from flydsl.expr.typing import T, Vector
 from flydsl.expr.utils.arith import _to_raw as _raw
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
@@ -127,6 +134,7 @@ def compile_groupwise_wide_gemm(
     waves_m: int = 4,
     waves_n: int = 2,
     waves_per_eu: int | None = None,
+    wide_mfma: bool = True,
 ):
     """Compile the kernel for one shape and tile config; return the launcher.
 
@@ -135,6 +143,15 @@ def compile_groupwise_wide_gemm(
     ``num_warps`` and letting the compiler choose the grid; here it is explicit,
     since the grid shape drives LDS read traffic and cannot be left implicit.
     """
+    # 32x32x64 and 16x16x128 retire the same MACs from the same 32-byte operands
+    # and need the same accumulator registers for a given tile; the wide one just
+    # does it in half the issues. Both are neutral-scaled, so this selects the
+    # shape, not the technique.
+    mfma_m = 32 if wide_mfma else 16
+    mfma_k = 64 if wide_mfma else 128
+    lane_groups = WAVE // mfma_m          # lane // mfma_m selects the K quarter/half
+    acc_regs_v = mfma_m * mfma_m // WAVE  # 16 wide, 4 narrow
+
     if tile_k != SCALE_BLOCK:
         raise ValueError(
             f"tile_k ({tile_k}) must equal the scale block ({SCALE_BLOCK}): the "
@@ -148,13 +165,13 @@ def compile_groupwise_wide_gemm(
         )
     if n % SCALE_BLOCK:
         raise ValueError(f"n ({n}) must be a multiple of {SCALE_BLOCK}")
-    if tile_m % (waves_m * MFMA_M) or tile_n % (waves_n * MFMA_N):
+    if tile_m % (waves_m * mfma_m) or tile_n % (waves_n * mfma_m):
         raise ValueError(
             f"tile {tile_m}x{tile_n} does not divide into {waves_m}x{waves_n} "
-            f"waves of {MFMA_M}x{MFMA_N} MFMA tiles"
+            f"waves of {mfma_m}x{mfma_m} MFMA tiles"
         )
-    if tile_k % MFMA_K:
-        raise ValueError(f"tile_k ({tile_k}) must be a multiple of {MFMA_K}")
+    if tile_k % mfma_k:
+        raise ValueError(f"tile_k ({tile_k}) must be a multiple of {mfma_k}")
     if tile_n > SCALE_BLOCK:
         raise ValueError(
             f"tile_n ({tile_n}) must not exceed the scale block ({SCALE_BLOCK}), "
@@ -166,9 +183,9 @@ def compile_groupwise_wide_gemm(
     wave_tile_m = tile_m // waves_m
     wave_tile_n = tile_n // waves_n
     # MFMA tiles each wave owns, and hence its accumulator count.
-    acc_m = wave_tile_m // MFMA_M
-    acc_n = wave_tile_n // MFMA_N
-    k_steps = tile_k // MFMA_K
+    acc_m = wave_tile_m // mfma_m
+    acc_n = wave_tile_n // mfma_m
+    k_steps = tile_k // mfma_k
     num_k_tiles = k // tile_k
     scale_n = n // SCALE_BLOCK
 
@@ -186,7 +203,7 @@ def compile_groupwise_wide_gemm(
     # 16-byte chunks per row, the modulus of the XOR swizzle.
     k_chunks = tile_k // LOAD_BYTES
     # Accumulator registers per MFMA tile.
-    acc_regs = MFMA_M * MFMA_N // WAVE
+    acc_regs = acc_regs_v
     # 16-byte reads per operand fragment.
     frag_loads = MFMA_OPERAND_BYTES // LOAD_BYTES
 
@@ -249,8 +266,8 @@ def compile_groupwise_wide_gemm(
         wn = wave_id % fx.Index(waves_n)
         # The wide MFMA splits a lane's role by half-wave: which 32 of K it
         # supplies, and which four of the 32 output rows it holds.
-        lane_lo = lane % fx.Index(32)
-        lane_hi = lane // fx.Index(32)
+        lane_lo = lane % fx.Index(mfma_m)
+        lane_hi = lane // fx.Index(mfma_m)
 
         wave_m0 = wm * fx.Index(wave_tile_m)
         wave_n0 = wn * fx.Index(wave_tile_n)
@@ -398,7 +415,7 @@ def compile_groupwise_wide_gemm(
             halves = []
             for j in range_constexpr(frag_loads):
                 col = (
-                    fx.Index(ks * MFMA_K)
+                    fx.Index(ks * mfma_k)
                     + lane_hi * fx.Index(32)
                     + fx.Index(j * LOAD_BYTES)
                 )
@@ -412,18 +429,14 @@ def compile_groupwise_wide_gemm(
             return Vector(halves[0]).shuffle(Vector(halves[1]), list(range(8))).ir_value()
 
         def mfma(a_op, b_op, c_in):
-            return rocdl.mfma_scale_f32_32x32x64_f8f6f4(
-                v_acc_ty,
-                _raw(a_op),
-                _raw(b_op),
-                _raw(c_in),
-                0,
-                0,
-                0,
-                _raw(fx.Int32(NEUTRAL_E8M0)),
-                0,
-                _raw(fx.Int32(NEUTRAL_E8M0)),
-            ).result
+            ops = [
+                _raw(a_op), _raw(b_op), _raw(c_in),
+                0, 0, 0,
+                _raw(fx.Int32(NEUTRAL_E8M0)), 0, _raw(fx.Int32(NEUTRAL_E8M0)),
+            ]
+            if const_expr(wide_mfma):
+                return rocdl.mfma_scale_f32_32x32x64_f8f6f4(v_acc_ty, *ops).result
+            return rocdl.mfma_scale_f32_16x16x128_f8f6f4(v_acc_ty, ops)
 
         zero_acc = Vector.from_elements(
             [fx.Float32(0.0) for _ in range_constexpr(acc_regs)], fx.Float32
@@ -440,11 +453,11 @@ def compile_groupwise_wide_gemm(
             for ks in range_constexpr(k_steps):
                 a_frags = []
                 for ai in range_constexpr(acc_m):
-                    row = wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
+                    row = wave_m0 + fx.Index(ai * mfma_m) + lane_lo
                     a_frags.append(read_frag(row, a_base, ks))
                 b_frags = []
                 for aj in range_constexpr(acc_n):
-                    row = wave_n0 + fx.Index(aj * MFMA_N) + lane_lo
+                    row = wave_n0 + fx.Index(aj * mfma_m) + lane_lo
                     b_frags.append(read_frag(row, b_base, ks))
                 for ai in range_constexpr(acc_m):
                     for aj in range_constexpr(acc_n):
@@ -475,7 +488,7 @@ def compile_groupwise_wide_gemm(
             )
             out = []
             for ai in range_constexpr(acc_m):
-                row = bx_m + wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
+                row = bx_m + wave_m0 + fx.Index(ai * mfma_m) + lane_lo
                 sa = fx.Float32(
                     buffer_ops.buffer_load(
                         sa_rsrc, kt * m_in + row, vec_width=1, dtype=T.f32
@@ -590,42 +603,62 @@ def compile_groupwise_wide_gemm(
             return fx.Int32(packed[0]), fx.Int32(packed[1])
 
         for ai in range_constexpr(acc_m):
-            row = bx_m + wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
+            row = bx_m + wave_m0 + fx.Index(ai * mfma_m) + lane_lo
             for aj in range_constexpr(acc_n):
                 acc = accs[ai * acc_n + aj]
-                for pair in range_constexpr(acc_regs // 8):
-                    even_lo, even_hi = group_dwords(acc, 2 * pair)
-                    odd_lo, odd_hi = group_dwords(acc, 2 * pair + 1)
-                    sw_lo = rocdl.permlane32_swap(
-                        pair_ty, _raw(even_lo), _raw(odd_lo), False, False
-                    )
-                    sw_hi = rocdl.permlane32_swap(
-                        pair_ty, _raw(even_hi), _raw(odd_hi), False, False
-                    )
-                    # Columns ascend with the address, so the dwords interleave:
-                    # this lane's own pair, then its partner's.
-                    quad = Vector.from_elements(
-                        [
-                            fx.Int32(llvm.extractvalue(T.i32, sw_lo, [0])),
-                            fx.Int32(llvm.extractvalue(T.i32, sw_hi, [0])),
-                            fx.Int32(llvm.extractvalue(T.i32, sw_lo, [1])),
-                            fx.Int32(llvm.extractvalue(T.i32, sw_hi, [1])),
-                        ],
-                        fx.Int32,
-                    )
-                    # Low lanes take the even group, high lanes the odd one.
-                    col = (
-                        by_n
-                        + wave_n0
-                        + fx.Index(aj * MFMA_N)
-                        + (fx.Index(2 * pair) + lane_hi) * fx.Index(8)
-                    )
-                    buffer_ops.buffer_store(
-                        quad,
-                        d_rsrc,
-                        (row * n_in + col) * fx.Index(2),
-                        offset_is_bytes=True,
-                    )
+                if const_expr(wide_mfma):
+                    for pair in range_constexpr(acc_regs // 8):
+                        even_lo, even_hi = group_dwords(acc, 2 * pair)
+                        odd_lo, odd_hi = group_dwords(acc, 2 * pair + 1)
+                        sw_lo = rocdl.permlane32_swap(
+                            pair_ty, _raw(even_lo), _raw(odd_lo), False, False
+                        )
+                        sw_hi = rocdl.permlane32_swap(
+                            pair_ty, _raw(even_hi), _raw(odd_hi), False, False
+                        )
+                        # Columns ascend with the address, so the dwords
+                        # interleave: this lane's own pair, then its partner's.
+                        quad = Vector.from_elements(
+                            [
+                                fx.Int32(llvm.extractvalue(T.i32, sw_lo, [0])),
+                                fx.Int32(llvm.extractvalue(T.i32, sw_hi, [0])),
+                                fx.Int32(llvm.extractvalue(T.i32, sw_lo, [1])),
+                                fx.Int32(llvm.extractvalue(T.i32, sw_hi, [1])),
+                            ],
+                            fx.Int32,
+                        )
+                        # Low lanes take the even group, high lanes the odd one.
+                        col = (
+                            by_n
+                            + wave_n0
+                            + fx.Index(aj * mfma_m)
+                            + (fx.Index(2 * pair) + lane_hi) * fx.Index(8)
+                        )
+                        buffer_ops.buffer_store(
+                            quad,
+                            d_rsrc,
+                            (row * n_in + col) * fx.Index(2),
+                            offset_is_bytes=True,
+                        )
+                else:
+                    # The narrow shape splits the wave four ways rather than two,
+                    # so a single permlane32_swap cannot gather eight adjacent
+                    # columns into one lane. Store the four it already holds.
+                    for g in range_constexpr(acc_regs // 4):
+                        lo, hi = group_dwords(acc, g)
+                        col = (
+                            by_n
+                            + wave_n0
+                            + fx.Index(aj * mfma_m)
+                            + lane_hi * fx.Index(4)
+                            + fx.Index(g * 4 * lane_groups)
+                        )
+                        buffer_ops.buffer_store(
+                            Vector.from_elements([lo, hi], fx.Int32),
+                            d_rsrc,
+                            (row * n_in + col) * fx.Index(2),
+                            offset_is_bytes=True,
+                        )
 
     @flyc.jit
     def launch_groupwise_wide_gemm(

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -536,6 +536,10 @@ def compile_groupwise_wide_gemm(
         #           waves are still reading.
         #   compute leaves that transfer in flight underneath this tile's MFMAs,
         #           which is the whole purpose of the arrangement.
+        #
+        # The scale loads sit with the fold that consumes them. Hoisting them
+        # above the transfer, which would leave the fold waiting behind fewer
+        # outstanding loads, measures slower at every tile tried.
         dma_stage(fx.Index(0), fx.Index(0))
 
         for _kt, _st in fx.range(0, num_k_tiles, 1, init=list(accs)):

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -120,11 +120,11 @@ def compile_groupwise_wide_gemm(
     *,
     n: int,
     k: int,
-    tile_m: int = 256,
-    tile_n: int = 128,
+    tile_m: int = 128,
+    tile_n: int = 64,
     tile_k: int = 128,
     waves_m: int = 4,
-    waves_n: int = 2,
+    waves_n: int = 1,
     waves_per_eu: int | None = None,
 ):
     """Compile the kernel for one shape and tile config; return the launcher.

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -49,6 +49,7 @@ import functools
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
+from flydsl._mlir.dialects import math as math_dialect
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
 from flydsl.expr.typing import T, Vector
@@ -431,8 +432,19 @@ def compile_groupwise_wide_gemm(
                 for aj in range_constexpr(acc_n):
                     i = ai * acc_n + aj
                     tile = Vector(tiles[i], (acc_regs,), fx.Float32)
+                    # Emitted as an explicit fused multiply-add. Written as
+                    # `acc + tile * scale` the two arith ops do not contract --
+                    # contraction changes rounding, so the compiler will not do
+                    # it unasked -- and the fold costs a separate v_pk_mul_f32
+                    # and v_pk_add_f32 per pair instead of one v_pk_fma_f32.
                     vals = [
-                        fx.Float32(cur[i][r]) + fx.Float32(tile[r]) * scales[ai]
+                        fx.Float32(
+                            math_dialect.fma(
+                                fx.Float32(tile[r]).ir_value(),
+                                scales[ai].ir_value(),
+                                fx.Float32(cur[i][r]).ir_value(),
+                            )
+                        )
                         for r in range_constexpr(acc_regs)
                     ]
                     out.append(Vector.from_elements(vals, fx.Float32))

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -1,0 +1,535 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""FP8 groupwise-scaled GEMM built on the wide gfx950 MFMA.
+
+Computes ``D[M, N] = dequant(A) @ dequant(B).T`` for
+
+  A        [M, K]           FP8 E4M3
+  B        [N, K]           FP8 E4M3 (already transposed by the caller)
+  scale_a  [K // 128, M]    FP32, one scale per (K-group, row)
+  scale_b  [K // 128, N // 128] FP32, one scale per (K-group, N-group)
+
+which is the contract of ``mslk::f8f8bf16_groupwise``.
+
+The schedule mirrors what the ROCm Triton kernel compiles to on gfx950, so that
+the two can be compared instruction for instruction:
+
+  * ``v_mfma_scale_f32_32x32x64_f8f6f4`` with a neutral E8M0 scale, which makes
+    the hardware block-scaling a no-op and lets the block-scaled instruction
+    serve this GEMM. One issue covers K=64 of a 32x32 output tile.
+  * A two-dimensional wave grid: ``waves_m x waves_n`` waves each own a
+    ``(tile_m / waves_m) x (tile_n / waves_n)`` slab of the output tile. LDS read
+    traffic per unit work is ``waves_m / tile_m + waves_n / tile_n``, minimised
+    when the wave grid is proportioned like the tile, which a one-dimensional
+    split cannot do.
+  * Both operands staged through LDS, since every wave needs rows and columns
+    that no single lane loads.
+  * The dot runs against a zero accumulator and the block scales are folded in
+    afterwards, because a scale changes every 128 elements of K while the
+    accumulator has to persist across the whole contraction.
+
+Fragment layouts for the wide MFMA (verified empirically, not assumed):
+
+  A operand   m = lane % 32,  k = (lane // 32) * 32 + byte
+  B operand   n = lane % 32,  k = (lane // 32) * 32 + byte
+  accumulator n = lane % 32,  m = 4 * (lane // 32) + 8 * (reg // 4) + reg % 4
+
+so a lane's 16 accumulator values sit in one column, across four groups of four
+consecutive rows.
+"""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr.typing import T, Vector
+from flydsl.expr.utils.arith import _to_raw as _raw
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from mslk.flydsl.kernels.mma.mfma_preshuffle_pipeline import swizzle_xor16
+
+# Wide MFMA geometry: one issue is a 32x32 output tile contracting 64 of K.
+MFMA_M = 32
+MFMA_N = 32
+MFMA_K = 64
+# Bytes each lane supplies per operand per issue (32 FP8 = 8 i32).
+MFMA_OPERAND_BYTES = 32
+
+WAVE = 64
+
+# Scale-block granularity, fixed by the op's contract.
+SCALE_BLOCK = 128
+
+# E8M0 exponent bias: a scale of 2^0, so the instruction's block scaling is the
+# identity and the FP32 scales can be applied in software instead.
+NEUTRAL_E8M0 = 0x7F7F7F7F
+
+# Widest global load, and hence the LDS swizzle granularity.
+LOAD_BYTES = 16
+
+# LDS per workgroup on gfx950.
+LDS_CAPACITY = 160 * 1024
+
+# LDS buffers per operand. Triton runs three, fed by a direct global-to-LDS DMA
+# so the depth costs only LDS. That route is closed here: `buffer_load_lds`
+# writes LDS opaquely, so SIInsertWaitcnts cannot prove the pending transfers do
+# not alias the fragment reads and drains them with a vmcnt(0) before every
+# ds_read -- an explicit vmcnt(9) comes back out of the assembler as vmcnt(0).
+# The instruction mix still matches Triton exactly; only the wait operands
+# differ, and it measured 20% slower. Staging through registers instead lets the
+# compiler pipeline on register dependences it can see, but then each extra
+# stage costs a whole tile of VGPRs as well as the LDS, which is why two wins.
+STAGES = 2
+
+
+@functools.lru_cache(maxsize=64)
+def compile_groupwise_wide_gemm(
+    *,
+    n: int,
+    k: int,
+    tile_m: int = 256,
+    tile_n: int = 128,
+    tile_k: int = 128,
+    waves_m: int = 4,
+    waves_n: int = 2,
+    waves_per_eu: int | None = None,
+):
+    """Compile the kernel for one shape and tile config; return the launcher.
+
+    ``waves_m``/``waves_n`` are the wave grid, so the block is
+    ``waves_m * waves_n * 64`` threads. Triton reaches the same place by picking
+    ``num_warps`` and letting the compiler choose the grid; here it is explicit,
+    since the grid shape drives LDS read traffic and cannot be left implicit.
+    """
+    if tile_k != SCALE_BLOCK:
+        raise ValueError(
+            f"tile_k ({tile_k}) must equal the scale block ({SCALE_BLOCK}): the "
+            "scales change every 128 elements of K, and a tile spanning more "
+            "than one block would need a fold per sub-block"
+        )
+    if k % tile_k or n % tile_n:
+        raise ValueError(
+            f"n ({n}) and k ({k}) must divide by tile_n ({tile_n}) and tile_k "
+            f"({tile_k}); the tail-masked variant is not built yet"
+        )
+    if n % SCALE_BLOCK:
+        raise ValueError(f"n ({n}) must be a multiple of {SCALE_BLOCK}")
+    if tile_m % (waves_m * MFMA_M) or tile_n % (waves_n * MFMA_N):
+        raise ValueError(
+            f"tile {tile_m}x{tile_n} does not divide into {waves_m}x{waves_n} "
+            f"waves of {MFMA_M}x{MFMA_N} MFMA tiles"
+        )
+    if tile_k % MFMA_K:
+        raise ValueError(f"tile_k ({tile_k}) must be a multiple of {MFMA_K}")
+    if tile_n > SCALE_BLOCK:
+        raise ValueError(
+            f"tile_n ({tile_n}) must not exceed the scale block ({SCALE_BLOCK}), "
+            "or a tile would span several B scales"
+        )
+
+    num_waves = waves_m * waves_n
+    total_threads = num_waves * WAVE
+    wave_tile_m = tile_m // waves_m
+    wave_tile_n = tile_n // waves_n
+    # MFMA tiles each wave owns, and hence its accumulator count.
+    acc_m = wave_tile_m // MFMA_M
+    acc_n = wave_tile_n // MFMA_N
+    k_steps = tile_k // MFMA_K
+    num_k_tiles = k // tile_k
+    scale_n = n // SCALE_BLOCK
+
+    # Each thread's share of a tile, in whole 16-byte loads.
+    a_bytes_per_thread = tile_m * tile_k // total_threads
+    b_bytes_per_thread = tile_n * tile_k // total_threads
+    if a_bytes_per_thread % LOAD_BYTES or b_bytes_per_thread % LOAD_BYTES:
+        raise ValueError(
+            f"tile {tile_m}x{tile_n}x{tile_k} does not split into whole "
+            f"{LOAD_BYTES}-byte loads across {total_threads} threads"
+        )
+    num_a_loads = a_bytes_per_thread // LOAD_BYTES
+    num_b_loads = b_bytes_per_thread // LOAD_BYTES
+
+    # 16-byte chunks per row, the modulus of the XOR swizzle.
+    k_chunks = tile_k // LOAD_BYTES
+    # Accumulator registers per MFMA tile.
+    acc_regs = MFMA_M * MFMA_N // WAVE
+    # 16-byte reads per operand fragment.
+    frag_loads = MFMA_OPERAND_BYTES // LOAD_BYTES
+
+    gpu_arch = get_hip_arch()
+    if not str(gpu_arch).startswith("gfx95"):
+        raise ValueError(
+            f"the wide f8f6f4 MFMA is gfx950-only; arch is {gpu_arch}"
+        )
+
+    allocator = SmemAllocator(None, arch=gpu_arch, global_sym_name="smem_gw_wide")
+    lds_a_elems = tile_m * tile_k
+    lds_b_elems = tile_n * tile_k
+    # A tile is written into one buffer while the other is being read, which is
+    # what lets a single barrier per K tile suffice.
+    lds_bytes = STAGES * (lds_a_elems + lds_b_elems)
+    if lds_bytes > LDS_CAPACITY:
+        raise ValueError(
+            f"tile {tile_m}x{tile_n}x{tile_k} double-buffered needs "
+            f"{lds_bytes} B of LDS, over the {LDS_CAPACITY} B budget"
+        )
+    lds_off = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_off + lds_bytes
+
+    module_name = (
+        f"gw_wide_n{n}_k{k}_t{tile_m}x{tile_n}x{tile_k}_w{waves_m}x{waves_n}"
+    )
+
+    # The AMDGPU default caps a workgroup at 256 threads; an eight-wave block
+    # needs the larger bound declared up front.
+    @flyc.kernel(name=module_name, known_block_size=[total_threads, 1, 1])
+    def groupwise_wide_gemm_kernel(
+        arg_d: fx.Tensor,
+        arg_a: fx.Tensor,
+        arg_b: fx.Tensor,
+        arg_scale_a: fx.Tensor,
+        arg_scale_b: fx.Tensor,
+        i32_m: fx.Int32,
+        i32_n: fx.Int32,
+        i32_k: fx.Int32,
+    ):
+        # MLIR types need a live context, so they are built during tracing.
+        v_acc_ty = Vector.make_type(acc_regs, fx.Float32)
+
+        m_in = fx.Index(i32_m)
+        n_in = fx.Index(i32_n)
+        k_in = fx.Index(i32_k)
+
+        tx = gpu.thread_id("x")
+        by = gpu.block_id("x")  # N-block
+        bx = gpu.block_id("y")  # M-tile
+
+        bx_m = bx * fx.Index(tile_m)
+        by_n = by * fx.Index(tile_n)
+
+        # Wave grid: wave w owns rows [wm * wave_tile_m, +wave_tile_m) and
+        # columns [wn * wave_tile_n, +wave_tile_n).
+        wave_id = tx // fx.Index(WAVE)
+        lane = tx % fx.Index(WAVE)
+        wm = wave_id // fx.Index(waves_n)
+        wn = wave_id % fx.Index(waves_n)
+        # The wide MFMA splits a lane's role by half-wave: which 32 of K it
+        # supplies, and which four of the 32 output rows it holds.
+        lane_lo = lane % fx.Index(32)
+        lane_hi = lane // fx.Index(32)
+
+        wave_m0 = wm * fx.Index(wave_tile_m)
+        wave_n0 = wn * fx.Index(wave_tile_n)
+
+        a_rsrc = buffer_ops.create_buffer_resource(
+            arg_a, max_size=False, num_records_bytes=m_in * k_in
+        )
+        b_rsrc = buffer_ops.create_buffer_resource(
+            arg_b, max_size=False, num_records_bytes=n_in * k_in
+        )
+        d_rsrc = buffer_ops.create_buffer_resource(
+            arg_d, max_size=False, num_records_bytes=m_in * n_in * fx.Index(2)
+        )
+        sa_rsrc = buffer_ops.create_buffer_resource(
+            arg_scale_a,
+            max_size=False,
+            num_records_bytes=m_in * fx.Index(num_k_tiles * 4),
+        )
+        sb_rsrc = buffer_ops.create_buffer_resource(
+            arg_scale_b,
+            max_size=False,
+            num_records_bytes=fx.Index(scale_n * num_k_tiles * 4),
+        )
+
+        base_ptr = allocator.get_base()
+        # One arena: the A buffers, then the B buffers. Both operands are
+        # row-major over K with the same stride, so one indexing helper serves
+        # both.
+        lds_a = SmemPtr(base_ptr, lds_off, T.f8, shape=(lds_bytes,)).get()
+
+        def a_buf(slot):
+            return slot * fx.Index(lds_a_elems)
+
+        def b_buf(slot):
+            return fx.Index(STAGES * lds_a_elems) + slot * fx.Index(lds_b_elems)
+        c_chunks = fx.Index(k_chunks)
+        c4 = fx.Index(4)
+
+        # ---- staging coordinates -------------------------------------------
+        # Load i of thread tx covers tile bytes [(i * threads + tx) * 16, +16),
+        # so consecutive lanes walk a row and the reads coalesce.
+        def stage_coords(num_loads):
+            coords = []
+            for i in range_constexpr(num_loads):
+                linear = (fx.Index(i * total_threads) + tx) * fx.Index(LOAD_BYTES)
+                coords.append((linear // fx.Index(tile_k), linear % fx.Index(tile_k)))
+            return coords
+
+        a_coords = stage_coords(num_a_loads)
+        b_coords = stage_coords(num_b_loads)
+
+        k_dwords = k_in // c4
+        tile_k_dwords = fx.Index(tile_k // 4)
+
+        def load_tile(rsrc, coords, row_base, kt):
+            """Read this thread's share of a tile from global into registers.
+
+            Reads past the last tile fall outside the buffer descriptor and come
+            back as zero, so the K tail needs no branch.
+            """
+            parts = []
+            for i in range_constexpr(len(coords)):
+                row, col = coords[i]
+                idx_dw = (row_base + row) * k_dwords + kt * tile_k_dwords + col // c4
+                parts.append(
+                    Vector(
+                        buffer_ops.buffer_load(rsrc, idx_dw, vec_width=4, dtype=T.i32)
+                    ).bitcast(fx.Int32)
+                )
+            return parts
+
+        def lds_index(row, col, lds_base):
+            """Byte offset of tile element ``(row, col)`` under the XOR16 swizzle.
+
+            Row-major LDS would start every row in bank 0, so a fragment read --
+            which is exactly "each lane takes a different row" -- would serialise
+            32 ways. XORing the chunk index with the row spreads them out.
+            """
+            return row * fx.Index(tile_k) + swizzle_xor16(row, col, c_chunks) + lds_base
+
+        def store_tile(parts, coords, lds_base):
+            for i in range_constexpr(len(coords)):
+                row, col = coords[i]
+                idx = lds_index(row, col, lds_base)
+                vector.store(vector.bitcast(T.f8x16, parts[i]), lds_a, [idx])
+
+        # ---- fragment reads --------------------------------------------------
+        def read_frag(row, lds_base, ks):
+            """Gather one lane's 32-byte operand fragment for MFMA step ``ks``."""
+            halves = []
+            for j in range_constexpr(frag_loads):
+                col = (
+                    fx.Index(ks * MFMA_K)
+                    + lane_hi * fx.Index(32)
+                    + fx.Index(j * LOAD_BYTES)
+                )
+                idx = lds_index(row, col, lds_base)
+                halves.append(Vector(Vector.load(T.f8x16, lds_a, [idx])).bitcast(fx.Int32))
+            return Vector(halves[0]).shuffle(Vector(halves[1]), list(range(8))).ir_value()
+
+        def mfma(a_op, b_op, c_in):
+            return rocdl.mfma_scale_f32_32x32x64_f8f6f4(
+                v_acc_ty,
+                _raw(a_op),
+                _raw(b_op),
+                _raw(c_in),
+                0,
+                0,
+                0,
+                _raw(fx.Int32(NEUTRAL_E8M0)),
+                0,
+                _raw(fx.Int32(NEUTRAL_E8M0)),
+            ).result
+
+        zero_acc = Vector.from_elements(
+            [fx.Float32(0.0) for _ in range_constexpr(acc_regs)], fx.Float32
+        ).ir_value()
+
+        def tile_product(a_base, b_base):
+            """Contract one K tile into a fresh accumulator.
+
+            The dot starts from zero rather than the running accumulator because
+            the scales apply per K tile; folding them afterwards is what lets a
+            single accumulator span the whole of K.
+            """
+            tiles = [zero_acc for _ in range_constexpr(acc_m * acc_n)]
+            for ks in range_constexpr(k_steps):
+                a_frags = []
+                for ai in range_constexpr(acc_m):
+                    row = wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
+                    a_frags.append(read_frag(row, a_base, ks))
+                b_frags = []
+                for aj in range_constexpr(acc_n):
+                    row = wave_n0 + fx.Index(aj * MFMA_N) + lane_lo
+                    b_frags.append(read_frag(row, b_base, ks))
+                for ai in range_constexpr(acc_m):
+                    for aj in range_constexpr(acc_n):
+                        idx = ai * acc_n + aj
+                        # Operands swapped on purpose. The hardware puts the
+                        # second operand's index on lane % 32 and the first
+                        # one's across the registers; feeding B first therefore
+                        # transposes the result, so a lane ends up holding one
+                        # output row and four runs of four adjacent columns.
+                        # That buys a vectorised store, and it makes the block
+                        # scale constant across a lane's whole accumulator.
+                        tiles[idx] = mfma(b_frags[aj], a_frags[ai], tiles[idx])
+            return tiles
+
+        def load_scales(kt):
+            """The combined scale for each of this lane's accumulators.
+
+            With the transposed accumulator a lane owns exactly one output row
+            per M subtile, so its A scale is a single value rather than one per
+            register. Every column of the tile falls in one N scale block, so B
+            contributes one scalar for the whole tile. The product is therefore
+            constant across an accumulator, and the fold is 16 FMAs against a
+            broadcast rather than 16 separate multipliers.
+            """
+            sb_idx = kt * fx.Index(scale_n) + (by_n // fx.Index(SCALE_BLOCK))
+            sb = fx.Float32(
+                buffer_ops.buffer_load(sb_rsrc, sb_idx, vec_width=1, dtype=T.f32)
+            )
+            out = []
+            for ai in range_constexpr(acc_m):
+                row = bx_m + wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
+                sa = fx.Float32(
+                    buffer_ops.buffer_load(
+                        sa_rsrc, kt * m_in + row, vec_width=1, dtype=T.f32
+                    )
+                )
+                out.append(sa * sb)
+            return out
+
+        # ---- K loop ----------------------------------------------------------
+        # Software pipeline, STAGES - 1 tiles deep, with nothing staged in
+        # registers: each iteration waits for the tile whose DMA was issued
+        # STAGES - 1 iterations ago, barriers, then issues the DMA for the tile
+        # STAGES - 1 ahead and computes.
+        #
+        # The one barrier does double duty. It publishes the tile just waited
+        # for, and it separates the reads of slot (kt - 1) % STAGES -- which the
+        # DMA below is about to overwrite -- from that overwrite, because those
+        # reads happened before it in every wave's program order.
+        #
+        # The scale loads are issued *before* the DMA rather than with the fold
+        # that consumes them. vmcnt retires in order, so consuming a scale
+        # loaded in the same iteration would force a wait that also drained
+        # every DMA behind it, collapsing the pipeline to nothing. Loading them
+        # two tiles ahead puts them behind the DMAs in the queue instead.
+        n_acc = acc_m * acc_n
+
+        def split_state(state):
+            vals = list(state) if isinstance(state, (list, tuple)) else [state]
+            return (
+                [Vector(v, (acc_regs,), fx.Float32) for v in vals[:n_acc]],
+                [Vector(v) for v in vals[n_acc : n_acc + num_a_loads]],
+                [Vector(v) for v in vals[n_acc + num_a_loads :]],
+            )
+
+        def fold(cur, tiles, scales):
+            out = []
+            for ai in range_constexpr(acc_m):
+                for aj in range_constexpr(acc_n):
+                    i = ai * acc_n + aj
+                    tile = Vector(tiles[i], (acc_regs,), fx.Float32)
+                    vals = [
+                        fx.Float32(cur[i][r]) + fx.Float32(tile[r]) * scales[ai]
+                        for r in range_constexpr(acc_regs)
+                    ]
+                    out.append(Vector.from_elements(vals, fx.Float32))
+            return out
+
+        accs = [Vector(zero_acc, (acc_regs,), fx.Float32) for _ in range_constexpr(n_acc)]
+
+        a_pre = load_tile(a_rsrc, a_coords, bx_m, fx.Index(0))
+        b_pre = load_tile(b_rsrc, b_coords, by_n, fx.Index(0))
+
+        for _kt, _st in fx.range(
+            0, num_k_tiles, 1, init=list(accs) + list(a_pre) + list(b_pre)
+        ):
+            _cur, _a_cur, _b_cur = split_state(_st)
+            _now = _kt % fx.Index(STAGES)
+            _a_now, _b_now = a_buf(_now), b_buf(_now)
+
+            store_tile(_a_cur, a_coords, _a_now)
+            store_tile(_b_cur, b_coords, _b_now)
+            gpu.barrier()
+
+            # Issued after the barrier so they are in flight underneath this
+            # tile's MFMAs; the compiler pipelines them on register dependences
+            # it can see, which is the thing the opaque DMA denied it.
+            _a_next = load_tile(a_rsrc, a_coords, bx_m, _kt + fx.Index(1))
+            _b_next = load_tile(b_rsrc, b_coords, by_n, _kt + fx.Index(1))
+
+            _tiles = tile_product(_a_now, _b_now)
+            _res = yield fold(
+                _cur, _tiles, load_scales(_kt)
+            ) + list(_a_next) + list(_b_next)
+
+        accs, _, _ = split_state(_res)
+
+        # ---- epilogue --------------------------------------------------------
+        # The transposed accumulator gives a lane one output row and four runs of
+        # four adjacent columns, so each run converts to four BF16 and leaves as
+        # one 8-byte store. No LDS round trip and no cross-lane shuffle: the
+        # layout the MFMA produced is already the layout the store wants.
+        for ai in range_constexpr(acc_m):
+            row = bx_m + wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
+            for aj in range_constexpr(acc_n):
+                acc = accs[ai * acc_n + aj]
+                for g in range_constexpr(acc_regs // 4):
+                    col = (
+                        by_n
+                        + wave_n0
+                        + fx.Index(aj * MFMA_N)
+                        + lane_hi * c4
+                        + fx.Index(g * 8)
+                    )
+                    quad = Vector.from_elements(
+                        [
+                            fx.BFloat16(arith.trunc_f(T.bf16, fx.Float32(acc[g * 4 + e])))
+                            for e in range_constexpr(4)
+                        ],
+                        fx.BFloat16,
+                    )
+                    buffer_ops.buffer_store(
+                        quad.bitcast(fx.Int32),
+                        d_rsrc,
+                        (row * n_in + col) * fx.Index(2),
+                        offset_is_bytes=True,
+                    )
+
+    @flyc.jit
+    def launch_groupwise_wide_gemm(
+        arg_d: fx.Tensor,
+        arg_a: fx.Tensor,
+        arg_b: fx.Tensor,
+        arg_scale_a: fx.Tensor,
+        arg_scale_b: fx.Tensor,
+        i32_m: fx.Int32,
+        i32_n: fx.Int32,
+        i32_k: fx.Int32,
+        stream: fx.Stream,
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        m_in = fx.Index(i32_m)
+        gx = fx.Index(i32_n) // fx.Index(tile_n)
+        gy = (m_in + fx.Index(tile_m - 1)) // fx.Index(tile_m)
+
+        launcher = groupwise_wide_gemm_kernel(
+            arg_d, arg_a, arg_b, arg_scale_a, arg_scale_b, i32_m, i32_n, i32_k
+        )
+        if waves_per_eu is not None and int(waves_per_eu) >= 1:
+            for op in ctx.gpu_module_body.operations:
+                if hasattr(op, "attributes") and op.OPERATION_NAME == "gpu.func":
+                    op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                        T.i32, int(waves_per_eu)
+                    )
+        launcher.launch(
+            grid=(gx, gy, fx.Index(1)), block=(total_threads, 1, 1), stream=stream
+        )
+
+    return launch_groupwise_wide_gemm

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -542,20 +542,38 @@ def compile_groupwise_wide_gemm(
         # outstanding loads, measures slower at every tile tried.
         dma_stage(fx.Index(0), fx.Index(0))
 
-        for _kt, _st in fx.range(0, num_k_tiles, 1, init=list(accs)):
-            _cur = split_state(_st)
-            _now = _kt % fx.Index(STAGES)
-            _next_slot = (_kt + fx.Index(1)) % fx.Index(STAGES)
+        # The loop stops one tile short and the last is peeled below, so that the
+        # transfer here is unconditional. Guarding it instead would put it in a
+        # block of its own, where it can no longer be interleaved with the MFMAs
+        # it is supposed to run underneath.
+        if num_k_tiles > 1:
+            for _kt, _st in fx.range(0, num_k_tiles - 1, 1, init=list(accs)):
+                _cur = split_state(_st)
+                _now = _kt % fx.Index(STAGES)
+                _next_slot = (_kt + fx.Index(1)) % fx.Index(STAGES)
 
-            rocdl.s_waitcnt(0)
-            gpu.barrier()
+                rocdl.s_waitcnt(0)
+                gpu.barrier()
 
-            dma_stage(_kt + fx.Index(1), _next_slot)
+                dma_stage(_kt + fx.Index(1), _next_slot)
 
-            _tiles = tile_product(a_buf(_now), b_buf(_now))
-            _res = yield fold(_cur, _tiles, load_scales(_kt))
+                _tiles = tile_product(a_buf(_now), b_buf(_now))
+                _res = yield fold(_cur, _tiles, load_scales(_kt))
 
-        accs = split_state(_res)
+            accs = split_state(_res)
+
+        # The peeled tile. Its operands are already in flight from the last
+        # iteration, and there is no successor to fetch, so this is the loop body
+        # without the transfer.
+        _last = num_k_tiles - 1
+        _last_slot = _last % STAGES
+        rocdl.s_waitcnt(0)
+        gpu.barrier()
+        accs = fold(
+            accs,
+            tile_product(a_buf(fx.Index(_last_slot)), b_buf(fx.Index(_last_slot))),
+            load_scales(fx.Index(_last)),
+        )
 
         # ---- epilogue --------------------------------------------------------
         # The transposed accumulator leaves a lane holding one output row and

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -562,31 +562,66 @@ def compile_groupwise_wide_gemm(
         accs = split_state(_res)
 
         # ---- epilogue --------------------------------------------------------
-        # The transposed accumulator gives a lane one output row and four runs of
-        # four adjacent columns, so each run converts to four BF16 and leaves as
-        # one 8-byte store. No LDS round trip and no cross-lane shuffle: the
-        # layout the MFMA produced is already the layout the store wants.
+        # The transposed accumulator leaves a lane holding one output row and
+        # four runs of four adjacent columns, with lanes L and L+32 holding
+        # complementary halves of the same eight columns. Stored as-is that caps
+        # the store at 8 bytes per lane, which fills only an eighth of a cache
+        # line per transaction -- fine when the operands dominate, expensive when
+        # the output does.
+        #
+        # `permlane32_swap(a, b)` gathers both half-wave halves of one operand
+        # into one half-wave: low lanes receive a[L] and a[L+32], high lanes
+        # receive b[L-32] and b[L]. Feeding it a pair of column groups therefore
+        # gives the low half all eight columns of the even group and the high
+        # half all eight of the odd one, both for the row the lane already owned.
+        # Two swaps per pair of groups turn four 8-byte stores into two 16-byte
+        # ones, which is what Triton's sixteen permlanes buy it as well.
+        pair_ty = ir.Type.parse("!llvm.struct<(i32, i32)>")
+
+        def group_dwords(acc, g):
+            """One column group's four values, as BF16 packed into two i32."""
+            packed = Vector.from_elements(
+                [
+                    fx.BFloat16(arith.trunc_f(T.bf16, fx.Float32(acc[g * 4 + e])))
+                    for e in range_constexpr(4)
+                ],
+                fx.BFloat16,
+            ).bitcast(fx.Int32)
+            return fx.Int32(packed[0]), fx.Int32(packed[1])
+
         for ai in range_constexpr(acc_m):
             row = bx_m + wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
             for aj in range_constexpr(acc_n):
                 acc = accs[ai * acc_n + aj]
-                for g in range_constexpr(acc_regs // 4):
+                for pair in range_constexpr(acc_regs // 8):
+                    even_lo, even_hi = group_dwords(acc, 2 * pair)
+                    odd_lo, odd_hi = group_dwords(acc, 2 * pair + 1)
+                    sw_lo = rocdl.permlane32_swap(
+                        pair_ty, _raw(even_lo), _raw(odd_lo), False, False
+                    )
+                    sw_hi = rocdl.permlane32_swap(
+                        pair_ty, _raw(even_hi), _raw(odd_hi), False, False
+                    )
+                    # Columns ascend with the address, so the dwords interleave:
+                    # this lane's own pair, then its partner's.
+                    quad = Vector.from_elements(
+                        [
+                            fx.Int32(llvm.extractvalue(T.i32, sw_lo, [0])),
+                            fx.Int32(llvm.extractvalue(T.i32, sw_hi, [0])),
+                            fx.Int32(llvm.extractvalue(T.i32, sw_lo, [1])),
+                            fx.Int32(llvm.extractvalue(T.i32, sw_hi, [1])),
+                        ],
+                        fx.Int32,
+                    )
+                    # Low lanes take the even group, high lanes the odd one.
                     col = (
                         by_n
                         + wave_n0
                         + fx.Index(aj * MFMA_N)
-                        + lane_hi * c4
-                        + fx.Index(g * 8)
-                    )
-                    quad = Vector.from_elements(
-                        [
-                            fx.BFloat16(arith.trunc_f(T.bf16, fx.Float32(acc[g * 4 + e])))
-                            for e in range_constexpr(4)
-                        ],
-                        fx.BFloat16,
+                        + (fx.Index(2 * pair) + lane_hi) * fx.Index(8)
                     )
                     buffer_ops.buffer_store(
-                        quad.bitcast(fx.Int32),
+                        quad,
                         d_rsrc,
                         (row * n_in + col) * fx.Index(2),
                         offset_is_bytes=True,

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -49,9 +49,11 @@ import functools
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm
 from flydsl._mlir.dialects import math as math_dialect
+from flydsl._mlir.dialects import memref as memref_dialect
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl
 from flydsl.expr.typing import T, Vector
 from flydsl.expr.utils.arith import _to_raw as _raw
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
@@ -79,6 +81,28 @@ LOAD_BYTES = 16
 
 # LDS per workgroup on gfx950.
 LDS_CAPACITY = 160 * 1024
+
+# Alias scopes telling the backend that the direct-to-LDS transfers and the MFMA
+# fragment reads never need a dependence inferred between them.
+#
+# `buffer_load_lds` writes LDS through an opaque pointer, so SIInsertWaitcnts
+# cannot see which bytes it touches and conservatively drains every transfer
+# with a vmcnt(0) before each ds_read -- which cancels exactly the overlap the
+# pipeline exists to create. Read literally these two op classes *do* alias:
+# the transfer issued in one iteration is consumed by the reads in the next.
+# What the metadata asserts is not disjointness but that the dependence is
+# carried explicitly, by the s_waitcnt and barrier at the top of the loop body.
+# Triton states the same thing the same way, in a domain it documents as
+# "aliasing information between AsyncCopyGlobalToLocal, BufferLoadToLocal and
+# LocalLoad ops".
+#
+# Because this suppresses the compiler's own analysis, that s_waitcnt becomes
+# load-bearing for correctness rather than just for speed: too permissive a wait
+# now reads LDS before the transfer lands, silently. The one-tile-deep pipeline
+# keeps it at vmcnt(0), the maximally conservative value, so there is no count
+# to get wrong.
+_LDS_DOMAIN = '#llvm.alias_scope_domain<id = "gw_wide.lds">'
+_SCOPE_NAMES = ("dma", "reads")
 
 # LDS buffers per operand. Triton runs three, fed by a direct global-to-LDS DMA
 # so the depth costs only LDS. That route is closed here: `buffer_load_lds`
@@ -278,25 +302,6 @@ def compile_groupwise_wide_gemm(
         a_coords = stage_coords(num_a_loads)
         b_coords = stage_coords(num_b_loads)
 
-        k_dwords = k_in // c4
-        tile_k_dwords = fx.Index(tile_k // 4)
-
-        def load_tile(rsrc, coords, row_base, kt):
-            """Read this thread's share of a tile from global into registers.
-
-            Reads past the last tile fall outside the buffer descriptor and come
-            back as zero, so the K tail needs no branch.
-            """
-            parts = []
-            for i in range_constexpr(len(coords)):
-                row, col = coords[i]
-                idx_dw = (row_base + row) * k_dwords + kt * tile_k_dwords + col // c4
-                parts.append(
-                    Vector(
-                        buffer_ops.buffer_load(rsrc, idx_dw, vec_width=4, dtype=T.i32)
-                    ).bitcast(fx.Int32)
-                )
-            return parts
 
         def lds_index(row, col, lds_base):
             """Byte offset of tile element ``(row, col)`` under the XOR16 swizzle.
@@ -307,15 +312,89 @@ def compile_groupwise_wide_gemm(
             """
             return row * fx.Index(tile_k) + swizzle_xor16(row, col, c_chunks) + lds_base
 
-        def store_tile(parts, coords, lds_base):
+        _scopes = [
+            ir.Attribute.parse(
+                f'#llvm.alias_scope<id = "gw_wide.{nm}", domain = {_LDS_DOMAIN}>'
+            )
+            for nm in _SCOPE_NAMES
+        ]
+
+        def tag_alias(op, mine):
+            """Claim scope ``mine`` for ``op`` and disclaim the other one."""
+            op = getattr(op, "owner", op)
+            op.attributes["alias_scopes"] = ir.ArrayAttr.get([_scopes[mine]])
+            op.attributes["noalias_scopes"] = ir.ArrayAttr.get(
+                [sc for i, sc in enumerate(_scopes) if i != mine]
+            )
+
+        lds_ptr_ty = ir.Type.parse("!llvm.ptr<3>")
+        lds_addr_i32 = fx.Int32(
+            arith.index_cast(
+                T.i32, memref_dialect.extract_aligned_pointer_as_index(lds_a)
+            )
+        )
+        lds_addr_base = fx.Int64(
+            arith.index_cast(
+                T.i64, memref_dialect.extract_aligned_pointer_as_index(lds_a)
+            )
+        )
+
+        def dma_tile(rsrc, coords, row_base, kt, lds_base):
+            """Move a tile from global straight into LDS, never touching a VGPR.
+
+            The destination is not ours to choose: lane L of a wave lands at a
+            fixed ``lds_ptr + L * 16``, so LDS fills linearly and the XOR swizzle
+            moves to the *source* address instead. That is sound because the
+            swizzle is an XOR and so its own inverse -- reading
+            ``global(row, swizzle(row, col))`` into the linear slot for
+            ``(row, col)`` leaves LDS holding what a swizzled store would have
+            written, which is what the fragment reads expect.
+            """
+            ptr = None
             for i in range_constexpr(len(coords)):
                 row, col = coords[i]
-                idx = lds_index(row, col, lds_base)
-                vector.store(vector.bitcast(T.f8x16, parts[i]), lds_a, [idx])
+                byte_off = (
+                    (row_base + row) * k_in
+                    + kt * fx.Index(tile_k)
+                    + swizzle_xor16(row, col, c_chunks)
+                )
+                if i == 0:
+                    ptr = rocdl.readfirstlane(
+                        T.i64,
+                        lds_addr_base
+                        + fx.Int64(lds_base)
+                        + fx.Int64(wave_id * fx.Index(WAVE * LOAD_BYTES)),
+                    )
+                else:
+                    ptr = ptr + fx.Int64(total_threads * LOAD_BYTES)
+                tag_alias(
+                    rocdl.raw_ptr_buffer_load_lds(
+                        rsrc,
+                        llvm.inttoptr(lds_ptr_ty, ptr),
+                        fx.Int32(LOAD_BYTES),
+                        fx.Int32(byte_off),
+                        fx.Int32(0),
+                        fx.Int32(0),
+                        fx.Int32(1),
+                    ),
+                    0,
+                )
+
+        def dma_stage(kt, slot):
+            dma_tile(a_rsrc, a_coords, bx_m, kt, a_buf(slot))
+            dma_tile(b_rsrc, b_coords, by_n, kt, b_buf(slot))
+
 
         # ---- fragment reads --------------------------------------------------
+        v4i32 = ir.VectorType.get([4], fx.Int32.ir_type)
+
         def read_frag(row, lds_base, ks):
-            """Gather one lane's 32-byte operand fragment for MFMA step ``ks``."""
+            """Gather one lane's 32-byte operand fragment for MFMA step ``ks``.
+
+            Issued as an LLVM load rather than a memref one so it can carry the
+            alias metadata; `vector.load` has nowhere to put it, and the
+            attributes would be dropped on the way down.
+            """
             halves = []
             for j in range_constexpr(frag_loads):
                 col = (
@@ -324,7 +403,12 @@ def compile_groupwise_wide_gemm(
                     + fx.Index(j * LOAD_BYTES)
                 )
                 idx = lds_index(row, col, lds_base)
-                halves.append(Vector(Vector.load(T.f8x16, lds_a, [idx])).bitcast(fx.Int32))
+                ptr = llvm.inttoptr(
+                    lds_ptr_ty, (lds_addr_i32 + fx.Int32(idx)).ir_value()
+                )
+                ld = llvm.LoadOp(v4i32, ptr, alignment=16)
+                tag_alias(ld, 1)
+                halves.append(Vector(ld.result))
             return Vector(halves[0]).shuffle(Vector(halves[1]), list(range(8))).ir_value()
 
         def mfma(a_op, b_op, c_in):
@@ -420,11 +504,7 @@ def compile_groupwise_wide_gemm(
 
         def split_state(state):
             vals = list(state) if isinstance(state, (list, tuple)) else [state]
-            return (
-                [Vector(v, (acc_regs,), fx.Float32) for v in vals[:n_acc]],
-                [Vector(v) for v in vals[n_acc : n_acc + num_a_loads]],
-                [Vector(v) for v in vals[n_acc + num_a_loads :]],
-            )
+            return [Vector(v, (acc_regs,), fx.Float32) for v in vals]
 
         def fold(cur, tiles, scales):
             out = []
@@ -452,32 +532,34 @@ def compile_groupwise_wide_gemm(
 
         accs = [Vector(zero_acc, (acc_regs,), fx.Float32) for _ in range_constexpr(n_acc)]
 
-        a_pre = load_tile(a_rsrc, a_coords, bx_m, fx.Index(0))
-        b_pre = load_tile(b_rsrc, b_coords, by_n, fx.Index(0))
+        # One-deep DMA pipeline. Nothing is staged in registers, so the
+        # accumulators are the only loop carry -- 64 values instead of the 88 the
+        # register path needs.
+        #
+        # Ordering matters more than it looks. The wait and barrier come first:
+        # the wait publishes tile kt (whose DMA was issued last iteration) and,
+        # because nothing newer has been issued yet at that point, vmcnt(0) there
+        # is free. The barrier additionally releases slot (kt+1) % STAGES, which
+        # the reads of two iterations ago finished with, so the DMA below may
+        # overwrite it. Only then is the next tile's DMA issued, and it stays in
+        # flight underneath this tile's MFMAs -- which is the entire point, and
+        # also the reason a conservative vmcnt before those reads would undo it.
+        dma_stage(fx.Index(0), fx.Index(0))
 
-        for _kt, _st in fx.range(
-            0, num_k_tiles, 1, init=list(accs) + list(a_pre) + list(b_pre)
-        ):
-            _cur, _a_cur, _b_cur = split_state(_st)
+        for _kt, _st in fx.range(0, num_k_tiles, 1, init=list(accs)):
+            _cur = split_state(_st)
             _now = _kt % fx.Index(STAGES)
-            _a_now, _b_now = a_buf(_now), b_buf(_now)
+            _next_slot = (_kt + fx.Index(1)) % fx.Index(STAGES)
 
-            store_tile(_a_cur, a_coords, _a_now)
-            store_tile(_b_cur, b_coords, _b_now)
+            rocdl.s_waitcnt(0)
             gpu.barrier()
 
-            # Issued after the barrier so they are in flight underneath this
-            # tile's MFMAs; the compiler pipelines them on register dependences
-            # it can see, which is the thing the opaque DMA denied it.
-            _a_next = load_tile(a_rsrc, a_coords, bx_m, _kt + fx.Index(1))
-            _b_next = load_tile(b_rsrc, b_coords, by_n, _kt + fx.Index(1))
+            dma_stage(_kt + fx.Index(1), _next_slot)
 
-            _tiles = tile_product(_a_now, _b_now)
-            _res = yield fold(
-                _cur, _tiles, load_scales(_kt)
-            ) + list(_a_next) + list(_b_next)
+            _tiles = tile_product(a_buf(_now), b_buf(_now))
+            _res = yield fold(_cur, _tiles, load_scales(_kt))
 
-        accs, _, _ = split_state(_res)
+        accs = split_state(_res)
 
         # ---- epilogue --------------------------------------------------------
         # The transposed accumulator gives a lane one output row and four runs of

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -55,7 +55,6 @@ from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import (
     arith,
     buffer_ops,
-    const_expr,
     gpu,
     range_constexpr,
     rocdl,
@@ -66,9 +65,13 @@ from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from mslk.flydsl.kernels.mma.mfma_preshuffle_pipeline import swizzle_xor16
 
-# Bytes each lane supplies per operand per MFMA issue (32 FP8 = 8 i32), the same
-# for either shape this kernel can be built with.
+# MFMA geometry: one issue is a 32x32 output tile contracting 64 of K.
+MFMA_M = 32
+MFMA_K = 64
+# Bytes each lane supplies per operand per issue (32 FP8 = 8 i32).
 MFMA_OPERAND_BYTES = 32
+# Accumulator registers per MFMA tile.
+ACC_REGS = MFMA_M * MFMA_M // 64
 
 WAVE = 64
 
@@ -123,7 +126,6 @@ def compile_groupwise_wide_gemm(
     waves_m: int = 4,
     waves_n: int = 2,
     waves_per_eu: int | None = None,
-    wide_mfma: bool = True,
 ):
     """Compile the kernel for one shape and tile config; return the launcher.
 
@@ -132,19 +134,7 @@ def compile_groupwise_wide_gemm(
     a wave count because its proportions drive LDS read traffic: reads per unit
     work are ``waves_m / tile_m + waves_n / tile_n``, which a grid proportioned
     like the tile minimises.
-
-    ``wide_mfma`` selects the MFMA shape. Both 32x32x64 and 16x16x128 retire the
-    same MACs from the same 32-byte operands and need the same accumulator
-    registers for a given tile, and both are neutral-scaled; the wide one does it
-    in half the issues, and is the only one whose epilogue can gather a lane's
-    columns into a 16-byte store.
     """
-    mfma_m = 32 if wide_mfma else 16
-    mfma_k = 64 if wide_mfma else 128
-    lane_groups = WAVE // mfma_m        # lane // mfma_m selects the K quarter/half
-    # Accumulator registers per MFMA tile: 16 wide, 4 narrow.
-    acc_regs = mfma_m * mfma_m // WAVE
-
     if tile_k != SCALE_BLOCK:
         raise ValueError(
             f"tile_k ({tile_k}) must equal the scale block ({SCALE_BLOCK}): the "
@@ -158,13 +148,13 @@ def compile_groupwise_wide_gemm(
         )
     if n % SCALE_BLOCK:
         raise ValueError(f"n ({n}) must be a multiple of {SCALE_BLOCK}")
-    if tile_m % (waves_m * mfma_m) or tile_n % (waves_n * mfma_m):
+    if tile_m % (waves_m * MFMA_M) or tile_n % (waves_n * MFMA_M):
         raise ValueError(
             f"tile {tile_m}x{tile_n} does not divide into {waves_m}x{waves_n} "
-            f"waves of {mfma_m}x{mfma_m} MFMA tiles"
+            f"waves of {MFMA_M}x{MFMA_M} MFMA tiles"
         )
-    if tile_k % mfma_k:
-        raise ValueError(f"tile_k ({tile_k}) must be a multiple of {mfma_k}")
+    if tile_k % MFMA_K:
+        raise ValueError(f"tile_k ({tile_k}) must be a multiple of {MFMA_K}")
     if tile_n > SCALE_BLOCK:
         raise ValueError(
             f"tile_n ({tile_n}) must not exceed the scale block ({SCALE_BLOCK}), "
@@ -176,9 +166,9 @@ def compile_groupwise_wide_gemm(
     wave_tile_m = tile_m // waves_m
     wave_tile_n = tile_n // waves_n
     # MFMA tiles each wave owns, and hence its accumulator count.
-    acc_m = wave_tile_m // mfma_m
-    acc_n = wave_tile_n // mfma_m
-    k_steps = tile_k // mfma_k
+    acc_m = wave_tile_m // MFMA_M
+    acc_n = wave_tile_n // MFMA_M
+    k_steps = tile_k // MFMA_K
     num_k_tiles = k // tile_k
     scale_n = n // SCALE_BLOCK
 
@@ -219,13 +209,12 @@ def compile_groupwise_wide_gemm(
     allocator.ptr = lds_off + lds_bytes
 
     # Everything that changes the emitted kernel has to reach the name, or two
-    # configs would collide in the compile cache. The occupancy hint and the
-    # MFMA shape do, as much as the tile does.
+    # configs would collide in the compile cache. The occupancy hint does, as
+    # much as the tile and the wave grid do.
     _wpe = f"_wpe{int(waves_per_eu)}" if waves_per_eu else ""
-    _mfma = "" if wide_mfma else "_narrow"
     module_name = (
         f"gw_wide_n{n}_k{k}_t{tile_m}x{tile_n}x{tile_k}"
-        f"_w{waves_m}x{waves_n}{_wpe}{_mfma}"
+        f"_w{waves_m}x{waves_n}{_wpe}"
     )
 
     # The AMDGPU default caps a workgroup at 256 threads; an eight-wave block
@@ -242,7 +231,7 @@ def compile_groupwise_wide_gemm(
         i32_k: fx.Int32,
     ):
         # MLIR types need a live context, so they are built during tracing.
-        v_acc_ty = Vector.make_type(acc_regs, fx.Float32)
+        v_acc_ty = Vector.make_type(ACC_REGS, fx.Float32)
 
         m_in = fx.Index(i32_m)
         n_in = fx.Index(i32_n)
@@ -263,8 +252,8 @@ def compile_groupwise_wide_gemm(
         wn = wave_id % fx.Index(waves_n)
         # The wide MFMA splits a lane's role by half-wave: which 32 of K it
         # supplies, and which four of the 32 output rows it holds.
-        lane_lo = lane % fx.Index(mfma_m)
-        lane_hi = lane // fx.Index(mfma_m)
+        lane_lo = lane % fx.Index(MFMA_M)
+        lane_hi = lane // fx.Index(MFMA_M)
 
         wave_m0 = wm * fx.Index(wave_tile_m)
         wave_n0 = wn * fx.Index(wave_tile_n)
@@ -410,7 +399,7 @@ def compile_groupwise_wide_gemm(
             halves = []
             for j in range_constexpr(frag_loads):
                 col = (
-                    fx.Index(ks * mfma_k)
+                    fx.Index(ks * MFMA_K)
                     + lane_hi * fx.Index(32)
                     + fx.Index(j * LOAD_BYTES)
                 )
@@ -424,17 +413,18 @@ def compile_groupwise_wide_gemm(
             return Vector(halves[0]).shuffle(Vector(halves[1]), list(range(8))).ir_value()
 
         def mfma(a_op, b_op, c_in):
-            ops = [
+            # The scale operands are the neutral exponent, so the instruction's
+            # own block scaling is the identity and the FP32 scales are folded in
+            # afterwards instead.
+            return rocdl.mfma_scale_f32_32x32x64_f8f6f4(
+                v_acc_ty,
                 _raw(a_op), _raw(b_op), _raw(c_in),
                 0, 0, 0,
                 _raw(fx.Int32(NEUTRAL_E8M0)), 0, _raw(fx.Int32(NEUTRAL_E8M0)),
-            ]
-            if const_expr(wide_mfma):
-                return rocdl.mfma_scale_f32_32x32x64_f8f6f4(v_acc_ty, *ops).result
-            return rocdl.mfma_scale_f32_16x16x128_f8f6f4(v_acc_ty, ops)
+            ).result
 
         zero_acc = Vector.from_elements(
-            [fx.Float32(0.0) for _ in range_constexpr(acc_regs)], fx.Float32
+            [fx.Float32(0.0) for _ in range_constexpr(ACC_REGS)], fx.Float32
         ).ir_value()
 
         def tile_product(a_base, b_base):
@@ -448,11 +438,11 @@ def compile_groupwise_wide_gemm(
             for ks in range_constexpr(k_steps):
                 a_frags = []
                 for ai in range_constexpr(acc_m):
-                    row = wave_m0 + fx.Index(ai * mfma_m) + lane_lo
+                    row = wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
                     a_frags.append(read_frag(row, a_base, ks))
                 b_frags = []
                 for aj in range_constexpr(acc_n):
-                    row = wave_n0 + fx.Index(aj * mfma_m) + lane_lo
+                    row = wave_n0 + fx.Index(aj * MFMA_M) + lane_lo
                     b_frags.append(read_frag(row, b_base, ks))
                 for ai in range_constexpr(acc_m):
                     for aj in range_constexpr(acc_n):
@@ -483,7 +473,7 @@ def compile_groupwise_wide_gemm(
             )
             out = []
             for ai in range_constexpr(acc_m):
-                row = bx_m + wave_m0 + fx.Index(ai * mfma_m) + lane_lo
+                row = bx_m + wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
                 sa = fx.Float32(
                     buffer_ops.buffer_load(
                         sa_rsrc, kt * m_in + row, vec_width=1, dtype=T.f32
@@ -497,14 +487,14 @@ def compile_groupwise_wide_gemm(
 
         def split_state(state):
             vals = list(state) if isinstance(state, (list, tuple)) else [state]
-            return [Vector(v, (acc_regs,), fx.Float32) for v in vals]
+            return [Vector(v, (ACC_REGS,), fx.Float32) for v in vals]
 
         def fold(cur, tiles, scales):
             out = []
             for ai in range_constexpr(acc_m):
                 for aj in range_constexpr(acc_n):
                     i = ai * acc_n + aj
-                    tile = Vector(tiles[i], (acc_regs,), fx.Float32)
+                    tile = Vector(tiles[i], (ACC_REGS,), fx.Float32)
                     # Emitted as an explicit fused multiply-add. Written as
                     # `acc + tile * scale` the two arith ops do not contract --
                     # contraction changes rounding, so the compiler will not do
@@ -518,12 +508,12 @@ def compile_groupwise_wide_gemm(
                                 fx.Float32(cur[i][r]).ir_value(),
                             )
                         )
-                        for r in range_constexpr(acc_regs)
+                        for r in range_constexpr(ACC_REGS)
                     ]
                     out.append(Vector.from_elements(vals, fx.Float32))
             return out
 
-        accs = [Vector(zero_acc, (acc_regs,), fx.Float32) for _ in range_constexpr(n_acc)]
+        accs = [Vector(zero_acc, (ACC_REGS,), fx.Float32) for _ in range_constexpr(n_acc)]
 
         # One tile deep: tile kt is read out of LDS while tile kt+1 is in flight
         # towards the other slot. Both operands go straight from global memory to
@@ -592,62 +582,42 @@ def compile_groupwise_wide_gemm(
             return fx.Int32(packed[0]), fx.Int32(packed[1])
 
         for ai in range_constexpr(acc_m):
-            row = bx_m + wave_m0 + fx.Index(ai * mfma_m) + lane_lo
+            row = bx_m + wave_m0 + fx.Index(ai * MFMA_M) + lane_lo
             for aj in range_constexpr(acc_n):
                 acc = accs[ai * acc_n + aj]
-                if const_expr(wide_mfma):
-                    for pair in range_constexpr(acc_regs // 8):
-                        even_lo, even_hi = group_dwords(acc, 2 * pair)
-                        odd_lo, odd_hi = group_dwords(acc, 2 * pair + 1)
-                        sw_lo = rocdl.permlane32_swap(
-                            pair_ty, _raw(even_lo), _raw(odd_lo), False, False
-                        )
-                        sw_hi = rocdl.permlane32_swap(
-                            pair_ty, _raw(even_hi), _raw(odd_hi), False, False
-                        )
-                        # Columns ascend with the address, so the dwords
-                        # interleave: this lane's own pair, then its partner's.
-                        quad = Vector.from_elements(
-                            [
-                                fx.Int32(llvm.extractvalue(T.i32, sw_lo, [0])),
-                                fx.Int32(llvm.extractvalue(T.i32, sw_hi, [0])),
-                                fx.Int32(llvm.extractvalue(T.i32, sw_lo, [1])),
-                                fx.Int32(llvm.extractvalue(T.i32, sw_hi, [1])),
-                            ],
-                            fx.Int32,
-                        )
-                        # Low lanes take the even group, high lanes the odd one.
-                        col = (
-                            by_n
-                            + wave_n0
-                            + fx.Index(aj * mfma_m)
-                            + (fx.Index(2 * pair) + lane_hi) * fx.Index(8)
-                        )
-                        buffer_ops.buffer_store(
-                            quad,
-                            d_rsrc,
-                            (row * n_in + col) * fx.Index(2),
-                            offset_is_bytes=True,
-                        )
-                else:
-                    # The narrow shape splits the wave four ways rather than two,
-                    # so a single permlane32_swap cannot gather eight adjacent
-                    # columns into one lane. Store the four it already holds.
-                    for g in range_constexpr(acc_regs // 4):
-                        lo, hi = group_dwords(acc, g)
-                        col = (
-                            by_n
-                            + wave_n0
-                            + fx.Index(aj * mfma_m)
-                            + lane_hi * fx.Index(4)
-                            + fx.Index(g * 4 * lane_groups)
-                        )
-                        buffer_ops.buffer_store(
-                            Vector.from_elements([lo, hi], fx.Int32),
-                            d_rsrc,
-                            (row * n_in + col) * fx.Index(2),
-                            offset_is_bytes=True,
-                        )
+                for pair in range_constexpr(ACC_REGS // 8):
+                    even_lo, even_hi = group_dwords(acc, 2 * pair)
+                    odd_lo, odd_hi = group_dwords(acc, 2 * pair + 1)
+                    sw_lo = rocdl.permlane32_swap(
+                        pair_ty, _raw(even_lo), _raw(odd_lo), False, False
+                    )
+                    sw_hi = rocdl.permlane32_swap(
+                        pair_ty, _raw(even_hi), _raw(odd_hi), False, False
+                    )
+                    # Columns ascend with the address, so the dwords interleave:
+                    # this lane's own pair, then its partner's.
+                    quad = Vector.from_elements(
+                        [
+                            fx.Int32(llvm.extractvalue(T.i32, sw_lo, [0])),
+                            fx.Int32(llvm.extractvalue(T.i32, sw_hi, [0])),
+                            fx.Int32(llvm.extractvalue(T.i32, sw_lo, [1])),
+                            fx.Int32(llvm.extractvalue(T.i32, sw_hi, [1])),
+                        ],
+                        fx.Int32,
+                    )
+                    # Low lanes take the even group, high lanes the odd one.
+                    col = (
+                        by_n
+                        + wave_n0
+                        + fx.Index(aj * MFMA_M)
+                        + (fx.Index(2 * pair) + lane_hi) * fx.Index(8)
+                    )
+                    buffer_ops.buffer_store(
+                        quad,
+                        d_rsrc,
+                        (row * n_in + col) * fx.Index(2),
+                        offset_is_bytes=True,
+                    )
 
     @flyc.jit
     def launch_groupwise_wide_gemm(

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -17,8 +17,7 @@ Computes ``D[M, N] = dequant(A) @ dequant(B).T`` for
 
 which is the contract of ``mslk::f8f8bf16_groupwise``.
 
-The schedule mirrors what the ROCm Triton kernel compiles to on gfx950, so that
-the two can be compared instruction for instruction:
+The schedule:
 
   * ``v_mfma_scale_f32_32x32x64_f8f6f4`` with a neutral E8M0 scale, which makes
     the hardware block-scaling a no-op and lets the block-scaled instruction
@@ -34,7 +33,7 @@ the two can be compared instruction for instruction:
     afterwards, because a scale changes every 128 elements of K while the
     accumulator has to persist across the whole contraction.
 
-Fragment layouts for the wide MFMA (verified empirically, not assumed):
+Fragment layouts for the wide MFMA:
 
   A operand   m = lane % 32,  k = (lane // 32) * 32 + byte
   B operand   n = lane % 32,  k = (lane // 32) * 32 + byte
@@ -67,11 +66,8 @@ from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 from mslk.flydsl.kernels.mma.mfma_preshuffle_pipeline import swizzle_xor16
 
-# Wide MFMA geometry: one issue is a 32x32 output tile contracting 64 of K.
-MFMA_M = 32
-MFMA_N = 32
-MFMA_K = 64
-# Bytes each lane supplies per operand per issue (32 FP8 = 8 i32).
+# Bytes each lane supplies per operand per MFMA issue (32 FP8 = 8 i32), the same
+# for either shape this kernel can be built with.
 MFMA_OPERAND_BYTES = 32
 
 WAVE = 64
@@ -95,13 +91,10 @@ LDS_CAPACITY = 160 * 1024
 # `buffer_load_lds` writes LDS through an opaque pointer, so SIInsertWaitcnts
 # cannot see which bytes it touches and conservatively drains every transfer
 # with a vmcnt(0) before each ds_read -- which cancels exactly the overlap the
-# pipeline exists to create. Read literally these two op classes *do* alias:
-# the transfer issued in one iteration is consumed by the reads in the next.
-# What the metadata asserts is not disjointness but that the dependence is
-# carried explicitly, by the s_waitcnt and barrier at the top of the loop body.
-# Triton states the same thing the same way, in a domain it documents as
-# "aliasing information between AsyncCopyGlobalToLocal, BufferLoadToLocal and
-# LocalLoad ops".
+# pipeline exists to create. Read literally these two op classes *do* alias: the
+# transfer issued in one iteration is consumed by the reads in the next. What
+# the metadata asserts is not disjointness but that the dependence is carried
+# explicitly, by the s_waitcnt and barrier at the top of the loop body.
 #
 # Because this suppresses the compiler's own analysis, that s_waitcnt becomes
 # load-bearing for correctness rather than just for speed: too permissive a wait
@@ -110,16 +103,12 @@ LDS_CAPACITY = 160 * 1024
 # to get wrong.
 _LDS_DOMAIN = '#llvm.alias_scope_domain<id = "gw_wide.lds">'
 _SCOPE_NAMES = ("dma", "reads")
+_SCOPE_DMA, _SCOPE_READS = range(len(_SCOPE_NAMES))
 
-# LDS buffers per operand. Triton runs three, fed by a direct global-to-LDS DMA
-# so the depth costs only LDS. That route is closed here: `buffer_load_lds`
-# writes LDS opaquely, so SIInsertWaitcnts cannot prove the pending transfers do
-# not alias the fragment reads and drains them with a vmcnt(0) before every
-# ds_read -- an explicit vmcnt(9) comes back out of the assembler as vmcnt(0).
-# The instruction mix still matches Triton exactly; only the wait operands
-# differ, and it measured 20% slower. Staging through registers instead lets the
-# compiler pipeline on register dependences it can see, but then each extra
-# stage costs a whole tile of VGPRs as well as the LDS, which is why two wins.
+# LDS buffers per operand: one being filled by the next tile's transfer while the
+# other is read by this tile's MFMAs. A deeper pipeline would need an exact
+# vmcnt rather than the vmcnt(0) above, which the alias metadata makes
+# load-bearing for correctness; see the K loop.
 STAGES = 2
 
 
@@ -139,18 +128,22 @@ def compile_groupwise_wide_gemm(
     """Compile the kernel for one shape and tile config; return the launcher.
 
     ``waves_m``/``waves_n`` are the wave grid, so the block is
-    ``waves_m * waves_n * 64`` threads. Triton reaches the same place by picking
-    ``num_warps`` and letting the compiler choose the grid; here it is explicit,
-    since the grid shape drives LDS read traffic and cannot be left implicit.
+    ``waves_m * waves_n * 64`` threads. The grid is given as a shape rather than
+    a wave count because its proportions drive LDS read traffic: reads per unit
+    work are ``waves_m / tile_m + waves_n / tile_n``, which a grid proportioned
+    like the tile minimises.
+
+    ``wide_mfma`` selects the MFMA shape. Both 32x32x64 and 16x16x128 retire the
+    same MACs from the same 32-byte operands and need the same accumulator
+    registers for a given tile, and both are neutral-scaled; the wide one does it
+    in half the issues, and is the only one whose epilogue can gather a lane's
+    columns into a 16-byte store.
     """
-    # 32x32x64 and 16x16x128 retire the same MACs from the same 32-byte operands
-    # and need the same accumulator registers for a given tile; the wide one just
-    # does it in half the issues. Both are neutral-scaled, so this selects the
-    # shape, not the technique.
     mfma_m = 32 if wide_mfma else 16
     mfma_k = 64 if wide_mfma else 128
-    lane_groups = WAVE // mfma_m          # lane // mfma_m selects the K quarter/half
-    acc_regs_v = mfma_m * mfma_m // WAVE  # 16 wide, 4 narrow
+    lane_groups = WAVE // mfma_m        # lane // mfma_m selects the K quarter/half
+    # Accumulator registers per MFMA tile: 16 wide, 4 narrow.
+    acc_regs = mfma_m * mfma_m // WAVE
 
     if tile_k != SCALE_BLOCK:
         raise ValueError(
@@ -161,7 +154,7 @@ def compile_groupwise_wide_gemm(
     if k % tile_k or n % tile_n:
         raise ValueError(
             f"n ({n}) and k ({k}) must divide by tile_n ({tile_n}) and tile_k "
-            f"({tile_k}); the tail-masked variant is not built yet"
+            f"({tile_k}); this kernel does not mask a partial tile"
         )
     if n % SCALE_BLOCK:
         raise ValueError(f"n ({n}) must be a multiple of {SCALE_BLOCK}")
@@ -202,8 +195,6 @@ def compile_groupwise_wide_gemm(
 
     # 16-byte chunks per row, the modulus of the XOR swizzle.
     k_chunks = tile_k // LOAD_BYTES
-    # Accumulator registers per MFMA tile.
-    acc_regs = acc_regs_v
     # 16-byte reads per operand fragment.
     frag_loads = MFMA_OPERAND_BYTES // LOAD_BYTES
 
@@ -309,8 +300,8 @@ def compile_groupwise_wide_gemm(
 
         def b_buf(slot):
             return fx.Index(STAGES * lds_a_elems) + slot * fx.Index(lds_b_elems)
+
         c_chunks = fx.Index(k_chunks)
-        c4 = fx.Index(4)
 
         # ---- staging coordinates -------------------------------------------
         # Load i of thread tx covers tile bytes [(i * threads + tx) * 16, +16),
@@ -324,7 +315,6 @@ def compile_groupwise_wide_gemm(
 
         a_coords = stage_coords(num_a_loads)
         b_coords = stage_coords(num_b_loads)
-
 
         def lds_index(row, col, lds_base):
             """Byte offset of tile element ``(row, col)`` under the XOR16 swizzle.
@@ -400,13 +390,12 @@ def compile_groupwise_wide_gemm(
                         fx.Int32(0),
                         fx.Int32(1),
                     ),
-                    0,
+                    _SCOPE_DMA,
                 )
 
         def dma_stage(kt, slot):
             dma_tile(a_rsrc, a_coords, bx_m, kt, a_buf(slot))
             dma_tile(b_rsrc, b_coords, by_n, kt, b_buf(slot))
-
 
         # ---- fragment reads --------------------------------------------------
         v4i32 = ir.VectorType.get([4], fx.Int32.ir_type)
@@ -430,7 +419,7 @@ def compile_groupwise_wide_gemm(
                     lds_ptr_ty, (lds_addr_i32 + fx.Int32(idx)).ir_value()
                 )
                 ld = llvm.LoadOp(v4i32, ptr, alignment=16)
-                tag_alias(ld, 1)
+                tag_alias(ld, _SCOPE_READS)
                 halves.append(Vector(ld.result))
             return Vector(halves[0]).shuffle(Vector(halves[1]), list(range(8))).ir_value()
 
@@ -504,21 +493,6 @@ def compile_groupwise_wide_gemm(
             return out
 
         # ---- K loop ----------------------------------------------------------
-        # Software pipeline, STAGES - 1 tiles deep, with nothing staged in
-        # registers: each iteration waits for the tile whose DMA was issued
-        # STAGES - 1 iterations ago, barriers, then issues the DMA for the tile
-        # STAGES - 1 ahead and computes.
-        #
-        # The one barrier does double duty. It publishes the tile just waited
-        # for, and it separates the reads of slot (kt - 1) % STAGES -- which the
-        # DMA below is about to overwrite -- from that overwrite, because those
-        # reads happened before it in every wave's program order.
-        #
-        # The scale loads are issued *before* the DMA rather than with the fold
-        # that consumes them. vmcnt retires in order, so consuming a scale
-        # loaded in the same iteration would force a wait that also drained
-        # every DMA behind it, collapsing the pipeline to nothing. Loading them
-        # two tiles ahead puts them behind the DMAs in the queue instead.
         n_acc = acc_m * acc_n
 
         def split_state(state):
@@ -551,18 +525,27 @@ def compile_groupwise_wide_gemm(
 
         accs = [Vector(zero_acc, (acc_regs,), fx.Float32) for _ in range_constexpr(n_acc)]
 
-        # One-deep DMA pipeline. Nothing is staged in registers, so the
-        # accumulators are the only loop carry -- 64 values instead of the 88 the
-        # register path needs.
+        # One tile deep: tile kt is read out of LDS while tile kt+1 is in flight
+        # towards the other slot. Both operands go straight from global memory to
+        # LDS, so the accumulators are the only value the loop carries.
         #
-        # Ordering matters more than it looks. The wait and barrier come first:
-        # the wait publishes tile kt (whose DMA was issued last iteration) and,
-        # because nothing newer has been issued yet at that point, vmcnt(0) there
-        # is free. The barrier additionally releases slot (kt+1) % STAGES, which
-        # the reads of two iterations ago finished with, so the DMA below may
-        # overwrite it. Only then is the next tile's DMA issued, and it stays in
-        # flight underneath this tile's MFMAs -- which is the entire point, and
-        # also the reason a conservative vmcnt before those reads would undo it.
+        # The order of the four steps in the body is forced, and each pairing
+        # matters:
+        #
+        #   wait    publishes tile kt, whose transfer was issued last iteration.
+        #           Nothing newer has been issued at this point, so vmcnt(0) here
+        #           costs nothing and there is no count to get wrong -- which the
+        #           alias metadata makes a correctness property, not just a
+        #           performance one.
+        #   barrier must follow the wait, or a wave crosses it with transfers
+        #           still in flight and its partners read bytes it has not
+        #           written; s_barrier orders execution, not memory. It also
+        #           releases the slot the previous iteration finished reading,
+        #           which the transfer below is about to overwrite.
+        #   DMA     must follow the barrier, or it overwrites a slot the other
+        #           waves are still reading.
+        #   compute leaves that transfer in flight underneath this tile's MFMAs,
+        #           which is the whole purpose of the arrangement.
         dma_stage(fx.Index(0), fx.Index(0))
 
         for _kt, _st in fx.range(0, num_k_tiles, 1, init=list(accs)):
@@ -594,7 +577,7 @@ def compile_groupwise_wide_gemm(
         # gives the low half all eight columns of the even group and the high
         # half all eight of the odd one, both for the row the lane already owned.
         # Two swaps per pair of groups turn four 8-byte stores into two 16-byte
-        # ones, which is what Triton's sixteen permlanes buy it as well.
+        # ones.
         pair_ty = ir.Type.parse("!llvm.struct<(i32, i32)>")
 
         def group_dwords(acc, g):

--- a/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py
@@ -227,8 +227,14 @@ def compile_groupwise_wide_gemm(
     lds_off = allocator._align(allocator.ptr, 16)
     allocator.ptr = lds_off + lds_bytes
 
+    # Everything that changes the emitted kernel has to reach the name, or two
+    # configs would collide in the compile cache. The occupancy hint and the
+    # MFMA shape do, as much as the tile does.
+    _wpe = f"_wpe{int(waves_per_eu)}" if waves_per_eu else ""
+    _mfma = "" if wide_mfma else "_narrow"
     module_name = (
-        f"gw_wide_n{n}_k{k}_t{tile_m}x{tile_n}x{tile_k}_w{waves_m}x{waves_n}"
+        f"gw_wide_n{n}_k{k}_t{tile_m}x{tile_n}x{tile_k}"
+        f"_w{waves_m}x{waves_n}{_wpe}{_mfma}"
     )
 
     # The AMDGPU default caps a workgroup at 256 threads; an eight-wave block

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -61,9 +61,9 @@ if torch.version.hip is not None:
     #
     # Targets that want the FlyDSL kernels depend on flydsl_ops themselves; the
     # lazy imports below then resolve, and Triton serves everyone else.
-    @functools.lru_cache(maxsize=1)
-    def _flydsl_gemm_module() -> ModuleType | None:
-        """The FlyDSL grouped-gemm module, or None when it is not opted into.
+    @functools.lru_cache(maxsize=8)
+    def _flydsl_gemm_module(name: str) -> ModuleType | None:
+        """A FlyDSL gemm module by name, or None when it is not opted into.
 
         Resolved through ``importlib`` rather than a static ``from .flydsl
         import ...``: this package deliberately does not depend on
@@ -75,11 +75,37 @@ if torch.version.hip is not None:
 
             if not is_flydsl_available():
                 return None
-            return importlib.import_module(
-                "mslk.gemm.flydsl.fp8_groupwise_grouped_gemm"
-            )
+            return importlib.import_module(f"mslk.gemm.flydsl.{name}")
         except ImportError:
             return None
+
+    if hasattr(torch.ops, "mslk") and hasattr(torch.ops.mslk, "f8f8bf16_groupwise"):
+        # Arbitrated the same way as the grouped op below: FlyDSL where it is
+        # opted into, Triton otherwise.
+        @functools.lru_cache(maxsize=1)
+        def _groupwise_impl() -> Callable[..., torch.Tensor]:
+            mod = _flydsl_gemm_module("fp8_groupwise_gemm")
+            if mod is not None:
+                return mod.matmul_f8f8bf16_groupwise
+            from .triton.fp8_groupwise_gemm import (
+                matmul_f8f8bf16_groupwise as _impl,
+            )
+
+            return _impl
+
+        try:
+
+            @torch.library.impl("mslk::f8f8bf16_groupwise", "CUDA")
+            def _f8f8bf16_groupwise_rocm(
+                XQ: torch.Tensor,
+                WQ: torch.Tensor,
+                x_scale: torch.Tensor,
+                w_scale: torch.Tensor,
+            ) -> torch.Tensor:
+                return _groupwise_impl()(XQ, WQ, x_scale, w_scale)
+
+        except RuntimeError:
+            pass  # already registered (e.g. module imported more than once)
 
     if hasattr(torch.ops, "mslk") and hasattr(
         torch.ops.mslk, "f8f8bf16_groupwise_grouped"
@@ -89,7 +115,7 @@ if torch.version.hip is not None:
         # module registers it and the choice is arbitrated here, on first call.
         @functools.lru_cache(maxsize=1)
         def _groupwise_grouped_impl() -> Callable[..., torch.Tensor]:
-            mod = _flydsl_gemm_module()
+            mod = _flydsl_gemm_module("fp8_groupwise_grouped_gemm")
             if mod is not None:
                 return mod.matmul_f8f8bf16_groupwise_grouped
             from .triton.fp8_groupwise_grouped_gemm import (
@@ -130,7 +156,7 @@ if torch.version.hip is not None:
                 w_scale: torch.Tensor,
                 M_sizes: torch.Tensor,
             ) -> torch.Tensor:
-                mod = _flydsl_gemm_module()
+                mod = _flydsl_gemm_module("fp8_groupwise_grouped_gemm")
                 if mod is None:
                     raise RuntimeError(
                         "mslk::f8f8bf16_groupwise_grouped_preshuffle requires the "

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -84,8 +84,11 @@ if torch.version.hip is not None:
         # opted into, Triton otherwise.
         @functools.lru_cache(maxsize=1)
         def _groupwise_impl() -> Callable[..., torch.Tensor]:
+            # Both conditions matter: FlyDSL reports itself available on the
+            # RDNA parts, where this op's kernels cannot run, so the module is
+            # asked whether it can serve this GPU rather than merely imported.
             mod = _flydsl_gemm_module("fp8_groupwise_gemm")
-            if mod is not None:
+            if mod is not None and mod.is_supported():
                 return mod.matmul_f8f8bf16_groupwise
             from .triton.fp8_groupwise_gemm import matmul_f8f8bf16_groupwise as _impl
 

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -87,9 +87,7 @@ if torch.version.hip is not None:
             mod = _flydsl_gemm_module("fp8_groupwise_gemm")
             if mod is not None:
                 return mod.matmul_f8f8bf16_groupwise
-            from .triton.fp8_groupwise_gemm import (
-                matmul_f8f8bf16_groupwise as _impl,
-            )
+            from .triton.fp8_groupwise_gemm import matmul_f8f8bf16_groupwise as _impl
 
             return _impl
 

--- a/mslk/gemm/flydsl/fp8_groupwise_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_gemm.py
@@ -44,10 +44,58 @@ import functools
 from collections.abc import Callable
 
 import torch
+from mslk.flydsl.autotune import next_pow2, prune_by_divisibility, tunable
 from mslk.gemm.flydsl import grouped_dispatch
 from mslk.utils.device import is_gfx942, is_gfx950
 
 _SCALE_BLOCK = grouped_dispatch.SCALE_BLOCK
+
+# Default config when autotuning is disabled: the kernel's own defaults, which
+# every supported shape can take, since tile_n divides the scale block and the
+# op's contract already makes N and K multiples of it.
+DEFAULT_TILE = {
+    "tile_m": 256,
+    "tile_n": 128,
+    "waves_m": 4,
+    "waves_n": 2,
+    "waves_per_eu": 0,
+}
+
+# Candidates swept by autotune. tile_k is absent: the scales change every 128
+# elements of K and a tile spanning more than one scale block would need a fold
+# per sub-block, so the kernel fixes it at the block size.
+_TILE_M = (32, 64, 128, 256)
+# Capped at the scale block, above which a tile would span several B scales.
+_TILE_N = (64, 128)
+# The wave grid is explicit rather than a wave count, because its shape is what
+# drives LDS read traffic: reads per unit work are waves_m / tile_m + waves_n /
+# tile_n, so the grid wants to be proportioned like the tile. Both four-wave and
+# eight-wave blocks are offered, in each proportion the tiles above can divide.
+_WAVE_GRIDS = ((1, 4), (2, 2), (4, 1), (2, 4), (4, 2), (8, 1))
+# Occupancy target, as a minimum waves-per-EU hint to the register allocator; 0
+# leaves the choice to the compiler.
+_WAVES_PER_EU = (0, 2)
+
+# Roughly half of these divide into whole MFMA tiles per wave and whole 16-byte
+# loads per lane, and fit LDS; the rest raise, which the autotuner reports and
+# skips. Enumerating the legal subset here instead would duplicate the kernel's
+# guards and drift from them.
+_TILES = tuple(
+    {
+        "tile_m": tm,
+        "tile_n": tn,
+        "waves_m": wm,
+        "waves_n": wn,
+        "waves_per_eu": wpe,
+    }
+    for tm in _TILE_M
+    for tn in _TILE_N
+    for (wm, wn) in _WAVE_GRIDS
+    for wpe in _WAVES_PER_EU
+)
+
+_PRUNE = prune_by_divisibility({"tile_n": "n"})
+_KEY = ["m_bucket", "n", "k"]
 
 
 def _matmul_gfx942(XQ, WQ, x_scale, w_scale, M, N, K):
@@ -66,22 +114,44 @@ def _matmul_gfx942(XQ, WQ, x_scale, w_scale, M, N, K):
     )
 
 
-def _matmul_gfx950(XQ, WQ, x_scale, w_scale, M, N, K):
-    """Serve the op from the kernel written for it.
+def _launch_gfx950(
+    XQ,
+    WQ,
+    x_scale,
+    w_scale,
+    out,
+    m_bucket,
+    n,
+    k,
+    *,
+    tile_m,
+    tile_n,
+    waves_m,
+    waves_n,
+    waves_per_eu=0,
+):
+    """Compile (cached) and launch the dedicated kernel for one config.
 
-    The tile and wave grid are left at the kernel's defaults until they are
-    swept: which one wins is a per-shape question, and a hand-written ladder
-    would only be a guess to unpick later.
+    ``m_bucket`` only feeds the autotune key: bucketing M keeps nearby token
+    counts on one tuned config. ``n``/``k`` are passed for the key and for tile
+    pruning, and are read back off the operands here.
     """
     from mslk.flydsl.jit import run_compiled
     from mslk.flydsl.kernels.gemm.fp8_groupwise_wide_gemm import (
         compile_groupwise_wide_gemm,
     )
 
-    launcher = compile_groupwise_wide_gemm(n=N, k=K, tile_k=_SCALE_BLOCK)
-    # The grid covers every row and column of the output, so nothing is left
-    # unwritten and the buffer does not have to start zeroed.
-    out = torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
+    launcher = compile_groupwise_wide_gemm(
+        n=n,
+        k=k,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        tile_k=_SCALE_BLOCK,
+        waves_m=waves_m,
+        waves_n=waves_n,
+        # 0 means the compiler picks.
+        waves_per_eu=None if waves_per_eu <= 0 else waves_per_eu,
+    )
     # The kernel addresses the operands as flat byte buffers; FP8 is viewed as
     # int8 for the handoff, as the grouped path does.
     run_compiled(
@@ -91,12 +161,25 @@ def _matmul_gfx950(XQ, WQ, x_scale, w_scale, M, N, K):
         WQ.contiguous().view(torch.int8),
         x_scale.contiguous(),
         w_scale.contiguous(),
-        M,
-        N,
-        K,
+        XQ.shape[0],
+        n,
+        k,
         torch.cuda.current_stream(),
     )
     return out
+
+
+_tuned_gfx950 = tunable(
+    configs=_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE
+)(_launch_gfx950)
+
+
+def _matmul_gfx950(XQ, WQ, x_scale, w_scale, M, N, K):
+    """Serve the op from the kernel written for it."""
+    # The grid covers every row and column of the output, so nothing is left
+    # unwritten and the buffer does not have to start zeroed.
+    out = torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
+    return _tuned_gfx950(XQ, WQ, x_scale, w_scale, out, next_pow2(M), N, K)
 
 
 @functools.lru_cache(maxsize=1)

--- a/mslk/gemm/flydsl/fp8_groupwise_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_gemm.py
@@ -51,14 +51,14 @@ from mslk.utils.device import is_gfx942, is_gfx950
 
 _SCALE_BLOCK = grouped_dispatch.SCALE_BLOCK
 
-# Default config when autotuning is disabled: the kernel's own defaults, which
-# every supported shape can take, since tile_n divides the scale block and the
-# op's contract already makes N and K multiples of it.
+# Config used when autotuning is disabled. Picked for the smallest worst case
+# against the per-shape best, not the most wins, so an untuned caller has a
+# bounded loss. Legal for every supported shape.
 DEFAULT_TILE = {
-    "tile_m": 256,
-    "tile_n": 128,
+    "tile_m": 128,
+    "tile_n": 64,
     "waves_m": 4,
-    "waves_n": 2,
+    "waves_n": 1,
     "waves_per_eu": 0,
 }
 

--- a/mslk/gemm/flydsl/fp8_groupwise_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_gemm.py
@@ -8,10 +8,11 @@
 
 """FP8 groupwise-scaled GEMM via FlyDSL.
 
-Registers ``mslk::f8f8bf16_groupwise``, the plain (non-grouped) GEMM whose
+Implements ``mslk::f8f8bf16_groupwise``, the plain (non-grouped) GEMM whose
 weights are scaled per 128x128 block and whose activations are scaled per token
-per 128 of K. CUDA implements it in CUTLASS; on ROCm it was a Triton kernel,
-which this replaces.
+per 128 of K. CUDA implements it in CUTLASS. The op is registered in
+``mslk/gemm/__init__.py``, which picks this implementation wherever the FlyDSL
+backend is opted into and Triton's otherwise.
 
 Two kernels serve it, chosen by architecture.
 
@@ -20,11 +21,11 @@ that architecture introduced -- the wide ``f8f6f4`` MFMA and ``permlane32_swap``
 -- and around the fact that a plain GEMM needs no group resolution at all. See
 ``mslk.flydsl.kernels.gemm.fp8_groupwise_wide_gemm``.
 
-Everywhere else it is the same kernel as the grouped ops, compiled for a single
-group under the ``batched`` layout: that layout gives each group a fixed slab of
-rows, so one group is one slab spanning all of M, which is a plain GEMM. The
-scale layouts coincide too. Block scaling addresses scale_a as per-group blocks
--- group g's block starts at ``m_start * scale_k`` and holds element
+On gfx942 it is the same kernel as the grouped ops, compiled for a single group
+under the ``batched`` layout: that layout gives each group a fixed slab of rows,
+so one group is one slab spanning all of M, which is a plain GEMM. The scale
+layouts coincide too. Block scaling addresses scale_a as per-group blocks --
+group g's block starts at ``m_start * scale_k`` and holds element
 ``(local_m, k_block)`` at ``local_m + k_block * M_g`` -- and at one group that is
 ``local_m + k_block * M``, which is exactly the ``[K//128, M]`` this op is
 handed. Likewise ``[G, K//128, N//128]`` is ``[K//128, N//128]`` at G = 1.

--- a/mslk/gemm/flydsl/fp8_groupwise_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_gemm.py
@@ -170,9 +170,9 @@ def _launch_gfx950(
     return out
 
 
-_tuned_gfx950 = tunable(
-    configs=_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE
-)(_launch_gfx950)
+_tuned_gfx950 = tunable(configs=_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE)(
+    _launch_gfx950
+)
 
 
 def _matmul_gfx950(XQ, WQ, x_scale, w_scale, M, N, K):

--- a/mslk/gemm/flydsl/fp8_groupwise_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_gemm.py
@@ -184,24 +184,33 @@ def _matmul_gfx950(XQ, WQ, x_scale, w_scale, M, N, K):
 
 
 @functools.lru_cache(maxsize=1)
-def _kernel() -> Callable[..., torch.Tensor]:
-    """Which kernel serves this op on the current GPU.
+def is_supported() -> bool:
+    """Whether this module can serve the op on the current GPU.
 
-    Named architectures rather than "gfx950 or else": FlyDSL reports itself
-    available on the RDNA parts too, which have no MFMA at all, and falling
-    through to a kernel built on one would fail somewhere deep inside it.
+    Both kernels below are built on MFMA, which the RDNA parts do not have --
+    and FlyDSL reports itself available on those, so having the backend says
+    nothing about whether this op can run. Callers pick an implementation with
+    this rather than with backend availability; ``mslk/gemm/__init__.py`` falls
+    back to Triton when it is False.
 
     Resolved once rather than per call: the architecture cannot change within a
     process, and reading it costs a device-property lookup that dwarfs a tensor
     attribute access.
     """
+    return is_gfx950() or is_gfx942()
+
+
+@functools.lru_cache(maxsize=1)
+def _kernel() -> Callable[..., torch.Tensor]:
+    """Which kernel serves this op on the current GPU."""
     if is_gfx950():
         return _matmul_gfx950
     if is_gfx942():
         return _matmul_gfx942
     raise RuntimeError(
         "mslk::f8f8bf16_groupwise on ROCm is implemented for gfx942 and gfx950; "
-        "this GPU is neither."
+        "this GPU is neither. Reach it through torch.ops.mslk, which falls back "
+        "to Triton elsewhere."
     )
 
 

--- a/mslk/gemm/flydsl/fp8_groupwise_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_gemm.py
@@ -13,11 +13,18 @@ weights are scaled per 128x128 block and whose activations are scaled per token
 per 128 of K. CUDA implements it in CUTLASS; on ROCm it was a Triton kernel,
 which this replaces.
 
-It is served by the same kernel as the grouped ops, compiled for a single group
-under the ``batched`` layout: that layout gives each group a fixed slab of rows,
-so one group is one slab spanning all of M, which is a plain GEMM. The scale
-layouts coincide too. Block scaling addresses scale_a as per-group blocks --
-group g's block starts at ``m_start * scale_k`` and holds element
+Two kernels serve it, chosen by architecture.
+
+On gfx950 it is a kernel written for this op alone, built around instructions
+that architecture introduced -- the wide ``f8f6f4`` MFMA and ``permlane32_swap``
+-- and around the fact that a plain GEMM needs no group resolution at all. See
+``mslk.flydsl.kernels.gemm.fp8_groupwise_wide_gemm``.
+
+Everywhere else it is the same kernel as the grouped ops, compiled for a single
+group under the ``batched`` layout: that layout gives each group a fixed slab of
+rows, so one group is one slab spanning all of M, which is a plain GEMM. The
+scale layouts coincide too. Block scaling addresses scale_a as per-group blocks
+-- group g's block starts at ``m_start * scale_k`` and holds element
 ``(local_m, k_block)`` at ``local_m + k_block * M_g`` -- and at one group that is
 ``local_m + k_block * M``, which is exactly the ``[K//128, M]`` this op is
 handed. Likewise ``[G, K//128, N//128]`` is ``[K//128, N//128]`` at G = 1.
@@ -33,10 +40,85 @@ Tensor contract:
                   * WQ[n, k] * w_scale[k//128, n//128]
 """
 
+import functools
+from collections.abc import Callable
+
 import torch
 from mslk.gemm.flydsl import grouped_dispatch
+from mslk.utils.device import is_gfx942, is_gfx950
 
 _SCALE_BLOCK = grouped_dispatch.SCALE_BLOCK
+
+
+def _matmul_gfx942(XQ, WQ, x_scale, w_scale, M, N, K):
+    """Serve the op from the grouped GEMM kernel, as one batched group."""
+    # One group owning every row, so the weights become the single-entry stack
+    # the kernel indexes by group. The view is free on a contiguous tensor.
+    return grouped_dispatch.dispatch(
+        XQ,
+        WQ.unsqueeze(0),
+        x_scale,
+        w_scale,
+        grouped_dispatch.unused_group_meta(XQ.device),
+        b_preshuffled=False,
+        blockscale=True,
+        layout="batched",
+    )
+
+
+def _matmul_gfx950(XQ, WQ, x_scale, w_scale, M, N, K):
+    """Serve the op from the kernel written for it.
+
+    The tile and wave grid are left at the kernel's defaults until they are
+    swept: which one wins is a per-shape question, and a hand-written ladder
+    would only be a guess to unpick later.
+    """
+    from mslk.flydsl.jit import run_compiled
+    from mslk.flydsl.kernels.gemm.fp8_groupwise_wide_gemm import (
+        compile_groupwise_wide_gemm,
+    )
+
+    launcher = compile_groupwise_wide_gemm(n=N, k=K, tile_k=_SCALE_BLOCK)
+    # The grid covers every row and column of the output, so nothing is left
+    # unwritten and the buffer does not have to start zeroed.
+    out = torch.empty((M, N), dtype=torch.bfloat16, device=XQ.device)
+    # The kernel addresses the operands as flat byte buffers; FP8 is viewed as
+    # int8 for the handoff, as the grouped path does.
+    run_compiled(
+        launcher,
+        out,
+        XQ.contiguous().view(torch.int8),
+        WQ.contiguous().view(torch.int8),
+        x_scale.contiguous(),
+        w_scale.contiguous(),
+        M,
+        N,
+        K,
+        torch.cuda.current_stream(),
+    )
+    return out
+
+
+@functools.lru_cache(maxsize=1)
+def _kernel() -> Callable[..., torch.Tensor]:
+    """Which kernel serves this op on the current GPU.
+
+    Named architectures rather than "gfx950 or else": FlyDSL reports itself
+    available on the RDNA parts too, which have no MFMA at all, and falling
+    through to a kernel built on one would fail somewhere deep inside it.
+
+    Resolved once rather than per call: the architecture cannot change within a
+    process, and reading it costs a device-property lookup that dwarfs a tensor
+    attribute access.
+    """
+    if is_gfx950():
+        return _matmul_gfx950
+    if is_gfx942():
+        return _matmul_gfx942
+    raise RuntimeError(
+        "mslk::f8f8bf16_groupwise on ROCm is implemented for gfx942 and gfx950; "
+        "this GPU is neither."
+    )
 
 
 def matmul_f8f8bf16_groupwise(
@@ -67,18 +149,7 @@ def matmul_f8f8bf16_groupwise(
         f"w_scale must be [{scale_k}, {scale_n}], got {tuple(w_scale.shape)}"
     )
 
-    # One group owning every row, so the weights become the single-entry stack
-    # the kernel indexes by group. The view is free on a contiguous tensor.
-    return grouped_dispatch.dispatch(
-        XQ,
-        WQ.unsqueeze(0),
-        x_scale,
-        w_scale,
-        grouped_dispatch.unused_group_meta(XQ.device),
-        b_preshuffled=False,
-        blockscale=True,
-        layout="batched",
-    )
+    return _kernel()(XQ, WQ, x_scale, w_scale, M, N, K)
 
 
 # This module deliberately does not register the op. FlyDSL owns it wherever it

--- a/mslk/gemm/flydsl/fp8_groupwise_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_gemm.py
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""FP8 groupwise-scaled GEMM via FlyDSL.
+
+Registers ``mslk::f8f8bf16_groupwise``, the plain (non-grouped) GEMM whose
+weights are scaled per 128x128 block and whose activations are scaled per token
+per 128 of K. CUDA implements it in CUTLASS; on ROCm it was a Triton kernel,
+which this replaces.
+
+It is served by the same kernel as the grouped ops, compiled for a single group
+under the ``batched`` layout: that layout gives each group a fixed slab of rows,
+so one group is one slab spanning all of M, which is a plain GEMM. The scale
+layouts coincide too. Block scaling addresses scale_a as per-group blocks --
+group g's block starts at ``m_start * scale_k`` and holds element
+``(local_m, k_block)`` at ``local_m + k_block * M_g`` -- and at one group that is
+``local_m + k_block * M``, which is exactly the ``[K//128, M]`` this op is
+handed. Likewise ``[G, K//128, N//128]`` is ``[K//128, N//128]`` at G = 1.
+
+Tensor contract:
+  XQ      : [M, K]               FP8  -- activations
+  WQ      : [N, K]               FP8  -- weights, already transposed
+  x_scale : [K//128, M]          FP32 -- per (K-group-of-128, row)
+  w_scale : [K//128, N//128]     FP32 -- per (K-group-of-128, N-group-of-128)
+  Output  : [M, N]               BF16
+
+  out[m, n] = sum_k XQ[m, k] * x_scale[k//128, m]
+                  * WQ[n, k] * w_scale[k//128, n//128]
+"""
+
+import torch
+from mslk.gemm.flydsl import grouped_dispatch
+
+_SCALE_BLOCK = grouped_dispatch.SCALE_BLOCK
+
+
+def matmul_f8f8bf16_groupwise(
+    XQ: torch.Tensor,
+    WQ: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+) -> torch.Tensor:
+    """FP8 groupwise-scaled GEMM -> BF16."""
+    assert XQ.ndim == 2, f"XQ must be [M, K], got {XQ.shape}"
+    assert WQ.ndim == 2, f"WQ must be [N, K], got {WQ.shape}"
+    M, K = XQ.shape
+    N, Kw = WQ.shape
+    assert Kw == K, f"K mismatch: XQ K={K}, WQ K={Kw}"
+    grouped_dispatch.assert_fp8_operands(XQ, WQ)
+    # A scale covers a whole block, so N and K have to span whole ones: a
+    # partial block at either end falls outside the count and misindexes the
+    # scales from there on. The CUDA implementation fixes the same granularity.
+    assert N % _SCALE_BLOCK == 0 and K % _SCALE_BLOCK == 0, (
+        f"n ({N}) and k ({K}) must be multiples of the {_SCALE_BLOCK}-element "
+        "scale block under block scaling"
+    )
+    scale_k, scale_n = K // _SCALE_BLOCK, N // _SCALE_BLOCK
+    assert x_scale.numel() == scale_k * M, (
+        f"x_scale must be [{scale_k}, {M}], got {tuple(x_scale.shape)}"
+    )
+    assert w_scale.numel() == scale_k * scale_n, (
+        f"w_scale must be [{scale_k}, {scale_n}], got {tuple(w_scale.shape)}"
+    )
+
+    # One group owning every row, so the weights become the single-entry stack
+    # the kernel indexes by group. The view is free on a contiguous tensor.
+    return grouped_dispatch.dispatch(
+        XQ,
+        WQ.unsqueeze(0),
+        x_scale,
+        w_scale,
+        grouped_dispatch.unused_group_meta(XQ.device),
+        b_preshuffled=False,
+        blockscale=True,
+        layout="batched",
+    )
+
+
+# This module deliberately does not register the op. FlyDSL owns it wherever it
+# is opted into and Triton is the fallback, but only one CUDA implementation can
+# win, so the choice is arbitrated in mslk/gemm/__init__.py on first call --
+# which also keeps registration from importing FlyDSL.

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -45,36 +45,14 @@ Tensor contract:
   out[m, n] = (sum_k XQ[m, k] * WQ[g, n, k]) * x_scale[m] * w_scale[g, n]
 """
 
-import functools
-
 import torch
 from mslk.flydsl.common import require_flydsl
 from mslk.gemm.flydsl import grouped_dispatch
-from mslk.utils.device import supports_float8_fnuz
 
-
-def _assert_fp8_operands(XQ: torch.Tensor, WQ: torch.Tensor) -> None:
-    """Reject a mismatched FP8 flavour.
-
-    The MFMA instructions read the operands in the arch's native FP8 format, and
-    the kernel passes them through as raw bytes, so an fnuz/OCP mismatch would be
-    applied with the wrong exponent bias rather than rejected.
-    """
-    expected = torch.float8_e4m3fnuz if supports_float8_fnuz() else torch.float8_e4m3fn
-    assert XQ.dtype == expected, f"XQ must be {expected}, got {XQ.dtype}"
-    assert WQ.dtype == expected, f"WQ must be {expected}, got {WQ.dtype}"
-
-
-@functools.lru_cache(maxsize=8)
-def _unused_group_meta(device: torch.device) -> torch.Tensor:
-    """Stand-in for the group-metadata operand under the batched layout.
-
-    That layout carries no per-group metadata and the kernel never reads the
-    argument, but the launcher's argument list is fixed at compile time. Caching
-    keeps a call free of an allocation and holds the address stable, which
-    CUDA-graph capture requires.
-    """
-    return torch.zeros((1,), dtype=torch.int32, device=device)
+# Both checks are common to every FlyDSL GEMM wrapper, so they live beside the
+# dispatch; these names are kept for the call sites below.
+_assert_fp8_operands = grouped_dispatch.assert_fp8_operands
+_unused_group_meta = grouped_dispatch.unused_group_meta
 
 
 def _dispatch_rowwise_grouped(

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -17,9 +17,12 @@ Tile selection is delegated to mslk.flydsl.autotune, which tunes only when
 MSLK_AUTOTUNE_ENABLE is set and otherwise uses a fixed default.
 """
 
+import functools
+
 import torch
 from mslk.flydsl.autotune import next_pow2, prune_by_divisibility, tunable
 from mslk.flydsl.jit import run_compiled
+from mslk.utils.device import supports_float8_fnuz
 
 # Scale-block granularity for the block-scaling scheme. It also sets the K-loop
 # sub-block size under either scheme, so tile_k must be a multiple of it.
@@ -68,6 +71,36 @@ _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
 # varies per call, and a tuning space containing a fully unrolled candidate would
 # have to compile one per tile config, at a cost that grows with K.
 _KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "layout"]
+
+
+def assert_fp8_operands(XQ: torch.Tensor, WQ: torch.Tensor) -> None:
+    """Reject a mismatched FP8 flavour.
+
+    The MFMA instructions read the operands in the arch's native FP8 format, and
+    the kernel passes them through as raw bytes, so an fnuz/OCP mismatch would be
+    applied with the wrong exponent bias rather than rejected.
+
+    Every wrapper has to make this check, so it sits beside the dispatch rather
+    than in any one of them.
+    """
+    expected = torch.float8_e4m3fnuz if supports_float8_fnuz() else torch.float8_e4m3fn
+    assert XQ.dtype == expected, f"XQ must be {expected}, got {XQ.dtype}"
+    assert WQ.dtype == expected, f"WQ must be {expected}, got {WQ.dtype}"
+
+
+@functools.lru_cache(maxsize=8)
+def unused_group_meta(device: torch.device) -> torch.Tensor:
+    """Stand-in for the group-metadata operand under the batched layout.
+
+    That layout carries no per-group metadata and the kernel never reads the
+    argument, but the launcher's argument list is fixed at compile time. Caching
+    keeps a call free of an allocation and holds the address stable, which
+    CUDA-graph capture requires.
+
+    Every wrapper that reaches the batched layout needs one, so it lives next to
+    the dispatch it is an argument to.
+    """
+    return torch.zeros((1,), dtype=torch.int32, device=device)
 
 
 def _group_and_n(WQ, group_meta, layout):

--- a/mslk/gemm/triton/fp8_groupwise_gemm.py
+++ b/mslk/gemm/triton/fp8_groupwise_gemm.py
@@ -268,24 +268,15 @@ def matmul_f8f8bf16_groupwise(
 
 
 # ---------------------------------------------------------------------------
-# Register as the ROCm implementation of mslk::f8f8bf16_groupwise
+# The ROCm implementation of mslk::f8f8bf16_groupwise
 # ---------------------------------------------------------------------------
 # The C++ schema is declared in gemm_ops.cpp (shared between CUDA and ROCm).
-# On ROCm the CUDA C++ implementation is absent; this module registers the
-# Triton kernel above as the dispatch target via torch.library.impl.
-
-if torch.version.hip is not None and hasattr(torch.ops, "mslk"):
-    if hasattr(torch.ops.mslk, "f8f8bf16_groupwise"):
-        try:
-
-            @torch.library.impl("mslk::f8f8bf16_groupwise", "CUDA")
-            def _f8f8bf16_groupwise_rocm(
-                XQ: torch.Tensor,
-                WQ: torch.Tensor,
-                x_scale: torch.Tensor,
-                w_scale: torch.Tensor,
-            ) -> torch.Tensor:
-                return matmul_f8f8bf16_groupwise(XQ, WQ, x_scale, w_scale)
-
-        except RuntimeError:
-            pass  # already registered (e.g. module imported more than once)
+# On ROCm the CUDA C++ implementation is absent, so one of the kernels here has
+# to be the dispatch target.
+#
+# FALLBACK ONLY: FlyDSL owns this op wherever it is usable (see
+# mslk/gemm/flydsl/fp8_groupwise_gemm.py) and Triton is the fallback. Only one
+# CUDA implementation can win, so the two are arbitrated in
+# mslk/gemm/__init__.py, which registers whichever one applies. Registering here
+# as well would need the FlyDSL probe at import time, and importing FlyDSL is
+# fatal in a process that already holds Triton's MLIR/LLVM.


### PR DESCRIPTION
## Summary

Serves `mslk::f8f8bf16_groupwise` — the plain FP8 GEMM whose weights are scaled per 128×128 block and activations per token per 128 of K — from FlyDSL on ROCm, replacing the Triton kernel. CUDA is unchanged. This is the non-grouped counterpart of the grouped op in #470.

| Architecture | Kernel |
|---|---|
| gfx950 | a new kernel written for this op, `fp8_groupwise_wide_gemm` |
| gfx942 | the existing grouped kernel from #470, compiled for a single group |
| anything else on ROCm | raises |

gfx942 needs no new kernel. The grouped kernel's `batched` layout gives each group a fixed slab of rows, so **one group is one slab spanning all of M — which is exactly a plain GEMM**. The scale layouts coincide at G=1 too, so the operands pass through unchanged.

The op is registered in `mslk/gemm/__init__.py`, matching what the grouped op already does: neither kernel module registers it, and the choice between FlyDSL and Triton is made there on first call. Registering inside the modules would mean probing for FlyDSL at import time, which is fatal in a process already holding Triton's MLIR/LLVM.

## Why a separate kernel for gfx950

The grouped kernel can serve this op, and does on gfx942. The new one exists because a plain GEMM on CDNA4 can drop work the grouped kernel has to keep:

- **No group resolution.** One group means no per-tile row lookup at all.
- **The wide MFMA.** `v_mfma_scale_f32_32x32x64_f8f6f4` covers K=64 per issue. It is a *block-scaled* instruction, used here with a neutral E8M0 scale so the hardware scaling is the identity — the FP32 scales are applied in software afterwards, since a scale changes every 128 elements of K while the accumulator spans the whole contraction.
- **Operands go straight to LDS.** `buffer_load_lds` moves both operands global→LDS without passing through registers, so the accumulators are the only value the K loop carries.
- **A wider store.** Feeding the MFMA its operands swapped leaves each lane holding one output row, which `permlane32_swap` then gathers into 16-byte stores.

## Performance

FlyDSL vs Triton, CUDA-graph replay on both sides after a clock ramp, gfx950, idle GPU, autotuning enabled. Figures are Triton's time saved, `(triton - fly) / triton * 100`.

**63 shapes: median +11.6% saved, faster on 56.** Best +31.1% (`ds_v3 7168×2304`, M=128), worst −11.7% (`llama3_70b 1280×8192`, M=16).

Losses cluster at M ≤ 16, where the kernel launches one block per N-tile and is latency-bound rather than tile-limited:

| M | 1 | 16 | 32 | 64 | 128 | 512 | 1024 | 4096 | 8192 |
|---|---|---|---|---|---|---|---|---|---|
| mean saved | +5.2% | +6.9% | +8.2% | +14.1% | +15.6% | +14.0% | +12.2% | +10.7% | +8.8% |

<details>
<summary>Per-shape detail — M ∈ {1, 128, 8192} of the 63 measured</summary>

| Family | M | N×K | Triton µs | FlyDSL µs | Time saved |
|---|---|---|---|---|---|
| ds_v3 | 1 | 2048×7168 | 19.2 | 21.3 | -10.9% |
| ds_v3 | 128 | 2048×7168 | 21.9 | 21.3 | +2.9% |
| ds_v3 | 8192 | 2048×7168 | 180.7 | 173.3 | +4.1% |
| ds_v3 | 1 | 7168×2304 | 8.7 | 8.6 | +1.4% |
| ds_v3 | 128 | 7168×2304 | 13.1 | 9.0 | +31.1% |
| ds_v3 | 8192 | 7168×2304 | 235.5 | 200.1 | +15.0% |
| llama3_70b | 1 | 1280×8192 | 21.5 | 23.5 | -9.4% |
| llama3_70b | 128 | 1280×8192 | 34.1 | 24.0 | +29.6% |
| llama3_70b | 8192 | 1280×8192 | 160.2 | 141.6 | +11.6% |
| llama3_70b | 1 | 8192×1024 | 6.4 | 6.2 | +2.6% |
| llama3_70b | 128 | 8192×1024 | 7.6 | 6.9 | +9.4% |
| llama3_70b | 8192 | 8192×1024 | 132.8 | 115.6 | +13.0% |
| llama3_70b | 1 | 7168×8192 | 34.0 | 32.4 | +4.7% |
| llama3_70b | 128 | 7168×8192 | 38.4 | 33.1 | +13.9% |
| llama3_70b | 8192 | 7168×8192 | 702.3 | 661.5 | +5.8% |
| llama3_70b | 1 | 8192×3584 | 17.6 | 12.5 | +29.1% |
| llama3_70b | 128 | 8192×3584 | 19.8 | 16.2 | +18.2% |
| llama3_70b | 8192 | 8192×3584 | 379.4 | 343.6 | +9.4% |
| llama3_405b | 1 | 13312×16384 | 75.3 | 61.0 | +19.1% |
| llama3_405b | 128 | 13312×16384 | 75.7 | 72.6 | +4.0% |
| llama3_405b | 8192 | 13312×16384 | 2614.3 | 2546.7 | +2.6% |

</details>

## Correctness

**Output is bit-identical to Triton on all 63 shapes** — equal, not close.

`test/gemm/gemm_test.py -k "grouped or groupwise or blockwise"`: **97 passed, 62 skipped** on gfx950. The existing `test_f8f8bf16_groupwise` cases now exercise FlyDSL and are the primary coverage; they pass with tuning both off and on.

Every tuning config was also checked against every other. None of them reorders the reduction — the tile and wave grid partition the *output*, and `tile_k` is pinned — so they must agree bit for bit, and a difference would mean an indexing bug rather than rounding. On six shapes, **all 46 legal configs produced identical bits and all matched Triton**.

## Tile selection

Tuning runs only under `MSLK_AUTOTUNE_ENABLE`, matching the CK and CUTLASS paths; otherwise a fixed default is used and nothing is benchmarked. The space is tile size × wave grid × occupancy hint. Configurations the kernel cannot build are left in the list and rejected by its own guards, rather than duplicating those guards in the wrapper.

The wave grid is tuned as a *shape* (`waves_m × waves_n`), not a wave count, because its proportions drive LDS read traffic. Triton tunes `num_warps` and lets its compiler derive the arrangement; there is no equivalent inference here, and the sweep picks four different grids across these shapes, so no simple rule substitutes for measuring.

The default is chosen for its **worst case**, not its average: measured against the best config per shape, it is within 1.30× everywhere. A default is what a caller falls back to rather than what they pick, so a bounded loss matters more there than a good mean with a bad tail.

## Reviewing

The substance is two files — the kernel `mslk/flydsl/kernels/gemm/fp8_groupwise_wide_gemm.py` and the wrapper `mslk/gemm/flydsl/fp8_groupwise_gemm.py`. The rest is small: the registration block in `mslk/gemm/__init__.py`, removing Triton's self-registration so the two do not both claim the op, moving two shared helpers into `grouped_dispatch`, and adding `mslk/gemm/__init__.py` to the ROCm CI path filter so a change to the op arbitration cannot skip CI.

Verified on gfx950 (MI350) and gfx942 (MI300).