### PR TITLE
Stop the CUDA conda-build CI job from OOMing the worker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -320,7 +320,12 @@ class MSLKBuild:
             return f"-D_GLIBCXX_USE_CXX11_ABI={value}"
 
         torch_root = os.path.dirname(torch.__file__)
-        os.environ["CMAKE_BUILD_PARALLEL_LEVEL"] = str((os.cpu_count() or 4) // 2)
+        # os.cpu_count() reports the host's CPUs, not the cgroup's, so under a
+        # memory-capped CI container the derived default can fan out far enough
+        # to OOM the container. Let the caller pin a level instead.
+        os.environ.setdefault(
+            "CMAKE_BUILD_PARALLEL_LEVEL", str((os.cpu_count() or 4) // 2)
+        )
 
         cmake_args = [
             f"-DCMAKE_PREFIX_PATH={torch_root}",


### PR DESCRIPTION
Summary:
`citadel-fbcode-test-mode-{dev,opt}-for-mslk_dev-linux-heavyweight-0` fail on
every diff that touches `fbcode/mslk/**`. Neither is a test failure: both jobs
get through checkout, build and test, then get SIGKILLed. From
`scutil oom debug 36028799929460546`:

```
Lost job: killed_by_oomd
Max memory used:      58.8 GiB
Max memory used job:  56.0 GiB
Host: worker.i4.smallplusplus.ecp.7
```

The whole job is one target, `fbcode//mslk/ci:mslk-conda-build-cuda`, a
`buck_sh_test` that runs a full conda + nvcc build of MSLK on the worker.

The build's parallelism came from `setup.py`, which set

```
os.environ["CMAKE_BUILD_PARALLEL_LEVEL"] = str((os.cpu_count() or 4) // 2)
```

`os.cpu_count()` reports the host's CPUs, not the cgroup's, so on a large
shared worker this derives a level far above what the container's memory can
support. Because it was a plain assignment rather than a `setdefault`, no
caller could override it. Switch it to `setdefault` and pin the level to 8 in
the target's `env`.

Separately, `ci.for_schedules([ci.diff, ci.land], [ci.linux()])` passed no
mode, so `ci.linux()` defaulted to dev and scheduled a second, identical job.
The script never touches buck-built artifacts, so the buck mode is irrelevant
to it and the dev run was pure duplicate cost. Pin both schedules to
`fbcode//mode/opt`.

Differential Revision: D118757794


