### PR TITLE
Serve the stacked BF16 grouped GEMM from FlyDSL on ROCm

### DIFF
--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -159,7 +159,6 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   m.impl("bf16bf16bf16_grouped", bf16bf16bf16_grouped);
   m.impl("bf16bf16bf16_grouped_cat", bf16bf16bf16_grouped_cat);
   m.impl("bf16bf16bf16_grouped_dynamic", bf16bf16bf16_grouped_dynamic);
-  m.impl("bf16bf16bf16_grouped_stacked", bf16bf16bf16_grouped_stacked);
 
 #ifdef USE_ROCM
   m.impl("f8f8f16_rowwise", f8f8f16_rowwise);
@@ -177,9 +176,17 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   //   f8f8bf16_groupwise -> mslk/gemm/triton/fp8_groupwise_gemm.py
   //   i8i8bf16 / i8i8bf16_dynamic -> mslk/gemm/triton/int8_gemm.py
   //   bf16bf16bf16_grouped_grad / _wgrad -> mslk/gemm/triton/grouped_gemm.py
+  //   bf16bf16bf16_grouped_stacked -> mslk/gemm/flydsl/bf16_grouped_gemm.py.
+  //     This one displaces a CK kernel that did serve ROCm, rather than
+  //     filling an empty slot, and nothing stands behind it: without the
+  //     FlyDSL backend the op raises here, CK and Triton both being on the way
+  //     out. A C++ registration could not have been the fallback anyway --
+  //     whichever of the two registers last owns the key outright.
 #else
   // The rowwise grouped ops share a schema with ROCm, where FlyDSL implements
-  // them from Python; these registrations serve CUTLASS on CUDA only.
+  // them from Python; these registrations serve CUTLASS on CUDA only. So does
+  // the stacked BF16 grouped op, whose ROCm CK kernel FlyDSL now displaces.
+  m.impl("bf16bf16bf16_grouped_stacked", bf16bf16bf16_grouped_stacked);
   m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
   m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
   m.impl("f8f8bf16_groupwise", f8f8bf16_groupwise);
@@ -227,7 +234,6 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   m.impl("bf16bf16bf16_grouped", bf16bf16bf16_grouped);
   m.impl("bf16bf16bf16_grouped_cat", bf16bf16bf16_grouped_cat);
   m.impl("bf16bf16bf16_grouped_dynamic", bf16bf16bf16_grouped_dynamic);
-  m.impl("bf16bf16bf16_grouped_stacked", bf16bf16bf16_grouped_stacked);
 
 #ifdef USE_ROCM
   m.impl("f8f8f16_rowwise", f8f8f16_rowwise);
@@ -239,6 +245,7 @@ TORCH_LIBRARY_IMPL(mslk, CPU, m) {
   // back, which is what the note at the top of this block is about.
 #else
   // Shared with ROCm, where FlyDSL implements them from Python.
+  m.impl("bf16bf16bf16_grouped_stacked", bf16bf16bf16_grouped_stacked);
   m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
   m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);
   m.impl("f8f8bf16_groupwise", f8f8bf16_groupwise);

--- a/csrc/gemm/gemm_ops.cpp
+++ b/csrc/gemm/gemm_ops.cpp
@@ -177,15 +177,13 @@ TORCH_LIBRARY_IMPL(mslk, CUDA, m) {
   //   i8i8bf16 / i8i8bf16_dynamic -> mslk/gemm/triton/int8_gemm.py
   //   bf16bf16bf16_grouped_grad / _wgrad -> mslk/gemm/triton/grouped_gemm.py
   //   bf16bf16bf16_grouped_stacked -> mslk/gemm/flydsl/bf16_grouped_gemm.py.
-  //     This one displaces a CK kernel that did serve ROCm, rather than
-  //     filling an empty slot, and nothing stands behind it: without the
-  //     FlyDSL backend the op raises here, CK and Triton both being on the way
-  //     out. A C++ registration could not have been the fallback anyway --
-  //     whichever of the two registers last owns the key outright.
+  //     FlyDSL is the only ROCm implementation; without that backend the op
+  //     raises. Registering it here as well would not provide a fallback,
+  //     since whichever registration runs last owns the dispatch key.
 #else
-  // The rowwise grouped ops share a schema with ROCm, where FlyDSL implements
-  // them from Python; these registrations serve CUTLASS on CUDA only. So does
-  // the stacked BF16 grouped op, whose ROCm CK kernel FlyDSL now displaces.
+  // The rowwise grouped ops and the stacked BF16 grouped op share a schema with
+  // ROCm, where FlyDSL implements them from Python; these registrations serve
+  // CUTLASS on CUDA only.
   m.impl("bf16bf16bf16_grouped_stacked", bf16bf16bf16_grouped_stacked);
   m.impl("f8f8bf16_rowwise_grouped_stacked", f8f8bf16_rowwise_grouped_stacked);
   m.impl("f8f8bf16_rowwise_grouped_dynamic", f8f8bf16_rowwise_grouped_dynamic);

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -301,6 +301,7 @@ def compile_fp8_grouped_gemm(
         scale_block_n=scale_block_n,
         k_padding=k_padding,
         in_dtype=in_dtype,
+        scaling=scaling,
     )
     # Check the LDS budget before tracing: the compiler treats an overflow as a
     # hard error that kills the process, which an autotuner cannot skip. Capacity
@@ -332,6 +333,7 @@ def compile_fp8_grouped_gemm(
     scale_k = _c.scale_k
     scale_n = _c.scale_n
     sb_per_tile = _c.sb_per_tile
+    ku_per_sb = _c.ku_per_sb
     k_unroll = _c.k_unroll
     kpack_bytes = _c.kpack_bytes
     tile_k_bytes = _c.tile_k_bytes
@@ -762,10 +764,6 @@ def compile_fp8_grouped_gemm(
 
             mfma_res_ty = T.f32x4
 
-            # Operand packs per scale block. The K loop steps 64 bytes at a
-            # time, so a scale block's K extent has to be measured the same way;
-            # sb_per_tile * ku_per_sb is then k_unroll for any dtype.
-            ku_per_sb = scale_block_k * elem_bytes // 64
             rocdl.sched_barrier(0)
 
             if const_expr(b_preshuffled):

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -137,6 +137,7 @@ def compile_fp8_grouped_gemm(
     layout: str = "sizes",
     k_padding: bool = False,
     n_padding: bool = False,
+    group_based_b: bool = False,
     group_based_rows: bool = False,
     roll_k: bool = False,
 ):
@@ -171,6 +172,17 @@ def compile_fp8_grouped_gemm(
         n_padding: Emit the per-store column predicate so N need only reach an
             8-column store boundary rather than a whole tile. Forced on where
             the groups divide N, for the same reason.
+        group_based_b: Address B from the owning group's first row rather than
+            from the stack's, and bound the descriptor by that group. Needed
+            once the whole stack passes the 4 GiB a buffer descriptor reaches,
+            which a realistic expert count does: 128 experts of 16384x5120 in
+            BF16 is 21.5 GB. It is not free either, and least so where it might
+            have seemed so -- on the preshuffled path B goes HBM->registers
+            inside the K loop rather than staging through LDS, so its descriptor
+            sits on the critical path of every B load, and basing it costs
+            40-55% at tile_n=256. The host therefore sets it only for stacks
+            that need it, which it can decide exactly, G * N * K being wholly
+            host-known.
         group_based_rows: Address A and D from the owning group's first row
             rather than from the operand's, and bound each descriptor by that
             group rather than by the whole operand. Needed once A or D passes
@@ -414,10 +426,11 @@ def compile_fp8_grouped_gemm(
     # The row basing changes the emitted kernel, so it has to reach the name or
     # the two forms would collide in the JIT cache.
     _gbr = "_gbr" if group_based_rows else ""
+    _gbb = "_gbb" if group_based_b else ""
     module_name = (
         f"grouped_gemm_{in_dtype}_{_scaling}_{layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
-        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}{_wpe}{_wg}{_gbr}"
+        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}{_wpe}{_wg}{_gbr}{_gbb}"
     ).replace("-", "_")
 
     # The AMDGPU default caps a workgroup at 256 threads, so a grid of more than
@@ -545,6 +558,13 @@ def compile_fp8_grouped_gemm(
         # whole operand, so that none of them has to address more than one
         # group's worth. See `rebased_resource`.
         b_nbytes = n_in * k_bytes_in
+        # What one descriptor must cover when it is not based at a group.
+        b_whole_nbytes = (
+            b_nbytes if (n_grouped or k_grouped) else num_groups_in * b_nbytes
+        )
+        b_rsrc_whole = (
+            None if group_based_b else rebased_resource(arg_b, b_whole_nbytes)
+        )
 
         # The output is [M, total_N] when the groups divide N: m_in counts the
         # rows of every group's slab, but they share the output's rows.
@@ -671,12 +691,15 @@ def compile_fp8_grouped_gemm(
             # stack of num_groups [N, K] ones otherwise. Only the stack has a
             # group axis to fold into the base; the single matrix is already one
             # slab, which every block reads whole.
-            if const_expr(n_grouped or k_grouped):
-                b_rsrc = rebased_resource(arg_b, b_nbytes)
-            else:
+            if const_expr(group_based_b):
                 b_rsrc = rebased_resource(
                     arg_b, b_nbytes, byte_offset=group_idx * b_nbytes
                 )
+            else:
+                # One descriptor over the whole stack, so the group stays in the
+                # coordinates rather than in the base. Built before this branch,
+                # needing no group to build.
+                b_rsrc = b_rsrc_whole
 
             # Global row base of this tile and the exclusive row end of its group
             # (the group end masks the partial-tile tail in the epilogue store).
@@ -764,6 +787,7 @@ def compile_fp8_grouped_gemm(
                 lane_mod_16=lane_mod_16,
                 kpack_bytes=kpack_bytes,
                 elem_bytes=elem_bytes,
+                b_group_based=group_based_b,
                 scale_block_n=scale_block_n,
                 scale_k=scale_k,
                 n_per_wave=n_per_wave,
@@ -854,6 +878,13 @@ def compile_fp8_grouped_gemm(
                     lds_b=lds_b,
                     layout_lds_b=layout_lds_b,
                     by_n=by_n,
+                    # The base carries the group when B is based per group, so
+                    # the row offset must not carry it too.
+                    b_group_off=(
+                        None
+                        if group_based_b
+                        else group_idx * n_in * (k_bytes_in // fx.Index(4))
+                    ),
                     tx=tx,
                     tile_n=tile_n,
                     tile_k=tile_k,

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -7,7 +7,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-"""Grouped FP8 GEMM kernel.
+"""Grouped GEMM kernel.
+
+The `in_dtype` argument selects the operand element type: "fp8", which the
+kernel was written for and is still named after, or "bf16". It decides the MFMA
+the K loop issues and the width of every operand address, and it fixes the
+scaling scheme, since only a quantised operand carries scales. Everything else
+-- the group resolution, the loaders, the LDS swizzle and the epilogue -- is
+shared, the operand staging being expressed in bytes throughout.
 
 The `layout` argument selects both which axis the groups divide and how their
 geometry is encoded. Where the groups divide M they are concatenated with
@@ -18,17 +25,24 @@ and are masked out of the store. Groups may instead occupy fixed per-group
 slabs, or divide N or K. Only the resolution step differs between them, so the
 loaders, the K loop and the epilogue are shared.
 
-Scales are FP32 (software scaling) on all architectures.
+Where there are scales they are FP32 (software scaling) on all architectures.
 
 Tensors:
-  - A: [M_total, K] FP8 - the rows of every group, packed or in per-group slabs
-  - B: [num_groups, N, K] FP8 - one weight matrix per group, in the MFMA B
+  - A: [M_total, K] - the rows of every group, packed or in per-group slabs
+  - B: [num_groups, N, K] - one weight matrix per group, in the MFMA B
     layout when b_preshuffled; a single [total_N, K] or [N, total_K] matrix
     where the groups divide N or K
   - m_sizes: [num_groups] - the group geometry, whose encoding the `layout`
     argument selects: INT64 row counts, INT32 cumulative offsets, or unused
   - D: [M_total, N] BF16 - output, which is the flattened [G * M, N] where the
     groups divide K and each produces a whole output of its own
+
+A and B carry `in_dtype` elements; the output is BF16 or FP16 whichever they
+are.
+
+BF16 operands carry their own exponent, so they have no scales: the scale
+arguments go unread, nothing is folded in the K loop, and the epilogue writes
+the accumulators straight out.
 
 Rowwise scaling carries one FP32 scale per row of A and per column of B, both
 constant along K, and applies them in the epilogue.
@@ -85,6 +99,7 @@ from mslk.flydsl.kernels.gemm.fp8_grouped_gemm_common import (
     resolve_group_k,
     resolve_group_rows,
     SCALING_BLOCK,
+    SCALING_NONE,
     SCALING_ROW,
     setup_lds_allocation,
     setup_lds_allocation_plain,
@@ -115,6 +130,7 @@ def compile_fp8_grouped_gemm(
     out_dtype: str = "bf16",
     waves_per_eu: int | None = None,
     b_preshuffled: bool = True,
+    in_dtype: str = "fp8",
     scaling: str = SCALING_ROW,
     layout: str = "sizes",
     k_padding: bool = False,
@@ -148,6 +164,12 @@ def compile_fp8_grouped_gemm(
             like A. The two paths share the entire kernel body (tile-map group
             dispatch, scaling, wide-MFMA, CShuffle epilogue); only the B load
             stage and its LDS allocation differ.
+        in_dtype: Element type of A and B, "fp8" (default) or "bf16". It sets
+            the MFMA the K loop issues and the width of every operand address,
+            and it fixes `scaling`: fp8 is quantised and needs a scheme, bf16
+            carries its own exponent and needs "none". A bf16 tile spans twice
+            the LDS of the fp8 tile of the same shape, so the tile space the
+            LDS budget admits is correspondingly smaller.
         scaling: Selects the scaling scheme, which sets the expected layout of
             scale_a / scale_b and where the scales are applied.
             "row" (default): scale_a is [M_total] and scale_b is [num_groups, N],
@@ -254,26 +276,20 @@ def compile_fp8_grouped_gemm(
         tile_n=tile_n,
         tile_k=tile_k,
         scaling=scaling,
+        in_dtype=in_dtype,
         k_padding=k_padding,
         n_padding=n_padding,
         scale_block_k=scale_block_k,
         scale_block_n=scale_block_n,
         out_dtype=out_dtype,
     )
-    # Check the LDS budget before tracing: the compiler treats an overflow as a
-    # hard error that kills the process, which an autotuner cannot skip. Capacity
-    # is arch-dependent (64 KiB gfx942, 160 KiB gfx950).
-    if b_preshuffled:
-        # Preshuffled B goes HBM->registers; only A ping-pong / epilogue use LDS.
-        validate_lds_budget_preshuffle(
-            tile_m=tile_m, tile_n=tile_n, tile_k=tile_k, arch=gpu_arch
+    if in_dtype != "fp8" and b_preshuffled:
+        # The preshuffled B layout, its HBM->register loader and the hot loop's
+        # instruction-group counts are all written around a one-byte element.
+        raise ValueError(
+            f"in_dtype {in_dtype!r} is supported with plain B only; pass "
+            "b_preshuffled=False"
         )
-    else:
-        # Plain B needs its own LDS buffer alongside A.
-        validate_lds_budget_plain(
-            tile_m=tile_m, tile_n=tile_n, tile_k=tile_k, b_pingpong=False, arch=gpu_arch
-        )
-    out_mlir = out_mlir_for(out_dtype)
 
     _c = compute_compile_constants(
         n=n,
@@ -284,7 +300,32 @@ def compile_fp8_grouped_gemm(
         scale_block_k=scale_block_k,
         scale_block_n=scale_block_n,
         k_padding=k_padding,
+        in_dtype=in_dtype,
     )
+    # Check the LDS budget before tracing: the compiler treats an overflow as a
+    # hard error that kills the process, which an autotuner cannot skip. Capacity
+    # is arch-dependent (64 KiB gfx942, 160 KiB gfx950).
+    if b_preshuffled:
+        # Preshuffled B goes HBM->registers; only A ping-pong / epilogue use LDS.
+        validate_lds_budget_preshuffle(
+            tile_m=tile_m,
+            tile_n=tile_n,
+            tile_k=tile_k,
+            elem_bytes=_c.elem_bytes,
+            arch=gpu_arch,
+        )
+    else:
+        # Plain B needs its own LDS buffer alongside A.
+        validate_lds_budget_plain(
+            tile_m=tile_m,
+            tile_n=tile_n,
+            tile_k=tile_k,
+            elem_bytes=_c.elem_bytes,
+            b_pingpong=False,
+            arch=gpu_arch,
+        )
+    out_mlir = out_mlir_for(out_dtype)
+
     total_threads = _c.total_threads
     elem_bytes = _c.elem_bytes
     num_k_tiles = _c.num_k_tiles
@@ -301,16 +342,16 @@ def compile_fp8_grouped_gemm(
     num_b_loads = _c.num_b_loads
 
     if b_preshuffled:
-        lds_alloc_offset, lds_tile_elems = setup_lds_allocation(
+        lds_alloc_offset, lds_tile_bytes = setup_lds_allocation(
             allocator=allocator,
             tile_m=tile_m,
             tile_k=tile_k,
             tile_n=tile_n,
             elem_bytes=elem_bytes,
         )
-        lds_b_offset_elems = None
+        lds_b_offset_bytes = None
     else:
-        lds_alloc_offset, lds_tile_elems, lds_b_offset_elems = (
+        lds_alloc_offset, lds_tile_bytes, lds_b_offset_bytes = (
             setup_lds_allocation_plain(
                 allocator=allocator,
                 tile_m=tile_m,
@@ -329,7 +370,7 @@ def compile_fp8_grouped_gemm(
     _wpe = f"_wpe{int(waves_per_eu)}" if waves_per_eu else ""
     _npad = "_npad" if n_padding else ""
     module_name = (
-        f"grouped_gemm_{_scaling}_{layout}_{_variant}_{out_dtype}"
+        f"grouped_gemm_{in_dtype}_{_scaling}_{layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
         f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}{_wpe}"
     ).replace("-", "_")
@@ -376,14 +417,18 @@ def compile_fp8_grouped_gemm(
 
         # LDS setup: ping-pong A buffers (preshuffle) or A ping-pong + single B
         # buffer (plain). B LDS is only needed for the plain path.
+        # The A/B arena is addressed as raw bytes -- T.f8 is its byte element
+        # type, not the dtype of the operands -- so its shapes, strides and
+        # column coordinates are all byte quantities. That is what lets the
+        # XOR16 swizzle and the LDS pack loads be shared across input dtypes.
         base_ptr = allocator.get_base()
         lds_a = SmemPtr(
-            base_ptr, lds_alloc_offset, T.f8, shape=(2 * tile_m * tile_k,)
+            base_ptr, lds_alloc_offset, T.f8, shape=(2 * tile_m * tile_k_bytes,)
         ).get()
-        lds_stride = tile_k
-        layout_lds = fx.make_layout((tile_m, tile_k), stride=(lds_stride, 1))
+        lds_stride = tile_k_bytes
+        layout_lds = fx.make_layout((tile_m, tile_k_bytes), stride=(lds_stride, 1))
         lds_base_pong = fx.Index(0)
-        lds_base_ping = fx.Index(lds_tile_elems)
+        lds_base_ping = fx.Index(lds_tile_bytes)
 
         if const_expr(not b_preshuffled):
             # Plain-B LDS buffer, placed just past the A ping-pong region.
@@ -391,20 +436,25 @@ def compile_fp8_grouped_gemm(
                 base_ptr,
                 lds_alloc_offset,
                 T.f8,
-                shape=((lds_b_offset_elems + tile_n * tile_k),),
+                shape=((lds_b_offset_bytes + tile_n * tile_k_bytes),),
             ).get()
-            layout_lds_b = fx.make_layout((tile_n, tile_k), stride=(tile_k, 1))
-            lds_base_b = fx.Index(lds_b_offset_elems)
+            layout_lds_b = fx.make_layout(
+                (tile_n, tile_k_bytes), stride=(tile_k_bytes, 1)
+            )
+            lds_base_b = fx.Index(lds_b_offset_bytes)
 
         # CShuffle epilogue LDS (aliased from same base, out-dtype element type)
         lds_out = SmemPtr(
             base_ptr, lds_alloc_offset, out_mlir(), shape=(tile_m * tile_n,)
         ).get()
 
-        # Buffer resources
+        # Buffer resources. These extents are byte counts, so the K extent of a
+        # row has to be widened by the element size.
+        k_bytes_in = k_in if elem_bytes == 1 else k_in * fx.Index(elem_bytes)
+
         # Where the groups divide K, A is [M, total_K] -- one set of rows shared
         # by every group -- while the output and scale_a hold a slab per group.
-        a_nbytes = m_in * k_in
+        a_nbytes = m_in * k_bytes_in
         a_rsrc = buffer_ops.create_buffer_resource(
             arg_a, max_size=False, num_records_bytes=a_nbytes
         )
@@ -414,9 +464,9 @@ def compile_fp8_grouped_gemm(
         if const_expr(n_grouped or k_grouped):
             # One matrix the groups divide, by row under n_offsets and by column
             # under k_offsets.
-            b_nbytes = n_in * k_in
+            b_nbytes = n_in * k_bytes_in
         else:
-            b_nbytes = num_groups_in * n_in * k_in
+            b_nbytes = num_groups_in * n_in * k_bytes_in
         b_rsrc = buffer_ops.create_buffer_resource(
             arg_b, max_size=False, num_records_bytes=b_nbytes
         )
@@ -438,7 +488,12 @@ def compile_fp8_grouped_gemm(
         # pre-packed on host); gfx942 SW path consumes f32.
         scale_byte_size = 1 if _use_hw_scale else 4
 
-        if const_expr(scaling == SCALING_BLOCK):
+        if const_expr(scaling == SCALING_NONE):
+            # Unscaled operands: nothing reads these, and the caller has no
+            # scales to hand over, so the resources cover no bytes at all.
+            sa_nbytes = fx.Index(0)
+            sb_nbytes = fx.Index(0)
+        elif const_expr(scaling == SCALING_BLOCK):
             # scale_a: per-group [M_g, scale_k] blocks, scale_k values per row.
             sa_nbytes = fx.Index(scale_k) * m_in * fx.Index(scale_byte_size)
             # scale_b: [num_groups, scale_k, scale_n]
@@ -607,6 +662,7 @@ def compile_fp8_grouped_gemm(
                 k=k,
                 tile_k=tile_k,
                 k_in=k_in,
+                elem_bytes=elem_bytes,
                 always=roll_k,
                 k_bound=k_bound,
             )
@@ -706,7 +762,10 @@ def compile_fp8_grouped_gemm(
 
             mfma_res_ty = T.f32x4
 
-            ku_per_sb = scale_block_k // 64
+            # Operand packs per scale block. The K loop steps 64 bytes at a
+            # time, so a scale block's K extent has to be measured the same way;
+            # sb_per_tile * ku_per_sb is then k_unroll for any dtype.
+            ku_per_sb = scale_block_k * elem_bytes // 64
             rocdl.sched_barrier(0)
 
             if const_expr(b_preshuffled):
@@ -762,6 +821,7 @@ def compile_fp8_grouped_gemm(
                 group_m_start=fx.Index(group_m_start_i32),
                 group_m_size=fx.Index(group_m_size_i32),
                 scaling=scaling,
+                in_dtype=in_dtype,
             )
 
             if const_expr(b_preshuffled):

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -880,9 +880,12 @@ def compile_fp8_grouped_gemm(
                     by_n=by_n,
                     # The base carries the group when B is based per group, so
                     # the row offset must not carry it too.
+                    # No group term where the base already carries it, and
+                    # none where B has no group axis to carry: the layouts that
+                    # divide N or K give every block one shared matrix.
                     b_group_off=(
                         None
-                        if group_based_b
+                        if (group_based_b or n_grouped or k_grouped)
                         else group_idx * n_in * (k_bytes_in // fx.Index(4))
                     ),
                     tx=tx,

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -128,6 +128,8 @@ def compile_fp8_grouped_gemm(
     scale_block_k: int = 128,
     scale_block_n: int = 128,
     out_dtype: str = "bf16",
+    waves_m: int = 1,
+    waves_n: int = 4,
     waves_per_eu: int | None = None,
     b_preshuffled: bool = True,
     in_dtype: str = "fp8",
@@ -146,6 +148,16 @@ def compile_fp8_grouped_gemm(
         tile_m: M tile size (default 128)
         tile_n: N tile size (default 128)
         tile_k: K tile size (default 128)
+        waves_m: Waves dividing the tile's rows (default 1).
+        waves_n: Waves dividing the tile's columns (default 4). The block is
+            waves_m * waves_n * 64 threads and each wave owns a
+            (tile_m / waves_m) x (tile_n / waves_n) slab of the output tile.
+            Each wave reads its whole slab's worth of both operands out of LDS,
+            so reads per unit work go as waves_m / tile_m + waves_n / tile_n,
+            which a grid proportioned like the tile minimises: at a square tile
+            2x2 reads a fifth less than the 1x4 default, while at 64x128 the two
+            are equal. Raising the product past 4 buys more waves per tile
+            rather than a better shape, and costs the register budget.
         scale_block_k: K-dimension scale block size (default 128)
         scale_block_n: N-dimension scale block size (default 128)
         out_dtype: Output data type ("bf16" or "f16")
@@ -258,6 +270,17 @@ def compile_fp8_grouped_gemm(
         # boundary, which validate_params checks below.
         n_padding = True
 
+    # The wave grid has to cut the tile into whole 16x16 MFMA tiles, since a
+    # wave's accumulators are counted in them and cannot straddle a boundary.
+    if waves_m < 1 or waves_n < 1:
+        raise ValueError(f"wave grid must be positive, got {waves_m}x{waves_n}")
+    if tile_m % (waves_m * 16) or tile_n % (waves_n * 16):
+        raise ValueError(
+            f"tile {tile_m}x{tile_n} does not divide into a {waves_m}x{waves_n} "
+            "wave grid of whole 16x16 MFMA tiles"
+        )
+    num_waves = waves_m * waves_n
+
     gpu_arch = get_hip_arch()
     # This FP8 kernel always uses the FP32 software-scaling path; the shared
     # helpers' hardware E8M0 microscaling path is not used here.
@@ -302,6 +325,7 @@ def compile_fp8_grouped_gemm(
         k_padding=k_padding,
         in_dtype=in_dtype,
         scaling=scaling,
+        num_waves=num_waves,
     )
     # Check the LDS budget before tracing: the compiler treats an overflow as a
     # hard error that kills the process, which an autotuner cannot skip. Capacity
@@ -371,13 +395,24 @@ def compile_fp8_grouped_gemm(
     _roll = "_rollk" if roll_k else ""
     _wpe = f"_wpe{int(waves_per_eu)}" if waves_per_eu else ""
     _npad = "_npad" if n_padding else ""
+    # The wave grid changes the emitted kernel, so it has to reach the name or a
+    # second grid over the same tile would collide in the JIT cache.
+    _wg = f"_w{waves_m}x{waves_n}" if (waves_m, waves_n) != (1, 4) else ""
     module_name = (
         f"grouped_gemm_{in_dtype}_{_scaling}_{layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
-        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}{_wpe}"
+        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}{_wpe}{_wg}"
     ).replace("-", "_")
 
-    @flyc.kernel(name=module_name)
+    # The AMDGPU default caps a workgroup at 256 threads, so a grid of more than
+    # four waves has to declare its size up front. Below that the bound is
+    # already right, and declaring it anyway would perturb register allocation
+    # on every existing configuration for no reason.
+    _kernel_attrs = (
+        {"known_block_size": [total_threads, 1, 1]} if total_threads > 256 else {}
+    )
+
+    @flyc.kernel(name=module_name, **_kernel_attrs)
     def fp8_grouped_gemm_kernel(
         arg_d: fx.Tensor,
         arg_a: fx.Tensor,
@@ -405,11 +440,20 @@ def compile_fp8_grouped_gemm(
         # N-block position; bx_m (global row base) is loaded from the tile map below.
         by_n = by * fx.Index(tile_n)
 
-        # Wave/lane decomposition (256 threads = 4 waves x 64 lanes)
-        layout_wave_lane = fx.make_layout((4, 64), stride=(64, 1))
+        # Wave/lane decomposition (total_threads = num_waves x 64 lanes)
+        layout_wave_lane = fx.make_layout((num_waves, 64), stride=(64, 1))
         coord_wave_lane = fx.idx2crd(fx.Int32(tx), layout_wave_lane)
         wave_id = fx.get(coord_wave_lane, 0)
         lane_id = fx.get(coord_wave_lane, 1)
+
+        # Wave grid: wave w owns rows [wm * tile_m / waves_m, +tile_m / waves_m)
+        # and, via n_tile_base below, the matching slab of columns. A 1 x waves_n
+        # grid leaves every wave spanning the whole of tile_m, and the row
+        # derivations then take no offset at all.
+        if const_expr(waves_m > 1):
+            m_wave_base = (wave_id // fx.Index(waves_n)) * fx.Index(tile_m // waves_m)
+        else:
+            m_wave_base = None
 
         # Lane decomposition for MFMA (lane_id -> lane_div_16, lane_mod_16)
         layout_lane16 = fx.make_layout((4, 16), stride=(16, 1))
@@ -627,7 +671,9 @@ def compile_fp8_grouped_gemm(
                 k_base_div4 = None
                 k_bound = None
 
-            _t = compute_mfma_tiling(tile_m=tile_m, tile_n=tile_n)
+            _t = compute_mfma_tiling(
+                tile_m=tile_m, tile_n=tile_n, waves_m=waves_m, waves_n=waves_n
+            )
             m_repeat = _t.m_repeat
             n_per_wave = _t.n_per_wave
             num_acc_n = _t.num_acc_n
@@ -635,6 +681,7 @@ def compile_fp8_grouped_gemm(
             acc_init, accs = init_accumulators(_t.num_accs)
 
             _nb = make_n_block_coords(
+                waves_n=waves_n,
                 wave_id=wave_id,
                 by_n=by_n,
                 group_idx=group_idx,
@@ -702,6 +749,8 @@ def compile_fp8_grouped_gemm(
 
             # Base coordinates for A0 prefetch (mi=0, ku=0)
             row_a_lds_base = lane_mod_16  # mi=0
+            if const_expr(m_wave_base is not None):
+                row_a_lds_base = row_a_lds_base + m_wave_base
             col_offset_base_bytes = lane_div_16 * fx.Index(16)  # ku=0
 
             # ---- B load path: preshuffled (HBM->registers) vs plain (HBM->LDS->registers) ----
@@ -778,6 +827,7 @@ def compile_fp8_grouped_gemm(
                 )
 
             prefetch_scales = make_prefetch_scales(
+                m_wave_base=m_wave_base,
                 _use_hw_scale=_use_hw_scale,
                 sa_rsrc=sa_rsrc,
                 sb_rsrc=sb_rsrc,
@@ -795,6 +845,7 @@ def compile_fp8_grouped_gemm(
             )
 
             compute_tile = make_compute_tile(
+                m_wave_base=m_wave_base,
                 _use_hw_scale=_use_hw_scale,
                 _is_gfx950=_is_gfx950,
                 lds_load_packs_k64=lds_load_packs_k64,
@@ -982,6 +1033,7 @@ def compile_fp8_grouped_gemm(
                 # Rowwise scales are constant along K, so the whole reduction is
                 # scaled here in one pass rather than per K tile.
                 accs = make_rowwise_scaler(
+                    m_wave_base=m_wave_base,
                     sa_rsrc=sa_rsrc,
                     sb_rsrc=sb_rsrc,
                     group_idx=group_idx,
@@ -1026,6 +1078,7 @@ def compile_fp8_grouped_gemm(
 
             mfma_epilog(
                 use_cshuffle=True,
+                m_wave_base=m_wave_base,
                 arith=arith,
                 vector=vector,
                 gpu=gpu,
@@ -1034,6 +1087,7 @@ def compile_fp8_grouped_gemm(
                 tile_m=tile_m,
                 tile_n=tile_n,
                 e_vec=e_vec,
+                block_size=total_threads,
                 m_repeat=m_repeat,
                 num_acc_n=num_acc_n,
                 tx=tx,

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -498,6 +498,32 @@ def compile_fp8_grouped_gemm(
         # row has to be widened by the element size.
         k_bytes_in = k_in if elem_bytes == 1 else k_in * fx.Index(elem_bytes)
 
+        def rebased_resource(arg, num_records_bytes, byte_offset=None):
+            """Buffer descriptor over one slab of an operand, based at that slab.
+
+            A descriptor addresses at most 4 GiB: both its num_records and the
+            voffset a buffer_load adds are 32-bit. A stack of per-group weights
+            passes that at a realistic expert count -- 128 experts of 16384x5120
+            BF16 is 21.5 GB -- and the hardware answers an out-of-range load with
+            zero, so the kernel would return a wrong result at full speed rather
+            than fail.
+
+            Folding the group into the base address instead keeps the descriptor
+            over one group, which no realistic shape exceeds, and does the
+            arithmetic that selects the group in 64 bits. `preshuffle_gemm.py`
+            bases its batched operands the same way.
+
+            The offset goes to `base_byte_offset`, which is applied to the
+            descriptor's base pointer, so the group term never passes through a
+            32-bit quantity on its way in.
+            """
+            return buffer_ops.create_buffer_resource(
+                arg,
+                max_size=False,
+                num_records_bytes=num_records_bytes,
+                base_byte_offset=byte_offset,
+            )
+
         # Where the groups divide K, A is [M, total_K] -- one set of rows shared
         # by every group -- while the output and scale_a hold a slab per group.
         a_nbytes = m_in * k_bytes_in
@@ -505,17 +531,9 @@ def compile_fp8_grouped_gemm(
             arg_a, max_size=False, num_records_bytes=a_nbytes
         )
 
-        # B is one [total_N, K] matrix when the groups divide N, and a stack of
-        # num_groups [N, K] ones otherwise.
-        if const_expr(n_grouped or k_grouped):
-            # One matrix the groups divide, by row under n_offsets and by column
-            # under k_offsets.
-            b_nbytes = n_in * k_bytes_in
-        else:
-            b_nbytes = num_groups_in * n_in * k_bytes_in
-        b_rsrc = buffer_ops.create_buffer_resource(
-            arg_b, max_size=False, num_records_bytes=b_nbytes
-        )
+        # B's descriptor is built further down, once the group is resolved: it is
+        # based at this block's group rather than at the whole stack.
+        b_nbytes = n_in * k_bytes_in
 
         # The output is [M, total_N] when the groups divide N: m_in counts the
         # rows of every group's slab, but they share the output's rows.
@@ -625,24 +643,32 @@ def compile_fp8_grouped_gemm(
             # Where the owning group's columns stop; the bound for both the B
             # row tail and the epilogue's column mask.
             n_bound = fx.Index(_col.col_limit)
-            b_group_off = fx.Index(0)
             # scale_b is one flat [total_N] here, so the group is already in by_n.
             sb_group_off = fx.Index(0)
         elif const_expr(k_grouped):
-            # B is a single [N, total_K] the groups slice by column, so it has no
-            # per-group row base -- the slice is expressed as a K offset instead.
+            # B is a single [N, total_K] the groups slice by column, so the slice
+            # is expressed as a K offset rather than a row base.
             # scale_b is still [G, N], one set of column scales per group.
             n_bound = None
-            b_group_off = fx.Index(0)
             sb_group_off = None
         else:
             n_bound = None
-            b_group_off = None
             sb_group_off = None
 
         # Early exit for surplus/no-op tiles.
         if is_valid:
             group_idx = fx.Index(group_id_i32)
+
+            # B is one [total_N, K] matrix when the groups divide N or K, and a
+            # stack of num_groups [N, K] ones otherwise. Only the stack has a
+            # group axis to fold into the base; the single matrix is already one
+            # slab, which every block reads whole.
+            if const_expr(n_grouped or k_grouped):
+                b_rsrc = rebased_resource(arg_b, b_nbytes)
+            else:
+                b_rsrc = rebased_resource(
+                    arg_b, b_nbytes, byte_offset=group_idx * b_nbytes
+                )
 
             # Global row base of this tile and the exclusive row end of its group
             # (the group end masks the partial-tile tail in the epilogue store).
@@ -779,7 +805,6 @@ def compile_fp8_grouped_gemm(
                     lds_b=lds_b,
                     layout_lds_b=layout_lds_b,
                     by_n=by_n,
-                    group_idx=group_idx,
                     tx=tx,
                     tile_n=tile_n,
                     tile_k=tile_k,
@@ -793,7 +818,6 @@ def compile_fp8_grouped_gemm(
                     k_in=k_in,
                     k_tail_mask=k_tail_mask,
                     n_padding=n_padding,
-                    b_group_off=b_group_off,
                     n_bound=n_bound,
                     k_base_div4=k_base_div4,
                 )

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -137,6 +137,7 @@ def compile_fp8_grouped_gemm(
     layout: str = "sizes",
     k_padding: bool = False,
     n_padding: bool = False,
+    group_based_rows: bool = False,
     roll_k: bool = False,
 ):
     """Compile grouped FP8 GEMM kernel and return the JIT launcher.
@@ -170,6 +171,18 @@ def compile_fp8_grouped_gemm(
         n_padding: Emit the per-store column predicate so N need only reach an
             8-column store boundary rather than a whole tile. Forced on where
             the groups divide N, for the same reason.
+        group_based_rows: Address A and D from the owning group's first row
+            rather than from the operand's, and bound each descriptor by that
+            group rather than by the whole operand. Needed once A or D passes
+            the 4 GiB a buffer descriptor reaches, past which the hardware reads
+            zero and drops stores rather than faulting -- a wrong answer at full
+            speed. It costs about a quarter of the runtime on the FP8 groupwise
+            shapes, measured at a pinned config and not explained by anything in
+            the emitted code -- the hot loop is the same size, the registers and
+            LDS are unchanged, and where the descriptor is built makes no
+            difference -- so the host sets it only for the shapes that have no
+            alternative. B is based at its group either way, which measures
+            free.
         b_preshuffled: When True (default) B is expected pre-swizzled into the
             MFMA layout and loaded HBM->registers (no B LDS). When False, B is
             plain row-major [num_groups, N, K] and is staged HBM->LDS->registers
@@ -398,10 +411,13 @@ def compile_fp8_grouped_gemm(
     # The wave grid changes the emitted kernel, so it has to reach the name or a
     # second grid over the same tile would collide in the JIT cache.
     _wg = f"_w{waves_m}x{waves_n}" if (waves_m, waves_n) != (1, 4) else ""
+    # The row basing changes the emitted kernel, so it has to reach the name or
+    # the two forms would collide in the JIT cache.
+    _gbr = "_gbr" if group_based_rows else ""
     module_name = (
         f"grouped_gemm_{in_dtype}_{_scaling}_{layout}_{_variant}_{out_dtype}"
         f"_n{n}_k{k}_g{num_groups}"
-        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}{_wpe}{_wg}"
+        f"_t{tile_m}x{tile_n}x{tile_k}{_kpad}{_npad}{_roll}{_wpe}{_wg}{_gbr}"
     ).replace("-", "_")
 
     # The AMDGPU default caps a workgroup at 256 threads, so a grid of more than
@@ -689,30 +705,44 @@ def compile_fp8_grouped_gemm(
                 k_base_div4 = None
                 k_bound = None
 
-            # A and D are addressed from this group's first row rather than from
-            # the operand's, for the reason B is: a whole operand can exceed what
-            # one descriptor reaches. A packed A at 300k rows of K=8192 in BF16
-            # is 4.6 GB with only four groups, so this is not the many-expert
-            # case alone. Rows inside the loaders and the epilogue are then
-            # group-local, and the group's own extent bounds each descriptor.
-            a_group_rows = fx.Index(group_m_size_i32)
-            a_row_base = fx.Index(group_m_start_i32)
-            a_rsrc = rebased_resource(
-                arg_a,
-                a_group_rows * k_bytes_in,
-                byte_offset=a_row_base * k_bytes_in,
-            )
-            # Where the groups divide N the output rows are already slab-local,
-            # so the group is in the column and there is no row base to take.
-            d_row_base = fx.Index(0) if const_expr(n_grouped) else a_row_base
-            d_base_bytes = d_row_base * d_row_bytes
-            if d_group_off is not None:
-                # The groups divide K, so each owns a whole [M, N] output.
-                d_base_bytes = d_base_bytes + d_group_off * fx.Index(2)
-            d_group_rows = d_rows if const_expr(n_grouped) else a_group_rows
-            d_rsrc = rebased_resource(
-                arg_d, d_group_rows * d_row_bytes, byte_offset=d_base_bytes
-            )
+            if const_expr(group_based_rows):
+                # A and D are addressed from this group's first row rather than
+                # from the operand's, for the reason B always is: a whole operand
+                # can exceed what one descriptor reaches. A packed A at 300k rows
+                # of K=8192 in BF16 is 4.6 GB with only four groups, so this is
+                # not the many-expert case alone. Rows inside the loader and the
+                # epilogue are then group-local, and the group's own extent
+                # bounds each descriptor. This form is the slower one; see
+                # `group_based_rows`.
+                a_group_rows = fx.Index(group_m_size_i32)
+                a_row_base = fx.Index(group_m_start_i32)
+                a_rsrc = rebased_resource(
+                    arg_a,
+                    a_group_rows * k_bytes_in,
+                    byte_offset=a_row_base * k_bytes_in,
+                )
+                # Where the groups divide N the output rows are already
+                # slab-local, so the group is in the column and there is no row
+                # base to take.
+                d_row_base = fx.Index(0) if const_expr(n_grouped) else a_row_base
+                d_base_bytes = d_row_base * d_row_bytes
+                if d_group_off is not None:
+                    # The groups divide K, so each owns a whole [M, N] output.
+                    d_base_bytes = d_base_bytes + d_group_off * fx.Index(2)
+                    # Folded into the base, so the store must not add it again.
+                    d_group_off = None
+                d_group_rows = d_rows if const_expr(n_grouped) else a_group_rows
+                d_rsrc = rebased_resource(
+                    arg_d, d_group_rows * d_row_bytes, byte_offset=d_base_bytes
+                )
+                a_loader_row_base = a_row_base
+            else:
+                # One descriptor spans each whole operand, so the rows stay
+                # global and nothing is subtracted.
+                a_rsrc = rebased_resource(arg_a, m_in * k_bytes_in)
+                d_rsrc = rebased_resource(arg_d, d_rows * d_row_bytes)
+                d_row_base = None
+                a_loader_row_base = None
 
             _t = compute_mfma_tiling(
                 tile_m=tile_m, tile_n=tile_n, waves_m=waves_m, waves_n=waves_n
@@ -769,8 +799,9 @@ def compile_fp8_grouped_gemm(
                 a_rsrc=a_rsrc,
                 lds_a=lds_a,
                 layout_lds=layout_lds,
-                # Group-local: a_rsrc is based at this group's first row.
-                bx_m=bx_m - a_row_base,
+                # Group-local where a_rsrc is based at the group's first row;
+                # the plain global row otherwise.
+                bx_m=(bx_m if a_loader_row_base is None else bx_m - a_loader_row_base),
                 tx=tx,
                 tile_m=tile_m,
                 tile_k=tile_k,
@@ -1105,6 +1136,7 @@ def compile_fp8_grouped_gemm(
                 c_n=c_n,
                 n_padding=n_padding,
                 n_bound=n_bound,
+                d_group_off=d_group_off,
                 d_row_base=d_row_base,
             )
 

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -524,15 +524,10 @@ def compile_fp8_grouped_gemm(
                 base_byte_offset=byte_offset,
             )
 
-        # Where the groups divide K, A is [M, total_K] -- one set of rows shared
-        # by every group -- while the output and scale_a hold a slab per group.
-        a_nbytes = m_in * k_bytes_in
-        a_rsrc = buffer_ops.create_buffer_resource(
-            arg_a, max_size=False, num_records_bytes=a_nbytes
-        )
-
-        # B's descriptor is built further down, once the group is resolved: it is
-        # based at this block's group rather than at the whole stack.
+        # A's, B's and D's descriptors are all built further down, once the group
+        # is resolved: each is based at this block's group rather than at the
+        # whole operand, so that none of them has to address more than one
+        # group's worth. See `rebased_resource`.
         b_nbytes = n_in * k_bytes_in
 
         # The output is [M, total_N] when the groups divide N: m_in counts the
@@ -543,10 +538,7 @@ def compile_fp8_grouped_gemm(
             d_rows = num_groups_in * m_in
         else:
             d_rows = m_in
-        d_nbytes = d_rows * n_in * fx.Index(2)  # bf16/f16 = 2 bytes
-        d_rsrc = buffer_ops.create_buffer_resource(
-            arg_d, max_size=False, num_records_bytes=d_nbytes
-        )
+        d_row_bytes = n_in * fx.Index(2)  # bf16/f16 = 2 bytes
 
         # Scale buffers — gfx950 HW E8M0 path consumes int8 (one byte/scale,
         # pre-packed on host); gfx942 SW path consumes f32.
@@ -697,6 +689,31 @@ def compile_fp8_grouped_gemm(
                 k_base_div4 = None
                 k_bound = None
 
+            # A and D are addressed from this group's first row rather than from
+            # the operand's, for the reason B is: a whole operand can exceed what
+            # one descriptor reaches. A packed A at 300k rows of K=8192 in BF16
+            # is 4.6 GB with only four groups, so this is not the many-expert
+            # case alone. Rows inside the loaders and the epilogue are then
+            # group-local, and the group's own extent bounds each descriptor.
+            a_group_rows = fx.Index(group_m_size_i32)
+            a_row_base = fx.Index(group_m_start_i32)
+            a_rsrc = rebased_resource(
+                arg_a,
+                a_group_rows * k_bytes_in,
+                byte_offset=a_row_base * k_bytes_in,
+            )
+            # Where the groups divide N the output rows are already slab-local,
+            # so the group is in the column and there is no row base to take.
+            d_row_base = fx.Index(0) if const_expr(n_grouped) else a_row_base
+            d_base_bytes = d_row_base * d_row_bytes
+            if d_group_off is not None:
+                # The groups divide K, so each owns a whole [M, N] output.
+                d_base_bytes = d_base_bytes + d_group_off * fx.Index(2)
+            d_group_rows = d_rows if const_expr(n_grouped) else a_group_rows
+            d_rsrc = rebased_resource(
+                arg_d, d_group_rows * d_row_bytes, byte_offset=d_base_bytes
+            )
+
             _t = compute_mfma_tiling(
                 tile_m=tile_m, tile_n=tile_n, waves_m=waves_m, waves_n=waves_n
             )
@@ -752,7 +769,8 @@ def compile_fp8_grouped_gemm(
                 a_rsrc=a_rsrc,
                 lds_a=lds_a,
                 layout_lds=layout_lds,
-                bx_m=bx_m,
+                # Group-local: a_rsrc is based at this group's first row.
+                bx_m=bx_m - a_row_base,
                 tx=tx,
                 tile_m=tile_m,
                 tile_k=tile_k,
@@ -1087,7 +1105,7 @@ def compile_fp8_grouped_gemm(
                 c_n=c_n,
                 n_padding=n_padding,
                 n_bound=n_bound,
-                d_group_off=d_group_off,
+                d_row_base=d_row_base,
             )
 
             # Mask the partial-tile tail: skip stores for global rows at or beyond

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -84,6 +84,8 @@ from mslk.flydsl.kernels.gemm.fp8_grouped_gemm_common import (
     resolve_group_cols,
     resolve_group_k,
     resolve_group_rows,
+    SCALING_BLOCK,
+    SCALING_ROW,
     setup_lds_allocation,
     setup_lds_allocation_plain,
     validate_lds_budget_plain,
@@ -113,7 +115,7 @@ def compile_fp8_grouped_gemm(
     out_dtype: str = "bf16",
     waves_per_eu: int | None = None,
     b_preshuffled: bool = True,
-    blockscale: bool = False,
+    scaling: str = SCALING_ROW,
     layout: str = "sizes",
     k_padding: bool = False,
     n_padding: bool = False,
@@ -146,15 +148,18 @@ def compile_fp8_grouped_gemm(
             like A. The two paths share the entire kernel body (tile-map group
             dispatch, scaling, wide-MFMA, CShuffle epilogue); only the B load
             stage and its LDS allocation differ.
-        blockscale: Selects the scaling scheme, which sets the expected layout of
+        scaling: Selects the scaling scheme, which sets the expected layout of
             scale_a / scale_b and where the scales are applied.
-            False (default) is rowwise: scale_a is [M_total] and scale_b is
-            [num_groups, N], one factor per row of A and per column of B, applied
-            once in the epilogue. Tiles are then free of scale-block alignment,
-            so tile_n may be smaller than scale_block_n.
-            True is block scaling: scale_a is per-group [M_g, scale_k] blocks and
-            scale_b is [num_groups, scale_k, scale_n], applied per scale block
-            inside the K loop, which requires the tile to align to the blocks.
+            "row" (default): scale_a is [M_total] and scale_b is [num_groups, N],
+            one factor per row of A and per column of B, applied once in the
+            epilogue. Tiles are then free of scale-block alignment, so tile_n may
+            be smaller than scale_block_n.
+            "block": scale_a is per-group [M_g, scale_k] blocks and scale_b is
+            [num_groups, scale_k, scale_n], applied per scale block inside the K
+            loop, which requires the tile to align to the blocks.
+            "none": the operands carry no scales at all, as bf16 does. Nothing is
+            folded in the K loop and nothing is applied in the epilogue, and the
+            scale arguments are ignored.
         layout: How the kernel learns which rows belong to which group. The
             encodings differ only in that resolution step; the loaders, the K
             loop and the epilogue are shared.
@@ -207,7 +212,7 @@ def compile_fp8_grouped_gemm(
     # and produces a whole output of its own.
     k_grouped = layout == "k_offsets"
     if k_grouped:
-        if blockscale or b_preshuffled:
+        if scaling != SCALING_ROW or b_preshuffled:
             raise ValueError(
                 "layout 'k_offsets' supports only rowwise scaling with plain B: "
                 "a scale block cannot straddle a group's K slice, and the "
@@ -220,7 +225,7 @@ def compile_fp8_grouped_gemm(
         roll_k = True
         k_padding = True
     if n_grouped:
-        if blockscale or b_preshuffled:
+        if scaling != SCALING_ROW or b_preshuffled:
             raise ValueError(
                 "layout 'n_offsets' supports only rowwise scaling with plain B: "
                 "ragged N would need per-group scale blocks, and the preshuffled "
@@ -248,7 +253,7 @@ def compile_fp8_grouped_gemm(
         k=k,
         tile_n=tile_n,
         tile_k=tile_k,
-        blockscale=blockscale,
+        scaling=scaling,
         k_padding=k_padding,
         n_padding=n_padding,
         scale_block_k=scale_block_k,
@@ -318,7 +323,7 @@ def compile_fp8_grouped_gemm(
 
     # Module name for caching
     _variant = "pingpong" if b_preshuffled else "plain"
-    _scaling = "blockscale" if blockscale else "rowwise"
+    _scaling = scaling if scaling != SCALING_ROW else "rowwise"
     _kpad = "_kpad" if k_padding else ""
     _roll = "_rollk" if roll_k else ""
     _wpe = f"_wpe{int(waves_per_eu)}" if waves_per_eu else ""
@@ -433,7 +438,7 @@ def compile_fp8_grouped_gemm(
         # pre-packed on host); gfx942 SW path consumes f32.
         scale_byte_size = 1 if _use_hw_scale else 4
 
-        if const_expr(blockscale):
+        if const_expr(scaling == SCALING_BLOCK):
             # scale_a: per-group [M_g, scale_k] blocks, scale_k values per row.
             sa_nbytes = fx.Index(scale_k) * m_in * fx.Index(scale_byte_size)
             # scale_b: [num_groups, scale_k, scale_n]
@@ -756,7 +761,7 @@ def compile_fp8_grouped_gemm(
                 acc_init=acc_init,
                 group_m_start=fx.Index(group_m_start_i32),
                 group_m_size=fx.Index(group_m_size_i32),
-                blockscale=blockscale,
+                scaling=scaling,
             )
 
             if const_expr(b_preshuffled):
@@ -915,7 +920,7 @@ def compile_fp8_grouped_gemm(
             else:
                 accs = run_kloop(accs)
 
-            if const_expr(not blockscale):
+            if const_expr(scaling == SCALING_ROW):
                 # Rowwise scales are constant along K, so the whole reduction is
                 # scaled here in one pass rather than per K tile.
                 accs = make_rowwise_scaler(

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm.py
@@ -141,7 +141,10 @@ def compile_fp8_grouped_gemm(
     group_based_rows: bool = False,
     roll_k: bool = False,
 ):
-    """Compile grouped FP8 GEMM kernel and return the JIT launcher.
+    """Compile the grouped GEMM kernel and return the JIT launcher.
+
+    Serves FP8 operands with block or rowwise scales and BF16 operands with
+    none; ``in_dtype`` and ``scaling`` select between them.
 
     Args:
         n: N dimension (output columns per group)
@@ -155,11 +158,9 @@ def compile_fp8_grouped_gemm(
             waves_m * waves_n * 64 threads and each wave owns a
             (tile_m / waves_m) x (tile_n / waves_n) slab of the output tile.
             Each wave reads its whole slab's worth of both operands out of LDS,
-            so reads per unit work go as waves_m / tile_m + waves_n / tile_n,
-            which a grid proportioned like the tile minimises: at a square tile
-            2x2 reads a fifth less than the 1x4 default, while at 64x128 the two
-            are equal. Raising the product past 4 buys more waves per tile
-            rather than a better shape, and costs the register budget.
+            so LDS reads per unit of work go as
+            waves_m / tile_m + waves_n / tile_n, which is minimised by a grid
+            proportioned like the tile.
         scale_block_k: K-dimension scale block size (default 128)
         scale_block_n: N-dimension scale block size (default 128)
         out_dtype: Output data type ("bf16" or "f16")
@@ -173,28 +174,15 @@ def compile_fp8_grouped_gemm(
             8-column store boundary rather than a whole tile. Forced on where
             the groups divide N, for the same reason.
         group_based_b: Address B from the owning group's first row rather than
-            from the stack's, and bound the descriptor by that group. Needed
-            once the whole stack passes the 4 GiB a buffer descriptor reaches,
-            which a realistic expert count does: 128 experts of 16384x5120 in
-            BF16 is 21.5 GB. It is not free either, and least so where it might
-            have seemed so -- on the preshuffled path B goes HBM->registers
-            inside the K loop rather than staging through LDS, so its descriptor
-            sits on the critical path of every B load, and basing it costs
-            40-55% at tile_n=256. The host therefore sets it only for stacks
-            that need it, which it can decide exactly, G * N * K being wholly
+            from the stack's, and bound the descriptor by that group. Required
+            once the whole stack exceeds the 4 GiB a buffer descriptor
+            addresses. The caller decides this from G * N * K, which is
             host-known.
         group_based_rows: Address A and D from the owning group's first row
             rather than from the operand's, and bound each descriptor by that
-            group rather than by the whole operand. Needed once A or D passes
-            the 4 GiB a buffer descriptor reaches, past which the hardware reads
-            zero and drops stores rather than faulting -- a wrong answer at full
-            speed. It costs about a quarter of the runtime on the FP8 groupwise
-            shapes, measured at a pinned config and not explained by anything in
-            the emitted code -- the hot loop is the same size, the registers and
-            LDS are unchanged, and where the descriptor is built makes no
-            difference -- so the host sets it only for the shapes that have no
-            alternative. B is based at its group either way, which measures
-            free.
+            group rather than by the whole operand. Required once A or D
+            exceeds the 4 GiB a buffer descriptor addresses, past which the
+            hardware reads zero and drops stores rather than faulting.
         b_preshuffled: When True (default) B is expected pre-swizzled into the
             MFMA layout and loaded HBM->registers (no B LDS). When False, B is
             plain row-major [num_groups, N, K] and is staged HBM->LDS->registers
@@ -531,20 +519,14 @@ def compile_fp8_grouped_gemm(
             """Buffer descriptor over one slab of an operand, based at that slab.
 
             A descriptor addresses at most 4 GiB: both its num_records and the
-            voffset a buffer_load adds are 32-bit. A stack of per-group weights
-            passes that at a realistic expert count -- 128 experts of 16384x5120
-            BF16 is 21.5 GB -- and the hardware answers an out-of-range load with
-            zero, so the kernel would return a wrong result at full speed rather
-            than fail.
+            voffset a buffer_load adds are 32-bit. An out-of-range load reads
+            zero and an out-of-range store is dropped, so an operand past that
+            limit yields a wrong result rather than an error.
 
-            Folding the group into the base address instead keeps the descriptor
-            over one group, which no realistic shape exceeds, and does the
-            arithmetic that selects the group in 64 bits. `preshuffle_gemm.py`
-            bases its batched operands the same way.
-
-            The offset goes to `base_byte_offset`, which is applied to the
-            descriptor's base pointer, so the group term never passes through a
-            32-bit quantity on its way in.
+            Folding the group into the base address keeps the descriptor over a
+            single group and does the group arithmetic in 64 bits. The offset
+            goes to `base_byte_offset`, which applies to the descriptor's base
+            pointer, so the group term never passes through a 32-bit quantity.
             """
             return buffer_ops.create_buffer_resource(
                 arg,
@@ -697,8 +679,8 @@ def compile_fp8_grouped_gemm(
                 )
             else:
                 # One descriptor over the whole stack, so the group stays in the
-                # coordinates rather than in the base. Built before this branch,
-                # needing no group to build.
+                # coordinates rather than in the base. Built outside this
+                # conditional, since it does not depend on the group.
                 b_rsrc = b_rsrc_whole
 
             # Global row base of this tile and the exclusive row end of its group
@@ -730,13 +712,10 @@ def compile_fp8_grouped_gemm(
 
             if const_expr(group_based_rows):
                 # A and D are addressed from this group's first row rather than
-                # from the operand's, for the reason B always is: a whole operand
-                # can exceed what one descriptor reaches. A packed A at 300k rows
-                # of K=8192 in BF16 is 4.6 GB with only four groups, so this is
-                # not the many-expert case alone. Rows inside the loader and the
-                # epilogue are then group-local, and the group's own extent
-                # bounds each descriptor. This form is the slower one; see
-                # `group_based_rows`.
+                # from the operand's, since a whole operand can exceed what one
+                # descriptor reaches. Rows inside the loader and the epilogue
+                # are then group-local, and the group's own extent bounds each
+                # descriptor.
                 a_group_rows = fx.Index(group_m_size_i32)
                 a_row_base = fx.Index(group_m_start_i32)
                 a_rsrc = rebased_resource(

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -35,6 +35,16 @@ from mslk.flydsl.kernels.mma.mfma_preshuffle_pipeline import (
     tile_chunk_coord_i32,
 )
 
+# How the operands are scaled, which decides where the scales are applied and
+# whether they exist at all.
+#   block  one scale per (128, 128) block of B and per (1, 128) of A, folded in
+#          per scale block inside the K loop, so the tile must align to them.
+#   row    one scale per row of A and per column of B, constant along K, so they
+#          factor out of the reduction and apply once in the epilogue.
+#   none   unscaled operands, as bf16 has; the scale machinery compiles away.
+SCALING_BLOCK, SCALING_ROW, SCALING_NONE = "block", "row", "none"
+SCALINGS = (SCALING_BLOCK, SCALING_ROW, SCALING_NONE)
+
 # FP8 elements covered by one 16-byte vectorised load. With k_padding the tail K
 # tile is masked a whole load at a time, so this is the finest K granularity the
 # kernel can end on.
@@ -126,7 +136,7 @@ def validate_params(
     scale_block_k,
     scale_block_n,
     out_dtype,
-    blockscale=False,
+    scaling=SCALING_ROW,
     k_padding=False,
     n_padding=False,
 ):
@@ -134,15 +144,18 @@ def validate_params(
     the grouped GEMM kernels.
 
     scale_block_k splits a K tile into the sub-blocks the MFMA schedule steps
-    through, so tile_k must cover a whole number of them under either scaling
+    through, so tile_k must cover a whole number of them under any scaling
     scheme -- a tile_k below scale_block_k yields zero sub-blocks and a compute
     loop that never runs.
 
     scale_block_n only matters to block scaling, where a tile must not straddle
     a scale block. Rowwise scaling carries one scale per row of A and per column
     of B and applies it in the epilogue, so tile_n is free of that alignment and
-    may be smaller than scale_block_n.
+    may be smaller than scale_block_n; unscaled operands are freer still.
     """
+    if scaling not in SCALINGS:
+        raise ValueError(f"scaling must be one of {SCALINGS}, got {scaling!r}")
+    blockscale = scaling == SCALING_BLOCK
     if k_padding:
         # The tail K tile is masked off per 16-byte load, so K only has to land on
         # a load boundary rather than a whole tile.
@@ -1146,7 +1159,7 @@ def make_compute_tile(
     sa_group_off=None,
     group_m_start=None,
     group_m_size=None,
-    blockscale=False,
+    scaling=SCALING_ROW,
 ):
     """Build the per-K-tile compute closure.
 
@@ -1168,6 +1181,10 @@ def make_compute_tile(
     the K loop accumulates unscaled, leaving a single scaling in the epilogue
     (see `make_rowwise_scaler`).
     """
+    # Only block scaling folds anything inside the K loop. Rowwise scales are
+    # constant along K and apply once in the epilogue, and unscaled operands
+    # have nothing to apply, so both leave this loop accumulating straight.
+    blockscale = scaling == SCALING_BLOCK
 
     def compute_tile(
         accs_in, k_tile_idx_py, lds_base, b_tile_in, scales_pf, *, a0_prefetch=None

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -857,14 +857,16 @@ def make_b_tile_loaders(
     n_padding=False,
     n_bound=None,
     k_base_div4=None,
+    b_group_off=None,
 ):
     """Build the prefetch + LDS-store closures for a PLAIN (non-preshuffled)
     B tile [tile_n, tile_k].
 
     Mirror of `make_a_tile_loaders` with N in place of M. Addresses are relative
-    to the slab `b_rsrc` is based at, which the caller has already positioned on
-    this block's group, so nothing here carries a group term: the row is just
-    `by_n` (the block's N-block start) plus its tile-local offset. `n_bound`
+    to whatever `b_rsrc` is based at. Where that is this block's group the base
+    carries the group and `b_group_off` is None, leaving the row as `by_n` plus
+    its tile-local offset; where the descriptor spans the whole stack instead,
+    `b_group_off` is the group's leading offset in dwords and is added here. `n_bound`
     replaces the row bound the tail masks against, which is the group's column
     end rather than N where the groups divide the columns. Coalesced 16-byte
     (dwordx4) loads via `tile_chunk_coord_i32`; LDS store uses the same XOR16
@@ -907,8 +909,10 @@ def make_b_tile_loaders(
             base_k_div4 = k_base_div4 + base_k_div4
         parts = []
         for i in range_constexpr(num_b_loads):
-            row_global = by_n + b_row_local[i]  # N row within this group's slab
+            row_global = by_n + b_row_local[i]  # N row within B's own frame
             idx_i32 = row_global * _k_div4_factor + base_k_div4 + b_col_local_i32[i]
+            if b_group_off is not None:
+                idx_i32 = b_group_off + idx_i32
             kmask = _k_tail_mask(k_tile_idx_py, base_k_div4, b_col_local_i32[i])
             if n_padding:
                 # Rows past N hold the next group's weights, so read zero instead.
@@ -1968,6 +1972,7 @@ def make_n_block_coords(
     kpack_bytes,
     elem_bytes,
     scale_block_n,
+    b_group_based=False,
     scale_k,
     n_per_wave,
     num_acc_n,
@@ -1992,27 +1997,31 @@ def make_n_block_coords(
         n_block_for_scale.append(n_blk)
 
     # The preshuffle rearranges only the trailing (N, K) and leaves the group
-    # axis alone, so a group's weights stay one contiguous [N, K] block. The B
-    # descriptor is based at this block's group, which makes these coordinates
-    # group-local: the layout spans n_in rather than the whole stack, and the
-    # column carries no group term. Keeping the group in the column instead
-    # would put it in a 32-bit buffer offset, which a stack of experts overruns.
+    # axis alone, so a group's weights stay one contiguous [N, K] block, and the
+    # group can sit either in the descriptor's base or in these coordinates.
+    # Based per group, the layout spans n_in and the column carries no group
+    # term; spanning the whole stack, both take it back. The base is the only
+    # form a stack over 4 GiB can use, since the column is a 32-bit offset, but
+    # it is the more expensive one here: B goes HBM->registers inside the K loop
+    # on this path, so its descriptor is on the critical path of every load.
+    c_n_total = n_in if b_group_based else num_groups_in * n_in
     b_layout = make_preshuffle_b_layout(
         arith,
-        c_n=n_in,
+        c_n=c_n_total,
         c_k=k_in,
         kpack_bytes=kpack_bytes,
         elem_bytes=elem_bytes,
     )
     layout_b = b_layout.layout_b
 
-    c_n0 = n_in // fx.Index(16)
+    c_n0 = c_n_total // fx.Index(16)
     c_n0_i32 = arith.index_cast(T.i32, c_n0)
     layout_n_blk_intra = fx.make_layout((c_n0_i32, 16), stride=(16, 1))
     n_blk_list = []
     n_intra_list = []
+    group_n_off = fx.Index(0) if b_group_based else group_idx * n_in
     for ni in range_constexpr(num_acc_n):
-        col_global = by_n + n_tile_base + (ni * 16) + lane_mod_16
+        col_global = group_n_off + by_n + n_tile_base + (ni * 16) + lane_mod_16
         coord_ni = fx.idx2crd(fx.Int32(col_global), layout_n_blk_intra)
         n_blk_list.append(fx.get(coord_ni, 0))
         n_intra_list.append(fx.get(coord_ni, 1))

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -129,6 +129,7 @@ CompileConstants = namedtuple(
         "scale_k",
         "scale_n",
         "sb_per_tile",
+        "ku_per_sb",
         "k_unroll",
         "kpack_bytes",
         "kpack_elems",
@@ -163,9 +164,12 @@ def validate_params(
     the grouped GEMM kernels.
 
     scale_block_k splits a K tile into the sub-blocks the MFMA schedule steps
-    through, so tile_k must cover a whole number of them under any scaling
-    scheme -- a tile_k below scale_block_k yields zero sub-blocks and a compute
-    loop that never runs.
+    through to fold the scales, so where there are scales tile_k must cover a
+    whole number of them -- a tile_k below scale_block_k yields zero sub-blocks
+    and a compute loop that never runs. Unscaled operands have nothing to fold
+    and treat the whole tile as one sub-block, which frees tile_k from the
+    scale-block granularity: that is what lets bf16 pick a tile_k small enough
+    to keep more than one workgroup resident per CU.
 
     scale_block_n only matters to block scaling, where a tile must not straddle
     a scale block. Rowwise scaling carries one scale per row of A and per column
@@ -208,7 +212,7 @@ def validate_params(
             )
     elif n % tile_n != 0:
         raise ValueError(f"n ({n}) must be divisible by tile_n ({tile_n})")
-    if tile_k % scale_block_k != 0:
+    if scaling != SCALING_NONE and tile_k % scale_block_k != 0:
         raise ValueError(
             f"tile_k ({tile_k}) must be divisible by scale_block_k ({scale_block_k})"
         )
@@ -323,6 +327,7 @@ def compute_compile_constants(
     scale_block_n,
     k_padding=False,
     in_dtype="fp8",
+    scaling=SCALING_ROW,
 ):
     """Compute the compile-time scalar constants shared by both kernels.
 
@@ -343,11 +348,24 @@ def compute_compile_constants(
     num_k_tiles = -(-k // tile_k) if k_padding else k // tile_k
     scale_k = k // scale_block_k
     scale_n = n // scale_block_n
-    sb_per_tile = tile_k // scale_block_k  # scale blocks per K-tile
 
     tile_k_bytes = tile_k * elem_bytes
     # 64-byte micro-steps, one per pair of K32 MFMA issues.
     k_unroll = tile_k_bytes // 64
+    # The sub-block is the K extent over which one set of scales is constant,
+    # and so the unit the compute loop steps through to fold them in. Unscaled
+    # operands have nothing to fold, so the whole tile is one sub-block and
+    # tile_k stops being tied to the scale-block granularity.
+    sb_per_tile = 1 if scaling == SCALING_NONE else tile_k // scale_block_k
+    if sb_per_tile <= 0 or k_unroll % sb_per_tile != 0:
+        raise ValueError(
+            f"tile_k ({tile_k}) yields {sb_per_tile} scale sub-block(s) per tile "
+            f"and {k_unroll} 64-byte steps, which do not divide"
+        )
+    # Derived rather than stated, so the two cannot drift: the sub-blocks
+    # partition the tile's 64-byte steps exactly.
+    ku_per_sb = k_unroll // sb_per_tile
+
     # A lane reads its operand a 16-byte pack at a time whatever the dtype; how
     # many elements that covers is what changes.
     kpack_bytes = 16
@@ -366,6 +384,23 @@ def compute_compile_constants(
     chunk_i32_b = a_load_bytes // 4  # same 16-byte dwordx4 load
     num_b_loads = bytes_per_thread_b // a_load_bytes
 
+    # A tile too small to give every thread a whole 16-byte load rounds its load
+    # count to zero, which stages nothing and leaves the compute loop reading an
+    # LDS buffer that was never written. Reject it rather than emit a kernel
+    # that runs fast and returns garbage.
+    if num_a_loads <= 0 or bytes_per_thread_a % a_load_bytes != 0:
+        raise ValueError(
+            f"tile_m ({tile_m}) x tile_k ({tile_k}) at {elem_bytes} B/elem gives "
+            f"{bytes_per_thread_a} A bytes per thread, which is not a positive "
+            f"multiple of the {a_load_bytes}-byte load width"
+        )
+    if num_b_loads <= 0 or bytes_per_thread_b % a_load_bytes != 0:
+        raise ValueError(
+            f"tile_n ({tile_n}) x tile_k ({tile_k}) at {elem_bytes} B/elem gives "
+            f"{bytes_per_thread_b} B bytes per thread, which is not a positive "
+            f"multiple of the {a_load_bytes}-byte load width"
+        )
+
     return CompileConstants(
         total_threads=total_threads,
         elem_bytes=elem_bytes,
@@ -373,6 +408,7 @@ def compute_compile_constants(
         scale_k=scale_k,
         scale_n=scale_n,
         sb_per_tile=sb_per_tile,
+        ku_per_sb=ku_per_sb,
         k_unroll=k_unroll,
         kpack_bytes=kpack_bytes,
         kpack_elems=kpack_elems,

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -842,7 +842,6 @@ def make_b_tile_loaders(
     lds_b,
     layout_lds_b,
     by_n,
-    group_idx,
     tx,
     tile_n,
     tile_k,
@@ -856,21 +855,18 @@ def make_b_tile_loaders(
     k_in,
     k_tail_mask=None,
     n_padding=False,
-    b_group_off=None,
     n_bound=None,
     k_base_div4=None,
 ):
     """Build the prefetch + LDS-store closures for a PLAIN (non-preshuffled)
     B tile [tile_n, tile_k].
 
-    Mirror of `make_a_tile_loaders` with N in place of M. B is `[G, N, K]`
-    row-major, so the per-tile global base adds the group offset
-    `group_idx * n_in * (k_in/4)` (always present — B is always grouped) plus
-    the N-tile base `by_n` (the block's N-block start). `b_group_off` replaces
-    that leading offset where B is one flat [total_N, K] matrix and the group is
-    already folded into `by_n`, and `n_bound` replaces the row bound the tail
-    masks against, which is then the group's column end rather than N.
-    Coalesced 16-byte
+    Mirror of `make_a_tile_loaders` with N in place of M. Addresses are relative
+    to the slab `b_rsrc` is based at, which the caller has already positioned on
+    this block's group, so nothing here carries a group term: the row is just
+    `by_n` (the block's N-block start) plus its tile-local offset. `n_bound`
+    replaces the row bound the tail masks against, which is the group's column
+    end rather than N where the groups divide the columns. Coalesced 16-byte
     (dwordx4) loads via `tile_chunk_coord_i32`; LDS store uses the same XOR16
     swizzle as A. Returns `(prefetch_b_tile, store_b_tile_to_lds, b_row_local,
     b_col_local_i32, k_blocks16_b)`.
@@ -886,10 +882,6 @@ def make_b_tile_loaders(
     tx_i32_base = tx * c_chunk_b
     _k_bytes = k_in if elem_bytes == 1 else k_in * fx.Index(elem_bytes)
     _k_div4_factor = _k_bytes // fx.Index(4)
-    # B is [G, N, K]: leading offset selects this tile's group and N-block base.
-    b_tile_offset_div4 = (
-        b_group_off if b_group_off is not None else group_idx * n_in * _k_div4_factor
-    )
     _n_bound = n_in if n_bound is None else n_bound
     k_blocks16_b = arith.index(tile_k_bytes // 16)
     c4_bytes = fx.Index(4)
@@ -915,13 +907,8 @@ def make_b_tile_loaders(
             base_k_div4 = k_base_div4 + base_k_div4
         parts = []
         for i in range_constexpr(num_b_loads):
-            row_global = by_n + b_row_local[i]  # global N row
-            idx_i32 = (
-                b_tile_offset_div4
-                + row_global * _k_div4_factor
-                + base_k_div4
-                + b_col_local_i32[i]
-            )
+            row_global = by_n + b_row_local[i]  # N row within this group's slab
+            idx_i32 = row_global * _k_div4_factor + base_k_div4 + b_col_local_i32[i]
             kmask = _k_tail_mask(k_tile_idx_py, base_k_div4, b_col_local_i32[i])
             if n_padding:
                 # Rows past N hold the next group's weights, so read zero instead.
@@ -1996,24 +1983,28 @@ def make_n_block_coords(
         n_blk = col_base // c_scale_block_n
         n_block_for_scale.append(n_blk)
 
-    c_n_total = num_groups_in * n_in
+    # The preshuffle rearranges only the trailing (N, K) and leaves the group
+    # axis alone, so a group's weights stay one contiguous [N, K] block. The B
+    # descriptor is based at this block's group, which makes these coordinates
+    # group-local: the layout spans n_in rather than the whole stack, and the
+    # column carries no group term. Keeping the group in the column instead
+    # would put it in a 32-bit buffer offset, which a stack of experts overruns.
     b_layout = make_preshuffle_b_layout(
         arith,
-        c_n=c_n_total,
+        c_n=n_in,
         c_k=k_in,
         kpack_bytes=kpack_bytes,
         elem_bytes=elem_bytes,
     )
     layout_b = b_layout.layout_b
 
-    c_n0 = c_n_total // fx.Index(16)
+    c_n0 = n_in // fx.Index(16)
     c_n0_i32 = arith.index_cast(T.i32, c_n0)
     layout_n_blk_intra = fx.make_layout((c_n0_i32, 16), stride=(16, 1))
     n_blk_list = []
     n_intra_list = []
-    group_n_off = group_idx * n_in
     for ni in range_constexpr(num_acc_n):
-        col_global = group_n_off + by_n + n_tile_base + (ni * 16) + lane_mod_16
+        col_global = by_n + n_tile_base + (ni * 16) + lane_mod_16
         coord_ni = fx.idx2crd(fx.Int32(col_global), layout_n_blk_intra)
         n_blk_list.append(fx.get(coord_ni, 0))
         n_intra_list.append(fx.get(coord_ni, 1))

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -103,6 +103,7 @@ CompileConstants = namedtuple(
         "sb_per_tile",
         "k_unroll",
         "kpack_bytes",
+        "kpack_elems",
         "tile_k_bytes",
         "tile_k_dwords",
         "bytes_a_per_tile",
@@ -262,25 +263,50 @@ def out_mlir_for(out_dtype):
     return lambda: T.bf16 if out_dtype == "bf16" else T.f16
 
 
+#: Bytes an element of each supported input dtype occupies.
+ELEM_BYTES = {"fp8": 1, "bf16": 2}
+
+
 def compute_compile_constants(
-    *, n, k, tile_m, tile_n, tile_k, scale_block_k, scale_block_n, k_padding=False
+    *,
+    n,
+    k,
+    tile_m,
+    tile_n,
+    tile_k,
+    scale_block_k,
+    scale_block_n,
+    k_padding=False,
+    in_dtype="fp8",
 ):
     """Compute the compile-time scalar constants shared by both kernels.
 
     Returns a `CompileConstants` namedtuple. Pure-Python — no MLIR ops emitted.
+
+    Quantities that describe memory stay in bytes and quantities that describe
+    the contraction stay in elements, so that the two do not have to be
+    disentangled per dtype. They coincide only for the one-byte dtypes.
     """
+    if in_dtype not in ELEM_BYTES:
+        raise ValueError(
+            f"in_dtype must be one of {tuple(ELEM_BYTES)}, got {in_dtype!r}"
+        )
     total_threads = 256
-    elem_bytes = 1  # FP8
+    elem_bytes = ELEM_BYTES[in_dtype]
     # With k_padding the last tile is only partly covered by K; it still runs, with
     # its out-of-range loads masked to zero, which contribute nothing to the sum.
     num_k_tiles = -(-k // tile_k) if k_padding else k // tile_k
     scale_k = k // scale_block_k
     scale_n = n // scale_block_n
     sb_per_tile = tile_k // scale_block_k  # scale blocks per K-tile
-    k_unroll = tile_k // 64  # K64-byte micro-steps (for K32 MFMA pairs)
-    kpack_bytes = 16  # 16-byte packs for FP8
 
     tile_k_bytes = tile_k * elem_bytes
+    # 64-byte micro-steps, one per pair of K32 MFMA issues.
+    k_unroll = tile_k_bytes // 64
+    # A lane reads its operand a 16-byte pack at a time whatever the dtype; how
+    # many elements that covers is what changes.
+    kpack_bytes = 16
+    kpack_elems = kpack_bytes // elem_bytes
     tile_k_dwords = tile_k_bytes // 4
     bytes_a_per_tile = tile_m * tile_k * elem_bytes
     bytes_per_thread_a = bytes_a_per_tile // total_threads
@@ -304,6 +330,7 @@ def compute_compile_constants(
         sb_per_tile=sb_per_tile,
         k_unroll=k_unroll,
         kpack_bytes=kpack_bytes,
+        kpack_elems=kpack_elems,
         tile_k_bytes=tile_k_bytes,
         tile_k_dwords=tile_k_dwords,
         bytes_a_per_tile=bytes_a_per_tile,

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -966,6 +966,18 @@ def make_b_tile_loaders(
     )
 
 
+def _mfma_row_off(mi, m_wave_base):
+    """Tile-local row of MFMA sub-tile ``mi``, shifted to this wave's M slab.
+
+    With a one-dimensional wave grid every wave spans the whole of tile_m and the
+    offset is nothing, so this stays a plain Python int and the emitted IR is
+    unchanged. A two-dimensional grid gives each wave a slab of the rows, and the
+    base becomes a runtime value.
+    """
+    off = mi * 16
+    return off if m_wave_base is None else off + m_wave_base
+
+
 def make_lds_loader(*, lds_a, layout_lds, k_blocks16):
     """Build the LDS-side A pack loader.
 
@@ -1158,6 +1170,7 @@ def make_hot_loop_scheduler(
 
 def make_prefetch_scales(
     *,
+    m_wave_base=None,
     _use_hw_scale,
     sa_rsrc,
     sb_rsrc,
@@ -1203,7 +1216,7 @@ def make_prefetch_scales(
 
             sa_sb = []
             for mi in range_constexpr(m_repeat):
-                sa_row = bx_m + (mi * 16) + lane_mod_16
+                sa_row = bx_m + _mfma_row_off(mi, m_wave_base) + lane_mod_16
                 sa_idx = sa_base_pf + sa_row
                 sa_i8 = buffer_ops.buffer_load(sa_rsrc, sa_idx, vec_width=1, dtype=T.i8)
                 sa_e8m0 = ArithValue(sa_i8).extui(T.i32)
@@ -1227,6 +1240,7 @@ def make_prefetch_scales(
 
 def make_compute_tile(
     *,
+    m_wave_base=None,
     _use_hw_scale,
     _is_gfx950=False,
     lds_load_packs_k64,
@@ -1354,7 +1368,7 @@ def make_compute_tile(
                 for mi in range_constexpr(m_repeat):
                     s_a_row = []
                     for ii in range_constexpr(4):
-                        row_in_tile = (mi * 16) + row_off_base + fx.Index(ii)
+                        row_in_tile = _mfma_row_off(mi, m_wave_base) + row_off_base + fx.Index(ii)
                         row_global = bx_m + row_in_tile
                         sa_idx = sa_base + row_global
                         s_a_val = buffer_ops.buffer_load(
@@ -1390,7 +1404,7 @@ def make_compute_tile(
                 col_base1 = col_offset_base_bytes + fx.Index(ku1 * 64)
 
                 for mi in range_constexpr(m_repeat):
-                    curr_row_a_lds = lane_mod_16 + (mi * 16)
+                    curr_row_a_lds = lane_mod_16 + _mfma_row_off(mi, m_wave_base)
                     if a0_prefetch is not None and sb == 0 and mi == 0:
                         a0, a1 = a0_prefetch
                     else:
@@ -1453,7 +1467,7 @@ def make_compute_tile(
                 col_base1 = col_offset_base_bytes + fx.Index(ku1 * 64)
 
                 for mi in range_constexpr(m_repeat):
-                    curr_row_a_lds = lane_mod_16 + (mi * 16)
+                    curr_row_a_lds = lane_mod_16 + _mfma_row_off(mi, m_wave_base)
                     if a0_prefetch is not None and sb == 0 and mi == 0:
                         a0, a1 = a0_prefetch
                     else:
@@ -1505,7 +1519,7 @@ def make_compute_tile(
                         ):
                             a0, a1 = a0_prefetch
                         else:
-                            row_a_lds = lane_mod_16 + (mi * 16)
+                            row_a_lds = lane_mod_16 + _mfma_row_off(mi, m_wave_base)
                             col_a_base_bytes = lane_div_16 * fx.Index(16) + fx.Index(
                                 k_offset_bytes
                             )
@@ -1550,6 +1564,7 @@ def make_compute_tile(
 
 def make_rowwise_scaler(
     *,
+    m_wave_base=None,
     sa_rsrc,
     sb_rsrc,
     group_idx,
@@ -1588,7 +1603,7 @@ def make_rowwise_scaler(
         for mi in range_constexpr(m_repeat):
             s_a_row = []
             for ii in range_constexpr(4):
-                row_global = bx_m + (mi * 16) + row_off_base + fx.Index(ii)
+                row_global = bx_m + _mfma_row_off(mi, m_wave_base) + row_off_base + fx.Index(ii)
                 s_a_row.append(
                     buffer_ops.buffer_load(
                         sa_rsrc, row_global, vec_width=1, dtype=T.f32
@@ -1893,15 +1908,18 @@ MfmaTilingConstants = namedtuple(
 )
 
 
-def compute_mfma_tiling(*, tile_m, tile_n):
+def compute_mfma_tiling(*, tile_m, tile_n, waves_m=1, waves_n=4):
     """Pure-Python derivation of the MFMA tiling constants.
 
     Returns an `MfmaTilingConstants` namedtuple with `m_repeat`,
     `num_waves`, `n_per_wave`, `num_acc_n`, `num_accs`. Emits no MLIR.
     """
-    m_repeat = tile_m // 16  # 8 for tile_m=128
-    num_waves = 4
-    n_per_wave = tile_n // num_waves  # 32 for tile_n=128
+    # Waves tile the output as waves_m x waves_n. LDS read traffic per unit work
+    # is waves_m / tile_m + waves_n / tile_n, minimised when the wave grid is
+    # proportioned like the tile; the historical 1 x 4 split cannot do that.
+    num_waves = waves_m * waves_n
+    m_repeat = (tile_m // waves_m) // 16
+    n_per_wave = tile_n // waves_n
     num_acc_n = n_per_wave // 16  # 2 for n_per_wave=32
     num_accs = m_repeat * num_acc_n
     return MfmaTilingConstants(
@@ -1936,6 +1954,7 @@ NBlockCoords = namedtuple(
 
 def make_n_block_coords(
     *,
+    waves_n=4,
     wave_id,
     by_n,
     group_idx,
@@ -1958,8 +1977,8 @@ def make_n_block_coords(
     namedtuple matching the original local variable names so the caller
     can keep referring to them unchanged.
     """
-    wave_mod_4 = wave_id % fx.Index(4)
-    n_tile_base = wave_mod_4 * fx.Index(n_per_wave)
+    wave_n_idx = wave_id % fx.Index(waves_n)
+    n_tile_base = wave_n_idx * fx.Index(n_per_wave)
 
     c_scale_block_n = fx.Index(scale_block_n)
     c_scale_k = fx.Index(scale_k)

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -1372,7 +1372,9 @@ def make_compute_tile(
                 for mi in range_constexpr(m_repeat):
                     s_a_row = []
                     for ii in range_constexpr(4):
-                        row_in_tile = _mfma_row_off(mi, m_wave_base) + row_off_base + fx.Index(ii)
+                        row_in_tile = (
+                            _mfma_row_off(mi, m_wave_base) + row_off_base + fx.Index(ii)
+                        )
                         row_global = bx_m + row_in_tile
                         sa_idx = sa_base + row_global
                         s_a_val = buffer_ops.buffer_load(
@@ -1607,7 +1609,9 @@ def make_rowwise_scaler(
         for mi in range_constexpr(m_repeat):
             s_a_row = []
             for ii in range_constexpr(4):
-                row_global = bx_m + _mfma_row_off(mi, m_wave_base) + row_off_base + fx.Index(ii)
+                row_global = (
+                    bx_m + _mfma_row_off(mi, m_wave_base) + row_off_base + fx.Index(ii)
+                )
                 s_a_row.append(
                     buffer_ops.buffer_load(
                         sa_rsrc, row_global, vec_width=1, dtype=T.f32

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -1821,17 +1821,22 @@ def make_epilogue_writers(
     out_mlir,
     e_vec,
     c_n,
-    d_group_off=None,
+    d_row_base=None,
     n_padding=False,
     n_bound=None,
 ):
     """Build the CShuffle-epilogue writer closures.
 
-    Returns `(write_row_to_lds, store_pair)` to be passed to
-    `mfma_epilog`. `d_group_off` is None for the contig path (no
-    addition emitted) and `group_idx * m_in * n_in` for the masked
-    path. Using a Python `is None` guard keeps the contig MLIR
-    identical to the pre-extraction code.
+    Returns `(write_row_to_lds, store_pair)` to be passed to `mfma_epilog`.
+
+    `d_row_base` is the first output row of the slab `d_rsrc` is based at. The
+    epilogue works in global rows, so subtracting it gives the row within that
+    descriptor. It exists because a descriptor reaches only 4 GiB and a whole
+    output can exceed that, which the store would meet not as a fault but as a
+    dropped write; see `rebased_resource` in the grouped kernel. None means the
+    descriptor spans the whole output and the row needs no adjusting, which is
+    what a caller whose output is one matrix wants; no subtraction is then
+    emitted.
 
     `c_n` is the output's leading dimension, and normally also bounds the column
     mask, since a group's columns run to the end of its row. Where groups sit
@@ -1861,10 +1866,8 @@ def make_epilogue_writers(
             v1.store(lds_out, [lds_idx], alignment=2)
 
     def store_pair(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
-        if d_group_off is None:
-            idx_out = row * c_n + col_g0
-        else:
-            idx_out = d_group_off + row * c_n + col_g0
+        row_in_slab = row if d_row_base is None else row - d_row_base
+        idx_out = row_in_slab * c_n + col_g0
         byte_off = idx_out * 2
         col_mask = None
         if n_padding:

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -328,6 +328,7 @@ def compute_compile_constants(
     k_padding=False,
     in_dtype="fp8",
     scaling=SCALING_ROW,
+    num_waves=4,
 ):
     """Compute the compile-time scalar constants shared by both kernels.
 
@@ -341,7 +342,9 @@ def compute_compile_constants(
         raise ValueError(
             f"in_dtype must be one of {tuple(ELEM_BYTES)}, got {in_dtype!r}"
         )
-    total_threads = 256
+    # The block is one wave per SIMD lane group, so the staging split below
+    # follows the wave count rather than a fixed 256.
+    total_threads = num_waves * 64
     elem_bytes = ELEM_BYTES[in_dtype]
     # With k_padding the last tile is only partly covered by K; it still runs, with
     # its out-of-range loads masked to zero, which contribute nothing to the sum.
@@ -1040,7 +1043,8 @@ def make_plain_b_tile(
     N-row addressing must match what the MFMA B operand expects, i.e. the same
     N-column `make_n_block_coords` uses (common.py):
         col = by_n + n_tile_base + ni*16 + lane_mod_16
-    where `n_tile_base = wave_mod_4 * n_per_wave` is this WAVE's N sub-range.
+    where `n_tile_base = (wave_id % waves_n) * n_per_wave` is this WAVE's N
+    sub-range.
     Since the B LDS buffer holds the block's [tile_n, tile_k] tile (row 0 = the
     block's `by_n`), the LDS N-row for accumulator `ni` is the tile-LOCAL row
     `n_tile_base + ni*16 + lane_mod_16` (by_n is the tile base, already 0 in the

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -7,10 +7,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 FlyDSL Project Contributors
 
-"""Shared building blocks for the grouped FP8 GEMM kernel.
+"""Shared building blocks for the grouped GEMM kernel.
 
 Used by fp8_grouped_gemm.py: parameter validation, compile-time scalar
 constants, and the helper closures the kernel body is built from.
+
+Quantities that describe memory are held in bytes and quantities that describe
+the contraction in elements, so that the helpers serve any input dtype without
+disentangling the two per call. The LDS arena is byte-typed for the same
+reason: the XOR16 swizzle and the pack loads are then dtype-agnostic, and only
+the MFMA selection in `make_compute_tile` has to know the element size.
 
 Block scaling indexes scale_b as [num_groups, scale_k, scale_n] (per-group,
 per-K-block, per-N-block) and scale_a as [scale_k, M] (transposed, per-token
@@ -59,7 +65,15 @@ N_STORE_ELEMS = 8
 
 
 def make_k_tail_mask(
-    *, k_padding, num_k_tiles, k, tile_k, k_in, always=False, k_bound=None
+    *,
+    k_padding,
+    num_k_tiles,
+    k,
+    tile_k,
+    k_in,
+    elem_bytes=1,
+    always=False,
+    k_bound=None,
 ):
     """Build the per-load K-range predicate used by the A and B tile loaders.
 
@@ -93,10 +107,14 @@ def make_k_tail_mask(
         # Loads are 16-byte aligned and K is a multiple of that width, so a chunk
         # is either wholly inside K or wholly outside it.
         chunk_start_div4 = base_k_div4 + col_local_i32
+        # Both sides are dword positions in the row's byte stream, so a bound
+        # counted in K elements has to be widened by the element size first.
+        # The two coincide for the one-byte dtypes.
+        bound_bytes = _bound if elem_bytes == 1 else _bound * fx.Index(elem_bytes)
         return arith.cmpi(
             arith.CmpIPredicate.ult,
             arith.index_cast(T.i32, chunk_start_div4),
-            arith.index_cast(T.i32, _bound // fx.Index(4)),
+            arith.index_cast(T.i32, bound_bytes // fx.Index(4)),
         )
 
     return mask
@@ -137,6 +155,7 @@ def validate_params(
     scale_block_n,
     out_dtype,
     scaling=SCALING_ROW,
+    in_dtype="fp8",
     k_padding=False,
     n_padding=False,
 ):
@@ -155,6 +174,19 @@ def validate_params(
     """
     if scaling not in SCALINGS:
         raise ValueError(f"scaling must be one of {SCALINGS}, got {scaling!r}")
+    if in_dtype not in ELEM_BYTES:
+        raise ValueError(
+            f"in_dtype must be one of {tuple(ELEM_BYTES)}, got {in_dtype!r}"
+        )
+    # The dtype decides whether there are scales at all: a quantised operand is
+    # meaningless without them, and a bf16 one carries its own exponent and has
+    # none to apply. Pairing them the other way would silently read scale
+    # buffers the caller never filled, or drop the ones it did.
+    if (in_dtype == "fp8") != (scaling != SCALING_NONE):
+        raise ValueError(
+            f"in_dtype {in_dtype!r} does not admit scaling {scaling!r}: the "
+            "quantised dtypes require a scaling scheme and bf16 requires 'none'"
+        )
     blockscale = scaling == SCALING_BLOCK
     if k_padding:
         # The tail K tile is masked off per 16-byte load, so K only has to land on
@@ -361,8 +393,9 @@ def setup_lds_allocation(*, allocator, tile_m, tile_k, tile_n, elem_bytes):
 
     The ping-pong A buffers and the FP16/BF16 epilogue output share the same
     LDS arena (alias), so we reserve the max of the two. Returns
-    `(lds_alloc_offset, lds_tile_elems)` where `lds_tile_elems` is the
-    A-element stride between the ping and pong halves.
+    `(lds_alloc_offset, lds_tile_bytes)` where `lds_tile_bytes` is the byte
+    stride between the ping and pong halves. The kernel addresses its A/B
+    arena as raw bytes whatever the input dtype, so this is a byte offset.
     """
     lds_a_bytes = tile_m * tile_k * elem_bytes
     lds_pingpong_bytes = 2 * lds_a_bytes
@@ -370,8 +403,7 @@ def setup_lds_allocation(*, allocator, tile_m, tile_k, tile_n, elem_bytes):
     lds_total_bytes = max(lds_pingpong_bytes, lds_out_bytes)
     lds_alloc_offset = allocator._align(allocator.ptr, 16)
     allocator.ptr = lds_alloc_offset + lds_total_bytes
-    lds_tile_elems = tile_m * tile_k  # element offset between ping and pong
-    return lds_alloc_offset, lds_tile_elems
+    return lds_alloc_offset, lds_a_bytes
 
 
 def setup_lds_allocation_plain(
@@ -385,24 +417,25 @@ def setup_lds_allocation_plain(
     LDS coexist during the K-loop. The epilogue output aliases the whole arena
     (offset 0) since it runs after the final K-loop barrier.
 
-    Returns `(lds_alloc_offset, lds_tile_elems, lds_b_offset_elems)` where:
+    Returns `(lds_alloc_offset, lds_tile_bytes, lds_b_offset_bytes)` where:
       - `lds_alloc_offset` is the byte base of the arena (A ping half at 0),
-      - `lds_tile_elems` is the A ping<->pong element stride (= tile_m*tile_k),
-      - `lds_b_offset_elems` is the element offset (from arena base) to the B
+      - `lds_tile_bytes` is the A ping<->pong byte stride,
+      - `lds_b_offset_bytes` is the byte offset (from arena base) to the B
         buffer, i.e. just past the A ping-pong region.
+
+    All three are byte quantities because the kernel addresses this arena as
+    raw bytes whatever the input dtype.
     """
-    lds_a_elems = tile_m * tile_k
-    lds_a_pingpong_elems = 2 * lds_a_elems
+    lds_a_bytes = tile_m * tile_k * elem_bytes
+    lds_a_pingpong_bytes = 2 * lds_a_bytes
     b_buffers = 2 if b_pingpong else 1
-    lds_b_elems = b_buffers * tile_n * tile_k
-    kloop_elems = lds_a_pingpong_elems + lds_b_elems  # FP8: 1 byte/elem
+    lds_b_bytes = b_buffers * tile_n * tile_k * elem_bytes
+    kloop_bytes = lds_a_pingpong_bytes + lds_b_bytes
     lds_out_bytes = tile_m * tile_n * 2
-    lds_total_bytes = max(kloop_elems * elem_bytes, lds_out_bytes)
+    lds_total_bytes = max(kloop_bytes, lds_out_bytes)
     lds_alloc_offset = allocator._align(allocator.ptr, 16)
     allocator.ptr = lds_alloc_offset + lds_total_bytes
-    lds_tile_elems = lds_a_elems
-    lds_b_offset_elems = lds_a_pingpong_elems
-    return lds_alloc_offset, lds_tile_elems, lds_b_offset_elems
+    return lds_alloc_offset, lds_a_bytes, lds_a_pingpong_bytes
 
 
 GroupResolution = namedtuple(
@@ -672,6 +705,11 @@ def make_a_tile_loaders(
     shifts every load to the start of this group's K slice, for the layouts
     where the groups divide K rather than an output axis; the row stride stays
     the full K, since the slice is a column block of a wider matrix.
+
+    `elem_bytes` is the size of an A element. Addresses here are dword
+    positions in the row's byte stream, so it is what turns the row's K extent
+    into a stride; it coincides with the element count only for the one-byte
+    dtypes.
     """
     _k_tail_mask = k_tail_mask or (lambda *_: None)
     layout_a_tile_div4 = fx.make_layout(
@@ -679,7 +717,8 @@ def make_a_tile_loaders(
     )
     c_chunk_a = fx.Index(chunk_i32_a)
     tx_i32_base = tx * c_chunk_a
-    _k_div4_factor = k_in // fx.Index(4)
+    _k_bytes = k_in if elem_bytes == 1 else k_in * fx.Index(elem_bytes)
+    _k_div4_factor = _k_bytes // fx.Index(4)
     if m_in is not None and group_idx is not None:
         a_tile_offset_div4 = group_idx * m_in * _k_div4_factor  # 3D A Offset
     else:
@@ -743,7 +782,10 @@ def make_a_tile_loaders(
                 k_blocks16=k_blocks16,
                 lds_base=lds_base,
                 vec_part_i32x4=a_parts[i],
-                elem_bytes=elem_bytes,
+                # The store's elem_bytes is the element size of the LDS memref,
+                # not of A: this arena is byte-typed and `layout_lds` is in
+                # bytes, so the swizzled column needs no further conversion.
+                elem_bytes=1,
             )
 
     return (
@@ -793,6 +835,9 @@ def make_b_tile_loaders(
     (dwordx4) loads via `tile_chunk_coord_i32`; LDS store uses the same XOR16
     swizzle as A. Returns `(prefetch_b_tile, store_b_tile_to_lds, b_row_local,
     b_col_local_i32, k_blocks16_b)`.
+
+    `elem_bytes` is the size of a B element, which is what turns the row's K
+    extent into the dword stride the addresses here are counted in.
     """
     _k_tail_mask = k_tail_mask or (lambda *_: None)
     layout_b_tile_div4 = fx.make_layout(
@@ -800,7 +845,8 @@ def make_b_tile_loaders(
     )
     c_chunk_b = fx.Index(chunk_i32_b)
     tx_i32_base = tx * c_chunk_b
-    _k_div4_factor = k_in // fx.Index(4)
+    _k_bytes = k_in if elem_bytes == 1 else k_in * fx.Index(elem_bytes)
+    _k_div4_factor = _k_bytes // fx.Index(4)
     # B is [G, N, K]: leading offset selects this tile's group and N-block base.
     b_tile_offset_div4 = (
         b_group_off if b_group_off is not None else group_idx * n_in * _k_div4_factor
@@ -871,7 +917,8 @@ def make_b_tile_loaders(
                 k_blocks16=k_blocks16_b,
                 lds_base=lds_base,
                 vec_part_i32x4=b_parts[i],
-                elem_bytes=elem_bytes,
+                # As in the A store: byte-typed LDS, byte-based layout.
+                elem_bytes=1,
             )
 
     return (
@@ -884,11 +931,16 @@ def make_b_tile_loaders(
 
 
 def make_lds_loader(*, lds_a, layout_lds, k_blocks16):
-    """Build the LDS-side A K64 pack loader.
+    """Build the LDS-side A pack loader.
 
     Returns `lds_load_packs_k64(curr_row_a_lds, col_base_bytes, lds_base)`
     which loads 16B from LDS with the XOR16 swizzle and returns the two
     i64 halves.
+
+    The load is of 16 raw bytes -- `T.f8` names the LDS arena's byte element
+    type, not the dtype of the data -- so this is the same for every input
+    dtype. What differs downstream is how much of a pack one MFMA consumes:
+    see `make_compute_tile`.
     """
 
     def lds_load_packs_k64(curr_row_a_lds, col_base_bytes, lds_base):
@@ -1047,6 +1099,10 @@ def make_hot_loop_scheduler(
     Emits the dsrd / mfma / vmem_rd / dswr group barriers in the order
     matching the MoE stage-2 pattern. Returns a zero-arg closure to be
     invoked once per K-tile body inside the ping-pong loop.
+
+    The MFMA group size assumes the two issues per operand pack that the
+    one-byte dtypes make; a dtype whose MFMA consumes a whole pack would need
+    this counted differently.
     """
 
     def hot_loop_scheduler():
@@ -1160,6 +1216,7 @@ def make_compute_tile(
     group_m_start=None,
     group_m_size=None,
     scaling=SCALING_ROW,
+    in_dtype="fp8",
 ):
     """Build the per-K-tile compute closure.
 
@@ -1185,6 +1242,53 @@ def make_compute_tile(
     # constant along K and apply once in the epilogue, and unscaled operands
     # have nothing to apply, so both leave this loop accumulating straight.
     blockscale = scaling == SCALING_BLOCK
+    if in_dtype not in ELEM_BYTES:
+        raise ValueError(
+            f"in_dtype must be one of {tuple(ELEM_BYTES)}, got {in_dtype!r}"
+        )
+
+    # The wide 16x16x128 MFMA reads its operands as f8f6f4, so it serves the
+    # one-byte dtypes only; the two-byte ones take the narrow path below even
+    # on gfx950, where their own K32 instruction lives.
+    use_wide_mfma = _is_gfx950 and in_dtype == "fp8"
+
+    # How much of one 16-byte LDS pack a single MFMA issue consumes. A 16x16xK
+    # MFMA spreads 16*K element slots over a 64-lane wave, so a lane holds K/4
+    # elements, i.e. K*elem_bytes/4 bytes. fp8's 16x16x32 wants 8 of the 16 and
+    # so issues twice per pack; bf16's gfx950 16x16x32 wants all 16 and issues
+    # once. Either way a pack is one unit of K, which is what lets the two share
+    # the loop below.
+    mfma_res_ty_narrow = T.f32x4
+    if in_dtype == "bf16":
+        if _is_gfx950:
+
+            def mfma_pack(acc_in, a0, a1, b0, b1):
+                av = Vector.from_elements([a0, a1], fx.Int64).bitcast(fx.BFloat16)
+                bv = Vector.from_elements([b0, b1], fx.Int64).bitcast(fx.BFloat16)
+                return rocdl.mfma_f32_16x16x32_bf16(
+                    mfma_res_ty_narrow, [av, bv, acc_in, 0, 0, 0]
+                )
+
+        else:
+
+            def mfma_pack(acc_in, a0, a1, b0, b1):
+                # gfx942 has no K32 bf16 MFMA, so a pack is two K16 issues.
+                mid = rocdl.mfma_f32_16x16x16bf16_1k(
+                    mfma_res_ty_narrow, [a0, b0, acc_in, 0, 0, 0]
+                )
+                return rocdl.mfma_f32_16x16x16bf16_1k(
+                    mfma_res_ty_narrow, [a1, b1, mid, 0, 0, 0]
+                )
+
+    else:
+
+        def mfma_pack(acc_in, a0, a1, b0, b1):
+            mid = rocdl.mfma_f32_16x16x32_fp8_fp8(
+                mfma_res_ty_narrow, [a0, b0, acc_in, 0, 0, 0]
+            )
+            return rocdl.mfma_f32_16x16x32_fp8_fp8(
+                mfma_res_ty_narrow, [a1, b1, mid, 0, 0, 0]
+            )
 
     def compute_tile(
         accs_in, k_tile_idx_py, lds_base, b_tile_in, scales_pf, *, a0_prefetch=None
@@ -1280,7 +1384,7 @@ def make_compute_tile(
                                 sb_e8m0_list[ni],
                             ],
                         )
-            elif _is_gfx950:
+            elif use_wide_mfma:
                 # gfx950: use the wide 16x16x128 MFMA with a neutral E8M0 scale
                 # (0x7F7F7F7F = no-op hardware scaling), which avoids the
                 # 4x-narrower 16x16x32 MFMA of the path below.
@@ -1375,17 +1479,13 @@ def make_compute_tile(
 
                         for ni in range_constexpr(num_acc_n):
                             acc_idx = mi * num_acc_n + ni
-                            mfma_fn = rocdl.mfma_f32_16x16x32_fp8_fp8
 
                             if blockscale:
                                 # This block's partial sum starts from zero so it
                                 # can be scaled on its own before joining the
                                 # running accumulator.
-                                mfma_mid = mfma_fn(
-                                    T.f32x4, [a0, b_packs0[ni], acc_init, 0, 0, 0]
-                                )
-                                mfma_result = mfma_fn(
-                                    T.f32x4, [a1, b_packs1[ni], mfma_mid, 0, 0, 0]
+                                mfma_result = mfma_pack(
+                                    acc_init, a0, a1, b_packs0[ni], b_packs1[ni]
                                 )
 
                                 s_a_v4 = s_a_vecs[mi]
@@ -1399,12 +1499,12 @@ def make_compute_tile(
                             else:
                                 # Nothing to scale per block, so chain the MFMAs
                                 # straight onto the running accumulator.
-                                mfma_mid = mfma_fn(
-                                    T.f32x4,
-                                    [a0, b_packs0[ni], current_accs[acc_idx], 0, 0, 0],
-                                )
-                                current_accs[acc_idx] = mfma_fn(
-                                    T.f32x4, [a1, b_packs1[ni], mfma_mid, 0, 0, 0]
+                                current_accs[acc_idx] = mfma_pack(
+                                    current_accs[acc_idx],
+                                    a0,
+                                    a1,
+                                    b_packs0[ni],
+                                    b_packs1[ni],
                                 )
 
         return current_accs

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -1821,6 +1821,7 @@ def make_epilogue_writers(
     out_mlir,
     e_vec,
     c_n,
+    d_group_off=None,
     d_row_base=None,
     n_padding=False,
     n_bound=None,
@@ -1829,14 +1830,14 @@ def make_epilogue_writers(
 
     Returns `(write_row_to_lds, store_pair)` to be passed to `mfma_epilog`.
 
-    `d_row_base` is the first output row of the slab `d_rsrc` is based at. The
-    epilogue works in global rows, so subtracting it gives the row within that
-    descriptor. It exists because a descriptor reaches only 4 GiB and a whole
-    output can exceed that, which the store would meet not as a fault but as a
-    dropped write; see `rebased_resource` in the grouped kernel. None means the
-    descriptor spans the whole output and the row needs no adjusting, which is
-    what a caller whose output is one matrix wants; no subtraction is then
-    emitted.
+    The output row reaches the store one of two ways, and a caller supplies at
+    most one of them. `d_group_off` adds the group's slab to a global row, which
+    is what a descriptor spanning the whole output wants. `d_row_base` instead
+    subtracts the first row of the slab the descriptor is based at, which is
+    what a descriptor covering one group wants -- needed once the whole output
+    passes the 4 GiB a descriptor reaches, since past that the store is dropped
+    rather than faulting. Both None is the plain case: one matrix, global rows,
+    and no adjustment emitted.
 
     `c_n` is the output's leading dimension, and normally also bounds the column
     mask, since a group's columns run to the end of its row. Where groups sit
@@ -1866,8 +1867,12 @@ def make_epilogue_writers(
             v1.store(lds_out, [lds_idx], alignment=2)
 
     def store_pair(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
-        row_in_slab = row if d_row_base is None else row - d_row_base
-        idx_out = row_in_slab * c_n + col_g0
+        if d_group_off is not None:
+            idx_out = d_group_off + row * c_n + col_g0
+        elif d_row_base is not None:
+            idx_out = (row - d_row_base) * c_n + col_g0
+        else:
+            idx_out = row * c_n + col_g0
         byte_off = idx_out * 2
         col_mask = None
         if n_padding:

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -1318,10 +1318,8 @@ def make_compute_tile(
 
             def mfma_pack(acc_in, a0, a1, b0, b1):
                 # gfx942 has no K32 bf16 MFMA, so a pack is two K16 issues.
-                # Each issue wants its 4 bf16 per lane as a 4-wide 16-bit
-                # vector, which the intrinsic types as integers. That is the
-                # same 64 bits an LDS half already holds, so this only renames
-                # the bits -- but passing the raw i64 fails MLIR verification.
+                # Each issue takes its 4 bf16 per lane as a 4-wide vector of
+                # 16-bit integers, which is the same 64 bits an LDS half holds.
                 def v4(half):
                     return Vector.from_elements([half], fx.Int64).bitcast(fx.Int16)
 
@@ -1930,7 +1928,7 @@ def compute_mfma_tiling(*, tile_m, tile_n, waves_m=1, waves_n=4):
     """
     # Waves tile the output as waves_m x waves_n. LDS read traffic per unit work
     # is waves_m / tile_m + waves_n / tile_n, minimised when the wave grid is
-    # proportioned like the tile; the historical 1 x 4 split cannot do that.
+    # proportioned like the tile.
     num_waves = waves_m * waves_n
     m_repeat = (tile_m // waves_m) // 16
     n_per_wave = tile_n // waves_n
@@ -2007,10 +2005,8 @@ def make_n_block_coords(
     # axis alone, so a group's weights stay one contiguous [N, K] block, and the
     # group can sit either in the descriptor's base or in these coordinates.
     # Based per group, the layout spans n_in and the column carries no group
-    # term; spanning the whole stack, both take it back. The base is the only
-    # form a stack over 4 GiB can use, since the column is a 32-bit offset, but
-    # it is the more expensive one here: B goes HBM->registers inside the K loop
-    # on this path, so its descriptor is on the critical path of every load.
+    # term; spanning the whole stack, both take it back. Only the base form can
+    # address a stack over 4 GiB, the column being a 32-bit offset.
     c_n_total = n_in if b_group_based else num_groups_in * n_in
     b_layout = make_preshuffle_b_layout(
         arith,

--- a/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
+++ b/mslk/flydsl/kernels/gemm/fp8_grouped_gemm_common.py
@@ -1318,11 +1318,18 @@ def make_compute_tile(
 
             def mfma_pack(acc_in, a0, a1, b0, b1):
                 # gfx942 has no K32 bf16 MFMA, so a pack is two K16 issues.
+                # Each issue wants its 4 bf16 per lane as a 4-wide 16-bit
+                # vector, which the intrinsic types as integers. That is the
+                # same 64 bits an LDS half already holds, so this only renames
+                # the bits -- but passing the raw i64 fails MLIR verification.
+                def v4(half):
+                    return Vector.from_elements([half], fx.Int64).bitcast(fx.Int16)
+
                 mid = rocdl.mfma_f32_16x16x16bf16_1k(
-                    mfma_res_ty_narrow, [a0, b0, acc_in, 0, 0, 0]
+                    mfma_res_ty_narrow, [v4(a0), v4(b0), acc_in, 0, 0, 0]
                 )
                 return rocdl.mfma_f32_16x16x16bf16_1k(
-                    mfma_res_ty_narrow, [a1, b1, mid, 0, 0, 0]
+                    mfma_res_ty_narrow, [v4(a1), v4(b1), mid, 0, 0, 0]
                 )
 
     else:

--- a/mslk/flydsl/kernels/gemm/gemm_blockscale.py
+++ b/mslk/flydsl/kernels/gemm/gemm_blockscale.py
@@ -526,7 +526,6 @@ def compile_fp8_blockwise_gemm(
                 lds_b=lds_b,
                 layout_lds_b=layout_lds_b,
                 by_n=by_n,
-                group_idx=fx.Index(0),
                 tx=tx,
                 tile_n=tile_n,
                 tile_k=tile_k,

--- a/mslk/flydsl/kernels/mma/mfma_epilogues.py
+++ b/mslk/flydsl/kernels/mma/mfma_epilogues.py
@@ -53,6 +53,7 @@ def default_epilog(
     arith,
     range_constexpr,
     m_repeat: int,
+    m_wave_base=None,
     lane_div_16,
     bx_m,
     body_row: Callable,
@@ -85,6 +86,7 @@ def default_epilog(
 
 def c_shuffle_epilog(
     *,
+    m_wave_base=None,
     arith,
     vector,
     gpu,
@@ -237,6 +239,8 @@ def c_shuffle_epilog(
         _precomputed_rows_s = []
         for mr in range_constexpr(m_reps_s):
             row_base_m = arith.constant(mr * CShuffleMLane_s, index=True)
+            if m_wave_base is not None:
+                row_base_m = row_base_m + m_wave_base
             row_local = row_base_m + m_lane_s
             row = bx_m_v + row_local
             row_ctx_raw = (
@@ -362,6 +366,8 @@ def c_shuffle_epilog(
     _precomputed_rows = []
     for mr in range_constexpr(m_reps_shuffle):
         row_base_m = arith.constant(mr * CShuffleMLane, index=True)
+        if m_wave_base is not None:
+            row_base_m = row_base_m + m_wave_base
         row_local = row_base_m + m_lane
         row = bx_m_v + row_local
 
@@ -420,6 +426,7 @@ def c_shuffle_epilog(
 def mfma_epilog(
     *,
     use_cshuffle: bool,
+    m_wave_base=None,
     # Common (always required)
     arith,
     range_constexpr,
@@ -452,6 +459,7 @@ def mfma_epilog(
         if body_row is None:
             raise ValueError("mfma_epilog(use_cshuffle=False) requires `body_row`.")
         return default_epilog(
+            m_wave_base=m_wave_base,
             arith=arith,
             range_constexpr=range_constexpr,
             m_repeat=m_repeat,
@@ -461,6 +469,7 @@ def mfma_epilog(
         )
 
     return c_shuffle_epilog(
+        m_wave_base=m_wave_base,
         arith=arith,
         vector=vector,
         gpu=gpu,

--- a/mslk/flydsl/kernels/mma/mfma_epilogues.py
+++ b/mslk/flydsl/kernels/mma/mfma_epilogues.py
@@ -65,7 +65,9 @@ def default_epilog(
     Args:
       arith: flydsl arith ext module.
       range_constexpr: compile-time unrolled range helper.
-      m_repeat: tile_m // 16 (python int).
+      m_repeat: rows of the wave's slab, (tile_m // waves_m) // 16 (python int).
+      m_wave_base: first row of the wave's slab within the tile (index Value), or
+        None where the wave grid gives every wave the whole of tile_m.
       lane_div_16: index Value (0..3).
       bx_m: base row (index Value). For MoE, this is the base sorted-row for the tile.
       body_row: callback invoked as:
@@ -77,6 +79,8 @@ def default_epilog(
 
     for mi in range_constexpr(m_repeat):
         mi_base = arith.constant(mi * 16, index=True)
+        if m_wave_base is not None:
+            mi_base = mi_base + m_wave_base
         for ii in range_constexpr(4):
             row_off = lane_div_16_mul4 + ii_idx_list[ii]
             row_in_tile = mi_base + row_off
@@ -130,6 +134,14 @@ def c_shuffle_epilog(
       - `store_pair(...)` is called for each (row_local, col_pair0) half2 after shuffle.
 
     `store_pair` can implement either global stores or atomics.
+
+    The two phases map threads to rows differently, and only one of them is a
+    wave's own business. The write phase drains a thread's accumulators, so it
+    follows the wave grid and takes `m_wave_base`. The read phase then spreads
+    all `block_size` threads over the whole tile to make the global stores
+    coalesce, which is what staging through LDS buys; that mapping covers
+    `tile_m` regardless of how the waves are arranged, so shifting it by a
+    per-wave offset would leave rows unwritten and read past the buffer.
     """
     if int(block_size) <= 0 or (int(block_size) % int(cshuffle_nlane)) != 0:
         raise ValueError(
@@ -217,6 +229,7 @@ def c_shuffle_epilog(
             arith=arith,
             range_constexpr=range_constexpr,
             m_repeat=m_repeat,
+            m_wave_base=m_wave_base,
             lane_div_16=lane_div_16,
             bx_m=bx_m,
             body_row=_write_row_split,
@@ -239,8 +252,6 @@ def c_shuffle_epilog(
         _precomputed_rows_s = []
         for mr in range_constexpr(m_reps_s):
             row_base_m = arith.constant(mr * CShuffleMLane_s, index=True)
-            if m_wave_base is not None:
-                row_base_m = row_base_m + m_wave_base
             row_local = row_base_m + m_lane_s
             row = bx_m_v + row_local
             row_ctx_raw = (
@@ -333,6 +344,7 @@ def c_shuffle_epilog(
         arith=arith,
         range_constexpr=range_constexpr,
         m_repeat=m_repeat,
+        m_wave_base=m_wave_base,
         lane_div_16=lane_div_16,
         bx_m=bx_m,
         body_row=_write_row,
@@ -366,8 +378,6 @@ def c_shuffle_epilog(
     _precomputed_rows = []
     for mr in range_constexpr(m_reps_shuffle):
         row_base_m = arith.constant(mr * CShuffleMLane, index=True)
-        if m_wave_base is not None:
-            row_base_m = row_base_m + m_wave_base
         row_local = row_base_m + m_lane
         row = bx_m_v + row_local
 

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -10,6 +10,7 @@ import functools
 import importlib
 from collections.abc import Callable
 from types import ModuleType
+from typing import Optional
 
 from mslk.utils.torch.library import load_library_buck
 
@@ -166,6 +167,44 @@ if torch.version.hip is not None:
                     )
                 return mod.matmul_f8f8bf16_groupwise_grouped_preshuffle(
                     XQ, WQ, x_scale, w_scale, M_sizes
+                )
+
+        except RuntimeError:
+            pass  # already registered (e.g. module imported more than once)
+
+    if hasattr(torch.ops, "mslk") and hasattr(
+        torch.ops.mslk, "bf16bf16bf16_grouped_stacked"
+    ):
+        # FlyDSL is the only implementation of this op on ROCm, so there is
+        # nothing to arbitrate: CK served it until now and gemm_ops.cpp no
+        # longer registers it here. Calling it without having opted into
+        # flydsl_ops raises rather than silently reaching a slower kernel --
+        # deliberately, since CK and Triton are both on the way out. Nothing
+        # about registering may import FlyDSL, hence the first-call resolution.
+        try:
+
+            @torch.library.impl("mslk::bf16bf16bf16_grouped_stacked", "CUDA")
+            def _bf16bf16bf16_grouped_stacked_rocm(
+                X: torch.Tensor,
+                W: torch.Tensor,
+                M_sizes: torch.Tensor,
+                out: Optional[torch.Tensor] = None,
+                num_sms: Optional[int] = None,
+            ) -> torch.Tensor:
+                mod = _flydsl_gemm_module("bf16_grouped_gemm")
+                if mod is None:
+                    raise RuntimeError(
+                        "mslk::bf16bf16bf16_grouped_stacked requires the FlyDSL "
+                        "backend on ROCm. Add //mslk/mslk/gemm:flydsl_ops to "
+                        "your target's deps."
+                    )
+                if not mod.is_supported():
+                    raise RuntimeError(
+                        "mslk::bf16bf16bf16_grouped_stacked needs MFMA, which "
+                        "this GPU does not have. Supported: gfx942, gfx950."
+                    )
+                return mod.matmul_bf16bf16bf16_grouped_stacked(
+                    X, W, M_sizes, out, num_sms
                 )
 
         except RuntimeError:

--- a/mslk/gemm/__init__.py
+++ b/mslk/gemm/__init__.py
@@ -175,12 +175,10 @@ if torch.version.hip is not None:
     if hasattr(torch.ops, "mslk") and hasattr(
         torch.ops.mslk, "bf16bf16bf16_grouped_stacked"
     ):
-        # FlyDSL is the only implementation of this op on ROCm, so there is
-        # nothing to arbitrate: CK served it until now and gemm_ops.cpp no
-        # longer registers it here. Calling it without having opted into
-        # flydsl_ops raises rather than silently reaching a slower kernel --
-        # deliberately, since CK and Triton are both on the way out. Nothing
-        # about registering may import FlyDSL, hence the first-call resolution.
+        # FlyDSL is the only ROCm implementation of this op: gemm_ops.cpp does
+        # not register it here, so calling it without the flydsl_ops dep raises
+        # rather than reaching another kernel. Registration must not import
+        # FlyDSL, hence the first-call resolution.
         try:
 
             @torch.library.impl("mslk::bf16bf16bf16_grouped_stacked", "CUDA")

--- a/mslk/gemm/flydsl/bf16_grouped_gemm.py
+++ b/mslk/gemm/flydsl/bf16_grouped_gemm.py
@@ -1,0 +1,122 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""BF16 grouped GEMM via FlyDSL.
+
+Backed by the same kernel as the FP8 siblings in fp8_rowwise_grouped_gemm.py
+and fp8_groupwise_grouped_gemm.py, compiled for BF16 operands instead of
+quantised ones. BF16 carries its own exponent, so there are no scales: the
+kernel folds nothing in the K loop and applies nothing in the epilogue, which
+is what ``scaling="none"`` selects.
+
+* ``mslk::bf16bf16bf16_grouped_stacked`` -- groups packed along M with a ``[G]``
+  int64 row count per group, and row-major ``[G, N, K]`` weights.
+
+This op has a CK implementation on ROCm, unlike the FP8 grouped ops, whose C++
+slots were already free. mslk/gemm/__init__.py arbitrates between the two on
+first call and gemm_ops.cpp leaves the ROCm slot unregistered, so CK serves it
+only where FlyDSL is not opted in or cannot run.
+
+CK's own source marks ``bf16bf16bf16_grouped``, ``_cat`` and ``_dynamic``
+"UNSUPPORTED AND DEPRECATED -- use _stacked", so they are deliberately not
+served here. ``_grad``/``_wgrad`` are backward passes on a different kernel
+shape and are left to Triton.
+
+Tensor contract:
+  X       : [total_M, K]   BF16  -- all groups concatenated along M
+  W       : [G, N, K]      BF16  -- per-group weights, plain row-major
+  M_sizes : [G]            int64 -- rows per group (sum to total_M)
+  out     : [total_M, N]   BF16  -- optional caller-provided output
+  Output  : [total_M, N]   BF16
+
+  out[m, n] = sum_k X[m, k] * W[g, n, k]     for the group g owning row m
+"""
+
+from typing import Optional
+
+import torch
+from mslk.flydsl.common import require_flydsl
+from mslk.gemm.flydsl import grouped_dispatch
+from mslk.utils.device import is_gfx942, is_gfx950
+
+
+def is_supported() -> bool:
+    """Whether this module can serve the op on the current GPU.
+
+    The kernel is built on MFMA, which the RDNA parts do not have -- and FlyDSL
+    reports itself available on those, so having the backend says nothing about
+    whether this op can run. mslk/gemm/__init__.py falls back to CK when this is
+    False.
+    """
+    return is_gfx950() or is_gfx942()
+
+
+def _assert_bf16_operands(X: torch.Tensor, W: torch.Tensor) -> None:
+    """Reject operands the kernel would read as the wrong type.
+
+    It passes them through as raw bytes, so a mismatched dtype would be
+    contracted with the wrong exponent layout rather than rejected. The FP8
+    siblings check the same thing about the FP8 flavour.
+    """
+    assert X.dtype == torch.bfloat16, f"X must be bfloat16, got {X.dtype}"
+    assert W.dtype == torch.bfloat16, f"W must be bfloat16, got {W.dtype}"
+
+
+def matmul_bf16bf16bf16_grouped_stacked(
+    X: torch.Tensor,
+    W: torch.Tensor,
+    M_sizes: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    num_sms: Optional[int] = None,
+) -> torch.Tensor:
+    """BF16 grouped GEMM -> BF16, groups packed along M.
+
+    ``num_sms`` is accepted and ignored. CK takes it as a hint for a persistent
+    kernel that occupies a fixed number of CUs; this kernel launches one block
+    per output tile and lets the scheduler place them, so there is nothing for
+    the hint to bind to. It stays in the signature because the op's schema is
+    shared with the CUDA implementation.
+    """
+    # Registration does not probe for FlyDSL, so this is the first point at
+    # which it is required.
+    require_flydsl()
+    assert X.ndim == 2, f"X must be [total_M, K], got {X.shape}"
+    assert W.ndim == 3, f"W must be [G, N, K], got {W.shape}"
+    assert M_sizes.ndim == 1, f"M_sizes must be [G], got {M_sizes.shape}"
+    total_M, K = X.shape
+    G, N, Kw = W.shape
+    assert Kw == K, f"K mismatch: X K={K}, W K={Kw}"
+    assert M_sizes.shape[0] == G, f"M_sizes length {M_sizes.shape[0]} must equal G={G}"
+    _assert_bf16_operands(X, W)
+    assert M_sizes.dtype == torch.int64, f"M_sizes must be int64, got {M_sizes.dtype}"
+
+    if out is not None:
+        # CK's caller passes a flat buffer of total_M * N; the kernel writes a
+        # [total_M, N] output, so take whichever shape it arrived in as long as
+        # it holds the right number of elements.
+        assert out.dtype == torch.bfloat16, f"out must be bfloat16, got {out.dtype}"
+        assert out.numel() == total_M * N, (
+            f"out must hold {total_M * N} elements, got {out.numel()}"
+        )
+        out = out.view(total_M, N)
+
+    return grouped_dispatch.dispatch(
+        X,
+        W,
+        None,
+        None,
+        M_sizes,
+        b_preshuffled=False,
+        scaling="none",
+        in_dtype="bf16",
+        out=out,
+    )
+
+
+# This module registers nothing. The op is registered in mslk/gemm/__init__.py,
+# whose impl imports this module on the first call.

--- a/mslk/gemm/flydsl/bf16_grouped_gemm.py
+++ b/mslk/gemm/flydsl/bf16_grouped_gemm.py
@@ -17,16 +17,12 @@ is what ``scaling="none"`` selects.
 * ``mslk::bf16bf16bf16_grouped_stacked`` -- groups packed along M with a ``[G]``
   int64 row count per group, and row-major ``[G, N, K]`` weights.
 
-CK served this op on ROCm until now, unlike the FP8 grouped ops, whose C++ slots
-were already free. gemm_ops.cpp no longer registers it there and nothing takes
-CK's place: FlyDSL is the only ROCm implementation, and calling the op without
-the backend raises rather than quietly reaching a slower kernel. That is
-deliberate -- CK and Triton are both being deprecated.
+FlyDSL is the only ROCm implementation of this op: gemm_ops.cpp does not
+register it there, so calling it without the FlyDSL backend raises.
 
-CK's own source marks ``bf16bf16bf16_grouped``, ``_cat`` and ``_dynamic``
-"UNSUPPORTED AND DEPRECATED -- use _stacked", so they are deliberately not
-served here. ``_grad``/``_wgrad`` are backward passes on a different kernel
-shape and are left to Triton.
+``bf16bf16bf16_grouped``, ``_cat`` and ``_dynamic`` are marked "UNSUPPORTED AND
+DEPRECATED -- use _stacked" in CK and are not served here. ``_grad``/``_wgrad``
+are backward passes on a different kernel shape and are served by Triton.
 
 Tensor contract:
   X       : [total_M, K]   BF16  -- all groups concatenated along M
@@ -49,10 +45,9 @@ from mslk.utils.device import is_gfx942, is_gfx950
 def is_supported() -> bool:
     """Whether this module can serve the op on the current GPU.
 
-    The kernel is built on MFMA, which the RDNA parts do not have -- and FlyDSL
-    reports itself available on those, so having the backend says nothing about
-    whether this op can run. mslk/gemm/__init__.py raises when this is False,
-    there being no other ROCm implementation left to fall back to.
+    The kernel is built on MFMA, which the RDNA parts do not have, and FlyDSL
+    reports itself available on those, so the backend being present does not
+    imply this op can run. mslk/gemm/__init__.py raises when this is False.
     """
     return is_gfx950() or is_gfx942()
 
@@ -60,9 +55,8 @@ def is_supported() -> bool:
 def _assert_bf16_operands(X: torch.Tensor, W: torch.Tensor) -> None:
     """Reject operands the kernel would read as the wrong type.
 
-    It passes them through as raw bytes, so a mismatched dtype would be
-    contracted with the wrong exponent layout rather than rejected. The FP8
-    siblings check the same thing about the FP8 flavour.
+    Operands are passed through as raw bytes, so a mismatched dtype would be
+    contracted with the wrong exponent layout rather than rejected.
     """
     assert X.dtype == torch.bfloat16, f"X must be bfloat16, got {X.dtype}"
     assert W.dtype == torch.bfloat16, f"W must be bfloat16, got {W.dtype}"
@@ -77,11 +71,10 @@ def matmul_bf16bf16bf16_grouped_stacked(
 ) -> torch.Tensor:
     """BF16 grouped GEMM -> BF16, groups packed along M.
 
-    ``num_sms`` is accepted and ignored. CK takes it as a hint for a persistent
-    kernel that occupies a fixed number of CUs; this kernel launches one block
-    per output tile and lets the scheduler place them, so there is nothing for
-    the hint to bind to. It stays in the signature because the op's schema is
-    shared with the CUDA implementation.
+    ``num_sms`` is accepted and ignored: it hints at a persistent kernel
+    occupying a fixed number of CUs, while this kernel launches one block per
+    output tile and lets the scheduler place them. It stays in the signature
+    because the op's schema is shared with the CUDA implementation.
     """
     # Registration does not probe for FlyDSL, so this is the first point at
     # which it is required.

--- a/mslk/gemm/flydsl/bf16_grouped_gemm.py
+++ b/mslk/gemm/flydsl/bf16_grouped_gemm.py
@@ -17,10 +17,11 @@ is what ``scaling="none"`` selects.
 * ``mslk::bf16bf16bf16_grouped_stacked`` -- groups packed along M with a ``[G]``
   int64 row count per group, and row-major ``[G, N, K]`` weights.
 
-This op has a CK implementation on ROCm, unlike the FP8 grouped ops, whose C++
-slots were already free. mslk/gemm/__init__.py arbitrates between the two on
-first call and gemm_ops.cpp leaves the ROCm slot unregistered, so CK serves it
-only where FlyDSL is not opted in or cannot run.
+CK served this op on ROCm until now, unlike the FP8 grouped ops, whose C++ slots
+were already free. gemm_ops.cpp no longer registers it there and nothing takes
+CK's place: FlyDSL is the only ROCm implementation, and calling the op without
+the backend raises rather than quietly reaching a slower kernel. That is
+deliberate -- CK and Triton are both being deprecated.
 
 CK's own source marks ``bf16bf16bf16_grouped``, ``_cat`` and ``_dynamic``
 "UNSUPPORTED AND DEPRECATED -- use _stacked", so they are deliberately not
@@ -50,8 +51,8 @@ def is_supported() -> bool:
 
     The kernel is built on MFMA, which the RDNA parts do not have -- and FlyDSL
     reports itself available on those, so having the backend says nothing about
-    whether this op can run. mslk/gemm/__init__.py falls back to CK when this is
-    False.
+    whether this op can run. mslk/gemm/__init__.py raises when this is False,
+    there being no other ROCm implementation left to fall back to.
     """
     return is_gfx950() or is_gfx942()
 

--- a/mslk/gemm/flydsl/fp8_groupwise_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_gemm.py
@@ -110,7 +110,7 @@ def _matmul_gfx942(XQ, WQ, x_scale, w_scale, M, N, K):
         w_scale,
         grouped_dispatch.unused_group_meta(XQ.device),
         b_preshuffled=False,
-        blockscale=True,
+        scaling="block",
         layout="batched",
     )
 

--- a/mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_groupwise_grouped_gemm.py
@@ -90,7 +90,7 @@ def _dispatch_grouped_gemm(
         w_scale,
         M_sizes,
         b_preshuffled=b_preshuffled,
-        blockscale=True,
+        scaling="block",
     )
 
 

--- a/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
+++ b/mslk/gemm/flydsl/fp8_rowwise_grouped_gemm.py
@@ -93,7 +93,7 @@ def _dispatch_rowwise_grouped(
         w_scale,
         M_sizes,
         b_preshuffled=b_preshuffled,
-        blockscale=False,
+        scaling="row",
     )
 
 
@@ -168,7 +168,7 @@ def _dispatch_rowwise_grouped_dynamic(
         w_scale,
         zero_start_index_M,
         b_preshuffled=b_preshuffled,
-        blockscale=False,
+        scaling="row",
         layout="padded",
         out=out.view(G * expected_m, N),
     )
@@ -273,7 +273,7 @@ def _rowwise_grouped_mm_2d3d(
         w_scale,
         offsets,
         b_preshuffled=b_preshuffled,
-        blockscale=False,
+        scaling="row",
         layout="offsets",
         out=out,
     )
@@ -317,7 +317,7 @@ def _rowwise_grouped_mm_3d3d(
         w_scale,
         _unused_group_meta(XQ.device),
         b_preshuffled=b_preshuffled,
-        blockscale=False,
+        scaling="row",
         layout="batched",
         out=out.view(G * M, N),
     )
@@ -364,7 +364,7 @@ def _rowwise_grouped_mm_3d2d(XQ, WQ, x_scale, w_scale, offsets, out):
         w_scale,
         offsets,
         b_preshuffled=False,
-        blockscale=False,
+        scaling="row",
         layout="n_offsets",
         out=out,
     )
@@ -415,7 +415,7 @@ def _rowwise_grouped_mm_2d2d(XQ, WQ, x_scale, w_scale, offsets, out):
         w_scale,
         offsets,
         b_preshuffled=False,
-        blockscale=False,
+        scaling="row",
         layout="k_offsets",
         out=out.view(G * M, N),
     )

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -6,12 +6,13 @@
 
 # pyre-unsafe
 
-"""Shared host dispatch for the FlyDSL grouped FP8 GEMM ops.
+"""Shared host dispatch for the FlyDSL grouped GEMM ops.
 
-One kernel serves every combination of B layout (plain or MFMA-preshuffled) and
-scaling scheme (block or rowwise); this module holds the host-side work common to
-all of them -- operand marshalling, grid extent, and tile selection -- so each op
-module only supplies its own contract checks.
+One kernel serves every combination of input dtype (fp8 or bf16), B layout
+(plain or MFMA-preshuffled) and scaling scheme (block, rowwise or none); this
+module holds the host-side work common to all of them -- operand marshalling,
+grid extent, and tile selection -- so each op module only supplies its own
+contract checks.
 
 Tile selection is delegated to mslk.flydsl.autotune, which tunes only when
 MSLK_AUTOTUNE_ENABLE is set and otherwise uses a fixed default.
@@ -70,7 +71,7 @@ _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
 # roll_k is deliberately absent: it is fixed policy rather than something that
 # varies per call, and a tuning space containing a fully unrolled candidate would
 # have to compile one per tile config, at a cost that grows with K.
-_KEY = ["m_bucket", "n", "k", "b_preshuffled", "scaling", "layout"]
+_KEY = ["m_bucket", "n", "k", "b_preshuffled", "scaling", "layout", "in_dtype"]
 
 
 def assert_fp8_operands(XQ: torch.Tensor, WQ: torch.Tensor) -> None:
@@ -103,6 +104,18 @@ def unused_group_meta(device: torch.device) -> torch.Tensor:
     return torch.zeros((1,), dtype=torch.int32, device=device)
 
 
+@functools.lru_cache(maxsize=8)
+def unused_scales(device: torch.device) -> torch.Tensor:
+    """Stand-in for the scale operands where the operands carry no scales.
+
+    Unscaled inputs have none to pass and the kernel emits no load against
+    them, but the launcher's argument list is fixed at compile time. Cached for
+    the same reasons as `unused_group_meta`: no per-call allocation, and a
+    stable address for CUDA-graph capture.
+    """
+    return torch.zeros((1,), dtype=torch.float32, device=device)
+
+
 def _group_and_n(WQ, group_meta, layout):
     """Group count and total N, which the weights only carry for some layouts.
 
@@ -131,6 +144,7 @@ def launch(
     scaling,
     layout="sizes",
     roll_k=True,
+    in_dtype="fp8",
     *,
     tile_m,
     tile_n,
@@ -146,6 +160,9 @@ def launch(
     ``m_bucket`` only feeds the autotune key: bucketing total_M keeps nearby token
     counts on one tuned config. ``n``/``k`` are likewise passed for the key and
     for tile pruning, and are read back off the operands here.
+
+    ``in_dtype`` names the operand element type the kernel is compiled for.
+    ``x_scale``/``w_scale`` may be None where it carries no scales.
     """
     from mslk.flydsl.kernels.gemm.fp8_grouped_gemm import compile_fp8_grouped_gemm
 
@@ -181,6 +198,7 @@ def launch(
         scale_block_k=SCALE_BLOCK,
         scale_block_n=SCALE_BLOCK,
         out_dtype="bf16",
+        in_dtype=in_dtype,
         b_preshuffled=b_preshuffled,
         scaling=scaling,
         layout=layout,
@@ -197,15 +215,16 @@ def launch(
     )
     # Operands keep their natural shape: argument marshalling packs each memref
     # extent as int32, which a flattened view overflows at 2**31 elements. The
-    # kernel addresses them as flat byte buffers regardless. FP8 is viewed as
-    # int8 for the handoff.
+    # kernel addresses them as flat byte buffers regardless, so every input
+    # dtype is viewed as int8 for the handoff.
+    _no_scales = unused_scales(XQ.device)
     run_compiled(
         launcher,
         out,
         XQ.contiguous().view(torch.int8),
         WQ.contiguous().view(torch.int8),
-        x_scale.contiguous(),
-        w_scale.contiguous(),
+        _no_scales if x_scale is None else x_scale.contiguous(),
+        _no_scales if w_scale is None else w_scale.contiguous(),
         m_sizes.contiguous(),
         total_M,
         N,
@@ -238,6 +257,7 @@ def dispatch(
     scaling,
     layout="sizes",
     roll_k=True,
+    in_dtype="fp8",
     out=None,
 ):
     """Allocate the output if needed and run the grouped GEMM with a selected tile.
@@ -278,6 +298,8 @@ def dispatch(
     # The groups divide K, so one group contracts over a fraction of it.
     k_key = K // G if layout == "k_offsets" else K
 
+    # Block scaling is the only scheme that constrains tile_n to the scale
+    # block; rowwise and unscaled operands both sweep the wider set.
     tuned_launch = _launch_blockscale if scaling == "block" else _launch_rowwise
     return tuned_launch(
         XQ,
@@ -293,4 +315,5 @@ def dispatch(
         scaling,
         layout,
         roll_k,
+        in_dtype,
     )

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -70,7 +70,7 @@ _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
 # roll_k is deliberately absent: it is fixed policy rather than something that
 # varies per call, and a tuning space containing a fully unrolled candidate would
 # have to compile one per tile config, at a cost that grows with K.
-_KEY = ["m_bucket", "n", "k", "b_preshuffled", "blockscale", "layout"]
+_KEY = ["m_bucket", "n", "k", "b_preshuffled", "scaling", "layout"]
 
 
 def assert_fp8_operands(XQ: torch.Tensor, WQ: torch.Tensor) -> None:
@@ -128,7 +128,7 @@ def launch(
     n,
     k,
     b_preshuffled,
-    blockscale,
+    scaling,
     layout="sizes",
     roll_k=True,
     *,
@@ -182,7 +182,7 @@ def launch(
         scale_block_n=SCALE_BLOCK,
         out_dtype="bf16",
         b_preshuffled=b_preshuffled,
-        blockscale=blockscale,
+        scaling=scaling,
         layout=layout,
         roll_k=roll_k,
         # 0 means the compiler picks.
@@ -235,7 +235,7 @@ def dispatch(
     M_sizes,
     *,
     b_preshuffled,
-    blockscale,
+    scaling,
     layout="sizes",
     roll_k=True,
     out=None,
@@ -278,7 +278,7 @@ def dispatch(
     # The groups divide K, so one group contracts over a fraction of it.
     k_key = K // G if layout == "k_offsets" else K
 
-    tuned_launch = _launch_blockscale if blockscale else _launch_rowwise
+    tuned_launch = _launch_blockscale if scaling == "block" else _launch_rowwise
     return tuned_launch(
         XQ,
         WQ,
@@ -290,7 +290,7 @@ def dispatch(
         n_key,
         k_key,
         b_preshuffled,
-        blockscale,
+        scaling,
         layout,
         roll_k,
     )

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -29,9 +29,19 @@ from mslk.utils.device import supports_float8_fnuz
 # also sets the K-loop sub-block size, so tile_k must then be a multiple of it.
 SCALE_BLOCK = 128
 
-# Default tile when autotuning is disabled. Valid for any supported shape
+# Default config when autotuning is disabled. Valid for any supported shape
 # (tile_n = tile_k = 128 divide every supported N/K, including a small N=128).
-DEFAULT_TILE = {"tile_m": 128, "tile_n": 128, "tile_k": 128, "waves_per_eu": 2}
+# The wave grid stays at the historical 1x4 rather than the 2x2 this square tile
+# would favour: changing it moves every untuned call, which is a decision to
+# take on measurement rather than on the shape of the tile alone.
+DEFAULT_TILE = {
+    "tile_m": 128,
+    "tile_n": 128,
+    "tile_k": 128,
+    "waves_m": 1,
+    "waves_n": 4,
+    "waves_per_eu": 2,
+}
 
 # Candidate tiles swept by autotune. Rowwise scaling allows tile_n below the
 # scale block, which block scaling cannot express, so the two schemes sweep
@@ -57,14 +67,36 @@ _UNSCALED_TILE_K = (64, 128, 256)
 # needs 128, which no configuration of this kernel comes close to.
 _WAVES_PER_EU = (0, 2)
 
+# How the block's four waves divide the tile, as (waves_m, waves_n). Each wave
+# reads its whole slab of both operands out of LDS, so reads per unit work go as
+# waves_m / tile_m + waves_n / tile_n, smallest when the grid is proportioned
+# like the tile: 1x4 suits a tile four times wider than tall, 2x2 a square one,
+# 4x1 a tall one. All three are four waves, so they cost the same in threads,
+# LDS and registers and differ only in shape. Grids past four waves are a
+# different trade -- more waves per tile against a smaller register budget each
+# -- and are left out until that is measured on its own.
+_WAVE_GRIDS = ((1, 4), (2, 2), (4, 1))
 
-def _tiles(tile_ns, tile_ms=_TILE_M, tile_ks=_TILE_K):
+
+def _tiles(tile_ns, tile_ms=_TILE_M, tile_ks=_TILE_K, wave_grids=_WAVE_GRIDS):
+    # The wave grid has to cut the tile into whole 16x16 MFMA tiles, the same
+    # rule the kernel factory enforces. Applying it here keeps the tuning space
+    # free of configs that would only be built and thrown away.
     return tuple(
-        {"tile_m": tm, "tile_n": tn, "tile_k": tk, "waves_per_eu": wpe}
+        {
+            "tile_m": tm,
+            "tile_n": tn,
+            "tile_k": tk,
+            "waves_m": wm,
+            "waves_n": wn,
+            "waves_per_eu": wpe,
+        }
         for tm in tile_ms
         for tn in tile_ns
         for tk in tile_ks
+        for wm, wn in wave_grids
         for wpe in _WAVES_PER_EU
+        if tm % (wm * 16) == 0 and tn % (wn * 16) == 0
     )
 
 

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -182,32 +182,44 @@ def _group_and_n(WQ, group_meta, layout):
 _BUFFER_LIMIT_BYTES = 1 << 32
 
 
-def _assert_addressable(total_M, N, K, G, elem_bytes, layout):
-    """Reject a shape whose operands a buffer descriptor could not reach.
+def _addressing_plan(total_M, N, K, G, elem_bytes, layout):
+    """Decide whether A and D need per-group basing, and reject the unreachable.
 
-    The kernel bases A, B and D at the block's own group so that each
-    descriptor spans one group rather than the whole operand, which is what
-    makes a many-expert weight stack addressable at all. A single group can
-    still exceed the limit, and the hardware would answer that by reading zero
-    and dropping stores rather than by faulting, so it is worth refusing here
-    instead of returning a wrong result.
+    B is always based at its group: a weight stack passes the limit at any
+    realistic expert count, and its group comes from the block index, so the
+    descriptor costs nothing to build. A and D are different -- theirs depends
+    on the group resolution, so basing them delays the first loads behind it and
+    measures about a quarter of the runtime on the FP8 groupwise shapes. They
+    keep addressing rows globally while their whole extent still fits one
+    descriptor, and only switch when it does not.
 
-    Only the extents the host knows are checked. Where the groups are packed
-    along M their row counts live on the device, and bounding them here by
-    total_M would reject the many-group shapes the re-basing exists to support,
-    so those go unchecked; the slab layouts divide M evenly and are known.
+    Returns ``group_based_rows``. Raises where even one group would not fit,
+    which no basing can rescue.
+
+    Only extents the host knows are checked. Where the groups are packed along M
+    their row counts live on the device, so a per-group extent cannot be
+    computed here; bounding it by total_M would reject the many-group shapes the
+    basing exists to support. Those get the basing whenever the whole operand is
+    too big, and are left to the kernel from there.
     """
+    d_rows = total_M // G if layout == "n_offsets" else total_M
+    d_whole = d_rows * N * 2 * (G if layout == "k_offsets" else 1)
+    a_whole = total_M * K * elem_bytes
+    group_based_rows = a_whole >= _BUFFER_LIMIT_BYTES or d_whole >= _BUFFER_LIMIT_BYTES
+
+    # B is per-group whatever happens, so its per-group extent always has to fit.
     checks = [("B (one group's weights)", N * K * elem_bytes)]
-    if layout in ("padded", "batched", "n_offsets"):
-        # Every group owns the same fixed slab, so its height is host-known.
-        slab_m = total_M // G
-        checks += [
-            ("A (one group's rows)", slab_m * K * elem_bytes),
-            ("D (one group's output)", slab_m * N * 2),
-        ]
-    elif layout == "k_offsets":
-        # Each group produces a whole [M, N] output of its own.
-        checks.append(("D (one group's output)", total_M * N * 2))
+    if group_based_rows:
+        if layout in ("padded", "batched", "n_offsets"):
+            # Every group owns the same fixed slab, so its height is host-known.
+            slab_m = total_M // G
+            checks += [
+                ("A (one group's rows)", slab_m * K * elem_bytes),
+                ("D (one group's output)", slab_m * N * 2),
+            ]
+        elif layout == "k_offsets":
+            # Each group produces a whole [M, N] output of its own.
+            checks.append(("D (one group's output)", total_M * N * 2))
     for what, nbytes in checks:
         if nbytes >= _BUFFER_LIMIT_BYTES:
             raise ValueError(
@@ -216,6 +228,7 @@ def _assert_addressable(total_M, N, K, G, elem_bytes, layout):
                 f"N={N} K={K} G={G} at {elem_bytes} B/element, layout {layout!r}. "
                 "Split the call along the axis that is too long."
             )
+    return group_based_rows
 
 
 def launch(
@@ -258,7 +271,7 @@ def launch(
 
     total_M, K = XQ.shape
     G, N = _group_and_n(WQ, m_sizes, layout)
-    _assert_addressable(total_M, N, K, G, XQ.element_size(), layout)
+    group_based_rows = _addressing_plan(total_M, N, K, G, XQ.element_size(), layout)
     if b_preshuffled and (K % tile_k != 0 or N % tile_n != 0):
         raise ValueError(
             f"n ({N}) and k ({K}) must be divisible by tile_n ({tile_n}) and "
@@ -305,6 +318,7 @@ def launch(
         # A group's column end is a runtime value when the groups divide N, so
         # the tail mask is always needed there.
         n_padding=(N % tile_n != 0) or layout == "n_offsets",
+        group_based_rows=group_based_rows,
     )
     # Operands keep their natural shape: argument marshalling packs each memref
     # extent as int32, which a flattened view overflows at 2**31 elements. The

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -163,6 +163,8 @@ def launch(
     tile_m,
     tile_n,
     tile_k,
+    waves_m=1,
+    waves_n=4,
     waves_per_eu=0,
 ):
     """Compile (cached) and launch the grouped GEMM for one tile config.
@@ -209,6 +211,8 @@ def launch(
         tile_m=tile_m,
         tile_n=tile_n,
         tile_k=tile_k,
+        waves_m=waves_m,
+        waves_n=waves_n,
         scale_block_k=SCALE_BLOCK,
         scale_block_n=SCALE_BLOCK,
         out_dtype="bf16",

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -25,20 +25,29 @@ from mslk.flydsl.autotune import next_pow2, prune_by_divisibility, tunable
 from mslk.flydsl.jit import run_compiled
 from mslk.utils.device import supports_float8_fnuz
 
-# Scale-block granularity for the block-scaling scheme. It also sets the K-loop
-# sub-block size under either scheme, so tile_k must be a multiple of it.
+# Scale-block granularity for the block-scaling scheme. Where there are scales it
+# also sets the K-loop sub-block size, so tile_k must then be a multiple of it.
 SCALE_BLOCK = 128
 
 # Default tile when autotuning is disabled. Valid for any supported shape
 # (tile_n = tile_k = 128 divide every supported N/K, including a small N=128).
 DEFAULT_TILE = {"tile_m": 128, "tile_n": 128, "tile_k": 128, "waves_per_eu": 2}
 
-# Candidate tiles swept by autotune. tile_k is a multiple of the K-loop sub-block
-# size under either scheme. Rowwise scaling additionally allows tile_n below the
+# Candidate tiles swept by autotune. Rowwise scaling allows tile_n below the
 # scale block, which block scaling cannot express, so the two schemes sweep
 # different sets. Tiles that overflow LDS are rejected at compile time.
 _TILE_M = (64, 128, 256)
 _TILE_K = (128, 256)
+
+# Unscaled operands sweep wider on both axes. tile_k is not pinned to the scale
+# block, and a two-byte dtype needs the room: its tile spans twice the LDS of the
+# one-byte tile of the same shape, so at tile_k=128 a 128x128 tile already holds
+# a whole CU's worth and runs one workgroup at a time. Shrinking tile_k buys that
+# back most cheaply, since LDS grows as (tile_m + tile_n) * tile_k while the MFMA
+# work grows as tile_m * tile_n * tile_k. tile_m=32 is the other end of the same
+# trade, for the decode shapes where a group holds only a few rows.
+_UNSCALED_TILE_M = (32, 64, 128, 256)
+_UNSCALED_TILE_K = (64, 128, 256)
 
 # Occupancy target, as a minimum waves-per-EU hint to the register allocator; 0
 # leaves the choice to the compiler. Preshuffled B is held in registers across a
@@ -49,18 +58,23 @@ _TILE_K = (128, 256)
 _WAVES_PER_EU = (0, 2)
 
 
-def _tiles(tile_ns):
+def _tiles(tile_ns, tile_ms=_TILE_M, tile_ks=_TILE_K):
     return tuple(
         {"tile_m": tm, "tile_n": tn, "tile_k": tk, "waves_per_eu": wpe}
-        for tm in _TILE_M
+        for tm in tile_ms
         for tn in tile_ns
-        for tk in _TILE_K
+        for tk in tile_ks
         for wpe in _WAVES_PER_EU
     )
 
 
 BLOCKSCALE_TILES = _tiles((128, 256))
 ROWWISE_TILES = _tiles((64, 128, 256))
+# tile_n stops at 64: the CShuffle epilogue lays 32 lanes across N at 2 columns
+# each, so a narrower tile has no store to make.
+UNSCALED_TILES = _tiles(
+    (64, 128, 256), tile_ms=_UNSCALED_TILE_M, tile_ks=_UNSCALED_TILE_K
+)
 
 # A tile that overruns N or K still compiles, as the tail-masked variant, but it
 # wastes part of its work on padding and is not going to win, so prune on both
@@ -236,13 +250,16 @@ def launch(
     return out
 
 
-# The two scaling schemes sweep different tiles, so each gets its own tuned entry
-# point; the cache key carries the scheme as well, since the kernels differ.
+# Each scaling scheme sweeps a different tile set, so each gets its own tuned
+# entry point; the cache key carries the scheme as well, since the kernels differ.
 _launch_blockscale = tunable(
     configs=BLOCKSCALE_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE
 )(launch)
 _launch_rowwise = tunable(
     configs=ROWWISE_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE
+)(launch)
+_launch_unscaled = tunable(
+    configs=UNSCALED_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE
 )(launch)
 
 
@@ -298,9 +315,14 @@ def dispatch(
     # The groups divide K, so one group contracts over a fraction of it.
     k_key = K // G if layout == "k_offsets" else K
 
-    # Block scaling is the only scheme that constrains tile_n to the scale
-    # block; rowwise and unscaled operands both sweep the wider set.
-    tuned_launch = _launch_blockscale if scaling == "block" else _launch_rowwise
+    # Each scheme is free of the constraints the one before it carries: block
+    # scaling pins tile_n and tile_k to the scale block, rowwise pins only
+    # tile_k, and unscaled operands pin neither.
+    tuned_launch = {
+        "block": _launch_blockscale,
+        "row": _launch_rowwise,
+        "none": _launch_unscaled,
+    }[scaling]
     return tuned_launch(
         XQ,
         WQ,

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -185,16 +185,19 @@ _BUFFER_LIMIT_BYTES = 1 << 32
 def _addressing_plan(total_M, N, K, G, elem_bytes, layout):
     """Decide whether A and D need per-group basing, and reject the unreachable.
 
-    B is always based at its group: a weight stack passes the limit at any
-    realistic expert count, and its group comes from the block index, so the
-    descriptor costs nothing to build. A and D are different -- theirs depends
-    on the group resolution, so basing them delays the first loads behind it and
-    measures about a quarter of the runtime on the FP8 groupwise shapes. They
-    keep addressing rows globally while their whole extent still fits one
-    descriptor, and only switch when it does not.
+    Every operand keeps addressing its whole self while that self still fits one
+    descriptor, and switches to its group's base only when it does not. None of
+    the basing is free: on the preshuffled-B path, whose weights go
+    HBM->registers inside the K loop rather than through LDS, basing B costs
+    40-55% at tile_n=256, and basing A and D costs about a quarter of the
+    runtime on the FP8 groupwise shapes.
 
-    Returns ``group_based_rows``. Raises where even one group would not fit,
-    which no basing can rescue.
+    B's threshold is exact -- ``G * N * K`` is entirely host-known -- while A's
+    and D's is a bound, since the packed layouts keep their group row counts on
+    the device.
+
+    Returns ``(group_based_b, group_based_rows)``. Raises where even one group
+    would not fit, which no basing can rescue.
 
     Only extents the host knows are checked. Where the groups are packed along M
     their row counts live on the device, so a per-group extent cannot be
@@ -207,8 +210,18 @@ def _addressing_plan(total_M, N, K, G, elem_bytes, layout):
     a_whole = total_M * K * elem_bytes
     group_based_rows = a_whole >= _BUFFER_LIMIT_BYTES or d_whole >= _BUFFER_LIMIT_BYTES
 
-    # B is per-group whatever happens, so its per-group extent always has to fit.
-    checks = [("B (one group's weights)", N * K * elem_bytes)]
+    # Where the groups divide N or K, B is a single matrix every block reads
+    # whole, so there is no group axis to base on and its whole extent is what
+    # has to fit.
+    b_stacked = layout not in ("n_offsets", "k_offsets")
+    b_whole = N * K * elem_bytes * (G if b_stacked else 1)
+    group_based_b = b_stacked and b_whole >= _BUFFER_LIMIT_BYTES
+
+    checks = []
+    if group_based_b or not b_stacked:
+        checks.append(("B (one group's weights)", N * K * elem_bytes))
+    else:
+        checks.append(("B (the whole weight stack)", b_whole))
     if group_based_rows:
         if layout in ("padded", "batched", "n_offsets"):
             # Every group owns the same fixed slab, so its height is host-known.
@@ -228,7 +241,7 @@ def _addressing_plan(total_M, N, K, G, elem_bytes, layout):
                 f"N={N} K={K} G={G} at {elem_bytes} B/element, layout {layout!r}. "
                 "Split the call along the axis that is too long."
             )
-    return group_based_rows
+    return group_based_b, group_based_rows
 
 
 def launch(
@@ -271,7 +284,9 @@ def launch(
 
     total_M, K = XQ.shape
     G, N = _group_and_n(WQ, m_sizes, layout)
-    group_based_rows = _addressing_plan(total_M, N, K, G, XQ.element_size(), layout)
+    group_based_b, group_based_rows = _addressing_plan(
+        total_M, N, K, G, XQ.element_size(), layout
+    )
     if b_preshuffled and (K % tile_k != 0 or N % tile_n != 0):
         raise ValueError(
             f"n ({N}) and k ({K}) must be divisible by tile_n ({tile_n}) and "
@@ -318,6 +333,7 @@ def launch(
         # A group's column end is a runtime value when the groups divide N, so
         # the tail mask is always needed there.
         n_padding=(N % tile_n != 0) or layout == "n_offsets",
+        group_based_b=group_based_b,
         group_based_rows=group_based_rows,
     )
     # Operands keep their natural shape: argument marshalling packs each memref

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -176,6 +176,48 @@ def _group_and_n(WQ, group_meta, layout):
     return WQ.shape[0], WQ.shape[1]
 
 
+#: What one AMD buffer descriptor can address. Its num_records is a 32-bit
+#: field, and so is the voffset a buffer_load adds, so nothing beyond this is
+#: reachable through one of them.
+_BUFFER_LIMIT_BYTES = 1 << 32
+
+
+def _assert_addressable(total_M, N, K, G, elem_bytes, layout):
+    """Reject a shape whose operands a buffer descriptor could not reach.
+
+    The kernel bases A, B and D at the block's own group so that each
+    descriptor spans one group rather than the whole operand, which is what
+    makes a many-expert weight stack addressable at all. A single group can
+    still exceed the limit, and the hardware would answer that by reading zero
+    and dropping stores rather than by faulting, so it is worth refusing here
+    instead of returning a wrong result.
+
+    Only the extents the host knows are checked. Where the groups are packed
+    along M their row counts live on the device, and bounding them here by
+    total_M would reject the many-group shapes the re-basing exists to support,
+    so those go unchecked; the slab layouts divide M evenly and are known.
+    """
+    checks = [("B (one group's weights)", N * K * elem_bytes)]
+    if layout in ("padded", "batched", "n_offsets"):
+        # Every group owns the same fixed slab, so its height is host-known.
+        slab_m = total_M // G
+        checks += [
+            ("A (one group's rows)", slab_m * K * elem_bytes),
+            ("D (one group's output)", slab_m * N * 2),
+        ]
+    elif layout == "k_offsets":
+        # Each group produces a whole [M, N] output of its own.
+        checks.append(("D (one group's output)", total_M * N * 2))
+    for what, nbytes in checks:
+        if nbytes >= _BUFFER_LIMIT_BYTES:
+            raise ValueError(
+                f"{what} is {nbytes} bytes, which a buffer descriptor cannot "
+                f"address (limit {_BUFFER_LIMIT_BYTES}). Shape: total_M={total_M} "
+                f"N={N} K={K} G={G} at {elem_bytes} B/element, layout {layout!r}. "
+                "Split the call along the axis that is too long."
+            )
+
+
 def launch(
     XQ,
     WQ,
@@ -216,6 +258,7 @@ def launch(
 
     total_M, K = XQ.shape
     G, N = _group_and_n(WQ, m_sizes, layout)
+    _assert_addressable(total_M, N, K, G, XQ.element_size(), layout)
     if b_preshuffled and (K % tile_k != 0 or N % tile_n != 0):
         raise ValueError(
             f"n ({N}) and k ({K}) must be divisible by tile_n ({tile_n}) and "

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -32,9 +32,6 @@ SCALE_BLOCK = 128
 # Default config when autotuning is disabled, for the scaled schemes; the
 # unscaled one takes UNSCALED_DEFAULT_TILE below. Valid for any supported shape
 # (tile_n = tile_k = 128 divide every supported N/K, including a small N=128).
-# The wave grid stays at the historical 1x4 rather than the 2x2 this square tile
-# would favour: changing it moves every untuned call, which is a decision to
-# take on measurement rather than on the shape of the tile alone.
 DEFAULT_TILE = {
     "tile_m": 128,
     "tile_n": 128,
@@ -44,14 +41,12 @@ DEFAULT_TILE = {
     "waves_per_eu": 2,
 }
 
-# The unscaled scheme needs its own default, because a 2-byte operand doubles
-# the LDS a tile costs. 128x128x128 in BF16 wants 2*128*128*2 for the ping-pong
-# A plus 128*128*2 for B, i.e. 98304 bytes against the 65536 a CDNA3 workgroup
-# has: on gfx942 the default does not merely run slowly, it raises before the
-# kernel is traced, which leaves the untuned path -- CI, graph capture -- with
-# nothing to run. Halving tile_k brings it to 49152, which fits both CDNA3 and
-# CDNA4. tile_k=64 is available only here: where there are scales it is tied to
-# the scale block.
+# The unscaled scheme takes a smaller tile_k, since a 2-byte operand doubles what
+# a tile occupies in LDS: 128x128x128 in BF16 needs 2*128*128*2 for the ping-pong
+# A plus 128*128*2 for B, which is 98304 bytes against the 65536 a CDNA3
+# workgroup has. tile_k=64 brings it to 49152 and fits both CDNA3 and CDNA4. Only
+# this scheme can move tile_k; where there are scales it is tied to the scale
+# block.
 UNSCALED_DEFAULT_TILE = {**DEFAULT_TILE, "tile_k": 64}
 
 # Candidate tiles swept by autotune. Rowwise scaling allows tile_n below the
@@ -83,9 +78,7 @@ _WAVES_PER_EU = (0, 2)
 # waves_m / tile_m + waves_n / tile_n, smallest when the grid is proportioned
 # like the tile: 1x4 suits a tile four times wider than tall, 2x2 a square one,
 # 4x1 a tall one. All three are four waves, so they cost the same in threads,
-# LDS and registers and differ only in shape. Grids past four waves are a
-# different trade -- more waves per tile against a smaller register budget each
-# -- and are left out until that is measured on its own.
+# LDS and registers and differ only in shape.
 _WAVE_GRIDS = ((1, 4), (2, 2), (4, 1))
 
 
@@ -197,11 +190,8 @@ def _addressing_plan(total_M, N, K, G, elem_bytes, layout):
     """Decide whether A and D need per-group basing, and reject the unreachable.
 
     Every operand keeps addressing its whole self while that self still fits one
-    descriptor, and switches to its group's base only when it does not. None of
-    the basing is free: on the preshuffled-B path, whose weights go
-    HBM->registers inside the K loop rather than through LDS, basing B costs
-    40-55% at tile_n=256, and basing A and D costs about a quarter of the
-    runtime on the FP8 groupwise shapes.
+    descriptor, and switches to its group's base only when it does not, since
+    per-group basing carries a runtime cost on every path that uses it.
 
     B's threshold is exact -- ``G * N * K`` is entirely host-known -- while A's
     and D's is a bound, since the packed layouts keep their group row counts on
@@ -296,8 +286,8 @@ def launch(
 
     ``g`` feeds the key alone. The group count changes both the grid, which
     carries one partial tile per group, and whether an operand clears the
-    buffer-descriptor limit and has to be re-based per group; the best tile
-    differs enough between group counts that they cannot share a tuned entry.
+    buffer-descriptor limit and has to be re-based per group, so group counts
+    do not share a tuned entry.
 
     ``in_dtype`` names the operand element type the kernel is compiled for.
     ``x_scale``/``w_scale`` may be None where it carries no scales.

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -117,7 +117,7 @@ _PRUNE = prune_by_divisibility({"tile_n": "n", "tile_k": "k"})
 # roll_k is deliberately absent: it is fixed policy rather than something that
 # varies per call, and a tuning space containing a fully unrolled candidate would
 # have to compile one per tile config, at a cost that grows with K.
-_KEY = ["m_bucket", "n", "k", "b_preshuffled", "scaling", "layout", "in_dtype"]
+_KEY = ["m_bucket", "n", "k", "g", "b_preshuffled", "scaling", "layout", "in_dtype"]
 
 
 def assert_fp8_operands(XQ: torch.Tensor, WQ: torch.Tensor) -> None:
@@ -254,6 +254,7 @@ def launch(
     m_bucket,
     n,
     k,
+    g,
     b_preshuffled,
     scaling,
     layout="sizes",
@@ -276,6 +277,11 @@ def launch(
     ``m_bucket`` only feeds the autotune key: bucketing total_M keeps nearby token
     counts on one tuned config. ``n``/``k`` are likewise passed for the key and
     for tile pruning, and are read back off the operands here.
+
+    ``g`` feeds the key alone. The group count changes both the grid, which
+    carries one partial tile per group, and whether an operand clears the
+    buffer-descriptor limit and has to be re-based per group; the best tile
+    differs enough between group counts that they cannot share a tuned entry.
 
     ``in_dtype`` names the operand element type the kernel is compiled for.
     ``x_scale``/``w_scale`` may be None where it carries no scales.
@@ -442,6 +448,7 @@ def dispatch(
         next_pow2(m_key),
         n_key,
         k_key,
+        G,
         b_preshuffled,
         scaling,
         layout,

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -29,7 +29,8 @@ from mslk.utils.device import supports_float8_fnuz
 # also sets the K-loop sub-block size, so tile_k must then be a multiple of it.
 SCALE_BLOCK = 128
 
-# Default config when autotuning is disabled. Valid for any supported shape
+# Default config when autotuning is disabled, for the scaled schemes; the
+# unscaled one takes UNSCALED_DEFAULT_TILE below. Valid for any supported shape
 # (tile_n = tile_k = 128 divide every supported N/K, including a small N=128).
 # The wave grid stays at the historical 1x4 rather than the 2x2 this square tile
 # would favour: changing it moves every untuned call, which is a decision to
@@ -42,6 +43,16 @@ DEFAULT_TILE = {
     "waves_n": 4,
     "waves_per_eu": 2,
 }
+
+# The unscaled scheme needs its own default, because a 2-byte operand doubles
+# the LDS a tile costs. 128x128x128 in BF16 wants 2*128*128*2 for the ping-pong
+# A plus 128*128*2 for B, i.e. 98304 bytes against the 65536 a CDNA3 workgroup
+# has: on gfx942 the default does not merely run slowly, it raises before the
+# kernel is traced, which leaves the untuned path -- CI, graph capture -- with
+# nothing to run. Halving tile_k brings it to 49152, which fits both CDNA3 and
+# CDNA4. tile_k=64 is available only here: where there are scales it is tied to
+# the scale block.
+UNSCALED_DEFAULT_TILE = {**DEFAULT_TILE, "tile_k": 64}
 
 # Candidate tiles swept by autotune. Rowwise scaling allows tile_n below the
 # scale block, which block scaling cannot express, so the two schemes sweep
@@ -379,7 +390,7 @@ _launch_rowwise = tunable(
     configs=ROWWISE_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE
 )(launch)
 _launch_unscaled = tunable(
-    configs=UNSCALED_TILES, default=DEFAULT_TILE, key=_KEY, prune=_PRUNE
+    configs=UNSCALED_TILES, default=UNSCALED_DEFAULT_TILE, key=_KEY, prune=_PRUNE
 )(launch)
 
 

--- a/mslk/gemm/flydsl/grouped_dispatch.py
+++ b/mslk/gemm/flydsl/grouped_dispatch.py
@@ -233,6 +233,11 @@ def _addressing_plan(total_M, N, K, G, elem_bytes, layout):
         elif layout == "k_offsets":
             # Each group produces a whole [M, N] output of its own.
             checks.append(("D (one group's output)", total_M * N * 2))
+            # A is the one operand no basing can shrink here: the groups divide
+            # the contraction, so a group owns a set of columns of [M, total_K]
+            # and its last row sits near the end of the matrix whatever its base
+            # is. The whole extent is what has to be reachable.
+            checks.append(("A (the whole activation matrix)", a_whole))
     for what, nbytes in checks:
         if nbytes >= _BUFFER_LIMIT_BYTES:
             raise ValueError(


### PR DESCRIPTION
## Summary

Serves `mslk::bf16bf16bf16_grouped_stacked` — the BF16 grouped GEMM whose groups are packed along M with a `[G]` int64 row count each — from FlyDSL on ROCm, replacing CK. CUDA is unchanged. This extends the shared grouped kernel of #470 and #471 to unquantised operands.

Two things carry the change: a BF16 codepath in the shared kernel, and per-group basing of the buffer descriptors so that operands past 4 GiB are addressable at all.

## BF16 in the shared kernel

`scaling` becomes `{block, row, none}` and the operand element type a compile-time parameter, rather than a second kernel.

**One K loop serves both dtypes.** Operand bytes per lane are `MFMA_K × elem_bytes / 4`. FP8's `16x16x32` fills half a 16-byte LDS pack and so issues twice per pack; BF16's gfx950 `16x16x32` fills the whole pack and issues once. Either way a pack is one unit of K, which is what lets them share the loop body. The wide `mfma_scale_f32_16x16x128_f8f6f4` reads its operands as f8f6f4, so BF16 takes the narrow path even on gfx950; gfx942 has no K32 BF16 MFMA and issues the K16 instruction twice. LDS is byte-typed, so the swizzle and the pack loads stay dtype-agnostic.

**Unscaled tiles are freed from the scale block.** Where there are scales, `tile_k` is the extent one set of them covers and must be a multiple of `scale_block_k`; unscaled operands have none, so `tile_k = 64` and `tile_m = 32` become available. A BF16 tile occupies twice the LDS of the FP8 tile of the same shape: at `tile_k = 128` a 128×128 tile holds 96 KB of gfx950's 160 KB and runs one workgroup per CU. Occupancy goes 1 → 3 at 128×128×64 and 1 → 5 at 64×128×64, and the untuned default gets a tile that fits CDNA3's 64 KB.

**The wave grid is two-dimensional and tuned.** Waves divide the tile as `waves_m × waves_n`, and LDS reads per unit of work go as `waves_m / tile_m + waves_n / tile_n`, minimised by a grid proportioned like the tile. The three four-wave grids differ only in shape, so the tuner sweeps all of them.

## Per-group basing of buffer descriptors

A buffer descriptor addresses at most 4 GiB: its `num_records` and the `voffset` a `buffer_load` adds are both 32-bit. Past that the hardware reads zero and drops stores rather than faulting, so the kernel returns a wrong answer at full speed. A stack of 128 experts of 16384×5120 in BF16 is 21.5 GB. Each descriptor is now based at the group it belongs to, with the group folded into the base address so the selecting arithmetic happens in 64 bits.

**This is a pre-existing bug and the fix reaches the FP8 grouped ops too** — they share these modules and had the same limit, and only the smaller element size kept it out of reach on the shapes tested so far.

**Basing is decided per shape on the host,** as it costs runtime wherever it is used, most on the preshuffled path where B goes HBM→registers inside the K loop and its descriptor sits on the critical path of every load. B's threshold is exact, `G × N × K` being host-known; A's and D's is a bound, since the packed layouts keep group row counts on the device. A shape no descriptor can reach even one group at a time is rejected on the host, naming the operand.

## Performance

FlyDSL vs CK, CUDA-graph replay after a 0.5 s clock ramp, gfx950, idle GPU. Figures are the reduction in kernel time against CK,

```
(ck_time - fly_time) / ck_time * 100
```

so a positive number is the share of CK's time saved. Sixty shapes: Llama4 MoE projections at the expert counts CK tuned against — Scout's 16 and Maverick's 128 — over an M grid spanning decode to prefill, forty inside CK's tuned lookup and twenty outside. **44 of 60 shapes are faster; median +14.7%.**

| Variant | Shapes faster | Median | Worst | Best |
|---|---|---|---|---|
| G=16 | 29/30 | +40.1% | -1.4% | +83.1% |
| G=128, B under 4 GiB | 11/20 | +6.0% | -29.1% | +52.2% |
| G=128, B re-based | 4/10 | -3.7% | -24.0% | +60.8% |

Losses cluster at G=128 with total_M ≤ 1024, twelve of the sixteen sitting there. That is where most experts get no rows: the grid launches `total_M / tile_m + G` M-tiles and self-skips the surplus, while CK's persistent kernel with `num_sms` is built for that case. `num_sms` is accepted and ignored here, this kernel launching one block per output tile.

<details>
<summary>Per-shape detail</summary>

**Llama4 Scout, G=16** — total_M at the ends of the grid

| N×K | total_M | CK µs | FlyDSL µs | Time saved |
|---|---|---|---|---|
| 896×5120 | 16 | 76.7 | 29.9 | +61.0% |
| 896×5120 | 8192 | 141.5 | 135.6 | +4.2% |
| 2048×5120 | 16 | 63.9 | 61.4 | +3.9% |
| 2048×5120 | 8192 | 1034.8 | 265.9 | +74.3% |
| 5120×640 | 16 | 37.8 | 22.1 | +41.5% |
| 5120×640 | 8192 | 104.2 | 83.5 | +19.9% |
| 5120×1024 | 16 | 34.3 | 31.5 | +8.2% |
| 5120×1024 | 8192 | 541.8 | 123.5 | +77.2% |
| 5120×8192 | 16 | 269.1 | 254.6 | +5.4% |
| 5120×8192 | 8192 | 5373.0 | 1024.5 | +80.9% |
| 16384×5120 | 16 | 447.4 | 442.4 | +1.1% |
| 16384×5120 | 8192 | 11427.8 | 1926.7 | +83.1% |

**Llama4 Maverick, G=128** — total_M at the ends of the grid

| N×K | total_M | CK µs | FlyDSL µs | Time saved |
|---|---|---|---|---|
| 896×5120 | 16 | 87.1 | 41.6 | +52.2% |
| 896×5120 | 8192 | 320.5 | 283.1 | +11.7% |
| 2048×5120 | 16 | 77.6 | 92.7 | -19.5% |
| 2048×5120 | 8192 | 1082.9 | 586.1 | +45.9% |
| 5120×640 | 16 | 66.3 | 49.1 | +25.9% |
| 5120×640 | 8192 | 243.5 | 312.0 | -28.1% |
| 5120×1024 | 16 | 68.6 | 53.9 | +21.4% |
| 5120×1024 | 8192 | 570.0 | 406.9 | +28.6% |
| 5120×8192 | 16 | 267.1 | 306.7 | -14.8% |
| 5120×8192 | 8192 | 5717.0 | 2240.0 | +60.8% |
| 16384×5120 | 16 | 459.9 | 570.5 | -24.0% |
| 16384×5120 | 8192 | 7739.6 | 4574.5 | +40.9% |

</details>

## Correctness

`test/gemm/gemm_test.py -k "grouped or groupwise or blockwise"`: **97 passed, 62 skipped** on gfx950. The upstream contract tests for `bf16bf16bf16_grouped_stacked` now exercise FlyDSL rather than CK and are the primary coverage; they pass with tuning both off and on. Also checked outside the suite: results bit-identical across all 17 tile shapes and the four wave grids, and correct output past 4 GiB on A, B and D up to 6 GiB.

**No FP8 regression.** Those ops share the kernel, so they were re-timed on the same cells before and after, pinned to a fixed tile to isolate the kernel from the tuner. At the default tile, 24 cells: worst +1.9%. At 64×256×128, measured separately because the default tile does not reach the preshuffled B path where basing costs most, 25 cells over three alternating runs: worst +0.7%, against a run-to-run spread of up to 4.6%. Every cell's output fingerprint takes one value across those runs, so FP8 results are bit-identical either side of this PR.

Unit tests pass on MI350 (gfx950) and MI300 (gfx942).

## Notes for reviewers

- **`gemm_ops.cpp` frees the CK slot on ROCm**, so the Python binding is the only implementation there rather than an override of one. A ROCm build without FlyDSL has no implementation for this op and raises.
- `bf16bf16bf16_grouped`, `_cat` and `_dynamic` stay on CK, all three being marked `UNSUPPORTED AND DEPRECATED — use _stacked` in CK's own source; `_grad`/`_wgrad` are backward passes on a different kernel shape and stay on Triton.
- **The group count now enters the autotune key,** changing both the grid and whether an operand has to be re-based. Compilation was already keyed correctly, so this affects only which tile a shape is handed.
- **`fp8_grouped_gemm.py` and `compile_fp8_grouped_gemm` keep their names** though they now compile BF16 too; the rename touches four files and was left out to keep this diff reviewable.
